### PR TITLE
cron test simple timer

### DIFF
--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -998,7 +998,7 @@ class testConstraintReplication():
         self.monitor = []
         self.g = self.db.select_graph(GRAPH_ID)
 
-        self.monitor_thread = threading.Thread(target=self.monitor_thread)
+        self.monitor_thread = threading.Thread(target=self.monitor_thread, daemon=True)
         self.monitor_thread.start()
 
         # wait for monitor thread to attach


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced clock()-based timing in cron unit tests with a precise internal timer API, removing time.h dependency and keeping existing abort timing thresholds.
  * Made a replication monitor thread a daemon in constraint flow tests to adjust thread lifecycle and improve test stability.
  * No changes to public APIs; only test reliability and CI flakiness improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->