### PR TITLE
fix build dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Requirements:
 
 * The FalkorDB repository: `git clone --recurse-submodules -j8 https://github.com/FalkorDB/FalkorDB.git`
 
-* On Ubuntu Linux, run: `apt-get install build-essential cmake m4 automake peg libtool autoconf python3`
+* On Ubuntu Linux, run: `apt-get install build-essential cmake m4 automake peg libtool autoconf python3 python3-pip`
 
 * On OS X, verify that `homebrew` is installed and run: `brew install cmake m4 automake peg libtool autoconf`.
     * The version of Clang that ships with the OS X toolchain does not support OpenMP, which is a requirement for RedisGraph. One way to resolve this is to run `brew install gcc g++` and follow the on-screen instructions to update the symbolic links. Note that this is a system-wide change - setting the environment variables for `CC` and `CXX` will work if that is not an option.


### PR DESCRIPTION
Fix `deps/readies/mk/main:49: *** Cannot find python3 interpreter.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for Ubuntu Linux, including `python3-pip` as a requirement.
	- Added troubleshooting steps for Clang issues on OS X.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->