### PR TITLE
Updated the README for minimum Redis version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The FalkorDB build system runs within docker. For detailed instructions on build
 ## LOADING FALKORDB INTO REDIS
 
 FalkorDB is hosted by [Redis](https://redis.io), so you'll first have to load it as a Module to a Redis server. 
-> Note: [Redis 6.2](https://redis.io/download) is required for FalkorDB 2.12.
+> Note: [Redis 7.4](https://redis.io/download) is required for the latest FalkorDB version.
 
 💡 We recommend having Redis load FalkorDB during startup by adding the following to your redis.conf file:
 


### PR DESCRIPTION
1. Minimum redis dependency in the README is inaccurate if using the latest or recent FalkorDB releases.
2. The build mentions throws an error with a suggestion to install redis 7.2, although if downloading from https://redis.io/downloads/ only versions 8.0, 7.4, 7.0 and 6.2 are available in the dropdown menu.
3.  The redis dependency note can be made generic such that the minimum required and easily available version of redis can be mentioned. Hence version 7.4

<img width="1452" height="854" alt="image" src="https://github.com/user-attachments/assets/0180fe93-46fd-42ac-8c36-b9c3c1ef9c23" />
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to specify Redis 7.4 as the required version for the latest FalkorDB release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->