### PR TITLE
1153 alpine image must be based on redis alpine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -584,3 +584,52 @@ jobs:
   #        project_id: ${{ secrets.GCP_PROJECT_ID }}
   #        zone: ${{ vars.GCP_ZONE }}
   #        instance_label: upgrade-tests-${{ github.run_id }}-${{ github.run_number }}
+
+  trivy:
+    needs: build
+    runs-on: ${{ matrix.platform.machine_label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux/amd64
+            suffix: x64
+            os: ubuntu
+            machine_label: ubuntu-latest
+          - name: linux/arm64
+            suffix: arm64v8
+            os: ubuntu
+            machine_label: ubuntu-24.04-arm
+          - name: linux/x86_64
+            suffix: alpine-x64
+            os: alpine
+            machine_label: ubuntu-latest
+          - name: linux/arm64
+            suffix: alpine-arm64v8
+            os: alpine
+            machine_label: ubuntu-24.04-arm
+    steps:
+      - name: Download image
+        uses: actions/download-artifact@v4
+        with:
+          name: falkordb-${{ matrix.platform.suffix }}
+          path: /tmp
+
+      - name: Load image
+        id: load_image
+        run: |
+          docker load --input /tmp/falkordb-${{ matrix.platform.suffix }}.tar
+      - name: Set up Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: falkordb/falkordb-${{ matrix.platform.suffix }}
+          severity: CRITICAL,HIGH
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+          scan-type: image
+          # ignore-policy: .github/trivy-ignore-policy.json
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=falkordb/falkordb-compiler-alpine
 
 FROM $BASE_IMAGE AS compiler
 
-FROM alpine:latest
+FROM redis:8.0.2-alpine
 
 ENV FALKORDB_HOME=/var/lib/falkordb
 
@@ -11,11 +11,6 @@ ENV FALKORDB_DATA_PATH=${FALKORDB_HOME}/data
 ENV FALKORDB_BIN_PATH=${FALKORDB_HOME}/bin
 
 ENV FALKORDB_IMPORT_PATH=${FALKORDB_HOME}/import
-
-# Install runtime dependencies if any (FalkorDB is a Redis module, so Redis is required)
-# You would typically install Redis here or use a Redis base image.
-# For simplicity, let's assume we're just copying the FalkorDB module.
-RUN apk add --no-cache redis
 
 # Install runtime dependencies
 RUN apk add --no-cache libgomp openssl


### PR DESCRIPTION
fix #1153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning for Docker images using Trivy, with results uploaded to the GitHub Security tab.
  * Updated the Alpine-based Docker image to use the official Redis Alpine image as the base, simplifying dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->