### PR TITLE
install nodejs 22

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -12,7 +12,7 @@ FROM falkordb/falkordb-browser:$BROWSER_TAG AS browser
 FROM redis:7.2.4
 
 RUN apt-get update && apt-get install -y libgomp1 curl && \
-    curl -sL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh && \
+    curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -11,7 +11,11 @@ FROM falkordb/falkordb-browser:$BROWSER_TAG AS browser
 
 FROM redis:7.2.4
 
-RUN apt-get update && apt-get install -y libgomp1 nodejs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libgomp1 curl && \
+    curl -sL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /FalkorDB
 


### PR DESCRIPTION
fix #920 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Node.js installation process in Docker configuration to use NodeSource setup script for version 22.x
	- Improved Docker build reliability by using a more robust method of installing Node.js
<!-- end of auto-generated comment: release notes by coderabbit.ai -->