### PR TITLE
pass bounded record to cartesian product branches

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -1,7 +1,6 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #include "../ops/ops.h"
@@ -15,6 +14,220 @@
 #include "../optimizations/optimizations.h"
 #include "../../ast/ast_build_filter_tree.h"
 
+// build execution-plan operations which resolves traversal pattern
+static OpBase* _processPattern
+(
+	OpBase **tail,          // [optional] tail of the traversal chain
+	GraphContext *gc,       // graph context
+	QueryGraph *qg,         // pattern
+	ExecutionPlan *plan,    // execution plan
+	rax *bound_vars,        // bound variables
+	FT_FilterNode *filters  // filters
+) {
+	ASSERT(gc         != NULL);
+	ASSERT(qg         != NULL);
+	ASSERT(plan       != NULL);
+	ASSERT(bound_vars != NULL);
+
+	if(tail != NULL) *tail = NULL;
+
+	OpBase *child  = NULL;
+	OpBase *parent = NULL;
+	uint edge_count = array_len(qg->edges);
+
+	if(edge_count == 0) {
+		// if there are no edges in the pattern, we only need a node scan
+		// if no labels are introduced, and the var is bound, don't build
+		// a traversal
+		QGNode *n = qg->nodes[0];
+		if(raxFind(bound_vars, (unsigned char *)n->alias, strlen(n->alias))
+				!= raxNotFound && QGNode_LabelCount(n) == 0) {
+			return NULL;
+		}
+	}
+
+	// build an algebraic expression(s) for the current pattern
+	AlgebraicExpression **exps = AlgebraicExpression_FromQueryGraph(qg);
+	uint expCount = array_len(exps);
+
+	// reorder exps, to the most performant arrangement of evaluation
+	orderExpressions(qg, exps, &expCount, filters, bound_vars);
+
+	// create SCAN operation that will be the tail of the traversal chain
+	QGNode *src = QueryGraph_GetNodeByAlias(qg,
+			AlgebraicExpression_Src(exps[0]));
+
+	uint label_count = QGNode_LabelCount(src);
+	if(label_count > 0) {
+		AlgebraicExpression *ae_src =
+			AlgebraicExpression_RemoveSource(&exps[0]);
+		ASSERT(AlgebraicExpression_DiagonalOperand(ae_src, 0));
+
+		const char *label = AlgebraicExpression_Label(ae_src);
+		const char *alias = AlgebraicExpression_Src(ae_src);
+		ASSERT(label != NULL);
+		ASSERT(alias != NULL);
+
+		int label_id = GRAPH_UNKNOWN_LABEL;
+		Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
+		if(s != NULL) label_id = Schema_GetID(s);
+
+		// resolve source node by performing label scan
+		NodeScanCtx *ctx = NodeScanCtx_New((char *)alias, (char *)label,
+				label_id, src);
+		parent = child = NewNodeByLabelScanOp(plan, ctx);
+
+		// first operand has been converted into a label scan op
+		AlgebraicExpression_Free(ae_src);
+	} else {
+		parent = child = NewAllNodeScanOp(plan, src->alias);
+		// free expression source
+		// in-case there are additional patterns to traverse
+		if(array_len(qg->edges) == 0) {
+			AlgebraicExpression_Free(
+					AlgebraicExpression_RemoveSource(&exps[0]));
+		}
+	}
+
+	if(tail != NULL) *tail = child;
+
+	// for each expression, build the appropriate traversal operation
+	for(int j = 0; j < expCount; j++) {
+		AlgebraicExpression *exp = exps[j];
+
+		// empty expression, already freed
+		if(AlgebraicExpression_OperandCount(exp) == 0) continue;
+
+		QGEdge *edge = NULL;
+		if(AlgebraicExpression_Edge(exp)) {
+			edge = QueryGraph_GetEdgeByAlias(qg, AlgebraicExpression_Edge(exp));
+		}
+
+		if(edge && (QGEdge_VariableLength(edge) || !QGEdge_SingleHop(edge))) {
+			if(QGEdge_IsShortestPath(edge)) {
+				// edge is part of a shortest-path
+				// MATCH allShortestPaths((a)-[*..]->(b))
+				// validate both edge ends are bounded
+				const char *src_alias  = QGNode_Alias(QGEdge_Src(edge));
+				const char *dest_alias = QGNode_Alias(QGEdge_Dest(edge));
+				bool src_bounded =
+					raxFind(bound_vars, (unsigned char *)src_alias,
+							strlen(src_alias)) != raxNotFound;
+				bool dest_bounded =
+					raxFind(bound_vars, (unsigned char *)dest_alias,
+							strlen(dest_alias)) != raxNotFound;
+
+				// TODO: would be great if we can perform this validation
+				// at AST validation time
+				if(!src_bounded || !dest_bounded) {
+					ErrorCtx_SetError(EMSG_ALLSHORTESTPATH_SRC_DST_RESLOVED);
+				}
+			}
+			parent = NewCondVarLenTraverseOp(plan, gc->g, exp);
+		} else {
+			parent = NewCondTraverseOp(plan, gc->g, exp);
+		}
+
+		// insert the new traversal op at the root of the chain
+		ExecutionPlan_AddOp(parent, child);
+		child = parent;
+	}
+
+	// free the expressions array
+	// as its parts have been converted into operations
+	array_free(exps);
+
+	return parent;
+}
+
+// build execution plan where multiple branches are joined together
+// by a cartesian product operation
+static void _BuildCartesianProduct
+(
+	GraphContext *gc,         // graph context
+	ExecutionPlan *plan,      // execution plan to build
+	QueryGraph **components,  // traversal patterns
+	uint n,                   // number of patterns
+	AST *ast,                 // AST
+	rax *bound_vars,          // bound variables
+	FT_FilterNode *ft         // filters
+) {
+	ASSERT(n          >  1);
+	ASSERT(gc         != NULL);
+	ASSERT(ast        != NULL);
+	ASSERT(plan       != NULL);
+	ASSERT(components != NULL);
+	ASSERT(bound_vars != NULL);
+
+	bool bounded = false;
+	const char **vars = NULL;
+
+	// bound branch exists
+	// MATCH (n) WITH n MATCH (a {v:n.v}), (b {x:n.x}) RETURN *
+	if(plan->root != NULL) {
+		vars    = (const char**)raxKeys(bound_vars);
+		bounded = true;
+	}
+
+	// creat the cartesian product operation
+	OpBase *cp = NewCartesianProductOp(plan);
+
+	for(uint i = 0; i < n; i++) {
+		OpBase *tail = NULL;
+		QueryGraph *p = components[i];
+		OpBase *branch = _processPattern(&tail, gc, p, plan, bound_vars, ft);
+
+		// it is possible to get a NULL branch
+		// MATCH (a) WITH a MATCH (a) RETURN a
+		if(branch == NULL) continue;
+
+		ExecutionPlan_AddOp(cp, branch);
+
+		if(bounded) {
+			OpBase *arg = NewArgumentOp(plan, vars);
+			// connect branch as the right child of cartesian product
+			// and connect the plan's root as the left child
+			ASSERT(tail != NULL);
+			ExecutionPlan_AddOp(tail, arg);
+		}
+	}
+
+	OpBase *branch = cp;
+
+	// cartesian product with a single branch is redundant
+	if(unlikely(OpBase_ChildCount(cp) == 1)) {
+		ASSERT(bounded == true);
+		// remove the cartesian product and Argument operations
+		branch = OpBase_GetChild(cp, 0);
+		OpBase *arg = ExecutionPlan_LocateOp(branch, OPType_ARGUMENT);
+		ASSERT(arg != NULL);
+
+		ExecutionPlan_RemoveOp(plan, cp);
+		ExecutionPlan_RemoveOp(plan, arg);
+
+		OpBase_Free(cp);
+		OpBase_Free(arg);
+
+		// no need to bind, simply directly link branches
+		bounded = false;
+	}
+
+	array_free(vars);
+
+	// if there are already operations in the plan
+	// then the plan's root becomes a "bound" branch
+	// for the cartesian product
+	if(bounded) {
+		// connect root as the left child of Apply
+		// and connect cartesian product as the right child
+		OpBase *apply = NewApplyOp(plan);
+		ExecutionPlan_UpdateRoot(plan, apply);
+		ExecutionPlan_AddOp(apply, branch);
+	} else {
+		ExecutionPlan_UpdateRoot(plan, branch);
+	}
+}
+
 static void _ExecutionPlan_ProcessQueryGraph
 (
 	ExecutionPlan *plan,
@@ -26,180 +239,80 @@ static void _ExecutionPlan_ProcessQueryGraph
 	// build the full FilterTree for this AST
 	// so that we can order traversals properly
 	FT_FilterNode *ft = AST_BuildFilterTree(ast);
-	QueryGraph **connectedComponents = QueryGraph_ConnectedComponents(qg);
+
+	// compute pattern connected components
+	QueryGraph **cc = QueryGraph_ConnectedComponents(qg);
+	uint n = array_len(cc);
 
 	// if we have already constructed any ops
 	// the plan's record map contains all variables bound at this time
-	uint connectedComponentsCount = array_len(connectedComponents);
 	rax *bound_vars = plan->record_map;
 
 	// if we have multiple graph components
 	// the root operation is a cartesian product
 	// each chain of traversals will be a child of this op
-	OpBase *cartesianProduct = NULL;
-	if(connectedComponentsCount > 1) {
-		cartesianProduct = NewCartesianProductOp(plan);
-		ExecutionPlan_UpdateRoot(plan, cartesianProduct);
+	if(n  > 1) {
+		_BuildCartesianProduct(gc, plan, cc, n, ast, bound_vars, ft);
+	} else {
+		OpBase *branch = _processPattern(NULL, gc, cc[0], plan, bound_vars, ft);
+		if(branch) ExecutionPlan_UpdateRoot(plan, branch);
 	}
 
-	// keep track after all traversal operations along a pattern
-	for(uint i = 0; i < connectedComponentsCount; i++) {
-		QueryGraph *cc = connectedComponents[i];
-		uint edge_count = array_len(cc->edges);
-		OpBase *root = NULL; // the root of the traversal chain will be added to the ExecutionPlan
-		OpBase *tail = NULL;
-
-		if(edge_count == 0) {
-			// if there are no edges in the component, we only need a node scan
-			// if no labels are introduced, and the var is bound, don't build
-			// a traversal
-			QGNode *n = cc->nodes[0];
-			if(raxFind(bound_vars, (unsigned char *)n->alias, strlen(n->alias))
-					!= raxNotFound && QGNode_LabelCount(n) == 0) {
-				continue;
-			}
-		}
-
-		AlgebraicExpression **exps = AlgebraicExpression_FromQueryGraph(cc);
-		uint expCount = array_len(exps);
-
-		// Reorder exps, to the most performant arrangement of evaluation.
-		orderExpressions(qg, exps, &expCount, ft, bound_vars);
-
-		// Create the SCAN operation that will be the tail of the traversal chain.
-		QGNode *src = QueryGraph_GetNodeByAlias(qg,
-			AlgebraicExpression_Src(exps[0]));
-
-		uint label_count = QGNode_LabelCount(src);
-		if(label_count > 0) {
-			AlgebraicExpression *ae_src =
-				AlgebraicExpression_RemoveSource(&exps[0]);
-			ASSERT(AlgebraicExpression_DiagonalOperand(ae_src, 0));
-
-			const char *label = AlgebraicExpression_Label(ae_src);
-			const char *alias = AlgebraicExpression_Src(ae_src);
-			ASSERT(label != NULL);
-			ASSERT(alias != NULL);
-
-			int label_id = GRAPH_UNKNOWN_LABEL;
-			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
-			if(s != NULL) label_id = Schema_GetID(s);
-
-			// resolve source node by performing label scan
-			NodeScanCtx *ctx = NodeScanCtx_New((char *)alias, (char *)label,
-				label_id, src);
-			root = tail = NewNodeByLabelScanOp(plan, ctx);
-
-			// first operand has been converted into a label scan op
-			AlgebraicExpression_Free(ae_src);
-		} else {
-			root = tail = NewAllNodeScanOp(plan, src->alias);
-			// free expression source
-			// in-case there are additional patterns to traverse
-			if(array_len(cc->edges) == 0) {
-				AlgebraicExpression_Free(
-						AlgebraicExpression_RemoveSource(&exps[0]));
-			}
-		}
-
-		// for each expression, build the appropriate traversal operation
-		for(int j = 0; j < expCount; j++) {
-			AlgebraicExpression *exp = exps[j];
-			// Empty expression, already freed.
-			if(AlgebraicExpression_OperandCount(exp) == 0) continue;
-
-			QGEdge *edge = NULL;
-			if(AlgebraicExpression_Edge(exp)) {
-				edge =
-					QueryGraph_GetEdgeByAlias(qg, AlgebraicExpression_Edge(exp));
-			}
-
-			if(edge && (QGEdge_VariableLength(edge) || !QGEdge_SingleHop(edge))) {
-				if(QGEdge_IsShortestPath(edge)) {
-					// edge is part of a shortest-path
-					// MATCH allShortestPaths((a)-[*..]->(b))
-					// validate both edge ends are bounded
-					const char *src_alias  = QGNode_Alias(QGEdge_Src(edge));
-					const char *dest_alias = QGNode_Alias(QGEdge_Dest(edge));
-					bool src_bounded =
-						raxFind(bound_vars, (unsigned char *)src_alias,
-								strlen(src_alias)) != raxNotFound;
-					bool dest_bounded =
-						raxFind(bound_vars, (unsigned char *)dest_alias,
-								strlen(dest_alias)) != raxNotFound;
-
-					// TODO: would be great if we can perform this validation
-					// at AST validation time
-					if(!src_bounded || !dest_bounded) {
-						ErrorCtx_SetError(EMSG_ALLSHORTESTPATH_SRC_DST_RESLOVED);
-					}
-				}
-				root = NewCondVarLenTraverseOp(plan, gc->g, exp);
-			} else {
-				root = NewCondTraverseOp(plan, gc->g, exp);
-			}
-			// Insert the new traversal op at the root of the chain.
-			ExecutionPlan_AddOp(root, tail);
-			tail = root;
-		}
-
-		// Free the expressions array, as its parts have been converted into operations
-		array_free(exps);
-
-		if(cartesianProduct) {
-			// We have multiple disjoint traversal chains.
-			// Add each chain as a child under the Cartesian Product.
-			ExecutionPlan_AddOp(cartesianProduct, root);
-		} else {
-			// We've built the only necessary traversal chain, update the ExecutionPlan root.
-			ExecutionPlan_UpdateRoot(plan, root);
-		}
-	}
-
-	for(uint i = 0; i < connectedComponentsCount; i++) {
-		QueryGraph_Free(connectedComponents[i]);
-	}
-	array_free(connectedComponents);
+	array_free(cc);
 	FilterTree_Free(ft);
 }
 
-static void _buildOptionalMatchOps(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *clause) {
+static void _buildOptionalMatchOps
+(
+	ExecutionPlan *plan,
+	AST *ast,
+	const cypher_astnode_t *clause
+) {
 	const char **arguments = NULL;
 	OpBase *optional = NewOptionalOp(plan);
 	rax *bound_vars = NULL;
 
-	// The root will be non-null unless the first clause is an OPTIONAL MATCH.
+	// the root will be non-null unless the first clause is an OPTIONAL MATCH
 	if(plan->root) {
-		// Collect the variables that are bound at this point.
+		// collect the variables that are bound at this point
 		bound_vars = raxNew();
-		// Rather than cloning the record map, collect the bound variables along with their
-		// parser-generated constant strings.
+		// rather than cloning the record map
+		// collect the bound variables along with their
+		// parser-generated constant strings
 		ExecutionPlan_BoundVariables(plan->root, bound_vars, plan);
-		// Collect the variable names from bound_vars to populate the Argument op we will build.
+		// collect the variable names from bound_vars to populate
+		// the Argument op we will build
 		arguments = (const char **)raxValues(bound_vars);
 		raxFree(bound_vars);
 	}
 
-	// Build the new Match stream and add it to the Optional stream.
+	// build the new Match stream and add it to the Optional stream
 	OpBase *match_stream = ExecutionPlan_BuildOpsFromPath(plan, arguments, clause);
 	array_free(arguments);
 	ExecutionPlan_AddOp(optional, match_stream);
 
-	// The root will be non-null unless the first clause is an OPTIONAL MATCH.
+	// the root will be non-null unless the first clause is an OPTIONAL MATCH
 	if(plan->root) {
-		// Create an Apply operator and make it the new root.
+		// create an Apply operator and make it the new root
 		OpBase *apply_op = NewApplyOp(plan);
 		ExecutionPlan_UpdateRoot(plan, apply_op);
 
-		// Create an Optional op and add it as an Apply child as a right-hand stream.
+		// create an Optional op and add it as an Apply child
+		// as a right-hand stream
 		ExecutionPlan_AddOp(apply_op, optional);
 	} else {
-		// If no root has been set (OPTIONAL was the first clause), set it to the Optional op.
+		// if no root has been set (OPTIONAL was the first clause)
+		// set it to the Optional op
 		ExecutionPlan_UpdateRoot(plan, optional);
 	}
 }
 
-void buildMatchOpTree(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *clause) {
+void buildMatchOpTree
+(
+	ExecutionPlan *plan,
+	AST *ast,
+	const cypher_astnode_t *clause
+) {
 	if(cypher_ast_match_is_optional(clause)) {
 		_buildOptionalMatchOps(plan, ast, clause);
 		return;
@@ -214,12 +327,13 @@ void buildMatchOpTree(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *cla
 	_ExecutionPlan_ProcessQueryGraph(plan, sub_qg, ast);
 	if(ErrorCtx_EncounteredError()) goto cleanup;
 
-	// Build the FilterTree to model any WHERE predicates on these clauses and place ops appropriately.
-	FT_FilterNode *sub_ft = AST_BuildFilterTreeFromClauses(ast,
-		&clause, 1);
+	// build the FilterTree to model any WHERE predicates on these clauses
+	// and place ops appropriately
+	FT_FilterNode *sub_ft = AST_BuildFilterTreeFromClauses(ast, &clause, 1);
 	ExecutionPlan_PlaceFilterOps(plan, plan->root, NULL, sub_ft);
 
-	// Clean up
+	// clean up
 cleanup:
 	QueryGraph_Free(sub_qg);
 }
+

--- a/src/execution_plan/execution_plan_build/execution_plan_util.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_util.c
@@ -1,7 +1,6 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #include "execution_plan_util.h"
@@ -109,16 +108,16 @@ OpBase *ExecutionPlan_LocateOpDepth
 // returns all operations of a certain type in a execution plan
 void ExecutionPlan_LocateOps
 (
-	OpBase ***plans,  // array in which ops are stored
-	OpBase *root,     // root operation of the plan to traverse
-	OPType type       // operation type to search
+	OpBase ***ops,  // array in which ops are stored
+	OpBase *root,   // root operation of the plan to traverse
+	OPType type     // operation type to search
 ) {
 	if(root->type == type) {
-		array_append(*plans, root);
+		array_append(*ops, root);
 	}
 
 	for(uint i = 0; i < root->childCount; i++) {
-		ExecutionPlan_LocateOps(plans, root->children[i], type);
+		ExecutionPlan_LocateOps(ops, root->children[i], type);
 	}
 }
 

--- a/src/execution_plan/execution_plan_build/execution_plan_util.h
+++ b/src/execution_plan/execution_plan_build/execution_plan_util.h
@@ -59,9 +59,9 @@ OpBase *ExecutionPlan_LocateOpDepth
 // returns all operations of a certain type in a execution plan
 void ExecutionPlan_LocateOps
 (
-	OpBase ***plans,  // array in which ops are stored
-	OpBase *root,     // root operation of the plan to traverse
-	OPType type       // operation type to search
+	OpBase ***ops,  // array in which ops are stored
+	OpBase *root,   // root operation of the plan to traverse
+	OPType type     // operation type to search
 );
 
 // Find the earliest operation above the provided recurse_limit, if any,

--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -1,69 +1,71 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #include "op_apply.h"
 #include "../execution_plan_build/execution_plan_util.h"
 
-/* Forward declarations. */
+// forward declarations
 static OpResult ApplyInit(OpBase *opBase);
 static Record ApplyConsume(OpBase *opBase);
 static OpResult ApplyReset(OpBase *opBase);
 static OpBase *ApplyClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void ApplyFree(OpBase *opBase);
 
-OpBase *NewApplyOp(const ExecutionPlan *plan) {
-	Apply *op = rm_malloc(sizeof(Apply));
+OpBase *NewApplyOp
+(
+	const ExecutionPlan *plan
+) {
+	Apply *op = rm_calloc(1, sizeof(Apply));
 
-	op->r            = NULL;
-	op->op_arg       = NULL;
-	op->records      = NULL;
-	op->rhs_branch   = NULL;
-	op->bound_branch = NULL;
-
-	// Set our Op operations
+	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_APPLY, "Apply", ApplyInit, ApplyConsume,
 			ApplyReset, NULL, ApplyClone, ApplyFree, false, plan);
 
 	return (OpBase *)op;
 }
 
-static OpResult ApplyInit(OpBase *opBase) {
+static OpResult ApplyInit
+(
+	OpBase *opBase
+) {
 	ASSERT(opBase->childCount == 2);
 
 	Apply *op = (Apply *)opBase;
-	// the op's bound branch and optional match branch have already been
-	// built as the Apply op's first and second child ops, respectively
 	op->records      = array_new(Record, 1);
 	op->rhs_branch   = opBase->children[1];
 	op->bound_branch = opBase->children[0];
 
 	// locate branch's Argument op tap
-	op->op_arg = (Argument *)ExecutionPlan_LocateOp(op->rhs_branch,
+	op->args = array_new(Argument*, 1);
+	ExecutionPlan_LocateOps((OpBase***)&op->args, op->rhs_branch,
 			OPType_ARGUMENT);
+
+	ASSERT(array_len(op->args) > 0);
 
 	return OP_OK;
 }
 
-static Record ApplyConsume(OpBase *opBase) {
+static Record ApplyConsume
+(
+	OpBase *opBase
+) {
 	Apply *op = (Apply *)opBase;
 
 	while(true) {
 		if(op->r == NULL) {
-			// retrieve a Record from the bound branch
+			// retrieve a record from the bound branch
 			op->r = OpBase_Consume(op->bound_branch);
 			if(op->r == NULL) {
-				return NULL; // Bound branch and this op are depleted.
+				return NULL; // bound branch and this op are depleted
 			}
 
-			// collect record for future freeing
-			array_append(op->records, op->r);
-
-			// Successfully pulled a new Record, propagate to the top of the RHS branch.
-			if(op->op_arg) {
-				Argument_AddRecord(op->op_arg, OpBase_CloneRecord(op->r));
+			// successfully pulled a new record
+			// propagate to the top of the RHS branch(s)
+			for(uint i = 0; i < array_len(op->args); i++) {
+				Argument *arg = op->args[i];
+				Argument_AddRecord(arg, OpBase_CloneRecord(op->r));
 			}
 		}
 
@@ -71,27 +73,30 @@ static Record ApplyConsume(OpBase *opBase) {
 		Record rhs_record = OpBase_Consume(op->rhs_branch);
 
 		if(rhs_record == NULL) {
-			// RHS branch depleted for the current bound Record
+			// RHS branch depleted for the current bound record
 			// free it and loop back to retrieve a new one
+			OpBase_DeleteRecord(op->r);
 			op->r = NULL;
+
 			// reset the RHS branch
 			OpBase_PropagateReset(op->rhs_branch);
 			continue;
 		}
 
-		// clone the bound Record and merge the RHS Record into it
-		Record r = OpBase_CloneRecord(op->r);
-		Record_Merge(r, rhs_record);
-		// delete the RHS record, as it has been merged into r
-		OpBase_DeleteRecord(rhs_record);
-
-		return r;
+		// merge bound branch record into retrieved RHS branch record
+		// and return it
+		Record_Merge(rhs_record, op->r);
+		return rhs_record;
 	}
 
+	// not suppose to reach this point
 	return NULL;
 }
 
-static OpResult ApplyReset(OpBase *opBase) {
+static OpResult ApplyReset
+(
+	OpBase *opBase
+) {
 	Apply *op = (Apply *)opBase;
 	op->r = NULL;
 
@@ -105,11 +110,18 @@ static OpResult ApplyReset(OpBase *opBase) {
 	return OP_OK;
 }
 
-static OpBase *ApplyClone(const ExecutionPlan *plan, const OpBase *opBase) {
+static OpBase *ApplyClone
+(
+	const ExecutionPlan *plan,
+	const OpBase *opBase
+) {
 	return NewApplyOp(plan);
 }
 
-static void ApplyFree(OpBase *opBase) {
+static void ApplyFree
+(
+	OpBase *opBase
+) {
 	Apply *op = (Apply *)opBase;
 
 	// free collected records
@@ -121,6 +133,11 @@ static void ApplyFree(OpBase *opBase) {
 
 		array_free(op->records);
 		op->records = NULL;
+	}
+
+	if(op->args != NULL) {
+		array_free(op->args);
+		op->args = NULL;
 	}
 
 	op->r = NULL;

--- a/src/execution_plan/ops/op_apply.h
+++ b/src/execution_plan/ops/op_apply.h
@@ -1,7 +1,6 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #pragma once
@@ -10,21 +9,25 @@
 #include "op_argument.h"
 #include "../execution_plan.h"
 
-/* The Apply op has a bound left-hand branch
- * and a right-hand branch that takes records
- * from the left-hand branch as input.
- * After retrieving a record from the left-hand branch,
- * it pulls data from the right-hand branch and passes
- * the merged record upwards until the right-hand branch
- * is depleted, at which time data is pulled from the
- * left-hand branch and the process repeats.  */
+// the Apply op has a bound left-hand branch
+// and a right-hand branch that takes records
+// from the left-hand branch as input
+// after retrieving a record from the left-hand branch
+// it pulls data from the right-hand branch and passes
+// the merged record upwards until the right-hand branch
+// is depleted, at which time data is pulled from the
+// left-hand branch and the process repeats
 typedef struct {
 	OpBase op;
-	Record r;                       // bound branch record
-	Record *records;                // LHS records
-	OpBase *bound_branch;           // bound branch
-	OpBase *rhs_branch;             // right-hand branch
-	Argument *op_arg;               // right-hand branch tap
+	Record r;              // bound branch record
+	Record *records;       // LHS records
+	OpBase *bound_branch;  // bound branch
+	OpBase *rhs_branch;    // right-hand branch
+	Argument **args;       // right-hand side taps
 } Apply;
 
-OpBase *NewApplyOp(const ExecutionPlan *plan);
+OpBase *NewApplyOp
+(
+	const ExecutionPlan *plan
+);
+

--- a/src/execution_plan/ops/op_argument.c
+++ b/src/execution_plan/ops/op_argument.c
@@ -1,25 +1,28 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
-#include "op_argument.h"
 #include "RG.h"
+#include "op_argument.h"
 
-// Forward declarations
+// forward declarations
 static Record ArgumentConsume(OpBase *opBase);
 static OpResult ArgumentReset(OpBase *opBase);
 static OpBase *ArgumentClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void ArgumentFree(OpBase *opBase);
 
-OpBase *NewArgumentOp(const ExecutionPlan *plan, const char **variables) {
-	Argument *op = rm_malloc(sizeof(Argument));
-	op->r = NULL;
+OpBase *NewArgumentOp
+(
+	const ExecutionPlan *plan,
+	const char **variables
+) {
+	Argument *op = rm_calloc(1, sizeof(Argument));
 
-	// Set our Op operations
+	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_ARGUMENT, "Argument", NULL,
-				ArgumentConsume, ArgumentReset, NULL, ArgumentClone, ArgumentFree, false, plan);
+			ArgumentConsume, ArgumentReset, NULL, ArgumentClone, ArgumentFree,
+			false, plan);
 
 	uint variable_count = array_len(variables);
 	for(uint i = 0; i < variable_count; i ++) {
@@ -29,18 +32,75 @@ OpBase *NewArgumentOp(const ExecutionPlan *plan, const char **variables) {
 	return (OpBase *)op;
 }
 
-static Record ArgumentConsume(OpBase *opBase) {
+static Record ArgumentConsume
+(
+	OpBase *opBase
+) {
 	Argument *arg = (Argument *)opBase;
 
-	// Emit the record only once.
-	// arg->r can already be NULL if the op is depleted.
+	// emit the record only once
+	// arg->r can already be NULL if the op is depleted
 	Record r = arg->r;
+	if(r != NULL) {
+		// save emitted record in case we're resetted
+		arg->reset_record = OpBase_CreateRecord((OpBase *)arg);
+		Record_Clone(r, arg->reset_record);
+	}
+
 	arg->r = NULL;
 	return r;
 }
 
-static OpResult ArgumentReset(OpBase *opBase) {
-	// Reset operation, freeing the Record if one is held.
+void Argument_AddRecord
+(
+	Argument *arg,
+	Record r
+) {
+	ASSERT(r   != NULL);
+	ASSERT(arg != NULL);
+
+	// free old record
+	if(arg->r != NULL)            OpBase_DeleteRecord(arg->r);
+	if(arg->reset_record != NULL) OpBase_DeleteRecord(arg->reset_record);
+
+	arg->r = r;
+}
+
+static OpResult ArgumentReset
+(
+	OpBase *opBase
+) {
+	// reset operation, freeing the Record if one is held
+	Argument *arg = (Argument *)opBase;
+
+	// clear current record
+	if(arg->r) {
+		OpBase_DeleteRecord(arg->r);
+		arg->r = NULL;
+	}
+
+	// restore original record
+	if(arg->reset_record != NULL) {
+		arg->r = arg->reset_record;
+		arg->reset_record = NULL;
+	}
+
+	return OP_OK;
+}
+
+static inline OpBase *ArgumentClone
+(
+	const ExecutionPlan *plan,
+	const OpBase *opBase
+) {
+	ASSERT(opBase->type == OPType_ARGUMENT);
+	return NewArgumentOp(plan, opBase->modifies);
+}
+
+static void ArgumentFree
+(
+	OpBase *opBase
+) {
 	Argument *arg = (Argument *)opBase;
 
 	if(arg->r) {
@@ -48,24 +108,9 @@ static OpResult ArgumentReset(OpBase *opBase) {
 		arg->r = NULL;
 	}
 
-	return OP_OK;
-}
-
-void Argument_AddRecord(Argument *arg, Record r) {
-	ASSERT(!arg->r && "tried to insert into a populated Argument op");
-	arg->r = r;
-}
-
-static inline OpBase *ArgumentClone(const ExecutionPlan *plan, const OpBase *opBase) {
-	ASSERT(opBase->type == OPType_ARGUMENT);
-	return NewArgumentOp(plan, opBase->modifies);
-}
-
-static void ArgumentFree(OpBase *opBase) {
-	Argument *arg = (Argument *)opBase;
-	if(arg->r) {
-		OpBase_DeleteRecord(arg->r);
-		arg->r = NULL;
+	if(arg->reset_record) {
+		OpBase_DeleteRecord(arg->reset_record);
+		arg->reset_record = NULL;
 	}
 }
 

--- a/src/execution_plan/ops/op_argument.h
+++ b/src/execution_plan/ops/op_argument.h
@@ -1,7 +1,6 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #pragma once
@@ -9,13 +8,22 @@
 #include "op.h"
 #include "../execution_plan.h"
 
-/* The Argument operation holds an internal Record that it will emit exactly once. */
+// argument operation holds an internal Record that it will emit exactly once
 typedef struct {
 	OpBase op;
-	Record r;
+	Record r;             // record to emit on consume
+	Record reset_record;  // last emitted record
 } Argument;
 
-OpBase *NewArgumentOp(const ExecutionPlan *plan, const char **variables);
+OpBase *NewArgumentOp
+(
+	const ExecutionPlan *plan,
+	const char **variables
+);
 
-void Argument_AddRecord(Argument *arg, Record r);
+void Argument_AddRecord
+(
+	Argument *arg,
+	Record r
+);
 

--- a/src/execution_plan/ops/op_cartesian_product.c
+++ b/src/execution_plan/ops/op_cartesian_product.c
@@ -1,37 +1,49 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #include "op_cartesian_product.h"
 #include "RG.h"
 
-/* Forward declarations. */
+// forward declarations
 static OpResult CartesianProductInit(OpBase *opBase);
 static Record CartesianProductConsume(OpBase *opBase);
 static OpResult CartesianProductReset(OpBase *opBase);
 static OpBase *CartesianProductClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void CartesianProductFree(OpBase *opBase);
 
-OpBase *NewCartesianProductOp(const ExecutionPlan *plan) {
+OpBase *NewCartesianProductOp
+(
+	const ExecutionPlan *plan
+) {
 	CartesianProduct *op = rm_malloc(sizeof(CartesianProduct));
 	op->init = true;
 	op->r = NULL;
 
-	// Set our Op operations
-	OpBase_Init((OpBase *)op, OPType_CARTESIAN_PRODUCT, "Cartesian Product", CartesianProductInit,
-				CartesianProductConsume, CartesianProductReset, NULL, CartesianProductClone, CartesianProductFree,
-				false, plan);
+	// set our Op operations
+	OpBase_Init((OpBase *)op, OPType_CARTESIAN_PRODUCT, "Cartesian Product",
+			CartesianProductInit, CartesianProductConsume,
+			CartesianProductReset, NULL, CartesianProductClone,
+			CartesianProductFree, false, plan);
 	return (OpBase *)op;
 }
 
-static void _ResetStreams(CartesianProduct *cp, int streamIdx) {
-	// Reset each child stream, Reset propagates upwards.
-	for(int i = 0; i < streamIdx; i++) OpBase_PropagateReset(cp->op.children[i]);
+static void _ResetStreams
+(
+	CartesianProduct *cp,
+	int streamIdx
+) {
+	// reset each child stream, Reset propagates upwards
+	for(int i = 0; i < streamIdx; i++) {
+		OpBase_PropagateReset(cp->op.children[i]);
+	}
 }
 
-static int _PullFromStreams(CartesianProduct *op) {
+static int _PullFromStreams
+(
+	CartesianProduct *op
+) {
 	for(int i = 1; i < op->op.childCount; i++) {
 		OpBase *child = op->op.children[i];
 		Record childRecord = OpBase_Consume(child);
@@ -39,11 +51,11 @@ static int _PullFromStreams(CartesianProduct *op) {
 		if(childRecord) {
 			Record_TransferEntries(&op->r, childRecord, true);
 			OpBase_DeleteRecord(childRecord);
-			/* Managed to get new data
-			 * Reset streams [0-i] */
+			// Managed to get new data
+			// Reset streams [0-i]
 			_ResetStreams(op, i);
 
-			// Pull from resetted streams.
+			// pull from resetted streams
 			for(int j = 0; j < i; j++) {
 				child = op->op.children[j];
 				childRecord = OpBase_Consume(child);
@@ -54,23 +66,29 @@ static int _PullFromStreams(CartesianProduct *op) {
 					return 0;
 				}
 			}
-			// Ready to continue.
+			// ready to continue
 			return 1;
 		}
 	}
 
-	/* If we're here, then we didn't manged to get new data.
-	 * Last stream depleted. */
+	// if we're here, then we didn't manged to get new data
+	// last stream depleted
 	return 0;
 }
 
-static OpResult CartesianProductInit(OpBase *opBase) {
+static OpResult CartesianProductInit
+(
+	OpBase *opBase
+) {
 	CartesianProduct *op = (CartesianProduct *)opBase;
 	op->r = OpBase_CreateRecord((OpBase *)op);
 	return OP_OK;
 }
 
-static Record CartesianProductConsume(OpBase *opBase) {
+static Record CartesianProductConsume
+(
+	OpBase *opBase
+) {
 	CartesianProduct *op = (CartesianProduct *)opBase;
 	OpBase *child;
 	Record childRecord;
@@ -88,36 +106,46 @@ static Record CartesianProductConsume(OpBase *opBase) {
 		return OpBase_CloneRecord(op->r);
 	}
 
-	// Pull from first stream.
+	// pull from first stream
 	child = op->op.children[0];
 	childRecord = OpBase_Consume(child);
 
 	if(childRecord) {
-		// Managed to get data from first stream.
+		// managed to get data from first stream
 		Record_TransferEntries(&op->r, childRecord, true);
 		OpBase_DeleteRecord(childRecord);
 	} else {
-		// Failed to get data from first stream,
-		// try pulling other streams for data.
+		// failed to get data from first stream
+		// try pulling other streams for data
 		if(!_PullFromStreams(op)) return NULL;
 	}
 
-	// Pass down a clone of record.
+	// pass down a clone of record
 	return OpBase_CloneRecord(op->r);
 }
 
-static OpResult CartesianProductReset(OpBase *opBase) {
+static OpResult CartesianProductReset
+(
+	OpBase *opBase
+) {
 	CartesianProduct *op = (CartesianProduct *)opBase;
 	op->init = true;
 	return OP_OK;
 }
 
-static OpBase *CartesianProductClone(const ExecutionPlan *plan, const OpBase *opBase) {
+static OpBase *CartesianProductClone
+(
+	const ExecutionPlan *plan,
+	const OpBase *opBase
+) {
 	ASSERT(opBase->type == OPType_CARTESIAN_PRODUCT);
 	return NewCartesianProductOp(plan);
 }
 
-static void CartesianProductFree(OpBase *opBase) {
+static void CartesianProductFree
+(
+	OpBase *opBase
+) {
 	CartesianProduct *op = (CartesianProduct *)opBase;
 	if(op->r) {
 		OpBase_DeleteRecord(op->r);

--- a/src/execution_plan/ops/op_cartesian_product.h
+++ b/src/execution_plan/ops/op_cartesian_product.h
@@ -1,7 +1,6 @@
 /*
- * Copyright Redis Ltd. 2018 - present
- * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
- * the Server Side Public License v1 (SSPLv1).
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
 #pragma once
@@ -9,11 +8,15 @@
 #include "op.h"
 #include "../execution_plan.h"
 
-/* Cartesian product AKA Join. */
+// cartesian product
 typedef struct {
 	OpBase op;
 	Record r;
 	bool init;
 } CartesianProduct;
 
-OpBase *NewCartesianProductOp(const ExecutionPlan *plan);
+OpBase *NewCartesianProductOp
+(
+	const ExecutionPlan *plan
+);
+

--- a/tests/flow/test_cartesian_product.py
+++ b/tests/flow/test_cartesian_product.py
@@ -1,0 +1,60 @@
+from common import *
+
+GRAPH_ID = "cartesian_product"
+
+class testCartesianProduct():
+    def __init__(self):
+        self.env = Env(decodeResponses=True)
+        self.con = self.env.getConnection()
+        self.g = Graph(self.con, GRAPH_ID)
+        self.populate_graph()
+
+    def populate_graph(self):
+        # create a graph with 3 A nodes, 2 B nodes and a single C node
+        q = """CREATE (:A {v:'a1'}), (:A {v:'a2'}), (:A {v:'a3'}),
+                      (:B {v:'b1'}), (:B {v:'b2'}),
+                      (:C {v:'c1'})"""
+
+        self.g.query(q)
+
+    def test01_permute_two_branches(self):
+        # permute all A nodes with all B nodes
+        q = "MATCH (a:A), (b:B) RETURN a.v, b.v ORDER BY a.v, b.v"
+        res = self.g.query(q).result_set
+
+        expected = [['a1', 'b1'], ['a1', 'b2'],
+                    ['a2', 'b1'], ['a2', 'b2'],
+                    ['a3', 'b1'], ['a3', 'b2']]
+
+        self.env.assertEquals(res, expected)
+
+    def test02_permute_three_branches(self):
+        # permute all A, B and C nodes
+        q = """MATCH (a:A), (b:B), (c:C)
+               RETURN a.v, b.v, c.v
+               ORDER BY a.v, b.v"""
+        res = self.g.query(q).result_set
+
+        expected = [['a1', 'b1', 'c1'], ['a1', 'b2', 'c1'],
+                    ['a2', 'b1', 'c1'], ['a2', 'b2', 'c1'],
+                    ['a3', 'b1', 'c1'], ['a3', 'b2', 'c1']]
+
+        self.env.assertEquals(res, expected)
+
+    def test03_write_bound_branch(self):
+        # cartesian product with a write bound branch
+        q = """CREATE (d:D)
+               DELETE d
+               WITH *
+               MATCH (a:A), (b:B)
+               RETURN a.v, b.v
+               ORDER BY a.v, b.v"""
+
+        res = self.g.query(q).result_set
+
+        expected = [['a1', 'b1'], ['a1', 'b2'],
+                    ['a2', 'b1'], ['a2', 'b2'],
+                    ['a3', 'b1'], ['a3', 'b2']]
+
+        self.env.assertEquals(res, expected)
+

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -593,9 +593,9 @@ class testGraphMergeFlow(FlowTestsBase):
         graph = Graph(redis_con, "merge_reuse")
         query = """
         CREATE (m:L1 {v: "abc"})
-        CREATE (u:L2 {v: "x"})
-        CREATE (n:L2 {v: "y"})
-        CREATE (:L2 {v: 'y'})
+        CREATE (u:L2 {v: 'x'})
+        CREATE (n:L2 {v: 'y'})
+        CREATE (x:L2 {v: 'y'})
         CREATE (u)-[:R]->(m), (u)-[:R]->(m)
         CREATE (n)-[:R]->(m), (n)-[:R]->(m)"""
         graph.query(query)
@@ -611,8 +611,8 @@ class testGraphMergeFlow(FlowTestsBase):
 
         res = graph.query(query)
         self.env.assertEquals(res.nodes_created, 0)
-        self.env.assertEquals(res.relationships_created, 0)
-        self.env.assertEquals(res.result_set, [['abcd', 'x', 'y']])
+        self.env.assertEquals(res.relationships_created, 2)
+        self.env.assertEquals(res.result_set, [['abcd', 'x', 'y'],['abcd', 'x', 'y']])
 
     def test30_record_clone_under_merge(self):
         # the following operations

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -114,7 +114,6 @@ class testMultiLabel():
 
     # Validate behavior of index scans on multi-labeled nodes
     def test05_index_scan(self):
-
         query_result = create_node_range_index(graph, 'L1', 'v', sync=True)
         self.env.assertEquals(query_result.indices_created, 1)
 
@@ -158,16 +157,22 @@ class testMultiLabel():
 
     # Validate that OPTIONAL MATCH enforces multi-label constraints
     def test07_multi_label_optional_match(self):
-        # Traverse to a multi-label destination in an OPTIONAL MATCH
-        query = """MATCH (a:L1) OPTIONAL MATCH (a)-[]->(b:L2:L1) RETURN labels(a) AS la, labels(b) AS lb ORDER BY la, lb"""
+        # traverse to a multi-label destination in an OPTIONAL MATCH
+        query = """MATCH (a:L1)
+                   OPTIONAL MATCH (a)-[]->(b:L2:L1)
+                   RETURN labels(a) AS la, labels(b) AS lb
+                   ORDER BY la, lb"""
         query_result = graph.query(query)
         expected_result = [[["L0", "L1"], None],
                            [["L1"], ["L1", "L2"]],
                            [["L1", "L2"], None]]
         self.env.assertEquals(query_result.result_set, expected_result)
 
-        # Specify an additional label for the source node in the OPTIONAL MATCH
-        query = """MATCH (a:L0) OPTIONAL MATCH (a:L1)-[]->(b:L1) RETURN labels(a) AS la, labels(b) AS lb ORDER BY la, lb"""
+        # specify an additional label for the source node in the OPTIONAL MATCH
+        query = """MATCH (a:L0)
+                   OPTIONAL MATCH (a:L1)-[]->(b:L1)
+                   RETURN labels(a) AS la, labels(b) AS lb
+                   ORDER BY la, lb"""
         query_result = graph.query(query)
         expected_result = [[["L0", "L1"], ["L1"]]]
         self.env.assertEquals(query_result.result_set, expected_result)


### PR DESCRIPTION
Bound variables should be available to cartesian product branches
```cypher
WITH 1 AS x MATCH (a {v:x}), (b {v:x+1}) RETURN *
```
This PR uses the `Apply` and `Argument` operations to pass records into the cartesian-product branches.