### PR TITLE
add ephemeral arm machines

### DIFF
--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -1,0 +1,29 @@
+name: Cleanup running runner
+description: Cleans a spot instance that has the specified label
+
+inputs:
+  service_account_key:
+    description: GCP Service account key
+    required: true
+  project_id:
+    description: GCP Project ID
+    required: true
+  zone:
+    description: GCP Zone
+    required: true
+  instance_label:
+    description: Label to identify the instance
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: auth
+      shell: bash
+      run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - &>/dev/null
+    - id: get-runner-id
+      shell: bash
+      run: echo "runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+    - id: kill-runner
+      shell: bash
+      run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ inputs.zone }} --quiet

--- a/.github/actions/cleanup-runner/action.yml
+++ b/.github/actions/cleanup-runner/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: GCP Zone
     required: true
   instance_label:
-    description: Label to identify the instance
+    description: Label to identify the inscompositetance
     required: true
 
 runs:
@@ -20,10 +20,16 @@ runs:
   steps:
     - id: auth
       shell: bash
-      run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - &>/dev/null
+      run: echo '${{ inputs.service_account_key }}' | gcloud --project  '${{ inputs.project_id }}' --quiet auth activate-service-account --key-file - >/dev/null 2>&1
     - id: get-runner-id
       shell: bash
-      run: echo "runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+      run: |
+        runner_id=$(gcloud compute instances list --filter=labels=${{ inputs.instance_label }} | awk '{print $1}' | tail +2)
+        if [ -z "$runner_id" ]; then
+          echo "Instance with label ${{ inputs.instance_label }} not found"
+          exit 1
+        fi
+        echo "runner_id=$runner_id" >> $GITHUB_OUTPUT
     - id: kill-runner
       shell: bash
       run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ inputs.zone }} --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
 
   unit-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'unit-tests') }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('unit-tests-{0}-{1}', github.run_id, github.run_number) }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,7 +190,7 @@ jobs:
 
   flow-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'flow-tests') }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('flow-tests-{0}-{1}', github.run_id, github.run_number) }}
     strategy:
       fail-fast: false
       matrix:
@@ -217,7 +217,7 @@ jobs:
 
   tck-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'tck-tests') }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('tck-tests-{0}-{1}', github.run_id, github.run_number) }}
     strategy:
       fail-fast: false
       matrix:
@@ -244,7 +244,7 @@ jobs:
 
   fuzz-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'fuzz-tests') }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('fuzz-tests-{0}-{1}', github.run_id, github.run_number) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: bash -c "echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null"
+        run: "echo ${{ secrets.GCP_SA_KEY }} | gcloud --project ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null"
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" auth activate-service-account --key-file -
+        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project '${{ secrets.GCP_PROJECT_ID }}' auth activate-service-account --key-file -
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file - &>/dev/null"
+        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file - &>/dev/null
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,19 @@ jobs:
           path: /tmp/falkordb-${{ env.ARCH_SUFFIX }}.tar
           if-no-files-found: error
 
+  cleanup-build:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('build-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+
   unit-tests:
     needs: build
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('unit-tests-{0}-{1}', github.run_id, github.run_number) }}
@@ -186,7 +199,20 @@ jobs:
 
       - name: Unit tests
         run: |
