### PR TITLE
remove graph500 from repo download it from gcp

### DIFF
--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -4,6 +4,7 @@ dataset.rdb
 falkordb.so
 venv/
 falkordb-benchmark-go
+datasets/graph500.rdb
 falkordb-benchmark-go.tar.gz
 compare.md
 README.md

--- a/tests/benchmarks/run_benchmarks.py
+++ b/tests/benchmarks/run_benchmarks.py
@@ -92,6 +92,15 @@ def single_iteration(bench: str, idx: int, bench_end: int):
     except subprocess.CalledProcessError:
         pass
 
+def verify_and_download_graph500():
+    if not os.path.exists("./datasets/graph500.rdb"):
+        print("Downloading missing dataset")
+        try:
+            urlretrieve("https://storage.googleapis.com/falkordb-benchmark-datasets/"
+                        "graph500.rdb", "./datasets/graph500.rdb")
+        except Exception as e:
+            print(f"Failed to download the dataset: {e}")
+            exit(1)
 
 def verify_sha256_checksum(target_file, checksum_file):
     # Read the existing checksum
@@ -196,6 +205,7 @@ def main():
         exit(1)
 
     verify_and_download_benchmark_tool()
+    verify_and_download_graph500()
 
     benches = glob.glob(f"{benchmark_group}/*.yml", recursive=False)
     benches_count = len(benches)


### PR DESCRIPTION
fix https://github.com/FalkorDB/FalkorDB/issues/844
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to verify and download the `graph500.rdb` dataset, ensuring necessary data is available before running benchmarks.
- **Chores**
	- Updated `.gitignore` to exclude the `graph500.rdb` dataset from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Benchmark results auto generation start -->
## Benchmark Comparison 'master' \<---> 'download-rdb-from-gcp'

### Benchmark List:

The following benchmarks were ran with the following settings:

| Benchmark                                                               | Branch '_download-rdb-from-gcp_' Benchmark Duration | Branch '_master_' Benchmark Duration | Number of Concurrent Clients | Commands Issued |
| ----------------------------------------------------------------------- | :-------------------------------------------------: | :----------------------------------: | :--------------------------: | :-------------: |
| GRAPH500-SCALE_18-EF_16-2_HOP                                           |                       195000                        |                215000                |              32              |     1000000     |
| GRAPH500-SCALE_18-EF_16-1_HOP                                           |                        25000                        |                30000                 |              32              |     1000000     |
| SORT_ENTITIES                                                           |                        5003                         |                 5003                 |              32              |      1000       |
| UPDATE-BASELINE                                                         |                        45000                        |                50000                 |              32              |     1000000     |
| allShortestPaths-10hop-100Kpaths                                        |                       110001                        |                130002                |              32              |      3000       |
| NODE-INDEX-LOOKUP                                                       |                        25000                        |                25000                 |              32              |      1000       |
| VARIABLE_LENGTH_EXPAND_INTO                                             |                        5004                         |                 5004                 |              32              |      1000       |
| ENTITY_COUNT                                                            |                        20001                        |                20000                 |              32              |     1000000     |
| NODE-BATCH-DELETE                                                       |                        10000                        |                15003                 |              1               |      1000       |
| GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc            |                       100000                        |                105000                |              32              |      10000      |
| EXPLICIT-EDGE-DELETION                                                  |                        5004                         |                 5000                 |              1               |      1000       |
| GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc            |                        95000                        |                105001                |              32              |      10000      |
| VARIABLE-LENGTH-FILTER                                                  |                        20001                        |                20000                 |              32              |     1000000     |
| GRAPH500-SCALE_18-EF_16-3_HOP                                           |                       2215000                       |               2050000                |              32              |     1000000     |
| GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc |                       120000                        |                130000                |              32              |      10000      |
| INSPECT-EDGES                                                           |                        30000                        |                35000                 |              32              |      50000      |
| GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc            |                       110000                        |                125001                |              32              |      10000      |
| MIX_READ_WRITE                                                          |                        80000                        |                90001                 |              32              |     1000000     |
| allShortestPaths-4hop-10Kpaths                                          |                       175001                        |                180000                |              32              |      50000      |
| IMPLICIT-EDGE-DELETION                                                  |                        5004                         |                 5004                 |              1               |       500       |

