### PR TITLE
generate ca.crt and openssl.cnf if not provided

### DIFF
--- a/build/docker/gen-certs.sh
+++ b/build/docker/gen-certs.sh
@@ -33,8 +33,8 @@ generate_cert() {
 }
 
 mkdir -p tls
-[ -f tls/ca.key ] || openssl genrsa -out tls/ca.key 4096
-[ -f tls/ca.crt ] || openssl req \
+[ -f "tls/ca.key" ] || openssl genrsa -out tls/ca.key 4096
+[ -f "tls/ca.crt" ] || openssl req \
     -x509 -new -nodes -sha256 \
     -key tls/ca.key \
     -days 3650 \

--- a/build/docker/gen-certs.sh
+++ b/build/docker/gen-certs.sh
@@ -41,7 +41,7 @@ mkdir -p tls
     -subj '/O=Redis Test/CN=Certificate Authority' \
     -out tls/ca.crt
 
-[ -f tls/openssl.cnf ] || cat > tls/openssl.cnf <<_END_
+[ -f "tls/openssl.cnf" ] || cat > tls/openssl.cnf <<_END_
 [ server_cert ]
 keyUsage = digitalSignature, keyEncipherment
 nsCertType = server

--- a/build/docker/gen-certs.sh
+++ b/build/docker/gen-certs.sh
@@ -34,14 +34,14 @@ generate_cert() {
 
 mkdir -p tls
 [ -f tls/ca.key ] || openssl genrsa -out tls/ca.key 4096
-openssl req \
+[ -f tls/ca.crt ] || openssl req \
     -x509 -new -nodes -sha256 \
     -key tls/ca.key \
     -days 3650 \
     -subj '/O=Redis Test/CN=Certificate Authority' \
     -out tls/ca.crt
 
-cat > tls/openssl.cnf <<_END_
+[ -f tls/openssl.cnf ] || cat > tls/openssl.cnf <<_END_
 [ server_cert ]
 keyUsage = digitalSignature, keyEncipherment
 nsCertType = server


### PR DESCRIPTION
fix #670 