### PR TITLE
do not hijack redis sigusr2 signal handler

### DIFF
--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -186,3 +186,4 @@ void CommandCtx_Free
 		rm_free(command_ctx);
 	}
 }
+

--- a/src/debug.c
+++ b/src/debug.c
@@ -13,33 +13,6 @@
 #include "util/thpool/pools.h"
 #include "commands/cmd_context.h"
 
-static struct sigaction old_act;
-
-static void startCrashReport(void) {
-	RedisModule_Log(NULL, "warning", "=== REDISGRAPH BUG REPORT START: ===");
-}
-
-static void endCrashReport(void) {
-	RedisModule_Log(NULL, "warning", "=== REDISGRAPH BUG REPORT END. ===");
-}
-
-static void logCommands(void) {
-	// #readers + #writers + Redis main thread
-	uint32_t n = ThreadPools_ThreadCount() + 1;
-	CommandCtx* commands[n];
-	Globals_GetCommandCtxs(commands, &n);
-
-	for(uint32_t i = 0; i < n; i++) {
-		CommandCtx *cmd = commands[i];
-		ASSERT(cmd != NULL);
-
-		RedisModule_Log(NULL, "warning", "%s %s", cmd->command_name,
-				cmd->query);
-
-		CommandCtx_Free(cmd);
-	}
-}
-
 void InfoFunc
 (
 	RedisModuleInfoCtx *ctx,
@@ -47,11 +20,6 @@ void InfoFunc
 ) {
 	// make sure information is requested for crash report
 	if(!for_crash_report) return;
-
-	// pause all working threads
-	// NOTE: pausing is not an atomic action;
-	// other threads can potentially change states before being interrupted.
-	ThreadPools_Pause();
 
 	// #readers + #writers + Redis main thread
 	uint32_t n = ThreadPools_ThreadCount() + 1;
@@ -74,57 +42,11 @@ void InfoFunc
 	}
 }
 
-void crashHandler
-(
-	int sig,
-	siginfo_t *info,
-	void *ucontext
-) {
-	// pause all working threads
-	// NOTE: pausing is an async operation
-	ThreadPools_Pause();
-
-	startCrashReport();
-
-	// log currently executing GRAPH commands
-	logCommands();
-
-	endCrashReport();
-
-	// call previous (Redis original) handler
-	(*old_act.sa_sigaction)(sig, info, ucontext);
-}
-
 void setupCrashHandlers
 (
 	RedisModuleCtx *ctx
 ) {
-	// if RedisModule_RegisterInfoFunc is available use it
-	// to report RedisGraph additional information in case of a crash
-	// otherwise overwrite Redis signal handler
-
-	// block SIGUSR2 in calling thread (redis main thread)
-	// we need to block SIGUSR2 signal as it is used to move a thread
-	// into a "pause" state (see: src/util/thpool/thpool.c) 
-	sigset_t set;
-	sigemptyset(&set);
-	sigaddset(&set, SIGUSR2);
-	pthread_sigmask(SIG_BLOCK, &set, NULL);
-
-	if(RedisModule_RegisterInfoFunc) {
-		int registered = RedisModule_RegisterInfoFunc(ctx, InfoFunc);
-		ASSERT(registered == REDISMODULE_OK);
-	} else {
-		// RegisterInfoFunc is not available, replace redis
-		// SIGSEGV signal handler
-
-		struct sigaction act;
-
-		sigemptyset(&act.sa_mask);
-		act.sa_flags = SA_NODEFER | SA_RESETHAND | SA_SIGINFO;
-		act.sa_sigaction = crashHandler;
-
-		sigaction(SIGSEGV, &act, &old_act);
-	}
+	int registered = RedisModule_RegisterInfoFunc(ctx, InfoFunc);
+	ASSERT(registered == REDISMODULE_OK);
 }
 

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -123,30 +123,6 @@ int ThreadPools_GetThreadID
 	return 0; // assuming Redis main thread
 }
 
