### PR TITLE
Report indexing progress

### DIFF
--- a/src/procedures/proc_list_indexes.c
+++ b/src/procedures/proc_list_indexes.c
@@ -216,7 +216,8 @@ static bool _EmitIndex
 			char *status;
 			size_t m = info.numDocuments;
 			asprintf(&status, "[Indexing] %zu/%zu: UNDER CONSTRUCTION", m, n);
-			*ctx->yield_status = SI_TransferStringVal(status);
+			*ctx->yield_status = SI_DuplicateStringVal(status);
+			free(status);
 		}
 	}
 

--- a/src/procedures/proc_list_indexes.c
+++ b/src/procedures/proc_list_indexes.c
@@ -215,7 +215,7 @@ static bool _EmitIndex
 			// report progress
 			char *status;
 			size_t m = info.numDocuments;
-			asprintf(&status, "UNDER CONSTRUCTION %zu/%zu", m, n);
+			asprintf(&status, "[Indexing] %zu/%zu: UNDER CONSTRUCTION", m, n);
 			*ctx->yield_status = SI_TransferStringVal(status);
 		}
 	}

--- a/src/procedures/proc_list_indexes.c
+++ b/src/procedures/proc_list_indexes.c
@@ -168,6 +168,14 @@ static bool _EmitIndex
 	IndexesContext *ctx,
 	Index idx
 ) {
+	GraphContext *gc = ctx->gc;
+	Graph        *g = GraphContext_GetGraph(gc);
+
+	// get index info
+	RSIdxInfo info = { .version = RS_INFO_CURRENT_VERSION };
+	RSIndex *rsIdx = Index_RSIndex(idx);
+	RediSearch_IndexInfo(rsIdx, &info);
+
 	//--------------------------------------------------------------------------
 	// index entity type
 	//--------------------------------------------------------------------------
@@ -186,9 +194,29 @@ static bool _EmitIndex
 
 	if(ctx->yield_status != NULL) {
 		if(Index_Enabled(idx)) {
+			// index is operational
 			*ctx->yield_status = SI_ConstStringVal("OPERATIONAL");
 		} else {
-			*ctx->yield_status = SI_ConstStringVal("UNDER CONSTRUCTION");
+			// report index construction progress
+			// determine number of entities being indexed
+			size_t n;                               // total number of entities
+			Schema *s;                              // entities schema
+			const char *lbl = Index_GetLabel(idx);  // entities label
+
+			// get total number of entities from the graph
+			if(Index_GraphEntityType(idx) == GETYPE_NODE) {
+				s = GraphContext_GetSchema(gc, lbl, SCHEMA_NODE);
+				n = Graph_LabeledNodeCount(g, Schema_GetID(s));
+			} else {
+				s = GraphContext_GetSchema(gc, lbl, SCHEMA_EDGE);
+				n = Graph_RelationEdgeCount(g, Schema_GetID(s));
+			}
+
+			// report progress
+			char *status;
+			size_t m = info.numDocuments;
+			asprintf(&status, "UNDER CONSTRUCTION %zu/%zu", m, n);
+			*ctx->yield_status = SI_TransferStringVal(status);
 		}
 	}
 
@@ -331,11 +359,6 @@ static bool _EmitIndex
 	//--------------------------------------------------------------------------
 
 	if(ctx->yield_info) {
-		RSIdxInfo info = { .version = RS_INFO_CURRENT_VERSION };
-
-		RSIndex *rsIdx = Index_RSIndex(idx);
-
-		RediSearch_IndexInfo(rsIdx, &info);
 		SIValue map = SI_Map(23);
 
 		Map_Add(&map, SI_ConstStringVal("gcPolicy"), SI_LongVal(info.gcPolicy));
@@ -377,9 +400,11 @@ static bool _EmitIndex
 		Map_Add(&map, SI_ConstStringVal("totalMSRun"),       SI_LongVal(info.totalMSRun));
 		Map_Add(&map, SI_ConstStringVal("lastRunTimeMs"),    SI_LongVal(info.lastRunTimeMs));
 
-		RediSearch_IndexInfoFree(&info);
 		*ctx->yield_info = map;
 	}
+
+	// clean up
+	RediSearch_IndexInfoFree(&info);
 
 	return true;
 }

--- a/tests/flow/test_index_create.py
+++ b/tests/flow/test_index_create.py
@@ -809,3 +809,35 @@ class testIndexCreationFlow():
         self.env.assertEquals(types, expected_types)
         self.env.assertEquals(language, 'english')
         self.env.assertEquals(entitytype, 'NODE')
+
+    def test15_index_progress_report(self):
+        # create a relatively large graph
+        node_count = 200000
+        q = "UNWIND range(1, $node_count) AS x CREATE (:P {v:x})"
+        self.graph.query(q, {'node_count': node_count})
+
+        # create index over P.v
+        self.graph.create_node_range_index('P', 'v')
+
+        # pull index status
+        status = self.graph.query("CALL db.indexes() yield status").result_set[0][0]
+
+        # index is operational
+        if("OPERATIONAL" in status):
+            return
+
+        self.env.assertTrue("UNDER CONSTRUCTION" in status)
+        while "UNDER CONSTRUCTION" in status:
+            # extract progress n/m
+            # "UNDER CONSTRUCTION 8000001/7537358"
+            status = status[len("UNDER CONSTRUCTION "):]
+            n, m = status.split('/')
+            n = int(n)
+            m = int(m)
+
+            self.env.assertGreaterEqual(m, n) # m >= n
+            self.env.assertEqual(m, node_count)   # m == node_count
+
+            # re-pull index status
+            status = self.graph.query("CALL db.indexes() yield status").result_set[0][0]
+

--- a/tests/flow/test_index_create.py
+++ b/tests/flow/test_index_create.py
@@ -1,5 +1,6 @@
 import asyncio
 from common import *
+from time import sleep
 from index_utils import *
 from time import sleep, time
 from collections import OrderedDict
@@ -830,13 +831,17 @@ class testIndexCreationFlow():
         while "UNDER CONSTRUCTION" in status:
             # extract progress n/m
             # "UNDER CONSTRUCTION 8000001/7537358"
-            status = status[len("UNDER CONSTRUCTION "):]
+            # "[Indexing] 800001/742387462: UNDER CONSTRUCTION"
+            status = status[len("[Indexing] "):]
+            status = status[:-len(": UNDER CONSTRUCTION")]
             n, m = status.split('/')
             n = int(n)
             m = int(m)
 
             self.env.assertGreaterEqual(m, n) # m >= n
             self.env.assertEqual(m, node_count)   # m == node_count
+
+            sleep(0.1)
 
             # re-pull index status
             status = self.graph.query("CALL db.indexes() yield status").result_set[0][0]


### PR DESCRIPTION
Fix: #835

```
127.0.0.1:6379> GRAPH.QUERY g "call db.indexes()"
1) 1) "label"
   2) "properties"
   3) "types"
   4) "options"
   5) "language"
   6) "stopwords"
   7) "entitytype"
   8) "status"
   9) "info"
2) 1) 1) "P"
      2) "[v]"
      3) "{v: [RANGE]}"
      4) "{v: {}}"
      5) "english"
      6) "[]"
      7) "NODE"
      8) "[Indexing] 4829048/8000001: UNDER CONSTRUCTION"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced index status reporting, providing more comprehensive operational updates during indexing.
	- Added a new test method to verify index progress reporting for large graphs.

- **Bug Fixes**
	- Improved memory management by cleaning up the index information structure to prevent potential memory leaks.

- **Tests**
	- Introduced a test for monitoring the status of index creation and ensuring accurate progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->