### PR TITLE
string join on an empty list

### DIFF
--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -212,7 +212,12 @@ SIValue AR_SUBSTRING(SIValue *argv, int argc, void *private_data) {
 // given a list of strings and an optional delimiter
 // return a concatenation of all the strings using the given delimiter
 // string.join(list, delimiter = '') -> string
-SIValue AR_JOIN(SIValue *argv, int argc, void *private_data) {
+SIValue AR_JOIN
+(
+	SIValue *argv,
+	int argc,
+	void *private_data
+) {
 	SIValue list = argv[0];
 	if(SI_TYPE(list) == T_NULL) {
 		return SI_NullVal();
@@ -226,6 +231,11 @@ SIValue AR_JOIN(SIValue *argv, int argc, void *private_data) {
 	int str_len = 0;                           // output string length
 	uint32_t n = SIArray_Length(list);         // number of strings to join
 	size_t delimeter_len = strlen(delimiter);  // length of the delimiter
+
+	// empty list
+	if(unlikely(n) == 0) {
+		return SI_ConstStringVal("");
+	}
 
 	//--------------------------------------------------------------------------
 	// compute required string length

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2511,6 +2511,15 @@ class testFunctionCallsFlow(FlowTestsBase):
         except ResponseError as e:
             self.env.assertContains("String overflow", str(e))
 
+        # join empty list
+        queries = ["RETURN string.join([])",
+                   "RETURN string.join([], '|')"]
+
+        for q in queries:
+            actual_result = self.graph.query(q).result_set[0][0]
+            # expecting an empty string
+            self.env.assertEquals(actual_result, "")
+
     def test90_size(self):
         query_to_expected_result = {
             "RETURN size(NULL)" : [[None]],


### PR DESCRIPTION
Resolves: #963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for the string-joining function to return an empty string when an empty list is provided.
- **Tests**
	- Introduced additional test cases to confirm correct behavior of the string-joining function with empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->