### PR TITLE
switch to mutex

### DIFF
--- a/src/string_pool/string_pool.c
+++ b/src/string_pool/string_pool.c
@@ -17,7 +17,6 @@
 
 struct OpaqueStringPool {
 	dict *ht;                  // hash table mapping string -> reference count
-	pthread_rwlock_t rwlock;   // read-write lock to protect hash table
 	pthread_mutex_t lock;      // mutex protecting access to hash table
 	uint64_t total_ref_count;  // total number of active references
 };
@@ -80,32 +79,14 @@ static const dictType _dictType = {
 
 // create a new StringPool
 StringPool StringPool_create(void) {
-	StringPool pool = rm_malloc(sizeof(struct OpaqueStringPool));
-	ASSERT(pool != NULL);
+	StringPool pool = rm_malloc (sizeof(struct OpaqueStringPool)) ;
+	ASSERT (pool != NULL) ;
 
-	pool->ht = HashTableCreate(&_dictType);
+	pool->ht = HashTableCreate (&_dictType) ;
 	pool->total_ref_count = 0;
 
-	// initialize read-write lock with writer preference if supported
-
-	pthread_rwlockattr_t attr;
-	int res = pthread_rwlockattr_init(&attr);
-	ASSERT(res == 0);
-
-#ifdef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
-	int pref = PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP;
-	res = pthread_rwlockattr_setkind_np(&attr, pref);
-	ASSERT(res == 0);
-#endif
-
-	res = pthread_rwlock_init(&pool->rwlock, &attr);
-	ASSERT(res == 0);
-
-	res = pthread_mutex_init (&pool->lock, NULL) ;
+	int res = pthread_mutex_init (&pool->lock, NULL) ;
 	ASSERT (res == 0) ;
-
-	res = pthread_rwlockattr_destroy(&attr);
-	ASSERT(res == 0);
 
 	return pool;
 }
@@ -142,11 +123,10 @@ char *StringPool_rent
 	dictEntry *de;
 	dict *ht = pool->ht;
 
-	// first, try to find the string under a read lock
-	//pthread_rwlock_rdlock(&pool->rwlock);
+	// first, try to find the string
 	pthread_mutex_lock (&pool->lock) ;
 
-	de = HashTableFind(ht, (void*)str);
+	de = HashTableFind (ht, (void*)str) ;
 
 	if(de != NULL) {
         // found existing entry - increment reference count atomically
@@ -154,37 +134,25 @@ char *StringPool_rent
         __atomic_fetch_add(count, 1, __ATOMIC_RELAXED);
         __atomic_fetch_add(&pool->total_ref_count, 1, __ATOMIC_RELAXED);
 
-        //pthread_rwlock_unlock(&pool->rwlock);
 		pthread_mutex_unlock (&pool->lock) ;
 
-        char *stored_str = (char*)HashTableGetKey(de);
+        char *stored_str = (char*)HashTableGetKey (de) ;
         return stored_str;
     }
-    // pthread_rwlock_unlock(&pool->rwlock);
 
-	// entry not found, insert under write lock
-	// pthread_rwlock_wrlock(&pool->rwlock);
-
-	// double-check: another thread might have inserted while we waited
 	dictEntry *existing = NULL;  // existing dict entry
-	de = HashTableAddRaw(ht, (void*)str, &existing);
+	de = HashTableAddRaw (ht, (void*)str, &existing) ;
+	ASSERT (de != NULL) ;
 
 	uint32_t *count = NULL;
-	if(de != NULL) {
-		// new entry: duplicate key and insert
-		HashTableSetKey(ht, de, rm_strdup(str));
-		// set initial ref-count to 1
-		count = (uint32_t*)HashTableEntryMetadata(de);
-		*count = 1;
-	} else {
-		// another thread inserted it before us
-		de = existing;
-		count = (uint32_t*)HashTableEntryMetadata(de);
-		__atomic_fetch_add(count, 1, __ATOMIC_RELAXED);
-	}
+	// new entry: duplicate key and insert
+	HashTableSetKey (ht, de, rm_strdup(str)) ;
 
-	// release write lock
-	//pthread_rwlock_unlock(&pool->rwlock);
+	// set initial ref-count to 1
+	count = (uint32_t*)HashTableEntryMetadata(de);
+	*count = 1;
+
+	// release lock
 	pthread_mutex_unlock (&pool->lock) ;
 
 	// update total reference count
@@ -212,56 +180,37 @@ void StringPool_return
 #endif
 {
 	// validate arguments
-	ASSERT(str != NULL);
+	ASSERT (str != NULL) ;
 
-	StringPool pool = Globals_Get_StringPool();
-	ASSERT(pool != NULL);
+	StringPool pool = Globals_Get_StringPool () ;
+	ASSERT (pool != NULL) ;
 
 	#ifdef DEBUG_STRINGPOOL
-	RedisModule_Log(NULL, "debug", "StringPool_return: \"%s\" from %s:%d\n",
-			str, file, line);
+	RedisModule_Log (NULL, "debug", "StringPool_return: \"%s\" from %s:%d\n",
+			str, file, line) ;
 	#endif
 
 	dictEntry *de;
 	dict *ht = pool->ht;
 
-	// access entry under read lock
+	// access entry
 	pthread_mutex_lock (&pool->lock) ;
-    //pthread_rwlock_rdlock(&pool->rwlock);
 
-	de = HashTableFind(ht, str);
+	de = HashTableFind (ht, str) ;
 	ASSERT(de != NULL);
-
-    //pthread_rwlock_unlock(&pool->rwlock);
-	pthread_mutex_unlock (&pool->lock) ;
 
 	// decrease reference count
 	uint32_t *count = (uint32_t*)HashTableEntryMetadata(de);
 	uint32_t old_count = __atomic_fetch_sub(count, 1, __ATOMIC_RELAXED);
 
 	// if this was the last reference, delete the entry
-	if(old_count == 1) {
-		// acquire write lock for potential deletion
-		// pthread_rwlock_wrlock(&pool->rwlock);
-		pthread_mutex_lock (&pool->lock) ;
-
-		// re-check under write lock in case another thread modified the count
-		de = HashTableFind(ht, str);
-		if(de != NULL) {
-			count = (uint32_t*)HashTableEntryMetadata(de);
-            if(*count == 0) {
-                // safe to delete
-                int res = HashTableDelete(ht, (const void *)str);
-                ASSERT(res == DICT_OK);
-            }
-			// if count != 0, another thread incremented it, so don't delete
-		}
-		// if de == NULL, another thread already deleted it
-
-		// release write lock
-		//pthread_rwlock_unlock(&pool->rwlock);
-		pthread_mutex_unlock (&pool->lock) ;
+	if (old_count == 1) {
+		int res = HashTableDelete (ht, (const void *)str) ;
+		ASSERT(res == DICT_OK);
 	}
+
+	// release lock
+	pthread_mutex_unlock (&pool->lock) ;
 
 	// update total reference count
 	__atomic_fetch_sub(&pool->total_ref_count, 1, __ATOMIC_RELAXED);
@@ -278,11 +227,9 @@ StringPoolStats StringPool_stats
 	uint64_t total_refs    = 0;
 	double   avg_ref_count = 0;
 
-	// get hash table entry count under read lock
-	//pthread_rwlock_rdlock(&pool->rwlock);
+	// get hash table entry count under lock
 	pthread_mutex_lock (&pool->lock) ;
-	n_entries = HashTableElemCount(pool->ht);
-	//pthread_rwlock_unlock(&pool->rwlock);
+	n_entries = HashTableElemCount (pool->ht) ;
 	pthread_mutex_unlock (&pool->lock) ;
 
 	if(n_entries > 0) {
@@ -308,15 +255,12 @@ void StringPool_free
 	StringPool p = *pool;
 
 	// free hashtable
-	HashTableRelease(p->ht);
+	HashTableRelease (p->ht) ;
 
-	int res = pthread_rwlock_destroy(&p->rwlock);
-	ASSERT(res == 0);
-
-	res = pthread_mutex_destroy (&p->lock) ;
+	int res = pthread_mutex_destroy (&p->lock) ;
 	ASSERT (res == 0) ;
 
-	rm_free(*pool);
+	rm_free (*pool) ;
 	*pool = NULL;
 }
 


### PR DESCRIPTION
Resolves: #1195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated synchronization mechanism in the string pool to use a mutex lock instead of a read-write lock for managing concurrent access.
  * Improved consistency and reliability in accessing and modifying shared data within the string pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->