-// pause all thread pools
-void ThreadPools_Pause
-(
-	void
-) {
-	ASSERT(_readers_thpool != NULL);
-	ASSERT(_writers_thpool != NULL);
-
-	thpool_pause(_readers_thpool);
-	thpool_pause(_writers_thpool);
-}
-
-void ThreadPools_Resume
-(
-	void
-) {
-
-	ASSERT(_readers_thpool != NULL);
-	ASSERT(_writers_thpool != NULL);
-
-	thpool_resume(_readers_thpool);
-	thpool_resume(_writers_thpool);
-}
-
 // adds a read task
 int ThreadPools_AddWorkReader
 (

--- a/src/util/thpool/pools.h
+++ b/src/util/thpool/pools.h
@@ -37,12 +37,6 @@ uint ThreadPools_ReadersCount(void);
 // N + 2..   writers
 int ThreadPools_GetThreadID(void);
 
-// pause all thread pools
-void ThreadPools_Pause(void);
-
-// resume all threads
-void ThreadPools_Resume(void);
-
 // adds a read task
 int ThreadPools_AddWorkReader
 (

--- a/src/util/thpool/thpool.c
+++ b/src/util/thpool/thpool.c
@@ -228,29 +228,6 @@ void thpool_destroy(thpool_* thpool_p) {
 	rm_free(thpool_p);
 }
 
-/* Pause all threads in threadpool */
-void thpool_pause(thpool_* thpool_p) {
-	int n;
-	pthread_t caller = pthread_self();
-
-	for(n = 0; n < thpool_p->num_threads_alive; n++) {
-		// do not pause caller
-		if(thpool_p->threads[n]->pthread != caller) {
-			pthread_kill(thpool_p->threads[n]->pthread, SIGUSR2);
-		}
-	}
-}
-
-/* Resume all threads in threadpool */
-void thpool_resume(thpool_* thpool_p) {
-	// resuming a single threadpool hasn't been
-	// implemented yet, meanwhile this supresses
-	// the warnings
-	(void)thpool_p;
-
-	threads_on_hold = 0;
-}
-
 int thpool_num_threads_working(thpool_* thpool_p) {
 	return thpool_p->num_threads_working;
 }
@@ -405,15 +382,6 @@ static void *thread_do(struct thread *thread_p) {
 
 	/* Assure all threads have been created before starting serving */
 	thpool_* thpool_p = thread_p->thpool_p;
-
-	/* Register signal handler */
-	struct sigaction act;
-	sigemptyset(&act.sa_mask);
-	act.sa_flags = 0;
-	act.sa_handler = thread_hold;
-	if(sigaction(SIGUSR2, &act, NULL) == -1) {
-		err("thread_do(): cannot handle SIGUSR1");
-	}
 
 	/* Mark thread as alive (initialized) */
 	++thpool_p->num_threads_alive;

--- a/src/util/thpool/thpool.h
+++ b/src/util/thpool/thpool.h
@@ -102,46 +102,6 @@ void thpool_wait(threadpool);
 
 
 /**
- * @brief Pauses all threads immediately
- *
- * The threads will be paused no matter if they are idle or working.
- * The threads return to their previous states once thpool_resume
- * is called.
- *
- * While the thread is being paused, new work can be added.
- *
- * @example
- *
- *    threadpool thpool = thpool_init(4);
- *    thpool_pause(thpool);
- *    ..
- *    // Add a bunch of work
- *    ..
- *    thpool_resume(thpool); // Let the threads start their magic
- *
- * @param threadpool    the threadpool where the threads should be paused
- * @return nothing
- */
-void thpool_pause(threadpool);
-
-
-/**
- * @brief Unpauses all threads if they are paused
- *
- * @example
- *    ..
- *    thpool_pause(thpool);
- *    sleep(10);              // Delay execution 10 seconds
- *    thpool_resume(thpool);
- *    ..
- *
- * @param threadpool     the threadpool where the threads should be unpaused
- * @return nothing
- */
-void thpool_resume(threadpool);
-
-
-/**
  * @brief Destroy the threadpool
  *
  * This will wait for the currently active threads to finish and then 'kill'


### PR DESCRIPTION
Resolves: #1055
We can't use `SIGUSR2` as we'll be overwriting Redis signal handler. as such we've decided to avoid using thread-pool pause and resume.