### PR TITLE
fix release commit sha

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -23,7 +23,7 @@ env:
   # If the event is a workflow_dispatch, use the input value
   # If the event is a workflow_run, use the head_commit.id
   # If the event is a release, use the target_commitish
-  COMMIT_SHA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha || github.event_name == 'workflow_run' && github.event.workflow_run.head_commit.id || github.event_name == 'release' && github.event.release.target_commitish || github.sha }}
+  COMMIT_SHA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha || github.event_name == 'workflow_run' && github.event.workflow_run.head_commit.id || github.event_name == 'release' && github.sha || github.sha }}
 
 jobs:
   release:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to improve the determination of `COMMIT_SHA` for release images, ensuring more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->