### PR TITLE
Fix bug in MERGE clause

### DIFF
--- a/tests/flow/test_merge_clause.py
+++ b/tests/flow/test_merge_clause.py
@@ -1,0 +1,41 @@
+import redis
+from common import *
+
+GRAPH_ID = "merge_clause_test"
+redis_con = None
+
+class TestMergeClause:
+    @classmethod
+    def setup_class(cls):
+        global redis_con
+        redis_con = redis.Redis(host='localhost', port=6379)
+        redis_con.flushall()
+
+    @classmethod
+    def teardown_class(cls):
+        redis_con.flushall()
+        redis_con.close()
+
+    def test_merge_clause_behavior(self):
+        # Test case 1: MERGE () UNION MERGE ()
+        query = """
+        MERGE ()
+        RETURN 0 AS n0
+        UNION
+        MERGE ()
+        RETURN 0 AS n0
+        """
+        result = redis_con.execute_command("GRAPH.QUERY", GRAPH_ID, query)
+        assert len(result[1]) == 2, f"Expected 2 nodes, but got {len(result[1])}"
+
+        # Test case 2: MERGE () UNION WITH * MERGE ()
+        query = """
+        MERGE ()
+        RETURN 0 AS n0
+        UNION
+        WITH *
+        MERGE ()
+        RETURN 0 AS n0
+        """
+        result = redis_con.execute_command("GRAPH.QUERY", GRAPH_ID, query)
+        assert len(result[1]) == 1, f"Expected 1 node, but got {len(result[1])}"


### PR DESCRIPTION
Fixes #830

Fix the behavior of `MERGE` clauses to ensure consistent results for semantically equivalent queries.

* **src/ast/ast_rewrite_same_clauses.c**
  - Add `_replace_merge_clause` function to handle `MERGE` clauses correctly.
  - Adjust `_compress_clauses` to include `MERGE` clauses in the compression logic.
  - Update `_compress_clauses` to handle `MERGE` clauses and prevent the creation of new nodes mistakenly.

* **tests/flow/test_merge_clause.py**
  - Add test cases to verify the behavior of `MERGE` clauses.
  - Ensure tests cover both semantically equivalent queries to confirm consistent results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FalkorDB/FalkorDB/pull/833?shareId=56fde9a2-44c6-4e57-bfb9-2c4686725e71).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to compress multiple consecutive MERGE clauses into a single MERGE clause, enhancing the AST rewriting process.
  
- **Tests**
	- Added a new test class to validate the behavior of MERGE clauses in a graph database context, ensuring accurate results through various test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->