### PR TITLE
reset ast validation scope when moving from one union section to another

### DIFF
--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -688,3 +688,11 @@ class testQueryValidationFlow(FlowTestsBase):
             except redis.exceptions.ResponseError as e:
                 # Expecting an error.
                 self.env.assertIn("'a' not defined", str(e))
+
+    def test45_union_scope(self):
+        # make sure OPTIONAL MATCH followed by a MATCH clause in a different
+        # UNION scope do not effect one another
+        # in case the scopes had been mixed we would encounted an error
+
+        q = "OPTIONAL MATCH (a) RETURN a UNION MATCH (a) RETURN a"
+        self.graph.query(q)


### PR DESCRIPTION
Resolves: #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved logic for validating updating clauses and their order in queries, enhancing clarity and efficiency.
	- Added a new test case to verify the correct handling of `OPTIONAL MATCH` and `MATCH` clauses within different `UNION` scopes.

- **Bug Fixes**
	- Adjusted control flow for better error handling in clause validation, reducing potential issues with invalid sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->