### PR TITLE
updated parser repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/libcypher-parser"]
 	path = deps/libcypher-parser
-	url = https://github.com/RedisGraph/libcypher-parser.git
+	url = https://github.com/FalkorDB/libcypher-parser.git
 [submodule "deps/rax"]
 	path = deps/rax
 	url = https://github.com/antirez/rax.git


### PR DESCRIPTION
As part of the migration, need to update `libcypher-parser` repository URL