### PR TITLE
Update dict and xxhash

### DIFF
--- a/src/util/dict.c
+++ b/src/util/dict.c
@@ -139,7 +139,7 @@ dict *HashTableCreate
     assert(type != NULL);
 
     size_t metasize = type->dictMetadataBytes ? type->dictMetadataBytes() : 0;
-    dict *d = malloc(sizeof(*d) + metasize);
+    dict *d = rm_malloc(sizeof(*d) + metasize);
     if (metasize) {
         memset(HashTableMetadata(d), 0, metasize);
     }
@@ -216,12 +216,12 @@ int _HashTableExpand
 
     /* Allocate the new hash table and initialize all pointers to NULL */
     if (malloc_failed) {
-        new_ht_table = calloc(1, newsize*sizeof(dictEntry*));
+        new_ht_table = rm_calloc(1, newsize*sizeof(dictEntry*));
         *malloc_failed = new_ht_table == NULL;
         if (*malloc_failed)
             return DICT_ERR;
     } else
-        new_ht_table = calloc(1, newsize*sizeof(dictEntry*));
+        new_ht_table = rm_calloc(1, newsize*sizeof(dictEntry*));
 
     new_ht_used = 0;
 
@@ -306,7 +306,7 @@ int HashTableRehash(dict *d, int n) {
 
     /* Check if we already rehashed the whole table... */
     if (d->ht_used[0] == 0) {
-        free(d->ht_table[0]);
+        rm_free(d->ht_table[0]);
         /* Copy the new ht onto the old one */
         d->ht_table[0] = d->ht_table[1];
         d->ht_used[0] = d->ht_used[1];
@@ -415,7 +415,7 @@ dictEntry *HashTableAddRaw
      * more frequently. */
     htidx = dictIsRehashing(d) ? 1 : 0;
     size_t metasize = HashTableEntryMetadataSize(d);
-    entry = malloc(sizeof(*entry) + metasize);
+    entry = rm_malloc(sizeof(*entry) + metasize);
     if (metasize > 0) {
         memset(HashTableEntryMetadata(entry), 0, metasize);
     }
@@ -545,7 +545,7 @@ void HashTableFreeUnlinkedEntry(dict *d, dictEntry *he) {
     if (he == NULL) return;
     dictFreeKey(d, he);
     dictFreeVal(d, he);
-    free(he);
+    rm_free(he);
 }
 
 /* Destroy an entire dictionary */
@@ -563,13 +563,13 @@ static int _dictClear(dict *d, int htidx, void(callback)(dict*)) {
             nextHe = he->next;
             dictFreeKey(d, he);
             dictFreeVal(d, he);
-            free(he);
+            rm_free(he);
             d->ht_used[htidx]--;
             he = nextHe;
         }
     }
     /* Free the table and the allocated cache structure */
-    free(d->ht_table[htidx]);
+    rm_free(d->ht_table[htidx]);
     /* Re-initialize the table */
     _dictReset(d, htidx);
     return DICT_OK; /* never fails */
@@ -580,7 +580,7 @@ void HashTableRelease(dict *d)
 {
     _dictClear(d,0,NULL);
     _dictClear(d,1,NULL);
-    free(d);
+    rm_free(d);
 }
 
 dictEntry *HashTableFind(dict *d, const void *key)
@@ -661,7 +661,7 @@ void HashTableTwoPhaseUnlinkFree(dict *d, dictEntry *he, dictEntry **plink, int 
     *plink = he->next;
     dictFreeKey(d, he);
     dictFreeVal(d, he);
-    free(he);
+    rm_free(he);
     dictResumeRehashing(d);
 }
 
@@ -766,7 +766,7 @@ void HashTableResetIterator(dictIterator *iter)
 
 dictIterator *HashTableGetIterator(dict *d)
 {
-    dictIterator *iter = malloc(sizeof(*iter));
+    dictIterator *iter = rm_malloc(sizeof(*iter));
     HashTableInitIterator(iter, d);
     return iter;
 }
@@ -814,7 +814,7 @@ dictEntry *HashTableNext(dictIterator *iter)
 void HashTableReleaseIterator(dictIterator *iter)
 {
     HashTableResetIterator(iter);
-    free(iter);
+    rm_free(iter);
 }
 
 /* Reallocate the dictEntry allocations in a bucket using the provided

--- a/src/util/dict.h
+++ b/src/util/dict.h
@@ -38,7 +38,7 @@
 #include "mt19937-64.h"
 #include <limits.h>
 #include <stdint.h>
-#include <stdlib.h>
+#include "rmalloc.h"
 
 #define DICT_OK 0
 #define DICT_ERR 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated memory management strategy for hash table operations to utilize custom allocation functions.
	- Removed dependency on standard library for memory management, enhancing control over memory usage. 

These changes improve memory handling, but do not affect existing functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Benchmark results auto generation start -->
## Benchmark Comparison 'master' \<---> 'update-dict-and-xxhash'

### Benchmark List:

The following benchmarks were ran with the following settings:

| Benchmark                                                               | Branch '_update-dict-and-xxhash_' Benchmark Duration | Branch '_master_' Benchmark Duration | Number of Concurrent Clients | Commands Issued |
| ----------------------------------------------------------------------- | :--------------------------------------------------: | :----------------------------------: | :--------------------------: | :-------------: |
| GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc            |                        100000                        |                95000                 |              32              |      10000      |
| GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc            |                        110000                        |                105001                |              32              |      10000      |
| NODE-INDEX-LOOKUP                                                       |                        25001                         |                25001                 |              32              |      1000       |
| ENTITY_COUNT                                                            |                        20001                         |                20000                 |              32              |     1000000     |
| GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc            |                        105000                        |                95000                 |              32              |      10000      |
| allShortestPaths-4hop-10Kpaths                                          |                        195001                        |                180001                |              32              |      50000      |
| GRAPH500-SCALE_18-EF_16-2_HOP                                           |                        200000                        |                205000                |              32              |     1000000     |
| VARIABLE-LENGTH-FILTER                                                  |                        20001                         |                20000                 |              32              |     1000000     |
| VARIABLE_LENGTH_EXPAND_INTO                                             |                         5004                         |                 5004                 |              32              |      1000       |
| SORT_ENTITIES                                                           |                         5003                         |                 5003                 |              32              |      1000       |
| EXPLICIT-EDGE-DELETION                                                  |                         5003                         |                 5004                 |              1               |      1000       |
| GRAPH500-SCALE_18-EF_16-1_HOP                                           |                        30000                         |                25001                 |              32              |     1000000     |
| allShortestPaths-10hop-100Kpaths                                        |                        115001                        |                125001                |              32              |      3000       |
| NODE-BATCH-DELETE                                                       |                        10001                         |                10000                 |              1               |      1000       |
| GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc |                        119999                        |                115000                |              32              |      10000      |
| MIX_READ_WRITE                                                          |                        85000                         |                85000                 |              32              |     1000000     |
| INSPECT-EDGES                                                           |                        30000                         |                30001                 |              32              |      50000      |
| UPDATE-BASELINE                                                         |                        45001                         |                45000                 |              32              |     1000000     |
| GRAPH500-SCALE_18-EF_16-3_HOP                                           |                       1970000                        |               2065001                |              32              |     1000000     |
| IMPLICIT-EDGE-DELETION                                                  |                         5004                         |                 5004                 |              1               |       500       |

### Benchmarks:


<details>

<summary style='color:cadetblue'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **-2.73%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-2.97%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.1415896666666665 --> 290.0528325
    bar [9.689363499999999, 0, 290.0528325, 0]
    bar [0, 9.424769, 0, 281.4298274]
```

</details>


<details>

<summary style='color:green'>Benchmark 'GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-6.48%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-3.13%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-3_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 5.861453833333333 --> 329.0127179
    bar [18.803092499999998, 0, 329.0127179, 0]
    bar [0, 17.5843615, 0, 318.72524400000003]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'NODE-INDEX-LOOKUP' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **-4.77%** \
(Less is better)

Internal Latency diff between baseline and current branch: **2.22%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "NODE-INDEX-LOOKUP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 18.927895333333336 --> 670.36014
    bar [59.629432, 0, 655.7903220000001, 0]
    bar [0, 56.783686, 0, 670.36014]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'ENTITY_COUNT' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **4.85%** \
(Less is better)

Internal Latency diff between baseline and current branch: **2.19%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "ENTITY_COUNT"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.022688716666666664 --> 0.576538333
    bar [0.06806614999999999, 0, 0.564159271, 0]
    bar [0, 0.071369207, 0, 0.576538333]
```

</details>


<details>

<summary style='color:green'>Benchmark 'GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-7.71%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-8.32%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-2_HOP_MIXED_READ_75perc_WRITE_25perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.3531543666666668 --> 304.2375041
    bar [10.8997507, 0, 304.2375041, 0]
    bar [0, 10.0594631, 0, 278.9129305]
```

</details>


<details>

<summary style='color:green'>Benchmark 'allShortestPaths-4hop-10Kpaths' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-9.73%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-9.72%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "allShortestPaths-4hop-10Kpaths"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 9.325804813333333 --> 124.14378737999999
    bar [30.99391886, 0, 124.14378737999999, 0]
    bar [0, 27.97741444, 0, 112.07451408]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'GRAPH500-SCALE_18-EF_16-2_HOP' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **1.76%** \
(Less is better)

Internal Latency diff between baseline and current branch: **1.64%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-2_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.51426295 --> 6.392982265
    bar [1.54278885, 0, 6.289617964, 0]
    bar [0, 1.5699147290000002, 0, 6.392982265]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'VARIABLE-LENGTH-FILTER' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **-1.58%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-1.98%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "VARIABLE-LENGTH-FILTER"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.024374679 --> 0.5941464949999999
    bar [0.074294218, 0, 0.5941464949999999, 0]
    bar [0, 0.073124037, 0, 0.5824069930000001]
```

</details>


<details>

<summary style='color:yellow'>Benchmark 'VARIABLE_LENGTH_EXPAND_INTO' (POTENTIAL DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **6.55%** \
(Less is better)

Internal Latency diff between baseline and current branch: **3.88%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "VARIABLE_LENGTH_EXPAND_INTO"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.032001999999999996 --> 0.36547500000000005
    bar [0.096006, 0, 0.351829, 0]
    bar [0, 0.10229600000000001, 0, 0.36547500000000005]
```

</details>


<details>

<summary style='color:green'>Benchmark 'SORT_ENTITIES' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-4.43%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-5.61%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "SORT_ENTITIES"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 4.857149000000001 --> 60.176792999999996
    bar [15.247548, 0, 60.176792999999996, 0]
    bar [0, 14.571447000000001, 0, 56.802153]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'EXPLICIT-EDGE-DELETION' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **2.08%** \
(Less is better)

Internal Latency diff between baseline and current branch: **2.26%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "EXPLICIT-EDGE-DELETION"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.10481433333333333 --> 0.428254
    bar [0.314443, 0, 0.418792, 0]
    bar [0, 0.320969, 0, 0.428254]
```

</details>


<details>

<summary style='color:green'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-3.6%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-3.05%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.040166353333333335 --> 0.798361554
    bar [0.12499711999999999, 0, 0.798361554, 0]
    bar [0, 0.12049906, 0, 0.773994139]
```

</details>


<details>

<summary style='color:red'>Benchmark 'allShortestPaths-10hop-100Kpaths' (DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **6.85%** \
(Less is better)

Internal Latency diff between baseline and current branch: **6.83%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "allShortestPaths-10hop-100Kpaths"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 99.21165933333333 --> 1264.5862586666667
    bar [297.634978, 0, 1183.7173753333334, 0]
    bar [0, 318.0197, 0, 1264.5862586666667]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'NODE-BATCH-DELETE' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **-2.39%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-2.24%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "NODE-BATCH-DELETE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.018405 --> 9.502203
    bar [9.277218000000001, 0, 9.502203, 0]
    bar [0, 9.055215, 0, 9.289037]
```

</details>


<details>

<summary style='color:green'>Benchmark 'GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-4.59%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-4.96%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-1_HOP_MIXED_READ_65perc_WRITE_25perc_DEL_10perc"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 3.7076412666666667 --> 355.0528811
    bar [11.657648100000001, 0, 355.0528811, 0]
    bar [0, 11.1229238, 0, 337.4388884]
```

</details>


<details>

<summary style='color:green'>Benchmark 'MIX_READ_WRITE' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-2.13%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-3.94%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "MIX_READ_WRITE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.051617323666666666 --> 2.651618828
    bar [0.15821426, 0, 2.651618828, 0]
    bar [0, 0.154851971, 0, 2.547014909]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'INSPECT-EDGES' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **1.06%** \
(Less is better)

Internal Latency diff between baseline and current branch: **1.01%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "INSPECT-EDGES"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 1.4657215666666668 --> 17.907059580000002
    bar [4.3971647, 0, 17.72798968, 0]
    bar [0, 4.443737339999999, 0, 17.907059580000002]
```

</details>


<details>

<summary style='color:cadetblue'>Benchmark 'UPDATE-BASELINE' (STABLE)</summary>

Overall Latency diff between baseline and current branch: **0.36%** \
(Less is better)

Internal Latency diff between baseline and current branch: **0.56%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "UPDATE-BASELINE"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.015869441333333335 --> 1.369962037
    bar [0.047608324, 0, 1.3623989429999999, 0]
    bar [0, 0.047780135, 0, 1.369962037]
```

</details>


<details>

<summary style='color:yellow'>Benchmark 'GRAPH500-SCALE_18-EF_16-3_HOP' (POTENTIAL DEGRADATION)</summary>

Overall Latency diff between baseline and current branch: **4.76%** \
(Less is better)

Internal Latency diff between baseline and current branch: **4.76%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "GRAPH500-SCALE_18-EF_16-3_HOP"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 5.238773514333333 --> 65.9389036
    bar [15.716320543, 0, 62.940421865, 0]
    bar [0, 16.463704862, 0, 65.9389036]
```

</details>


<details>

<summary style='color:green'>Benchmark 'IMPLICIT-EDGE-DELETION' (POTENTIAL IMPROVEMENT)</summary>

Overall Latency diff between baseline and current branch: **-5.04%** \
(Less is better)

Internal Latency diff between baseline and current branch: **-5.05%** \
(Less is better)

```mermaid
---
config:
    xyChart:
        plotReservedSpacePercent: 0
        titleFontSize: 16
        xAxis:
            labelFontSize: 12
    themeVariables:
        xyChart:
            plotColorPalette: "#3498DB, #DB3409"
    
---
xychart-beta
    title "IMPLICIT-EDGE-DELETION"
    x-axis ["Baseline Internal Avg.", "New Internal Avg.", "Baseline Overall Avg.", "New Overall Avg."]
    y-axis "Graph Internal Latency (in ms)" 0.071194 --> 0.31944799999999995
    bar [0.22491399999999998, 0, 0.31944799999999995, 0]
    bar [0, 0.213582, 0, 0.3033]
```

</details>


<!-- Benchmark results auto generation end -->
