### PR TITLE
Modify Docker command for FalkorDB usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,7 @@ Our goal is to build a high-performance Knowledge Graph tailored for Large Langu
 To quickly try out FalkorDB, launch an instance using docker:
 
 ```
-docker run -p 6379:6379 -it --rm -v ./data:/var/lib/falkordb/data falkordb/falkordb:edge
-```
-
-Or, to use the built-in browser-based interface, run:
-
-```
-docker run -p 6379:6379 -p 3000:3000 -it --rm -v ./data:/var/lib/falkordb/data falkordb/falkordb:edge
+docker run -p 6379:6379 -p 3000:3000 -it --rm -v ./data:/var/lib/falkordb/data falkordb/falkordb
 ```
 
 ### Step 2


### PR DESCRIPTION
Updated Docker run command for FalkorDB and removed instructions for the built-in browser interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Docker setup by consolidating Redis-only and Redis+UI commands into a single docker run exposing ports 6379 and 3000.
  * Switched to the latest falkordb/falkordb image tag while preserving the ./data:/var/lib/falkordb/data volume mapping.
  * Removed separate browser-interface instructions; the unified command now provides UI access.
  * No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->