### Benchmarks:


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-2_HOP' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **10.07%** \
(Less is better)

Internal Latency diff between baseline and current branch: **10.0%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-2_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.499488297 --> 6.720147809
    bar [1.498464891, 0, 6.109070236, 0]
    bar [0, 1.64937362, 0, 6.720147809]
```

</details>


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **10.63%** \
(Less is better)

Internal Latency diff between baseline and current branch: **9.64%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.03949319033333334 --> 0.8316536720000001
    bar [0.118479571, 0, 0.7585224500000001, 0]
    bar [0, 0.13107218399999998, 0, 0.8316536720000001]
```

</details>


<details>

<summary style='color:red'>Benchmark 'SORT_ENTITIES' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **10.88%** \
(Less is better)

Internal Latency diff between baseline and current branch: **13.32%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "SORT_ENTITIES"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 4.960692666666667 --> 65.098434
    bar [14.882078, 0, 57.444558, 0]
    bar [0, 16.501227999999998, 0, 65.098434]
```

</details>


<details>

<summary style='color:red'>Benchmark 'UPDATE-BASELINE' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **8.76%** \
(Less is better)

Internal Latency diff between baseline and current branch: **8.32%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "UPDATE-BASELINE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.015461787 --> 1.441121455
    bar [0.046385361, 0, 1.330443743, 0]
    bar [0, 0.050447962, 0, 1.441121455]
```

</details>


<details>

<summary style='color:red'>Benchmark 'allShortestPaths-10hop-100Kpaths' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **14.78%** \
(Less is better)

Internal Latency diff between baseline and current branch: **14.87%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "allShortestPaths-10hop-100Kpaths"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 96.02293733333333 --> 1315.0584773333333
    bar [288.068812, 0, 1144.80572, 0]
    bar [0, 330.64339333333334, 0, 1315.0584773333333]
```

</details>


<details>

<summary style='color:red'>Benchmark 'NODE-INDEX-LOOKUP' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **14.26%** \
(Less is better)

Internal Latency diff between baseline and current branch: **11.96%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "NODE-INDEX-LOOKUP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 18.63174 --> 730.637814
    bar [55.89522, 0, 652.606628, 0]
    bar [0, 63.863475, 0, 730.637814]
```

</details>


<details>

<summary style='color:red'>Benchmark 'VARIABLE_LENGTH_EXPAND_INTO' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **9.87%** \
(Less is better)

Internal Latency diff between baseline and current branch: **17.53%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "VARIABLE_LENGTH_EXPAND_INTO"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.03082733333333333 --> 0.402034
    bar [0.092482, 0, 0.342057, 0]
    bar [0, 0.101613, 0, 0.402034]
```

</details>


<details>

<summary style='color:red'>Benchmark 'ENTITY_COUNT' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **6.0%** \
(Less is better)

Internal Latency diff between baseline and current branch: **6.82%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "ENTITY_COUNT"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.022798060666666665 --> 0.594520512
    bar [0.068394182, 0, 0.556545488, 0]
    bar [0, 0.072495837, 0, 0.594520512]
```

</details>


<details>

<summary style='color:red'>Benchmark 'NODE-BATCH-DELETE' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **22.72%** \
(Less is better)

Internal Latency diff between baseline and current branch: **22.43%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "NODE-BATCH-DELETE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 2.98666 --> 11.307127000000001
    bar [8.95998, 0, 9.235597, 0]
    bar [0, 10.995293, 0, 11.307127000000001]
