### PR TITLE
support backtick param name

### DIFF
--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -227,6 +227,21 @@ class testParams(FlowTestsBase):
             self.env.assertEqual(expected, actual)
             self.env.assertEqual(expected, raw)
 
+    def test_backtick_param_name(self):
+        queries = [("CYPHER `param`    = 1 RETURN $`param`",    1),
+                   ("CYPHER `.pa.ram.` = 1 RETURN $`.pa.ram.`", 1),
+                   ("CYPHER `pa\ram`   = 1 RETURN $`pa\ram`",   1),
+                   ("CYPHER `p~aram`   = 1 RETURN $`p~aram`",   1),
+
+                   ("CYPHER `p~aram` = 1 `x` = 2 RETURN $`p~aram` + $`x`", 3),
+                   ("CYPHER `p~aram` = 1 x = 2   RETURN $`p~aram` + $x",   3)
+                   ]
+
+        for q, expected in queries:
+            res = self.graph.query(q).result_set[0]
+            actual = res[0]
+            self.env.assertEqual(expected, actual)
+
     def test_invalid_param(self):
         invalid_queries = [
                 "CYPHER param=a RETURN $param",                            # 'a' is undefined
@@ -358,3 +373,4 @@ class testParams(FlowTestsBase):
         self._assert_resultset_equals_expected(self.graph.query(query, params), query_info)
         plan = str(self.graph.explain(query, params=params))
         self.env.assertIn('NodeByIdSeek', plan)
+


### PR DESCRIPTION
Resolves: #1179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using backticks to enclose parameter names and map keys, allowing special characters in identifiers.

* **Bug Fixes**
  * Improved handling and parsing of parameter names and map keys with special characters.

* **Tests**
  * Introduced new tests to verify correct parsing and usage of backtick-enclosed parameter names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->