### PR TITLE
add bound vars to op_argument_list

### DIFF
--- a/src/execution_plan/execution_plan_build/build_call_subquery.c
+++ b/src/execution_plan/execution_plan_build/build_call_subquery.c
@@ -269,7 +269,7 @@ void buildCallSubqueryPlan
 	uint n_feeding_points = array_len(feeding_points);
 	if(is_eager) {
 		for(uint i = 0; i < n_feeding_points; i++) {
-			OpBase *argument_list = NewArgumentListOp(plan);
+			OpBase *argument_list = NewArgumentListOp(plan, NULL);
 			ExecutionPlan_AddOp(feeding_points[i], argument_list);
 		}
 	} else {

--- a/src/execution_plan/execution_plan_build/execution_plan_construct.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.c
@@ -233,7 +233,13 @@ static void _buildForeachOp
 	ExecutionPlan *embedded_plan = ExecutionPlan_NewEmptyExecutionPlan();
 	embedded_plan->ast_segment = body_ast;
 	embedded_plan->record_map = raxClone(plan->record_map);
-	const char **arguments = (const char **)raxKeys(embedded_plan->record_map);
+	const char **arguments = NULL;
+	if(plan->root) {
+		rax *bound_vars = raxNew();
+		ExecutionPlan_BoundVariables(plan->root, bound_vars, plan);
+		arguments = (const char **)raxValues(bound_vars);
+		raxFree(bound_vars);
+	}
 
 	//--------------------------------------------------------------------------
 	// build Unwind op

--- a/src/execution_plan/execution_plan_build/execution_plan_construct.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.c
@@ -233,6 +233,7 @@ static void _buildForeachOp
 	ExecutionPlan *embedded_plan = ExecutionPlan_NewEmptyExecutionPlan();
 	embedded_plan->ast_segment = body_ast;
 	embedded_plan->record_map = raxClone(plan->record_map);
+	const char **arguments = (const char **)raxKeys(embedded_plan->record_map);
 
 	//--------------------------------------------------------------------------
 	// build Unwind op
@@ -249,7 +250,7 @@ static void _buildForeachOp
 	// build ArgumentList op
 	//--------------------------------------------------------------------------
 
-	OpBase *argument_list = NewArgumentListOp(embedded_plan);
+	OpBase *argument_list = NewArgumentListOp(embedded_plan, arguments);
 	// TODO: After refactoring the execution-plan freeing mechanism, bind the
 	// ArgumentList op to the outer-scope plan (plan), and change the condition
 	// for Unwind's 'free_rec' field to be whether the child plan is different
@@ -269,6 +270,7 @@ static void _buildForeachOp
 
 	// free the artificial body array (not its components)
 	array_free(clauses);
+	array_free(arguments);
 
 	// create the Foreach op, and update (outer) plan root
 	OpBase *foreach = NewForeachOp(plan);

--- a/src/execution_plan/ops/op_argument_list.c
+++ b/src/execution_plan/ops/op_argument_list.c
@@ -15,7 +15,8 @@ static OpBase *ArgumentListClone(const ExecutionPlan *plan, const OpBase *opBase
 
 OpBase *NewArgumentListOp
 (
-	const ExecutionPlan *plan
+	const ExecutionPlan *plan,
+	const char **variables
 ) {
 	ArgumentList *op = rm_malloc(sizeof(ArgumentList));
 	op->records = NULL;
@@ -25,6 +26,11 @@ OpBase *NewArgumentListOp
 	OpBase_Init((OpBase *)op, OPType_ARGUMENT_LIST, "Argument List", NULL,
 			ArgumentListConsume, ArgumentListReset, NULL, ArgumentListClone,
 			ArgumentListFree, false, plan);
+
+	uint variable_count = array_len(variables);
+	for(uint i = 0; i < variable_count; i ++) {
+		OpBase_Modifies((OpBase *)op, variables[i]);
+	}
 
 	return (OpBase *)op;
 }
@@ -82,7 +88,7 @@ static inline OpBase *ArgumentListClone
 	const OpBase *opBase
 ) {
 	ASSERT(opBase->type == OPType_ARGUMENT_LIST);
-	return NewArgumentListOp(plan);
+	return NewArgumentListOp(plan, opBase->modifies);
 }
 
 static void ArgumentListFree

--- a/src/execution_plan/ops/op_argument_list.h
+++ b/src/execution_plan/ops/op_argument_list.h
@@ -20,7 +20,8 @@ typedef struct {
 
 OpBase *NewArgumentListOp
 (
-	const ExecutionPlan *plan
+	const ExecutionPlan *plan,
+	const char **variables
 );
 
 void ArgumentList_AddRecordList

--- a/tests/flow/test_foreach.py
+++ b/tests/flow/test_foreach.py
@@ -663,3 +663,26 @@ class testForeachFlow():
         res = self.graph.query(query)
         # check that the `v` property of the node is now 1 + 0 + 1 + 2 + 3 = 7
         self.env.assertEquals(res.result_set[0][0], 7)
+
+    def test17_bound_variables(self):
+        """Tests that foreach bound variables correctly"""
+
+        self.graph.delete()
+
+        res = self.graph.query("""CREATE (:M), (:N {name: "a"}), (:N {name: "b"}), (:N {name: "c"})""")
+        self.env.assertEquals(res.nodes_created, 4)
+
+        query = """
+        MATCH (n:N)
+        WITH COLLECT(n) as ns
+        MATCH (m:M)
+        WITH m, ns
+        FOREACH (n IN ns |
+            MERGE (m)-[:R]->(n)
+        )
+        """
+
+        res = self.graph.query(query)
+        self.env.assertEquals(res.nodes_created, 0)
+        self.env.assertEquals(res.relationships_created, 3)
+


### PR DESCRIPTION
fix https://github.com/FalkorDB/FalkorDB/issues/699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `FOREACH` loop in Cypher queries to support additional bound variables, improving flexibility in graph database operations.
- **Tests**
	- Added a new test to validate the behavior of bound variables within a `FOREACH` loop in Cypher queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->