```

</details>


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **7.54%** \
(Less is better)

Internal Latency diff between baseline and current branch: **7.99%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.2085933 --> 307.6792018
    bar [9.6257799, 0, 284.92036129999997, 0]
    bar [0, 10.3515846, 0, 307.6792018]
```

</details>


<details>

<summary style='color:red'>Benchmark 'EXPLICIT-EDGE-DELETION' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **15.58%** \
(Less is better)

Internal Latency diff between baseline and current branch: **14.98%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "EXPLICIT-EDGE-DELETION"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.10140233333333333 --> 0.472511
    bar [0.304207, 0, 0.410963, 0]
    bar [0, 0.351615, 0, 0.472511]
```

</details>


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **8.05%** \
(Less is better)

Internal Latency diff between baseline and current branch: **10.47%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.4335925 --> 312.77523590000004
    bar [10.3007775, 0, 283.129394, 0]
    bar [0, 11.129629699999999, 0, 312.77523590000004]
```

</details>


<details>

<summary style='color:red'>Benchmark 'VARIABLE-LENGTH-FILTER' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **8.09%** \
(Less is better)

Internal Latency diff between baseline and current branch: **7.53%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "VARIABLE-LENGTH-FILTER"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.024159629000000002 --> 0.62007512
    bar [0.072478887, 0, 0.576652178, 0]
    bar [0, 0.078341294, 0, 0.62007512]
```

</details>


<details>

<summary style='color:green'>Benchmark 'GRAPH500-SCALE_18-EF_16-3_HOP' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-7.51%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-7.55%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-3_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 5.442917433000001 --> 70.74328602499999
    bar [17.654089062, 0, 70.74328602499999, 0]
    bar [0, 16.328752299, 0, 65.404744878]
```

</details>


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **9.92%** \
(Less is better)

Internal Latency diff between baseline and current branch: **10.88%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.8958459333333333 --> 391.8534485
    bar [11.6875378, 0, 353.3902083, 0]
    bar [0, 12.846455299999999, 0, 391.8534485]
```

</details>


<details>

<summary style='color:red'>Benchmark 'INSPECT-EDGES' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **9.35%** \
(Less is better)

Internal Latency diff between baseline and current branch: **9.4%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "INSPECT-EDGES"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 1.4748120333333334 --> 19.52105424
    bar [4.4244361, 0, 17.84303422, 0]
    bar [0, 4.83800902, 0, 19.52105424]
```

</details>


<details>

<summary style='color:red'>Benchmark 'GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **12.48%** \
(Less is better)

Internal Latency diff between baseline and current branch: **14.3%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 6.060367366666667 --> 365.4840826
    bar [18.1811021, 0, 319.7699275, 0]
    bar [0, 20.4497752, 0, 365.4840826]
```

</details>


<details>

<summary style='color:red'>Benchmark 'MIX_READ_WRITE' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **9.34%** \
(Less is better)

Internal Latency diff between baseline and current branch: **10.49%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "MIX_READ_WRITE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.04993804533333333 --> 2.797532498
    bar [0.149814136, 0, 2.531901389, 0]
    bar [0, 0.16381289300000001, 0, 2.797532498]
```

</details>


<details>

<summary style='color:red'>Benchmark 'allShortestPaths-4hop-10Kpaths' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **5.09%** \
(Less is better)

Internal Latency diff between baseline and current branch: **5.12%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "allShortestPaths-4hop-10Kpaths"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 9.060410126666667 --> 114.45051944000001
    bar [27.181230380000002, 0, 108.87475422, 0]
    bar [0, 28.564581399999998, 0, 114.45051944000001]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'IMPLICIT-EDGE-DELETION' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **2.21%** \
(Less is better)

Internal Latency diff between baseline and current branch: **2.55%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "IMPLICIT-EDGE-DELETION"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.07190933333333334 --> 0.309558
    bar [0.215728, 0, 0.30186, 0]
    bar [0, 0.2205, 0, 0.309558]
```

</details>


<!-- Benchmark results auto generation end -->
