### PR TITLE
avoid value cloning when performing aggregations

### DIFF
--- a/src/arithmetic/aggregate_funcs/agg_collect.c
+++ b/src/arithmetic/aggregate_funcs/agg_collect.c
@@ -14,15 +14,34 @@
 // Collect
 //------------------------------------------------------------------------------
 
-AggregateResult AGG_COLLECT(SIValue *argv, int argc, void *private_data) {
+AggregateResult AGG_COLLECT
+(
+	SIValue *argv,
+	int argc,
+	void *private_data
+) {
 	AggregateCtx *ctx = private_data;
 
 	SIValue v = argv[0];
 	if(SI_TYPE(v) == T_NULL) return AGGREGATE_OK;
 
-	// SIArray_Append will clone the added value, ensuring it can be
-	// safely accessed for the lifetime of the Collect context.
-	SIArray_Append(&ctx->result, v);
+	// depending on the value's allocation type we'll entier
+	// add a clone of it to the array (SIArray_Append clones the value)
+	// or transfer owership of the value to the array
+	SIAllocation allocation = SI_ALLOCATION(argv);
+
+	switch(allocation) {
+		case M_NONE:
+		case M_CONST:
+		case M_VOLATILE:
+			// array will clone the value
+			SIArray_Append(&ctx->result, v);
+			break;
+		case M_SELF:
+			// array will take ownership over the value
+			SIArray_AppendAsOwner(&ctx->result, argv);
+			break;
+	}
 
 	return AGGREGATE_OK;
 }

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -748,6 +748,8 @@ SIValue AR_EXP_FinalizeAggregations
 	// RETURN a, SUM(a.value) / 2
 	// finalize the aggregation and eveluate the entire expression
 
+	// note that an aggregation function can not be nested within
+	// another aggregation function
 	if(AGGREGATION_NODE(root)) {
 		return _AR_EXP_FinalizeAggregation(root);
 	} else {

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -678,6 +678,24 @@ void AR_EXP_Aggregate(AR_ExpNode *root, const Record r) {
 	}
 }
 
+// finalize an aggregation node
+// returns the node's aggregated value
+static SIValue _AR_EXP_FinalizeAggregation
+(
+	AR_ExpNode *root  // aggregation node
+) {
+	ASSERT(AGGREGATION_NODE(root));
+
+	AggregateCtx *ctx = root->op.private_data;
+
+	Aggregate_Finalize(root->op.f, ctx);
+
+	SIValue v = Aggregate_GetResult(ctx);
+	ASSERT(SI_TYPE(v) & AR_FuncDesc_RetType(root->op.f));
+
+	return v;
+}
+
 void _AR_EXP_FinalizeAggregations
 (
 	AR_ExpNode *root
@@ -687,10 +705,7 @@ void _AR_EXP_FinalizeAggregations
 	//--------------------------------------------------------------------------
 
 	if(AGGREGATION_NODE(root)) {
-		AggregateCtx *ctx = root->op.private_data;
-		Aggregate_Finalize(root->op.f, ctx);
-		SIValue v = Aggregate_GetResult(ctx);
-		ASSERT(SI_TYPE(v) & AR_FuncDesc_RetType(root->op.f));
+		SIValue v = _AR_EXP_FinalizeAggregation(root);
 
 		// free node internals
 		_AR_EXP_FreeOpInternals(root);
@@ -723,8 +738,22 @@ SIValue AR_EXP_FinalizeAggregations
 ) {
 	ASSERT(root != NULL);
 
-	_AR_EXP_FinalizeAggregations(root);
-	return AR_EXP_Evaluate(root, r);
+	// incase root is an aggregation node
+	// e.g.
+	// RETURN a, SUM(a.value)
+	// simply return the aggregated value
+	//
+	// otherwise, root is not an aggregation node
+	// e.g.
+	// RETURN a, SUM(a.value) / 2
+	// finalize the aggregation and eveluate the entire expression
+
+	if(AGGREGATION_NODE(root)) {
+		return _AR_EXP_FinalizeAggregation(root);
+	} else {
+		_AR_EXP_FinalizeAggregations(root);
+		return AR_EXP_Evaluate(root, r);
+	}
 }
 
 void AR_EXP_CollectEntities(AR_ExpNode *root, rax *aliases) {

--- a/src/datatypes/array.c
+++ b/src/datatypes/array.c
@@ -43,16 +43,36 @@ SIValue SIArray_FromRaw
 	return siarray;
 }
 
-// appends a new SIValue to a given array
+// appends a new SIValue to array
+// the value is cloned before it is added to the array
 void SIArray_Append
 (
 	SIValue *siarray,  // pointer to array
-	SIValue value      // new value
+	SIValue value      // value to add
 ) {
+	ASSERT(siarray != NULL);
+
 	// clone and persist incase of pointer values
 	SIValue clone = SI_CloneValue(value);
-	// append
+
 	array_append(siarray->array, clone);
+}
+
+// appends value to array
+// the value is added as is, no cloning is performed
+// the array takes ownership over the value
+void SIArray_AppendAsOwner
+(
+	SIValue *siarray,  // pointer to array
+	SIValue *value     // value to add
+) {
+	ASSERT(value   != NULL);
+	ASSERT(siarray != NULL);
+	ASSERT(SI_ALLOCATION(value) == M_SELF);
+
+	// add value as is
+	array_append(siarray->array, *value);
+	SIValue_SetAllocationType(value, M_VOLATILE);
 }
 
 // returns a volatile copy of the SIValue from an array in a given index

--- a/src/datatypes/array.h
+++ b/src/datatypes/array.h
@@ -22,11 +22,21 @@ SIValue SIArray_FromRaw
 	SIValue **raw  // raw array
 );
 
-// appends a new SIValue to a given array
+// appends a new SIValue to array
+// the value is cloned before it is added to the array
 void SIArray_Append
 (
 	SIValue *siarray,  // pointer to array
-	SIValue value      // new value
+	SIValue value      // value to add
+);
+
+// appends value to array
+// the value is added as is, no cloning is performed
+// the array takes ownership over the value
+void SIArray_AppendAsOwner
+(
+	SIValue *siarray,  // pointer to array
+	SIValue *value     // value to add
 );
 
 // returns a volatile copy of the SIValue from an array in a given index

--- a/tests/flow/test_aggregation.py
+++ b/tests/flow/test_aggregation.py
@@ -239,3 +239,21 @@ class testAggregations():
         res = self.graph.query(q).result_set[0]
         self.env.assertEquals(res, expected)
 
+        # Collecting passed values
+        q = """
+        WITH [{a: 'Hello', b: [1, {x: 'y'}, 'GoodBye!']}, 4] AS collection
+        MATCH (p:Person)
+        WITH p, collection[ID(p) % 2] AS elem0, collect(collection[0]) AS collection
+        ORDER BY ID(p) ASC
+        WITH elem0, collection[0] AS collection
+        RETURN elem0, collection
+        """
+
+        res = self.graph.query(q).result_set
+        expected = [
+            [4, {'a': 'Hello', 'b': [1, {'x': 'y'}, 'GoodBye!']}],
+            [{'a': 'Hello', 'b': [1, {'x': 'y'}, 'GoodBye!']},
+             {'a': 'Hello', 'b': [1, {'x': 'y'}, 'GoodBye!']}]
+        ]
+
+        self.env.assertEquals(res, expected)


### PR DESCRIPTION
Resolves: #960

Differentiate between `SIArray_Append` which always clones the value and `SIArray_AppendAsOwner` which will take ownership over the value.

In addition, when finalizing aggregations avoid value cloning when possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved memory management and code organization for aggregation functions.
  - Introduced a new method for appending values to arrays without cloning, enhancing ownership semantics.

- **Tests**
  - Expanded test coverage to validate the behavior of the aggregation function across various data types and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->