### PR TITLE
maintain char case when splitting

### DIFF
--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -678,8 +678,14 @@ SIValue AR_REPLACE(SIValue *argv, int argc, void *private_data) {
 	return SI_TransferStringVal(buffer);
 }
 
-// returns a list of strings resulting from the splitting of the original string around matches of the given delimiter
-SIValue AR_SPLIT(SIValue *argv, int argc, void *private_data) {
+// returns a list of strings resulting from the splitting of the original string
+// around matches of the given delimiter
+SIValue AR_SPLIT
+(
+	SIValue *argv,
+	int argc,
+	void *private_data
+) {
 	if(SIValue_IsNull(argv[0]) || SIValue_IsNull(argv[1])) {
 		return SI_NullVal();
 	}
@@ -699,7 +705,7 @@ SIValue AR_SPLIT(SIValue *argv, int argc, void *private_data) {
 			const utf8proc_uint8_t *str_i = (const utf8proc_uint8_t *)str;
 			while(str_i[0] != 0) {
 				str_i += utf8proc_iterate(str_i, -1, &c);
-				int i  = utf8proc_encode_char(utf8proc_tolower(c), token);
+				int i  = utf8proc_encode_char(c, token);
 				token[i] = '\0';
 				SIArray_Append(&tokens, SI_ConstStringVal((const char *)token));
 			}

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -1127,6 +1127,8 @@ class testFunctionCallsFlow(FlowTestsBase):
             "RETURN split('aa', 'a')": [[["", "", ""]]],
             "RETURN split('', ',')": [[[""]]],
             "RETURN split('', '')": [[[""]]],
+            "RETURN split('aAbBcC', '')": [[['a', 'A', 'b', 'B', 'c', 'C']]],
+            "RETURN split('aAbBcC', 'B')": [[['aAb', 'cC']]],
             # test unicode charecters
             "RETURN split('丁丂七丄丅丆万丈三上', '丄')": [[["丁丂七", "丅丆万丈三上"]]],
             "RETURN split('丁丂七丅', '')": [[["丁", "丂", "七", "丅"]]],


### PR DESCRIPTION
Resolves: #1061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where splitting a string by an empty delimiter incorrectly converted characters to lowercase. Now, original character casing is preserved.

- **Tests**
	- Added tests to verify that splitting by an empty string preserves character case and that splitting by a specific character works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->