### PR TITLE
resolve compilation warnings

### DIFF
--- a/deps/libcypher-parser/lib/src/ast_foreach.c
+++ b/deps/libcypher-parser/lib/src/ast_foreach.c
@@ -26,7 +26,7 @@ struct foreach_clause
     const cypher_astnode_t *identifier;
     const cypher_astnode_t *expression;
     unsigned int nclauses;
-    const cypher_astnode_t *clauses[];
+    cypher_astnode_t *clauses[];
 };
 
 

--- a/deps/libcypher-parser/lib/src/ast_query.c
+++ b/deps/libcypher-parser/lib/src/ast_query.c
@@ -26,7 +26,7 @@ struct query
     unsigned int noptions;
     const cypher_astnode_t **options;
     unsigned int nclauses;
-    const cypher_astnode_t *clauses[];
+    cypher_astnode_t *clauses[];
 };
 
 
@@ -219,7 +219,7 @@ ssize_t detailstr(const cypher_astnode_t *self, char *str, size_t size)
     size_t n = 8;
 
     ssize_t r = snprint_sequence(str + 8, (size > 8)? size-8 : 0,
-            node->clauses, node->nclauses);
+            (const cypher_astnode_t * const *)node->clauses, node->nclauses);
     if (r < 0)
     {
         return -1;

--- a/deps/libcypher-parser/lib/src/ast_statement.c
+++ b/deps/libcypher-parser/lib/src/ast_statement.c
@@ -22,7 +22,7 @@
 struct statement
 {
     cypher_astnode_t _astnode;
-    const cypher_astnode_t *body;
+    cypher_astnode_t *body;
     unsigned int noptions;
     const cypher_astnode_t *options[];
 };
@@ -41,7 +41,7 @@ const struct cypher_astnode_vt cypher_statement_astnode_vt =
 
 
 cypher_astnode_t *cypher_ast_statement(cypher_astnode_t * const *options,
-        unsigned int noptions, const cypher_astnode_t *body,
+        unsigned int noptions, cypher_astnode_t *body,
         cypher_astnode_t **children, unsigned int nchildren,
         struct cypher_input_range range)
 {
@@ -80,7 +80,7 @@ cleanup:
 void cypher_ast_statement_replace_body
 (
     cypher_astnode_t *astnode,
-    const cypher_astnode_t *body
+    cypher_astnode_t *body
 )
 {
     REQUIRE_TYPE(astnode, CYPHER_AST_STATEMENT, NULL);

--- a/deps/libcypher-parser/lib/src/cypher-parser.h.in
+++ b/deps/libcypher-parser/lib/src/cypher-parser.h.in
@@ -535,7 +535,7 @@ enum cypher_rel_direction
  */
 __cypherlang_must_check
 cypher_astnode_t *cypher_ast_statement(cypher_astnode_t * const *options,
-        unsigned int noptions, const cypher_astnode_t *body,
+        unsigned int noptions, cypher_astnode_t *body,
         cypher_astnode_t **children, unsigned int nchildren,
         struct cypher_input_range range);
 
@@ -550,7 +550,7 @@ cypher_astnode_t *cypher_ast_statement(cypher_astnode_t * const *options,
  * @return A `CYPHER_AST_QUERY` or `CYPHER_AST_SCHEMA_COMMAND` node.
  */
 void cypher_ast_statement_replace_body(cypher_astnode_t *astnode,
-        const cypher_astnode_t *body);
+        cypher_astnode_t *body);
 
 /**
  * Get the number of options in a `CYPHER_AST_STATEMENT` node.


### PR DESCRIPTION
Removed `const` quarriers from attributes which are modified after the AST is constructed. e.g. `Replace*` functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal data structures to enhance flexibility in query and statement manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->