### PR TITLE
use calloc to allocate operations

### DIFF
--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -224,11 +224,9 @@ OpBase *NewAggregateOp
 	const ExecutionPlan *plan,
 	AR_ExpNode **exps
 ) {
-	OpAggregate *op = rm_malloc(sizeof(OpAggregate));
+	OpAggregate *op = rm_calloc (1, sizeof(OpAggregate)) ;
 
-	op->groups               = HashTableCreate(&_dt);
-	op->group_iter           = NULL;
-	op->r 				     = NULL;
+	op->groups = HashTableCreate(&_dt);
 
 	OpBase_Init((OpBase *)op, OPType_AGGREGATE, "Aggregate", NULL,
 			AggregateConsume, AggregateReset, NULL, AggregateClone,

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -25,11 +25,9 @@ OpBase *NewAllNodeScanOp
 	const ExecutionPlan *plan,
 	const char *alias
 ) {
-	AllNodeScan *op = rm_malloc(sizeof(AllNodeScan));
+	AllNodeScan *op = rm_calloc (1, sizeof(AllNodeScan)) ;
 
-	op->iter         = NULL;
-	op->alias        = alias;
-	op->child_record = NULL;
+	op->alias = alias;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_ALL_NODE_SCAN, "All Node Scan",

--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -18,13 +18,9 @@ OpBase *NewApplyOp
 (
 	const ExecutionPlan *plan
 ) {
-	OpApply *op = rm_malloc(sizeof(OpApply));
+	OpApply *op = rm_calloc (1, sizeof(OpApply)) ;
 
-	op->r            = NULL;
-	op->op_arg       = NULL;
-	op->rhs_branch   = NULL;
-	op->bound_branch = NULL;
-	op->rhs_args     = array_new(OpArgument*, 1);
+	op->rhs_args = array_new(OpArgument*, 1);
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_APPLY, "Apply", ApplyInit, ApplyConsume,

--- a/src/execution_plan/ops/op_argument_list.c
+++ b/src/execution_plan/ops/op_argument_list.c
@@ -18,9 +18,7 @@ OpBase *NewArgumentListOp
 	const ExecutionPlan *plan,
 	const char **variables
 ) {
-	ArgumentList *op = rm_malloc(sizeof(ArgumentList));
-	op->records = NULL;
-	op->rec_len = 0;
+	ArgumentList *op = rm_calloc (1, sizeof(ArgumentList)) ;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_ARGUMENT_LIST, "Argument List", NULL,

--- a/src/execution_plan/ops/op_call_subquery.c
+++ b/src/execution_plan/ops/op_call_subquery.c
@@ -72,7 +72,7 @@ OpBase *NewCallSubqueryOp
 	bool is_eager,              // is the subquery eager or not
 	bool is_returning           // is the subquery returning or not
 ) {
-	OpCallSubquery *op = rm_calloc(1, sizeof(OpCallSubquery));
+	OpCallSubquery *op = rm_calloc (1, sizeof(OpCallSubquery)) ;
 
 	op->first        = true;
 	op->is_eager     = is_eager;

--- a/src/execution_plan/ops/op_cartesian_product.c
+++ b/src/execution_plan/ops/op_cartesian_product.c
@@ -18,10 +18,9 @@ OpBase *NewCartesianProductOp
 (
 	const ExecutionPlan *plan
 ) {
-	CartesianProduct *op = rm_malloc(sizeof(CartesianProduct));
+	CartesianProduct *op = rm_calloc (1, sizeof(CartesianProduct)) ;
 
-	op->init    = true;
-	op->records = NULL;
+	op->init = true;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CARTESIAN_PRODUCT, "Cartesian Product",

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -120,18 +120,11 @@ OpBase *NewCondVarLenTraverseOp
 	ASSERT(g  != NULL);
 	ASSERT(ae != NULL);
 
-	CondVarLenTraverse *op = rm_malloc(sizeof(CondVarLenTraverse));
+	CondVarLenTraverse *op = rm_calloc (1, sizeof(CondVarLenTraverse)) ;
 
-	op->g                 = g;
-	op->r                 = NULL;
-	op->M                 = NULL;
-	op->ae                = ae;
-	op->ft                = NULL;
-	op->expandInto        = false;
-	op->allPathsCtx       = NULL;
-	op->collect_paths     = true;
-	op->allNeighborsCtx   = NULL;
-	op->edgeRelationTypes = NULL;
+	op->g             = g;
+	op->ae            = ae;
+	op->collect_paths = true;
 
 	OpBase_Init((OpBase *)op, OPType_CONDITIONAL_VAR_LEN_TRAVERSE,
 				"Conditional Variable Length Traverse", CondVarLenTraverseInit,

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -92,7 +92,7 @@ OpBase *NewCondTraverseOp
 	Graph *g,
 	AlgebraicExpression *ae
 ) {
-	OpCondTraverse *op = rm_calloc(sizeof(OpCondTraverse), 1);
+	OpCondTraverse *op = rm_calloc (1, sizeof(OpCondTraverse)) ;
 
 	op->ae         = ae;
 	op->graph      = g;

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -23,9 +23,6 @@ OpBase *NewCreateOp
 ) {
 	OpCreate *op = rm_calloc(1, sizeof(OpCreate));
 
-	op->rec_idx  = 0;
-	op->records  = NULL;
-
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CREATE, "Create", NULL, CreateConsume,
 				NULL, NULL, CreateClone, CreateFree, true, plan);

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -139,7 +139,6 @@ OpBase *NewDeleteOp
 
 	op->gc            = QueryCtx_GetGraphCtx();
 	op->exps          = exps;
-	op->rec_idx       = 0;
 	op->exp_count     = array_len(exps);
 	op->deleted_nodes = array_new(Node, 32);
 	op->deleted_edges = array_new(Edge, 32);

--- a/src/execution_plan/ops/op_distinct.c
+++ b/src/execution_plan/ops/op_distinct.c
@@ -68,10 +68,9 @@ OpBase *NewDistinctOp
 	ASSERT(aliases != NULL);
 	ASSERT(alias_count > 0);
 
-	OpDistinct *op = rm_malloc(sizeof(OpDistinct));
+	OpDistinct *op = rm_calloc (1, sizeof(OpDistinct)) ;
 
 	op->found        = HashTableCreate(&def_dt);
-	op->mapping      = NULL;
 	op->aliases      = rm_malloc(alias_count * sizeof(const char *));
 	op->offset_count = alias_count;
 	op->offsets      = rm_calloc(op->offset_count, sizeof(uint));

--- a/src/execution_plan/ops/op_edge_by_index_scan.c
+++ b/src/execution_plan/ops/op_edge_by_index_scan.c
@@ -48,17 +48,11 @@ OpBase *NewEdgeIndexScanOp
 	ASSERT(QGEdge_Alias(e)         != NULL);
 	ASSERT(QGEdge_RelationCount(e) == 1);
 
-	OpEdgeIndexScan *op      =  rm_malloc(sizeof(OpEdgeIndexScan));
-	op->g                    =  g;
-	op->idx                  =  idx;
-	op->edge                 =  e;
-	op->iter                 =  NULL;
-	op->filter               =  filter;
-	op->child_record         =  NULL;
-	op->current_src_node_id  =  NULL;
-	op->current_dest_node_id =  NULL;
-	op->unresolved_filters   =  NULL;
-	op->rebuild_index_query  =  false;
+	OpEdgeIndexScan *op = rm_calloc (1, sizeof(OpEdgeIndexScan)) ;
+	op->g               = g;
+	op->idx             = idx;
+	op->edge            = e;
+	op->filter          = filter;
 
 	// set our Op operations
 	OpBase_Init(

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -93,18 +93,11 @@ OpBase *NewExpandIntoOp
 	Graph *g,
 	AlgebraicExpression *ae
 ) {
-	OpExpandInto *op = rm_malloc(sizeof(OpExpandInto));
+	OpExpandInto *op = rm_calloc (1, sizeof(OpExpandInto)) ;
 
-	op->r              = NULL;
-	op->F              = NULL;
-	op->M              = NULL;
-	op->ae             = ae;
-	op->graph          = g;
-	op->records        = NULL;
-	op->edge_ctx       = NULL;
-	op->record_cap     = BATCH_SIZE;
-	op->record_count   = 0;
-	op->single_operand = false;
+	op->ae         = ae;
+	op->graph      = g;
+	op->record_cap = BATCH_SIZE;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_EXPAND_INTO, "Expand Into", ExpandIntoInit,

--- a/src/execution_plan/ops/op_filter.c
+++ b/src/execution_plan/ops/op_filter.c
@@ -17,7 +17,7 @@ OpBase *NewFilterOp
 	const ExecutionPlan *plan,
 	FT_FilterNode *filterTree
 ) {
-	OpFilter *op = rm_malloc(sizeof(OpFilter));
+	OpFilter *op = rm_calloc (1, sizeof(OpFilter)) ;
 	op->filterTree = filterTree;
 
 	// Set our Op operations

--- a/src/execution_plan/ops/op_foreach.c
+++ b/src/execution_plan/ops/op_foreach.c
@@ -20,13 +20,7 @@ OpBase *NewForeachOp
 ) {
     OpForeach *op = rm_calloc(1, sizeof(OpForeach));
 
-	op->body           = NULL;
-	op->first          = true;
-	op->rec_idx        = 0;
-	op->records        = NULL;
-	op->supplier       = NULL;
-	op->body_records   = NULL;
-	op->argument_list  = NULL;
+	op->first = true;
 
     OpBase_Init((OpBase *)op, OPType_FOREACH, "Foreach", ForeachInit,
 			ForeachConsume, ForeachReset, NULL, ForeachClone, ForeachFree,

--- a/src/execution_plan/ops/op_join.c
+++ b/src/execution_plan/ops/op_join.c
@@ -15,8 +15,7 @@ static OpBase *JoinClone(const ExecutionPlan *plan, const OpBase *opBase);
 static OpResult JoinReset(OpBase *opBase);
 
 OpBase *NewJoinOp(const ExecutionPlan *plan) {
-	OpJoin *op = rm_malloc(sizeof(OpJoin));
-	op->stream = NULL;
+	OpJoin *op = rm_calloc (1, sizeof(OpJoin)) ;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_JOIN, "Join", JoinInit, JoinConsume, 

--- a/src/execution_plan/ops/op_limit.c
+++ b/src/execution_plan/ops/op_limit.c
@@ -51,11 +51,7 @@ OpBase *NewLimitOp
 	ASSERT(plan      != NULL);
 	ASSERT(limit_exp != NULL);
 
-	OpLimit *op = rm_malloc(sizeof(OpLimit));
-
-	op->limit     = 0;
-	op->consumed  = 0;
-	op->limit_exp = NULL;
+	OpLimit *op = rm_calloc (1, sizeof(OpLimit)) ;
 
 	_eval_limit(op, limit_exp);
 

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -128,11 +128,8 @@ OpBase *NewMergeOp
 	// (see CartesianProduct and ValueHashJoin)
 	OpMerge *op = rm_calloc(1, sizeof(OpMerge));
 
-	op->on_match             = on_match;
-	op->on_create            = on_create;
-	op->output_rec_idx       = 0;
-	op->node_pending_updates = NULL;
-	op->edge_pending_updates = NULL;
+	op->on_match  = on_match;
+	op->on_create = on_create;
 	
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_MERGE, "Merge", MergeInit, MergeConsume,

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -83,7 +83,6 @@ OpBase *NewMergeCreateOp
 
 	op->records         = array_new(Record, 32);  // accumulated records
 	op->hash_state      = XXH64_createState();    // create a hash state
-	op->handoff_mode    = false;                  // consume mode
 	op->unique_entities = raxNew();               // create a map to unique pending creations
 
 	// insert one NULL value to terminate execution of the op

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -33,14 +33,11 @@ OpBase *NewNodeByIdSeekOp
 	const char *alias,          // node alias
 	RangeExpression *ranges     // ID range expressions
 ) {
-	NodeByIdSeek *op = rm_malloc(sizeof(NodeByIdSeek));
+	NodeByIdSeek *op = rm_calloc (1, sizeof(NodeByIdSeek)) ;
 
 	op->g = QueryCtx_GetGraph();
-	op->it           = NULL;
-	op->ids          = NULL;
-	op->alias        = alias;
-	op->ranges       = ranges;
-	op->child_record = NULL;
+	op->alias  = alias;
+	op->ranges = ranges;
 
 	OpBase_Init((OpBase *)op, OPType_NODE_BY_ID_SEEK, "NodeByIdSeek",
 			NodeByIdSeekInit, NodeByIdSeekConsume, NodeByIdSeekReset,

--- a/src/execution_plan/ops/op_node_by_index_scan.c
+++ b/src/execution_plan/ops/op_node_by_index_scan.c
@@ -35,15 +35,11 @@ OpBase *NewIndexScanOp
 	ASSERT(plan   != NULL);
 	ASSERT(filter != NULL);
 
-	IndexScan *op = rm_malloc(sizeof(IndexScan));
-	op->g                   = g;
-	op->n                   = n;
-	op->idx                 = idx;
-	op->iter                = NULL;
-	op->filter              = filter;
-	op->child_record        = NULL;
-	op->unresolved_filters  = NULL;
-	op->rebuild_index_query = false;
+	IndexScan *op = rm_calloc (1, sizeof(IndexScan)) ;
+	op->g      = g;
+	op->n      = n;
+	op->idx    = idx;
+	op->filter = filter;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_NODE_BY_INDEX_SCAN, "Node By Index Scan", IndexScanInit, IndexScanConsume,

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -49,7 +49,7 @@ OpBase *NewNodeByLabelScanOp
 	const ExecutionPlan *plan,
 	NodeScanCtx *n
 ) {
-	NodeByLabelScan *op = rm_calloc(sizeof(NodeByLabelScan), 1);
+	NodeByLabelScan *op = rm_calloc (1, sizeof(NodeByLabelScan)) ;
 
 	op->g = QueryCtx_GetGraph();
 	op->n = n;

--- a/src/execution_plan/ops/op_optional.c
+++ b/src/execution_plan/ops/op_optional.c
@@ -12,8 +12,7 @@ static OpResult OptionalReset(OpBase *opBase);
 static OpBase *OptionalClone(const ExecutionPlan *plan, const OpBase *opBase);
 
 OpBase *NewOptionalOp(const ExecutionPlan *plan) {
-	Optional *op = rm_malloc(sizeof(Optional));
-	op->emitted_record = false;
+	Optional *op = rm_calloc (1, sizeof(Optional)) ;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_OPTIONAL, "Optional", NULL, OptionalConsume,

--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -61,14 +61,12 @@ OpBase *NewProcCallOp
 	ASSERT(arg_exps   != NULL);
 	ASSERT(yield_exps != NULL);
 
-	OpProcCall *op = rm_malloc(sizeof(OpProcCall));
+	OpProcCall *op = rm_calloc (1, sizeof(OpProcCall)) ;
 
-	op->r          = NULL;
 	op->args       = array_new(SIValue, array_len(arg_exps));
 	op->arg_exps   = arg_exps;
 	op->arg_count  = array_len(arg_exps);
 	op->proc_name  = proc_name;
-	op->yield_map  = NULL;
 	op->first_call = true;
 	op->yield_exps = yield_exps;
 

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -22,14 +22,11 @@ OpBase *NewProjectOp
 	const ExecutionPlan *plan,
 	AR_ExpNode **exps
 ) {
-	OpProject *op = rm_malloc(sizeof(OpProject));
+	OpProject *op = rm_calloc (1, sizeof(OpProject)) ;
 
-	op->r              = NULL;
 	op->exps           = exps;
 	op->exp_count      = array_len(exps);
-	op->projection     = NULL;
 	op->record_offsets = array_new(uint, op->exp_count);
-	op->singleResponse = false;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_PROJECT, "Project", NULL, ProjectConsume,

--- a/src/execution_plan/ops/op_results.c
+++ b/src/execution_plan/ops/op_results.c
@@ -19,7 +19,7 @@ static OpResult ResultsInit(OpBase *opBase);
 static OpBase *ResultsClone(const ExecutionPlan *plan, const OpBase *opBase);
 
 OpBase *NewResultsOp(const ExecutionPlan *plan) {
-	Results *op = rm_malloc(sizeof(Results));
+	Results *op = rm_calloc (1, sizeof(Results)) ;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_RESULTS, "Results", ResultsInit, ResultsConsume,

--- a/src/execution_plan/ops/op_semi_apply.c
+++ b/src/execution_plan/ops/op_semi_apply.c
@@ -28,12 +28,7 @@ OpBase *NewSemiApplyOp
 	const ExecutionPlan *plan,
 	bool anti
 ) {
-	OpSemiApply *op = rm_malloc(sizeof(OpSemiApply));
-
-	op->r            = NULL;
-	op->op_arg       = NULL;
-	op->bound_branch = NULL;
-	op->match_branch = NULL;
+	OpSemiApply *op = rm_calloc (1, sizeof(OpSemiApply)) ;
 
 	// set our Op operations
 	if(anti) {

--- a/src/execution_plan/ops/op_skip.c
+++ b/src/execution_plan/ops/op_skip.c
@@ -46,11 +46,7 @@ OpBase *NewSkipOp
 	const ExecutionPlan *plan,
 	AR_ExpNode *skip_exp
 ) {
-	OpSkip *op = rm_malloc(sizeof(OpSkip));
-
-	op->skip     = 0;
-	op->skipped  = 0;
-	op->skip_exp = NULL;
+	OpSkip *op = rm_calloc (1, sizeof(OpSkip)) ;
 
 	_eval_skip(op, skip_exp);
 

--- a/src/execution_plan/ops/op_sort.c
+++ b/src/execution_plan/ops/op_sort.c
@@ -91,17 +91,12 @@ OpBase *NewSortOp
 	AR_ExpNode **exps,
 	int *directions
 ) {
-	OpSort *op = rm_malloc(sizeof(OpSort));
+	OpSort *op = rm_calloc (1, sizeof(OpSort)) ;
 
-	op->exps           = exps;
-	op->heap           = NULL;
-	op->skip           = 0;
-	op->first          = true;
-	op->limit          = UNLIMITED;
-	op->buffer         = NULL;
-	op->record_idx     = 0;
-	op->directions     = directions;
-	op->record_offsets = NULL;
+	op->exps       = exps;
+	op->first      = true;
+	op->limit      = UNLIMITED;
+	op->directions = directions;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_SORT, "Sort", SortInit, SortConsume,

--- a/src/execution_plan/ops/op_unwind.c
+++ b/src/execution_plan/ops/op_unwind.c
@@ -23,13 +23,10 @@ OpBase *NewUnwindOp
 	const ExecutionPlan *plan,
 	AR_ExpNode *exp
 ) {
-	OpUnwind *op = rm_malloc(sizeof(OpUnwind));
+	OpUnwind *op = rm_calloc (1, sizeof(OpUnwind)) ;
 
-	op->exp           = exp;
-	op->list          = SI_NullVal();
-	op->listIdx       = 0;
-	op->listLen       = 0;
-	op->currentRecord = NULL;
+	op->exp  = exp;
+	op->list = SI_NullVal();
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_UNWIND, "Unwind", UnwindInit, UnwindConsume,

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -58,12 +58,12 @@ OpBase *NewUpdateOp
 	rax *update_exps
 ) {
 	OpUpdate *op = rm_calloc(1, sizeof(OpUpdate));
-	op->gc                = QueryCtx_GetGraphCtx();
-	op->rec_idx           = 0;
-	op->records           = array_new(Record, 64);
-	op->update_ctxs       = update_exps;
-	op->node_updates      = HashTableCreate(&_dt);
-	op->edge_updates      = HashTableCreate(&_dt);
+
+	op->gc           = QueryCtx_GetGraphCtx();
+	op->records      = array_new(Record, 64);
+	op->update_ctxs  = update_exps;
+	op->node_updates = HashTableCreate(&_dt);
+	op->edge_updates = HashTableCreate(&_dt);
 
 	// set our op operations
 	OpBase_Init((OpBase *)op, OPType_UPDATE, "Update", NULL, UpdateConsume,

--- a/src/execution_plan/ops/op_value_hash_join.c
+++ b/src/execution_plan/ops/op_value_hash_join.c
@@ -241,14 +241,11 @@ OpBase *NewValueHashJoin
 	ASSERT(lhs_exp != NULL);
 	ASSERT(rhs_exp != NULL);
 
-	OpValueHashJoin *op = rm_malloc(sizeof(OpValueHashJoin));
+	OpValueHashJoin *op = rm_calloc (1, sizeof(OpValueHashJoin)) ;
 
-	op->rhs_rec                 = NULL;
-	op->lhs_exp                 = lhs_exp;
-	op->rhs_exp                 = rhs_exp;
-	op->intersect_idx           = -1;
-	op->cached_records          = NULL;
-	op->number_of_intersections = 0;
+	op->lhs_exp       = lhs_exp;
+	op->rhs_exp       = rhs_exp;
+	op->intersect_idx = -1;
 
 	// set our Op operations
 	OpBase_Init((OpBase *)op, OPType_VALUE_HASH_JOIN, "Value Hash Join",


### PR DESCRIPTION
Resolves: #1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified and standardized internal initialization across many query operators for consistency.

- Performance/Stability
  - Safer, deterministic operator initialization reduces risk from uninitialized state and improves reliability when resetting/reusing operators.
  - No changes to query semantics or public APIs.

- Tests
  - Added a regression test exercising repeated expand-into / reset scenarios to guard against crashes.

- Style
  - Minor formatting and allocation-call convention cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->