### PR TITLE
do not build iterator as part of the reset callback

### DIFF
--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -51,11 +51,8 @@ OpBase *NewNodeByLabelScanOp
 ) {
 	NodeByLabelScan *op = rm_calloc(sizeof(NodeByLabelScan), 1);
 
-	op->g      = QueryCtx_GetGraph();
-	op->n      = n;
-	op->ID_it  = NULL;
-	op->ids    = NULL;
-	op->ranges = NULL;
+	op->g = QueryCtx_GetGraph();
+	op->n = n;
 
 	_update_label_id(op);
 
@@ -358,8 +355,10 @@ static OpResult NodeByLabelScanReset
 ) {
 	NodeByLabelScan *op = (NodeByLabelScan *)ctx;
 
-	if(OpBase_ChildCount(ctx) > 0 && op->child_record != NULL) {
-		OpBase_DeleteRecord(&op->child_record); // free old record
+	if(OpBase_ChildCount(ctx) > 0) {
+		if(op->child_record != NULL) {
+			OpBase_DeleteRecord(&op->child_record); // free old record
+		}
 	} else {
 		_ConstructIterator(op);
 	}

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -243,3 +243,19 @@ class testNodeByIDFlow(FlowTestsBase):
             self.env.assertEquals(len(resultset), 0)    # Expecting no results.
             self.env.assertIn("Node By Label and ID Scan", str(self.graph.explain(query)))
 
+    def test_node_by_id_scan_reset(self):
+        # the following query used to crash due to wrong reset handeling by
+        # the op_node_by_label_scan operation
+
+        q = """UNWIND $pairs AS pair
+               UNWIND pair.feature_ids AS feature_id
+               MATCH (f:Feature), (n)
+               WHERE id(f) = feature_id AND id(n) = pair.node_id
+               RETURN 1"""
+
+        try:
+            res = self.graph.query(q, {'pairs': [{'node_id':1,'feature_ids':[2]}]}).result_set
+            self.env.assertEquals(len(res), 0)
+        except Exception as e:
+            self.env.assertFalse("query crashed")
+


### PR DESCRIPTION
Resolves: #1104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to ensure stability when executing complex queries involving node ID scans and nested operations.

- **Refactor**
  - Improved internal logic for resetting node label scans, enhancing code clarity without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->