### PR TITLE
Add RHEL8 platform support to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,14 @@ jobs:
             build_test_image: false
             cache_path: linux-x64
             is_debug: "0"
+          - name: rhel8/amd64
+            platform: linux/amd64
+            suffix: rhel8-x64
+            os: rhel8
+            machine_label: ${{ format('rhel-build-{0}-{1}', github.run_id, github.run_number) }}
+            build_test_image: false
+            cache_path: linux-x64
+            is_debug: "0"
           - name: linux/amd64
             platform: linux/amd64
             suffix: x64
@@ -130,6 +138,14 @@ jobs:
             platform: linux/amd64
             suffix: rhel-x64
             os: rhel
+            machine_label: ${{ format('rhel-build-{0}-{1}', github.run_id, github.run_number) }}
+            build_test_image: false
+            cache_path: linux-x64
+            is_debug: "1"
+          - name: rhel8/amd64
+            platform: linux/amd64
+            suffix: rhel8-x64
+            os: rhel8
             machine_label: ${{ format('rhel-build-{0}-{1}', github.run_id, github.run_number) }}
             build_test_image: false
             cache_path: linux-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,11 +443,9 @@ jobs:
 
       - name: Unit tests
         run: |
-          did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests)
-          docker wait $did
-          docker cp $did:/FalkorDB/tests/unit/logs /tmp/logs
-          docker rm $did
-      
+          mkdir -p /tmp/logs
+          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/unit/logs falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+
       - name: Upload unit test logs
         uses: actions/upload-artifact@v4
         with:
@@ -491,11 +489,8 @@ jobs:
 
       - name: Flow tests
         run: |
-          did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests)
-          docker wait $did
-          docker cp $did:/FalkorDB/tests/flow/logs /tmp/logs
-          docker rm $did
-      
+          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/flow/logs falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+
       - name: Upload flow test logs
         uses: actions/upload-artifact@v4
         with:
@@ -540,10 +535,8 @@ jobs:
 
       - name: TCK tests
         run: |
-          did=$(docker run falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests)
-          docker wait $did
-          docker cp $did:/FalkorDB/tests/tck/logs /tmp/logs
-          docker rm $did
+          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/tck/logs falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+
       - name: Upload TCK test logs
         uses: actions/upload-artifact@v4
         with:
@@ -587,10 +580,8 @@ jobs:
 
       - name: Fuzz tests
         run: |
-          did=$(docker run falkordb/falkordb-tests make fuzz TIMEOUT=180)
-          docker wait $did
-          docker cp $did:/FalkorDB/tests/fuzz/logs /tmp/logs
-          docker rm $did
+          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/fuzz/logs falkordb/falkordb-tests make fuzz TIMEOUT=180
+          
       - name: Upload fuzz test logs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,7 +449,7 @@ jobs:
       - name: Unit tests
         run: |
           mkdir -p /tmp/logs
-          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/unit/logs falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+          docker run --rm -i -v /tmp/logs:/FalkorDB/tests/unit/logs falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
 
       - name: Upload unit test logs
         uses: actions/upload-artifact@v4
@@ -495,7 +495,7 @@ jobs:
       - name: Flow tests
         run: |
           mkdir -p /tmp/logs
-          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/flow/logs falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+          docker run --rm -i -v /tmp/logs:/FalkorDB/tests/flow/logs falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
 
       - name: Upload flow test logs
         uses: actions/upload-artifact@v4
@@ -542,7 +542,7 @@ jobs:
       - name: TCK tests
         run: |
           mkdir -p /tmp/logs
-          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/tck/logs falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+          docker run --rm -i -v /tmp/logs:/FalkorDB/tests/tck/logs falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
 
       - name: Upload TCK test logs
         uses: actions/upload-artifact@v4
@@ -588,7 +588,7 @@ jobs:
       - name: Fuzz tests
         run: |
           mkdir -p /tmp/logs
-          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/fuzz/logs falkordb/falkordb-tests make fuzz TIMEOUT=180
+          docker run --rm -i -v /tmp/logs:/FalkorDB/tests/fuzz/logs falkordb/falkordb-tests make fuzz TIMEOUT=180
 
       - name: Upload fuzz test logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,7 +444,7 @@ jobs:
       - name: Unit tests
         run: |
           mkdir -p /tmp/logs
-          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/unit/logs falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/unit/logs falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
 
       - name: Upload unit test logs
         uses: actions/upload-artifact@v4
@@ -489,7 +489,8 @@ jobs:
 
       - name: Flow tests
         run: |
-          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/flow/logs falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+          mkdir -p /tmp/logs
+          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/flow/logs falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
 
       - name: Upload flow test logs
         uses: actions/upload-artifact@v4
@@ -535,7 +536,8 @@ jobs:
 
       - name: TCK tests
         run: |
-          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/tck/logs falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+          mkdir -p /tmp/logs
+          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/tck/logs falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
 
       - name: Upload TCK test logs
         uses: actions/upload-artifact@v4
@@ -580,8 +582,9 @@ jobs:
 
       - name: Fuzz tests
         run: |
-          docker run --rm -it -v ${{ github.workspace }}/tmp/logs:/FalkorDB/tests/fuzz/logs falkordb/falkordb-tests make fuzz TIMEOUT=180
-          
+          mkdir -p /tmp/logs
+          docker run --rm -it -v /tmp/logs:/FalkorDB/tests/fuzz/logs falkordb/falkordb-tests make fuzz TIMEOUT=180
+
       - name: Upload fuzz test logs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,10 @@ jobs:
         with:
           # network=host driver-opt needed to push to local registry
           driver-opts: network=host
