### PR TITLE
fix union validation with call subquery

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1300,6 +1300,11 @@ static VISITOR_STRATEGY _Validate_call_subquery
 		}
 	}
 
+	// save current state
+	is_union_all union_all = vctx->union_all;
+	// reset state
+	vctx->union_all = NOT_DEFINED;
+
 	// visit the subquery clauses
 	bool last_is_union = false;
 	for(uint i = 0; i < nclauses; i++) {
@@ -1340,6 +1345,9 @@ static VISITOR_STRATEGY _Validate_call_subquery
 			last_is_union = false;
 		}
 	}
+
+	// restore state
+	vctx->union_all = union_all;
 
 	// free the temporary environment
 	raxFree(vctx->defined_identifiers);

--- a/tests/flow/test_call_subquery.py
+++ b/tests/flow/test_call_subquery.py
@@ -1313,6 +1313,21 @@ updating clause.")
             self.env.assertEquals(res.result_set[i-1][0], i)
             self.env.assertEquals(res.result_set[i-1][1], [i])
 
+        # mix union and union all in call sub query
+        res = self.graph.query(
+            """
+            CALL { 
+                RETURN 0 AS n1
+                UNION ALL
+                RETURN 0 AS n1
+            }
+            RETURN 0 AS n2
+            UNION
+            RETURN 0 AS n2
+            """
+        )
+        self.env.assertEquals(res.result_set, [[0]])
+
     def test22_indexes(self):
         """Tests that operations on indexes are properly executed (and reset)
         in subqueries"""


### PR DESCRIPTION
fix https://github.com/FalkorDB/FalkorDB/issues/603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of mixed `UNION` and `UNION ALL` clauses in subqueries to ensure accurate query results.

- **Tests**
	- Added new test cases to verify the correct behavior of mixed `UNION` and `UNION ALL` in subqueries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->