### PR TITLE
validate unwind declares a new variable

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1739,7 +1739,14 @@ static VISITOR_STRATEGY _Validate_UNWIND_Clause
 	// introduce alias to bound vars
 	const cypher_astnode_t *alias = cypher_ast_unwind_get_alias(n);
 	const char *identifier = cypher_ast_identifier_get_name(alias);
-	_IdentifierAdd(vctx, identifier, NULL);
+
+	// fail if UNWIND identifier is already defined
+	// e.g. MATCH (n) UNWIND [0,1] AS n RETURN n
+	if(_IdentifierAdd(vctx, identifier, NULL) == 0) {
+		ErrorCtx_SetError(EMSG_VAIABLE_ALREADY_DECLARED, identifier);
+		return VISITOR_BREAK;
+	}
+
 	return VISITOR_RECURSE;
 }
 

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1734,20 +1734,32 @@ static VISITOR_STRATEGY _Validate_UNWIND_Clause
 		return VISITOR_CONTINUE;
 	}
 
+	// set current clause
 	vctx->clause = cypher_astnode_type(n);
 
-	// introduce alias to bound vars
+	//--------------------------------------------------------------------------
+	// validate unwind collection
+	//--------------------------------------------------------------------------
+
+	const cypher_astnode_t *collection = cypher_ast_unwind_get_expression(n);
+
+	AST_Visitor_visit(collection, visitor);
+	if(ErrorCtx_EncounteredError()) {
+		return VISITOR_BREAK;
+	}
+
+	// introduce UNWIND alias to scope
+	// fail if alias is already defined
+	// e.g. MATCH (n) UNWIND [0,1] AS n RETURN n
 	const cypher_astnode_t *alias = cypher_ast_unwind_get_alias(n);
 	const char *identifier = cypher_ast_identifier_get_name(alias);
 
-	// fail if UNWIND identifier is already defined
-	// e.g. MATCH (n) UNWIND [0,1] AS n RETURN n
 	if(_IdentifierAdd(vctx, identifier, NULL) == 0) {
 		ErrorCtx_SetError(EMSG_VAIABLE_ALREADY_DECLARED, identifier);
 		return VISITOR_BREAK;
 	}
 
-	return VISITOR_RECURSE;
+	return VISITOR_CONTINUE;
 }
 
 // validate a FOREACH clause

--- a/tests/flow/test_unwind_clause.py
+++ b/tests/flow/test_unwind_clause.py
@@ -111,3 +111,12 @@ class testUnwindClause():
             except Exception as e:
                 self.env.assertTrue("Variable `i` already declared" in str(e))
 
+    def test05_access_undefined_var(self):
+        query = "UNWIND [0, i, 1] AS i RETURN i"
+        try:
+            redis_graph.query(query)
+            # should not reach this point
+            self.env.assertTrue(False)
+        except Exception as e:
+            self.env.assertTrue("'i' not defined" in str(e))
+

--- a/tests/flow/test_unwind_clause.py
+++ b/tests/flow/test_unwind_clause.py
@@ -91,10 +91,23 @@ class testUnwindClause():
         expected = [[None], [1], [2]]
         self.env.assertEqual(actual_result.result_set, expected)
 
-    def test02_unwind_set(self):
+    def test03_unwind_set(self):
         # delete property
         query = """CREATE (n:N {x:3})"""
         actual_result = redis_graph.query(query)
         query = """UNWIND ({x:null}) AS q MATCH (n:N) SET n.x= q.x RETURN n"""
         actual_result = redis_graph.query(query)
         self.env.assertEqual(actual_result.properties_removed, 1)
+
+    def test04_overwrite_var(self):
+        queries = ["UNWIND [0, 1] AS i UNWIND [2, 3] AS i RETURN i",
+                   "MATCH (i) UNWIND [0, 1] as i RETURN i"]
+
+        for q in queries:
+            try:
+                redis_graph.query(q)
+                # should not reach this point
+                self.env.assertTrue(False)
+            except Exception as e:
+                self.env.assertTrue("Variable `i` already declared" in str(e))
+


### PR DESCRIPTION
Resolves #383 
The `UNWIND` clause shouldn't overwrite existing variables
The following query is invalid
```cypher
UNWIND [0,1] AS i
    UNWIND [2,3] AS i
        RETURN i
```