-          docker run --platform ${{ matrix.platform }} --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+
+  cleanup-unit-tests:
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('unit-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   flow-tests:
     needs: build
@@ -213,7 +239,20 @@ jobs:
 
       - name: Flow tests
         run: |
-          docker run --platform ${{ matrix.platform }} --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=4 flow-tests
+          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+
+  cleanup-flow-tests:
+    needs: flow-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('flow-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   tck-tests:
     needs: build
@@ -240,7 +279,20 @@ jobs:
 
       - name: TCK tests
         run: |
-          docker run --platform ${{ matrix.platform }} --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+
+  cleanup-tck-tests:
+    needs: tck-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('tck-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   fuzz-tests:
     needs: build
@@ -267,25 +319,17 @@ jobs:
 
       - name: Fuzz tests
         run: |
-          docker run --platform ${{ matrix.platform }} --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
+          docker run -it --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
 
-  cleanup-runners:
-    needs: [ create-runners, unit-tests, flow-tests, tck-tests, fuzz-tests ]
+  cleanup-fuzz-tests:
+    needs: fuzz-tests
     runs-on: ubuntu-latest
-    strategy:
-        matrix:
-            arm_machine:
-              - build
-              - unit-tests
-              - flow-tests
-              - tck-tests
-              - fuzz-tests
     steps:
       - id: auth
         run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('fuzz-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup-runner
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -203,6 +204,7 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup-runner
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -241,6 +243,7 @@ jobs:
     needs: flow-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup-runner
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -279,6 +282,7 @@ jobs:
     needs: tck-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup-runner
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -317,6 +321,7 @@ jobs:
     needs: fuzz-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cleanup-runner
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,19 +161,6 @@ jobs:
           path: /tmp/falkordb-${{ env.ARCH_SUFFIX }}.tar
           if-no-files-found: error
 
-  cleanup-build:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('build-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
-
   unit-tests:
     needs: build
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('unit-tests-{0}-{1}', github.run_id, github.run_number) }}
@@ -200,19 +187,6 @@ jobs:
       - name: Unit tests
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
-
-  cleanup-unit-tests:
-    needs: unit-tests
-    runs-on: ubuntu-latest
-    steps:
-      - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('unit-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   flow-tests:
     needs: build
@@ -241,19 +215,6 @@ jobs:
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
 
-  cleanup-flow-tests:
-    needs: flow-tests
-    runs-on: ubuntu-latest
-    steps:
-      - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('flow-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
-
   tck-tests:
     needs: build
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('tck-tests-{0}-{1}', github.run_id, github.run_number) }}
@@ -280,19 +241,6 @@ jobs:
       - name: TCK tests
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
-
-  cleanup-tck-tests:
-    needs: tck-tests
-    runs-on: ubuntu-latest
-    steps:
-      - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('tck-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   fuzz-tests:
     needs: build
@@ -321,15 +269,23 @@ jobs:
         run: |
           docker run -i --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
 
-  cleanup-fuzz-tests:
-    needs: fuzz-tests
+  cleanup-runners:
+    needs: [ create-runners, unit-tests, flow-tests, tck-tests, fuzz-tests ]
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            arm_machine:
+              - build
+              - unit-tests
+              - flow-tests
+              - tck-tests
+              - fuzz-tests
     steps:
       - id: auth
         run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('fuzz-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file -
+        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" auth activate-service-account --key-file -
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file - &>/dev/null
+        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file -
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
           machine_type: t2a-standard-2
           network: gh-runner
           runner_label: ${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${{ matrix.arm_machine }}
+          arm: true
+          image: projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20240611
 
   build:
     needs: create-runners

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
 
   unit-tests:
     needs: build
@@ -213,7 +213,7 @@ jobs:
         run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
 
   flow-tests:
     needs: build
@@ -253,7 +253,7 @@ jobs:
         run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
 
   tck-tests:
     needs: build
@@ -293,7 +293,7 @@ jobs:
         run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
 
   fuzz-tests:
     needs: build
@@ -333,4 +333,4 @@ jobs:
         run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('build-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
@@ -210,7 +210,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('unit-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
@@ -250,7 +250,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('flow-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
@@ -290,7 +290,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('tck-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
@@ -330,7 +330,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('fuzz-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
   build:
     needs: create-runners
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-build' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || format('{0}-{1}-{2}', github.run_id, github.run_number, 'build')  }}
     container: falkordb/falkordb-build:latest
     services:
       registry:
@@ -162,7 +162,7 @@ jobs:
 
   unit-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-unit-tests' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'unit-tests') }}
     strategy:
       fail-fast: false
       matrix:
@@ -189,7 +189,7 @@ jobs:
 
   flow-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-flow-tests' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'flow-tests') }}
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +216,7 @@ jobs:
 
   tck-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-tck-tests' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'tck-tests') }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,7 +243,7 @@ jobs:
 
   fuzz-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-fuzz-tests' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('{0}-{1}-{2}', github.run_id, github.run_number, 'fuzz-tests') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,14 @@ jobs:
           machine_zone: ${{ vars.GCP_ZONE }}
           machine_type: t2a-standard-2
           network: gh-runner
-          runner_label: ${{ github.run_id }}-${{ github.run_number }}-${{ matrix.arm_machine }}
+          runner_label: ${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number }}
           arm: true
           image: projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20240611
           disk_size: 100
 
   build:
     needs: create-runners
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || format('{0}-{1}-{2}', github.run_id, github.run_number, 'build')  }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || format('build-{0}-{1}', github.run_id, github.run_number)  }}
     container: falkordb/falkordb-build:latest
     services:
       registry:
@@ -285,7 +285,7 @@ jobs:
         run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ github.run_id }}-${{ github.run_number}}-${{ matrix.arm_machine }}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           machine_zone: ${{ vars.GCP_ZONE }}
           machine_type: t2a-standard-2
           network: gh-runner
-          runner_label: ${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${{ matrix.arm_machine }}
+          runner_label: ${{ github.run_id }}-${{ github.run_number }}-${{ matrix.arm_machine }}
           arm: true
           image: projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20240611
           disk_size: 100
@@ -268,3 +268,24 @@ jobs:
       - name: Fuzz tests
         run: |
           docker run --platform ${{ matrix.platform }} --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
+
+  cleanup-runners:
+    needs: [ create-runners, unit-tests, flow-tests, tck-tests, fuzz-tests ]
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            arm_machine:
+              - build
+              - unit-tests
+              - flow-tests
+              - tck-tests
+              - fuzz-tests
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ github.run_id }}-${{ github.run_number}}-${{ matrix.arm_machine }}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
           runner_label: ${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${{ matrix.arm_machine }}
           arm: true
           image: projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20240611
+          disk_size: 100
 
   build:
     needs: create-runners

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Unit tests
         run: |
-          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
 
   cleanup-unit-tests:
     needs: unit-tests
@@ -239,7 +239,7 @@ jobs:
 
       - name: Flow tests
         run: |
-          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
 
   cleanup-flow-tests:
     needs: flow-tests
@@ -279,7 +279,7 @@ jobs:
 
       - name: TCK tests
         run: |
-          docker run -it --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
 
   cleanup-tck-tests:
     needs: tck-tests
@@ -319,7 +319,7 @@ jobs:
 
       - name: Fuzz tests
         run: |
-          docker run -it --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
+          docker run -i --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
 
   cleanup-fuzz-tests:
     needs: fuzz-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: test-thingy
+        run: |
+          echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+      - name: it-works-maybe
+        run: |
+          gcloud compute instances list
+          
+
   create-runners:
     strategy:
       matrix:
@@ -161,6 +172,20 @@ jobs:
           path: /tmp/falkordb-${{ env.ARCH_SUFFIX }}.tar
           if-no-files-found: error
 
+  cleanup-build:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: |
+          echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('build-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+
   unit-tests:
     needs: build
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('unit-tests-{0}-{1}', github.run_id, github.run_number) }}
@@ -187,6 +212,19 @@ jobs:
       - name: Unit tests
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+
+  cleanup-unit-tests:
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('unit-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   flow-tests:
     needs: build
@@ -215,6 +253,19 @@ jobs:
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
 
+  cleanup-flow-tests:
+    needs: flow-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('flow-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
+
   tck-tests:
     needs: build
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' ||  format('tck-tests-{0}-{1}', github.run_id, github.run_number) }}
@@ -241,6 +292,19 @@ jobs:
       - name: TCK tests
         run: |
           docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+
+  cleanup-tck-tests:
+    needs: tck-tests
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+
+      - id: get-runner-id
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('tck-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - id: kill-runner
+        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet
 
   fuzz-tests:
     needs: build
@@ -269,23 +333,15 @@ jobs:
         run: |
           docker run -i --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
 
-  cleanup-runners:
-    needs: [ create-runners, unit-tests, flow-tests, tck-tests, fuzz-tests ]
+  cleanup-fuzz-tests:
+    needs: fuzz-tests
     runs-on: ubuntu-latest
-    strategy:
-        matrix:
-            arm_machine:
-              - build
-              - unit-tests
-              - flow-tests
-              - tck-tests
-              - fuzz-tests
     steps:
       - id: auth
         run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter="labels=('fuzz-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=$machine_zone --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_job:
-    runs-on: ubuntu-latest
-    steps:
-      - name: test-thingy
-        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project '${{ secrets.GCP_PROJECT_ID }}' auth activate-service-account --key-file -
-      - name: it-works-maybe
-        run: gcloud compute instances list
-          
-
   create-runners:
     needs: test_job
     strategy:
@@ -177,7 +168,7 @@ jobs:
     steps:
       - id: auth
         run: |
-          echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+          echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
         run: echo "runner_id=$(gcloud compute instances list --filter="labels=('build-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
@@ -217,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
         run: echo "runner_id=$(gcloud compute instances list --filter="labels=('unit-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
@@ -257,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
         run: echo "runner_id=$(gcloud compute instances list --filter="labels=('flow-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
@@ -297,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
         run: echo "runner_id=$(gcloud compute instances list --filter="labels=('tck-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT
@@ -337,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        run: echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
         run: echo "runner_id=$(gcloud compute instances list --filter="labels=('fuzz-tests-${{ github.run_id }}-${{ github.run_number}}')" | awk '{print $1}')" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: |
-          echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null
+        run: bash -c "echo ${{ secrets.GCP_SA_KEY }} | gcloud --project  ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null"
       - name: it-works-maybe
-        run: |
-          gcloud compute instances list
+        run: gcloud compute instances list
           
 
   create-runners:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  create-runners:
+    strategy:
+      matrix:
+        arm_machine:
+          - build
+          - unit-tests
+          - flow-tests
+          - tck-tests
+          - fuzz-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Arm runners
+        id: create-runner
+        uses: FalkorDB/gce-github-runner@install_docker
+        with:
+          token: ${{ secrets.GH_SA_TOKEN }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          machine_zone: ${{ vars.GCP_ZONE }}
+          machine_type: t2a-standard-2
+          network: gh-runner
+          runner_label: ${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${{ matrix.arm_machine }}
+
   build:
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ARM64' }}
+    needs: create-runners
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-build' }}
     container: falkordb/falkordb-build:latest
     services:
       registry:
@@ -43,8 +67,8 @@ jobs:
         id: cache_graphblas
         uses: actions/cache@v4
         with:
-            path: /FalkorDB/bin/linux-${{ env.ARCH_SUFFIX  }}-release/GraphBLAS
-            key: graphblas-${{ env.ARCH_SUFFIX  }}-${{ hashFiles('./deps/GraphBLAS/Include/GraphBLAS.h') }}
+          path: /FalkorDB/bin/linux-${{ env.ARCH_SUFFIX  }}-release/GraphBLAS
+          key: graphblas-${{ env.ARCH_SUFFIX  }}-${{ hashFiles('./deps/GraphBLAS/Include/GraphBLAS.h') }}
 
       - name: Cache parser ${{ matrix.platform }}
         id: cache_parser
@@ -136,7 +160,7 @@ jobs:
 
   unit-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ARM64' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-unit-tests' }}
     strategy:
       fail-fast: false
       matrix:
@@ -151,7 +175,7 @@ jobs:
         with:
           name: falkordb-tests-${{ env.ARCH_SUFFIX }}
           path: /tmp
-  
+
       - name: Load image
         id: load_image
         run: |
@@ -163,7 +187,7 @@ jobs:
 
   flow-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ARM64' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-flow-tests' }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,7 +214,7 @@ jobs:
 
   tck-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ARM64' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-tck-tests' }}
     strategy:
       fail-fast: false
       matrix:
@@ -217,7 +241,7 @@ jobs:
 
   fuzz-tests:
     needs: build
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ARM64' }}
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || '${{ github.run_id }}-${{ github.run_number }}-fuzz-tests' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ concurrency:
 
 jobs:
   create-runners:
-    needs: test_job
     strategy:
       matrix:
         arm_machine:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           machine_zone: ${{ vars.GCP_ZONE }}
-          machine_type: t2a-standard-2
+          machine_type: t2a-standard-4
           network: gh-runner
           runner_label: ${{ matrix.arm_machine }}-${{ github.run_id }}-${{ github.run_number }}
           arm: true
@@ -210,7 +210,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=unit-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
@@ -250,7 +250,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=flow-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
@@ -290,7 +290,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=tck-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
@@ -330,7 +330,7 @@ jobs:
         run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
 
       - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
+        run: echo "runner_id=$(gcloud compute instances list --filter=labels=fuzz-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
 
       - id: kill-runner
         run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: test-thingy
-        run: "echo ${{ secrets.GCP_SA_KEY }} | gcloud --project ${{ secrets.GCP_PROJECT_ID }} --quiet auth activate-service-account --key-file - &>/dev/null"
+        run: echo "${{ secrets.GCP_SA_KEY }}" | gcloud --project "${{ secrets.GCP_PROJECT_ID }}" --quiet auth activate-service-account --key-file - &>/dev/null"
       - name: it-works-maybe
         run: gcloud compute instances list
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           
 
   create-runners:
+    needs: test_job
     strategy:
       matrix:
         arm_machine:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,15 +165,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - id: auth
-        run: |
-          echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=build-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: build-${{ github.run_id }}-${{ github.run_number }}
 
   unit-tests:
     needs: build
@@ -206,14 +203,12 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
-      - id: auth
-        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=unit-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: unit-tests-${{ github.run_id }}-${{ github.run_number }}
 
   flow-tests:
     needs: build
@@ -246,14 +241,12 @@ jobs:
     needs: flow-tests
     runs-on: ubuntu-latest
     steps:
-      - id: auth
-        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=flow-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: flow-tests-${{ github.run_id }}-${{ github.run_number }}
 
   tck-tests:
     needs: build
@@ -286,14 +279,12 @@ jobs:
     needs: tck-tests
     runs-on: ubuntu-latest
     steps:
-      - id: auth
-        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=tck-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: tck-tests-${{ github.run_id }}-${{ github.run_number }}
 
   fuzz-tests:
     needs: build
@@ -326,11 +317,9 @@ jobs:
     needs: fuzz-tests
     runs-on: ubuntu-latest
     steps:
-      - id: auth
-        run: echo '${{ secrets.GCP_SA_KEY }}' | gcloud --project  '${{ secrets.GCP_PROJECT_ID }}' --quiet auth activate-service-account --key-file - &>/dev/null
-
-      - id: get-runner-id
-        run: echo "runner_id=$(gcloud compute instances list --filter=labels=fuzz-tests-${{github.run_id}}-${{ github.run_number }} | awk '{print $1}' | tail +2)" >> $GITHUB_OUTPUT
-
-      - id: kill-runner
-        run: gcloud compute instances delete ${{ steps.get-runner-id.outputs.runner_id }} --zone=${{ vars.GCP_ZONE }} --quiet
+      - uses: ./.github/actions/cleanup-runner
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          zone: ${{ vars.GCP_ZONE }}
+          instance_label: fuzz-tests-${{ github.run_id }}-${{ github.run_number }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ on:
   schedule:
     - cron: '33 5 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,10 @@ on:
       - master
       - "[0-9]+.[0-9]+"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -9,6 +9,10 @@ on:
       - master
       - "[0-9]+.[0-9]+"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sanitize-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix #715 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a GitHub Action to clean up spot instances in Google Cloud Platform based on specified labels.
- **Chores**
  - Added jobs to create and clean up Arm runners in CI workflows.
  - Implemented concurrency settings for various workflows to group jobs by pull request number or branch reference and cancel in-progress runs.
  - Updated `runs-on` conditions and cache paths in several CI jobs for improved configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->