+      
+      - name: Ignore Errors if os is rhel8
+        if: ${{ matrix.platform.os == 'rhel8' }}
+        run: sed -i 's/-Werror//g' /FalkorDB/deps/RediSearch/deps/VectorSimilarity/src/VecSim/CMakeLists.txt
 
       - name: Build compiler image
         id: build_compiler
@@ -478,7 +482,16 @@ jobs:
 
       - name: Flow tests
         run: |
-          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests
+          did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests)
+          docker wait $did
+          docker cp $did:/logs /logs
+      
+      - name: Upload flow test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-test-logs-${{ matrix.platform.suffix }}
+          path: /logs
+
 
   tck-tests:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
             runner_label: rhel-build-${{ github.run_id }}-${{ github.run_number }}
             arm: false
             image: projects/rhel-cloud/global/images/rhel-9-v20241210
+          - name: rhel8-build
+            machine_type: e2-standard-4
+            runner_label: rhel8-build-${{ github.run_id }}-${{ github.run_number }}
+            arm: false
+            image: projects/rhel-cloud/global/images/rhel-9-v20241210
     runs-on: ubuntu-latest
     steps:
       - name: Create runners
@@ -112,7 +117,7 @@ jobs:
             platform: linux/amd64
             suffix: rhel8-x64
             os: rhel8
-            machine_label: ${{ format('rhel-build-{0}-{1}', github.run_id, github.run_number) }}
+            machine_label: ${{ format('rhel8-build-{0}-{1}', github.run_id, github.run_number) }}
             build_test_image: false
             cache_path: linux-x64
             is_debug: "0"
@@ -146,7 +151,7 @@ jobs:
             platform: linux/amd64
             suffix: rhel8-x64
             os: rhel8
-            machine_label: ${{ format('rhel-build-{0}-{1}', github.run_id, github.run_number) }}
+            machine_label: ${{ format('rhel8-build-{0}-{1}', github.run_id, github.run_number) }}
             build_test_image: false
             cache_path: linux-x64
             is_debug: "1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -484,7 +484,8 @@ jobs:
         run: |
           did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests)
           docker wait $did
-          docker cp $did:/logs /logs
+          docker cp $did:/FalkorDB/logs /logs || docker cp $did:/FalkorDB/tests/flow/logs /logs
+          docker rm $did
       
       - name: Upload flow test logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -483,15 +483,17 @@ jobs:
       - name: Flow tests
         run: |
           did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests)
+          path=$(docker exec -it $did find /FalkorDB -type d -name logs)
+          echo "Logs path: $path"
           docker wait $did
-          docker cp $did:/FalkorDB/logs /logs || docker cp $did:/FalkorDB/tests/flow/logs /logs
+          docker cp $did:$path /tmp/logs
           docker rm $did
       
       - name: Upload flow test logs
         uses: actions/upload-artifact@v4
         with:
           name: flow-test-logs-${{ matrix.platform.suffix }}
-          path: /logs
+          path: /tmp/logs
 
 
   tck-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,7 +443,16 @@ jobs:
 
       - name: Unit tests
         run: |
-          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests
+          did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 unit-tests)
+          docker wait $did
+          docker cp $did:/FalkorDB/tests/unit/logs /tmp/logs
+          docker rm $did
+      
+      - name: Upload unit test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-logs-${{ matrix.platform.suffix }}
+          path: /tmp/logs
 
   flow-tests:
     needs: build
@@ -483,10 +492,8 @@ jobs:
       - name: Flow tests
         run: |
           did=$(docker run -d falkordb/falkordb-tests make CLEAR_LOGS=0 PARALLEL=1 flow-tests)
-          path=$(docker exec -it $did find /FalkorDB -type d -name logs)
-          echo "Logs path: $path"
           docker wait $did
-          docker cp $did:$path /tmp/logs
+          docker cp $did:/FalkorDB/tests/flow/logs /tmp/logs
           docker rm $did
       
       - name: Upload flow test logs
@@ -533,7 +540,15 @@ jobs:
 
       - name: TCK tests
         run: |
-          docker run -i --rm falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests
+          did=$(docker run falkordb/falkordb-tests make CLEAR_LOGS=0 tck-tests)
+          docker wait $did
+          docker cp $did:/FalkorDB/tests/tck/logs /tmp/logs
+          docker rm $did
+      - name: Upload TCK test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: tck-test-logs-${{ matrix.platform.suffix }}
+          path: /tmp/logs
 
   fuzz-tests:
     needs: build
@@ -572,7 +587,15 @@ jobs:
 
       - name: Fuzz tests
         run: |
-          docker run -i --rm falkordb/falkordb-tests make fuzz TIMEOUT=180
+          did=$(docker run falkordb/falkordb-tests make fuzz TIMEOUT=180)
+          docker wait $did
+          docker cp $did:/FalkorDB/tests/fuzz/logs /tmp/logs
+          docker rm $did
+      - name: Upload fuzz test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-test-logs-${{ matrix.platform.suffix }}
+          path: /tmp/logs
 
   #upgrade-tests:
   #  needs: build

--- a/build/docker/Dockerfile.compiler_alpine
+++ b/build/docker/Dockerfile.compiler_alpine
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
     cmake \
     rust \
     cargo \
+    git \
     build-base # Essential for compiling C/C++ projects
 
 # Activate pyenv


### PR DESCRIPTION
fix #1224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added official RHEL 8 (x86_64) CI build variant for Release and Debug.

* **Bug Fixes / Compatibility**
  * Disabled strict -Werror enforcement on RHEL 8 builds to avoid platform-specific failures.

* **Tests**
  * Tests now write logs to host paths per platform and automatically upload unit, flow, TCK, and fuzz test logs for inspection.

* **Chores**
  * Added git to the Alpine builder image to support build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->