### PR TITLE
validate REMOVE operands

### DIFF
--- a/src/ast/ast_build_reference_map.c
+++ b/src/ast/ast_build_reference_map.c
@@ -304,10 +304,10 @@ static void _AST_MapRemoveClauseReferences
 
 	uint nitems = cypher_ast_remove_nitems(remove_clause);
 	for(uint i = 0; i < nitems; i++) {
-		// get the SET directive at this index
-		const cypher_astnode_t *set_item =
+		// get the REMOVE directive at this index
+		const cypher_astnode_t *remove_item =
 			cypher_ast_remove_get_item(remove_clause, i);
-		_AST_MapRemoveItemReferences(ast, set_item);
+		_AST_MapRemoveItemReferences(ast, remove_item);
 	}
 }
 

--- a/src/errors/error_msgs.h
+++ b/src/errors/error_msgs.h
@@ -122,4 +122,5 @@
 #define EMSG_INDEX_FIELD_ALREADY_EXISTS "Attribute '%s' is already indexed"
 #define EMSG_VECTOR_INDEX_INVALID_CONFIG "Invalid vector index configuration"
 #define EMSG_INDEX_CANT_RECONFIG "Can not override index configuration"
+#define EMSG_REMOVE_INVALID_INPUT "REMOVE operates on either a node, relationship or a map"
 

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -526,6 +526,17 @@ class testEntityUpdate():
             except ResponseError as e:
                 self.env.assertContains("Update error: alias 'x' did not resolve to a graph entity", str(e))
 
+        queries = ["REMOVE NULL.v",
+                   "REMOVE 1.v",
+                   "REMOVE 'a'.v",
+                   "REMOVE f(1).v"]
+        for q in queries:
+            try:
+                graph.query(q)
+                self.env.assertTrue(False)
+            except ResponseError as e:
+                self.env.assertContains("REMOVE operates on either a node, relationship or a map", str(e))
+
     def test_36_mix_add_and_remove_node_properties(self):
         graph.delete()
         graph.query("CREATE ({v:1})")


### PR DESCRIPTION
Resolves #411
The REMOVE clause is expected to operate on a simple construct: IDENTIFIER . PROPERTY when removing a property from either a Node, Edge or a Map.

This PR adds an AST validation for the REMOVE clause making sure the construct follows these simple rules.