### PR TITLE
validate configuration default values

### DIFF
--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -1365,6 +1365,7 @@ bool Config_Option_set
 		case Config_CMD_INFO_MAX_QUERY_COUNT: {
 			long long count = 0;
 			if (!_Config_ParseNonNegativeInteger(val, &count)) return false;
+			if (count > UINT64_MAX) return false;
 
 			Config_cmd_info_max_queries_set(count);
       }

--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -105,7 +105,7 @@ typedef struct {
 	uint64_t node_creation_buffer;     // number of extra node creations to buffer as margin in matrices
 	bool cmd_info_on;                  // if true, the GRAPH.INFO is enabled
 	uint64_t effects_threshold;        // replicate via effects when runtime exceeds threshold
-	uint32_t max_info_queries_count;   // maximum number of query info elements
+	uint64_t max_info_queries_count;   // maximum number of query info elements
 	int16_t bolt_port;                 // bolt protocol port
 	bool delay_indexing;               // delay index construction when decoding
 	char *import_folder;               // path to import folder, used for CSV loading
@@ -422,13 +422,13 @@ static void Config_cmd_info_set
 	config.cmd_info_on = cmd_info_on;
 }
 
-static uint32_t Config_cmd_info_max_queries_get(void) {
+static uint64_t Config_cmd_info_max_queries_get(void) {
 	return config.max_info_queries_count;
 }
 
 static void Config_cmd_info_max_queries_set
 (
-	const uint32_t count
+	const uint64_t count
 ) {
 	if (count > CMD_INFO_QUERIES_MAX_COUNT_DEFAULT) {
 		config.max_info_queries_count = CMD_INFO_QUERIES_MAX_COUNT_DEFAULT;
@@ -1079,7 +1079,7 @@ bool Config_Option_get
 
 		case Config_CMD_INFO_MAX_QUERY_COUNT: {
 			va_start(ap, field);
-			uint32_t *count = va_arg(ap, uint32_t *);
+			uint64_t *count = va_arg(ap, uint64_t *);
 			va_end(ap);
 
 			ASSERT(count != NULL);
@@ -1366,7 +1366,6 @@ bool Config_Option_set
 			long long count = 0;
 			if (!_Config_ParseNonNegativeInteger(val, &count)) return false;
 
-			// A downcast from <long long> to <uint32_t>.
 			Config_cmd_info_max_queries_set(count);
       }
   		break;

--- a/src/cron/tasks/stream_finished_queries.c
+++ b/src/cron/tasks/stream_finished_queries.c
@@ -217,7 +217,7 @@ bool CronTask_streamFinishedQueries
 	simple_timer_t stopwatch;
 	simple_tic(stopwatch);
 
-	uint32_t max_query_count = 0;  // determine max number of queries to collect
+	uint64_t max_query_count = 0;  // determine max number of queries to collect
 	Config_Option_get(Config_CMD_INFO_MAX_QUERY_COUNT, &max_query_count);
 
 	KeySpaceGraphIterator it;

--- a/src/module.c
+++ b/src/module.c
@@ -74,7 +74,7 @@ static void _Print_Config
 
 	bool cmd_info_enabled = false;
 	if(Config_Option_get(Config_CMD_INFO, &cmd_info_enabled) && cmd_info_enabled) {
-		uint32_t info_max_query_count = 0;
+		uint64_t info_max_query_count = 0;
 		Config_Option_get(Config_CMD_INFO_MAX_QUERY_COUNT, &info_max_query_count);
 		RedisModule_Log(ctx, "notice", "Query backlog size: %u", info_max_query_count);
 	}

--- a/src/queries_log/queries_log.c
+++ b/src/queries_log/queries_log.c
@@ -41,7 +41,7 @@ QueriesLog QueriesLog_New(void) {
 
 	// create circular buffer
 	// read buffer capacity from configuration
-	uint32_t cap;
+	uint64_t cap;
 	bool get = Config_Option_get(Config_CMD_INFO_MAX_QUERY_COUNT, &cap);
 	ASSERT(get == true);
 

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -22,6 +22,34 @@ class testConfig(FlowTestsBase):
         # 16 configurations should be reported
         self.env.assertEquals(len(response), NUMBER_OF_CONFIGURATIONS)
 
+        # validate default configuration values
+        default_config = [
+                ("TIMEOUT", 0),
+                ("TIMEOUT_DEFAULT", 0),
+                ("TIMEOUT_MAX",  0),
+                ("CACHE_SIZE", 25),
+                ("ASYNC_DELETE", 1),
+                ("OMP_THREAD_COUNT", 11),
+                ("THREAD_COUNT", 11),
+                ("RESULTSET_SIZE", -1),
+                ("VKEY_MAX_ENTITY_COUNT", 100000),
+                ("MAX_QUEUED_QUERIES", 4294967295),
+                ("QUERY_MEM_CAPACITY", 0),
+                ("DELTA_MAX_PENDING_CHANGES", 10000),
+                ("NODE_CREATION_BUFFER", 16384),
+                ("CMD_INFO", 1),
+                ("MAX_INFO_QUERIES", 1000),
+                ("EFFECTS_THRESHOLD", 300),
+                ("BOLT_PORT", 65535),
+                ("DELAY_INDEXING", 0),
+                ("IMPORT_FOLDER", "/var/lib/FalkorDB/import/")
+        ]
+
+        for i, config in enumerate(response):
+            name  = config[0]
+            value = config[1]
+            self.env.assertEquals((name, value), default_config[i])
+
     def test02_config_get_invalid_name(self):
         # Ensure that getter fails on invalid parameters appropriately
         fake_config_name = "FAKE_CONFIG_NAME"
@@ -287,4 +315,3 @@ class testConfig(FlowTestsBase):
         creation_buffer_size = self.db.config_get("NODE_CREATION_BUFFER")
         expected_response = 1024
         self.env.assertEqual(creation_buffer_size, expected_response)
-

--- a/tests/unit/tests.sh
+++ b/tests/unit/tests.sh
@@ -61,6 +61,13 @@ sanitizer_summary() {
 		echo "${NOCOLOR}"
 		E=1
 	fi
+	if grep -l "stack-buffer-overflow" ${LOGS_DIR}/*.asan.log* &> /dev/null; then
+		echo
+		echo "${LIGHTRED}Sanitizer: buffer overflow detected:${RED}"
+		grep -l "stack-buffer-overflow" ${LOGS_DIR}/*.asan.log*
+		echo "${NOCOLOR}"
+		E=1
+	fi
 	if grep -l "stack-use-after-scope" ${LOGS_DIR}/*.asan.log* &> /dev/null; then
 		echo
 		echo "${LIGHTRED}Sanitizer: stack use after scope detected:${RED}"


### PR DESCRIPTION
### **User description**
Resolves: #930 
Due to the recent change to our configuration we wrongly report a 32bit number as 64bit.
This PR switch the 32bit configuration to 64bit.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed incorrect data type for `max_info_queries_count` configuration.

- Updated related functions to use `uint64_t` instead of `uint32_t`.

- Added test cases to validate default configuration values.

- Ensured proper handling of configuration values in tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.c</strong><dd><code>Update `max_info_queries_count` to use `uint64_t`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/configuration/config.c

<li>Changed <code>max_info_queries_count</code> type from <code>uint32_t</code> to <code>uint64_t</code>.<br> <li> Updated getter and setter functions to use <code>uint64_t</code>.<br> <li> Adjusted logic to handle the new data type.<br> <li> Removed unnecessary downcast comment in setter function.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/FalkorDB/pull/932/files#diff-2bf79e996b26b5e05a9cd8985e7f50ee97de9262292262f559cd6b5fca75c176">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_config.py</strong><dd><code>Add tests for default configuration values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/flow/test_config.py

<li>Added test cases to validate default configuration values.<br> <li> Checked correctness of <code>MAX_INFO_QUERIES</code> default value.<br> <li> Ensured all configurations are validated against expected defaults.<br> <li> Removed redundant blank line in existing test.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/FalkorDB/pull/932/files#diff-394685431beb79bf2492dcea8b46cc5d6c37c08bbd0bac0efaea70609bca9ce2">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration management by expanding the range of maximum query info elements.
	- Improved capacity for handling circular buffer limits in the logging system.

- **Bug Fixes**
	- Added detection for "stack-buffer-overflow" errors in AddressSanitizer logs to improve error reporting.

- **Tests**
	- Added validation for default configuration values to improve test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->