### PR TITLE
Vector search score

### DIFF
--- a/src/arithmetic/vector_funcs/vector_funcs.c
+++ b/src/arithmetic/vector_funcs/vector_funcs.c
@@ -52,6 +52,42 @@ SIValue AR_VECTOR32F
 	return v;
 }
 
+// compute the euclidean distance between two vectors
+SIValue AR_EUCLIDEAN_DISTANCE
+(
+	SIValue *argv,      // arguments
+	int argc,           // number of arguments
+	void *private_data  // private data
+) {
+	// expecting input to be two vectors
+	// euclideanDistance(vecf32([0.2, 0.12, 0.3178]), vecf32([0.1, 0.2, 0.3]))
+
+	SIValue v1 = argv[0];
+	SIValue v2 = argv[1];
+
+	// return NULL if input is NULL
+	SIType t1 = SI_TYPE(v1);
+	SIType t2 = SI_TYPE(v2);
+	if(t1 == T_NULL || t2 == T_NULL) {
+		return SI_NullVal();
+	}
+
+	ASSERT(t1 == T_VECTOR);
+	ASSERT(t2 == T_VECTOR);
+
+	// validate input vectors are of the same length
+	uint32_t n1 = SIVector_Dim(v1);
+	uint32_t n2 = SIVector_Dim(v2);
+	if(n1 != n2) {
+		ErrorCtx_RaiseRuntimeException(EMSG_VECTOR_DIMENSION_MISMATCH);
+		return SI_NullVal();
+	}
+
+	// computes the euclidean distance between two vectors
+	float distance = SIVector_EuclideanDistance(v1, v2);
+	return SI_DoubleVal(distance);
+}
+
 void Register_VectorFuncs() {
 	SIType *types;
 	SIType ret_type;
@@ -61,6 +97,16 @@ void Register_VectorFuncs() {
 	array_append(types, T_NULL | T_ARRAY);
 	ret_type = T_NULL | T_VECTOR;
 	func_desc = AR_FuncDescNew("vecf32", AR_VECTOR32F, 1, 1, types, ret_type,
+			false, true);
+	AR_RegFunc(func_desc);
+
+
+	// euclidean distance between two vectors
+	types = array_new(SIType, 2);
+	array_append(types, T_NULL | T_VECTOR);
+	array_append(types, T_NULL | T_VECTOR);
+	ret_type = T_NULL | T_DOUBLE;
+	func_desc = AR_FuncDescNew("euclideanDistance", AR_EUCLIDEAN_DISTANCE, 2, 2, types, ret_type,
 			false, true);
 	AR_RegFunc(func_desc);
 }

--- a/src/arithmetic/vector_funcs/vector_funcs.c
+++ b/src/arithmetic/vector_funcs/vector_funcs.c
@@ -106,7 +106,7 @@ void Register_VectorFuncs() {
 	array_append(types, T_NULL | T_VECTOR);
 	array_append(types, T_NULL | T_VECTOR);
 	ret_type = T_NULL | T_DOUBLE;
-	func_desc = AR_FuncDescNew("euclideanDistance", AR_EUCLIDEAN_DISTANCE, 2, 2, types, ret_type,
+	func_desc = AR_FuncDescNew("vec.euclideanDistance", AR_EUCLIDEAN_DISTANCE, 2, 2, types, ret_type,
 			false, true);
 	AR_RegFunc(func_desc);
 }

--- a/src/datatypes/vector.c
+++ b/src/datatypes/vector.c
@@ -8,6 +8,8 @@
 #include "xxhash.h"
 #include "../util/rmalloc.h"
 
+#include <math.h>
+
 // vector struct
 typedef struct {
 	uint32_t dim;     // vector's dimension
@@ -175,6 +177,34 @@ size_t SIVector_ElementsByteSize
 	SIValue vector // vector to get binary size of
 ) {
 	return SIVector_Dim(vector) * sizeof(float);
+}
+
+// computes the euclidean distance between two vectors
+// distance = sqrt(sum((a[i] - b[i])^2))
+float SIVector_EuclideanDistance
+(
+	SIValue a,  // first vector
+	SIValue b   // second vector
+) {
+	// euclideanDistance(vecf32([0.2, 0.12, 0.3178]), vecf32([0.1, 0.2, 0.3]))
+	ASSERT(SI_TYPE(a) & T_VECTOR);
+	ASSERT(SI_TYPE(b) & T_VECTOR);
+
+	// validate input vectors are of the same length
+	uint32_t n1 = SIVector_Dim(a);
+	uint32_t n2 = SIVector_Dim(b);
+	ASSERT(n1 == n2);
+
+	// compute the euclidean distance between the two vectors
+	float sum        = 0;
+	float *elements1 = (float*)SIVector_Elements(a);
+	float *elements2 = (float*)SIVector_Elements(b);
+	for(uint32_t i = 0; i < n1; i++) {
+		float diff = elements1[i] - elements2[i];
+		sum += diff * diff;
+	}
+
+	return sqrtf(sum);
 }
 
 // write a string representation of vector to buf

--- a/src/datatypes/vector.h
+++ b/src/datatypes/vector.h
@@ -62,6 +62,14 @@ size_t SIVector_ElementsByteSize
 	SIValue vector // vector to get binary size of
 );
 
+// computes the euclidean distance between two vectors
+// distance = sqrt(sum((a[i] - b[i])^2))
+float SIVector_EuclideanDistance
+(
+	SIValue a,  // first vector
+	SIValue b   // second vector
+);
+
 // write a string representation of vector to buf
 void SIVector_ToString
 (

--- a/src/errors/error_msgs.h
+++ b/src/errors/error_msgs.h
@@ -123,4 +123,5 @@
 #define EMSG_VECTOR_INDEX_INVALID_CONFIG "Invalid vector index configuration"
 #define EMSG_INDEX_CANT_RECONFIG "Can not override index configuration"
 #define EMSG_REMOVE_INVALID_INPUT "REMOVE operates on either a node, relationship or a map"
+#define EMSG_VECTOR_DIMENSION_MISMATCH "Vector dimension mismatch"
 

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -39,7 +39,53 @@ class testVecsim():
         # wait for indices to be become operational
         wait_for_indices_to_sync(self.graph)
 
-    def test01_locate_similar_nodes(self):
+    def test01_vector_distance(self):
+        # compute euclidean distance between two vectors
+        q = """RETURN euclideanDistance(vecf32($a), vecf32($b)) AS dist"""
+
+        # distance between NULL and NULL should be NULL
+        # distance between NULL and vector should be NULL
+        # distance between vector and NULL should be NULL
+        inputs = [ (None, None), (None, [1,1]), ([1,1], None) ]
+        for a, b in inputs:
+            params = {'a': a, 'b': b}
+            distance = self.graph.ro_query(q, params=params).result_set[0][0]
+            self.env.assertIsNone(distance)
+
+        # distance between same vectors should be 0
+        params = {'a': [1,1], 'b': [1,1]}
+        distance = self.graph.ro_query(q, params=params).result_set[0][0]
+        distance = round(distance, 3)
+        self.env.assertEqual(distance, 0)
+
+        # distance between [1,1] and [2,2] should be 1.414
+        params = {'a': [1,1], 'b': [2,2]}
+        distance = self.graph.ro_query(q, params=params).result_set[0][0]
+        distance = round(distance, 3)
+        self.env.assertEqual(distance, 1.414)
+
+        # distance between [1,1] and [2,2,3] should fail
+        # dimension mismatch
+        inputs = [([1,1], [2,2,3]), ([2,2,3], [1,1]) ]
+        for a, b in inputs:
+            try:
+                params = {'a': [1,1], 'b': [2,2,3]}
+                distance = self.graph.ro_query(q, params=params).result_set[0][0]
+                self.env.assertFalse("Expected query to fail")
+            except Exception as e:
+                self.env.assertContains("Vector dimension mismatch", str(e))
+
+        # distance between incompatible types should fail
+        inputs = [([1,1], "foo"), ("foo", [1,1]) ]
+        for a, b in inputs:
+            try:
+                params = {'a': a, 'b': b}
+                distance = self.graph.ro_query(q, params=params).result_set[0][0]
+                self.env.assertFalse("Expected query to fail")
+            except Exception as e:
+                self.env.assertContains("Type mismatch", str(e))
+
+    def test02_locate_similar_nodes(self):
         k = 3
         x = 50
         y = 50
@@ -53,7 +99,7 @@ class testVecsim():
             self.env.assertLess(abs(embeddings[0] - x), k)
             self.env.assertLess(abs(embeddings[1] - y), k)
 
-    def test02_locate_similar_edges(self):
+    def test03_locate_similar_edges(self):
         k = 3
         x = -50
         y = -50
@@ -65,3 +111,69 @@ class testVecsim():
             embeddings = row[0].properties['embeddings']
             self.env.assertLess(abs(embeddings[0] - x), k)
             self.env.assertLess(abs(embeddings[1] - y), k)
+
+    def test04_vecsim_result_order(self):
+        # entities returned from vecsim should be sorted by distance
+        # starting with the closest entity and increasing distance
+
+        x = 50  # query vector x
+        y = 50  # query vector y
+        k = 100 # number of results to return
+
+        q = """WITH vecf32($q) as v
+               CALL db.idx.vector.queryNodes('Person', 'embeddings', $k, v)
+               YIELD node, score
+               RETURN score, euclideanDistance(node.embeddings, v) AS dist"""
+        res = self.graph.ro_query(q, params={'k':k, 'q': [x, y]}).result_set
+
+        prev_score = float('-inf')
+        for row in res:
+            score, dist = row
+            self.env.assertEqual(round(score, 3), round(dist, 3))
+            self.env.assertGreaterEqual(score, prev_score)
+            prev_score = score
+
+    def test05_not_enough_results(self):
+        # ask for more results than exist in the index
+        # should return all results
+        x = 50
+        y = 50
+        k = 1000000
+
+        q = """WITH vecf32($q) as v
+                CALL db.idx.vector.queryNodes('Person', 'embeddings', $k, v)
+                YIELD node
+                RETURN count(node) AS cnt"""
+
+        count = self.graph.ro_query(q, params={'k':k, 'q': [x, y]}).result_set[0][0]
+        self.env.assertEqual(count, 1001)
+
+    def test06_validate_arguments(self):
+        # validate arguments
+        # first arugment must be a string
+        # second argument must be a string
+        # third argument must be a positive integer > 0
+        # fourth argument must be a vector
+
+        q = "CALL db.idx.vector.queryNodes($lbl, $attr, $k, vecf32($q))"
+
+        params = [
+                    {'lbl': 2, 'attr': 'embeddings', 'k': 10, 'q': [1,1]},
+                    {'lbl': 'Person', 'attr':2, 'k': 10, 'q': [1,1]},
+                    {'lbl': 'Person', 'attr': 'embeddings', 'k': '10', 'q': [1,1]},
+                    {'lbl': 'Person', 'attr': 'embeddings', 'k': -10, 'q': [1,1]}]
+
+        for p in params:
+            try:
+                self.graph.ro_query(q, params=p)
+                self.env.assertFalse("Expected query to fail")
+            except Exception as e:
+                self.env.assertContains("Invalid arguments for procedure", str(e))
+
+        p = {'lbl': 'Person', 'attr': 'embeddings', 'k': 10, 'q': False}
+        q = "CALL db.idx.vector.queryNodes($lbl, $attr, $k, $q)"
+        try:
+            self.graph.ro_query(q, params=p)
+            self.env.assertFalse("Expected query to fail")
+        except Exception as e:
+            self.env.assertContains("Invalid arguments for procedure", str(e))

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -41,7 +41,7 @@ class testVecsim():
 
     def test01_vector_distance(self):
         # compute euclidean distance between two vectors
-        q = """RETURN euclideanDistance(vecf32($a), vecf32($b)) AS dist"""
+        q = """RETURN vec.euclideanDistance(vecf32($a), vecf32($b)) AS dist"""
 
         # distance between NULL and NULL should be NULL
         # distance between NULL and vector should be NULL
@@ -123,7 +123,7 @@ class testVecsim():
         q = """WITH vecf32($q) as v
                CALL db.idx.vector.queryNodes('Person', 'embeddings', $k, v)
                YIELD node, score
-               RETURN score, euclideanDistance(node.embeddings, v) AS dist"""
+               RETURN score, vec.euclideanDistance(node.embeddings, v) AS dist"""
         res = self.graph.ro_query(q, params={'k':k, 'q': [x, y]}).result_set
 
         prev_score = float('-inf')


### PR DESCRIPTION
Resolves #525

Introduces `euclideanDistance` which computes the distance between two vectors

`db.idx.vector.queryRelationships` and `db.idx.vector.queryNodes` both yield score, which represents the distance between the query vector and the yield entity vector.

Results are ordered by score, from the closest vector to the farthest one.