### PR TITLE
use browser edge for edge images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,11 @@ on:
         required: false
         default: 'latest'
   pull_request:
-    branches: [master]
+    branches: [master, "[0-9]+.[0-9]+"] 
   push:
     branches:
       - master
+      - "[0-9]+.[0-9]+"
     tags: 
       - v[0-9]+.[0-9]+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build on ubuntu
 
 on:
   workflow_dispatch:
+    inputs:
+      browser_tag:
+        description: 'Browser tag'
+        required: false
+        default: 'latest'
   pull_request:
     branches: [master, "v[0-9]+.[0-9]+"]
   push:
@@ -125,19 +130,20 @@ jobs:
       - name: Set browser tag
         id: set_browser_tag
         run: |
+          BROWSER_TAG="latest"
+          
           # If the event is a workflow_dispatch, use the input value
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BROWSER_TAG=${{ github.event.inputs.tag }}
-            BROWSER_TAG="latest"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BROWSER_TAG=${{ github.event.inputs.browser_tag }}
           fi
 
           # If the branch is master, set to "edge"
-          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/master" ]; then
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
             BROWSER_TAG="edge"
           fi
 
-          # If the branch is not master, set to 'lastest'
-          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" != "refs/heads/master" ]; then
+          # If the branch is not master, set to 'latest'
+          if [[ "${{ github.ref }}" != "refs/heads/master" ]]; then
             BROWSER_TAG="latest"
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,12 @@ on:
         required: false
         default: 'latest'
   pull_request:
-    branches: [master, "v[0-9]+.[0-9]+"]
+    branches: [master]
   push:
     branches:
       - master
-      - "v[0-9]+.[0-9]+"
+    tags: 
+      - v[0-9]+.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: Build on ubuntu
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master, "[0-9]+.[0-9]+"]
+    branches: [master, "v[0-9]+.[0-9]+"]
   push:
     branches:
       - master
-      - "[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -122,6 +122,28 @@ jobs:
           docker rm -v $id
           ls -l -R /FalkorDB/bin
 
+      - name: Set browser tag
+        id: set_browser_tag
+        run: |
+          # If the event is a workflow_dispatch, use the input value
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            BROWSER_TAG=${{ github.event.inputs.tag }}
+            BROWSER_TAG="latest"
+          fi
+
+          # If the branch is master, set to "edge"
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            BROWSER_TAG="edge"
+          fi
+
+          # If the branch is not master, set to 'lastest'
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            BROWSER_TAG="latest"
+          fi
+
+
+          echo "BROWSER_TAG=${BROWSER_TAG}" >> $GITHUB_ENV
+  
       - name: Build tests image
         uses: docker/build-push-action@v5
         with:
@@ -153,6 +175,7 @@ jobs:
           build-args: |
             BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler
             TARGETPLATFORM=${{ matrix.platform }}
+            BROWSER_TAG=${{ env.BROWSER_TAG }}
 
       - name: Upload image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -13,7 +13,7 @@ on:
     workflows: ["Build on ubuntu"]
     types:
       - completed
-    branches: [master, "[0-9]+.[0-9]+"]
+    branches: [master, "v[0-9]+.[0-9]+"]
   release:
     types: [published]
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,10 +2,11 @@ ARG BASE_IMAGE=falkordb/falkordb-compiler
 
 ARG TARGETPLATFORM=linux/amd64
 
+ARG BROWSER_TAG=latest
+
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE as compiler
 
-
-FROM falkordb/falkordb-browser as browser
+FROM falkordb/falkordb-browser:$BROWSER_TAG as browser
 
 
 FROM redis:7.2.4


### PR DESCRIPTION
- trigger only for vX.X and not X.X

fix #805 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `browser_tag` for dynamic browser tag assignment in workflows.
	- Enhanced the workflow for releasing images to DockerHub with improved branch pattern matching.

- **Improvements**
	- Updated the Dockerfile to allow dynamic tagging of the browser image based on the `BROWSER_TAG` argument.

These changes enhance flexibility and improve version control in the build and release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->