### PR TITLE
add TTL to telemetry streams

### DIFF
--- a/src/cron/tasks/stream_finished_queries.c
+++ b/src/cron/tasks/stream_finished_queries.c
@@ -27,6 +27,7 @@
 #define FLD_NAME_REPORT_DURATION     "Report duration"
 #define FLD_NAME_EXECUTION_DURATION  "Execution duration"
 
+#define TELEMETRY_STREAM_TTL 1000 * 60 * 30  // stream TTL ms, 30 minutes
 
 // event field:value pairs
 static RedisModuleString *_event[FLD_COUNT * 2] = {0};
@@ -279,6 +280,12 @@ bool CronTask_streamFinishedQueries
 			// cap stream
 			RedisModule_StreamTrimByLength(key,
 					REDISMODULE_STREAM_TRIM_APPROX, max_query_count);
+
+			// set stream TTL
+			if (key_type == REDISMODULE_KEYTYPE_EMPTY) {
+				int res = RedisModule_SetExpire (key, TELEMETRY_STREAM_TTL) ;
+				ASSERT (res == REDISMODULE_OK) ;
+			}
 		} else {
 			// TODO: decide how to handle this...
 		}

--- a/tests/flow/test_graph_info.py
+++ b/tests/flow/test_graph_info.py
@@ -434,3 +434,23 @@ class testGraphInfo(FlowTestsBase):
         for t in threads:
             t.join()
 
+    def test08_telemetry_ttl(self):
+        """make sure telemetry keys have ttl"""
+
+        # make sure graph exists
+        self.graph.query("RETURN 1")
+
+        # wait for telemetry stream to be created
+        key_type = 'none' # type of stream_key
+        telemetry_key = StreamName(self.graph)
+
+        while key_type == 'none':
+            key_type = self.conn.type(telemetry_key)
+
+        # make sure we're dealing with a telemetry stream
+        self.env.assertEquals(key_type, "stream")
+
+        # make sure stream is associated with TTL
+        ttl = self.conn.ttl(telemetry_key)
+        self.env.assertGreater(ttl, 0)
+


### PR DESCRIPTION
Resolves: #1259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Telemetry streams now auto-expire after 30 minutes when first created, reducing long-term storage and keeping data fresh.

- Tests
  - Added coverage to ensure telemetry streams are created and have a valid time-to-live (TTL).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->