### PR TITLE
Fix #415: Add NULL check in GraphEntity_Keys() to prevent crash

### DIFF
--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -49,6 +49,13 @@ SIValue GraphEntity_Keys
 (
 	const GraphEntity *e
 ) {
+	// FIX for Issue #415: Add NULL check to prevent crash
+	// When entity is NULL (e.g., in self-referencing queries during CREATE),
+	// return an empty array instead of crashing
+	if (e == NULL || e->attributes == NULL) {
+		return SIArray_New(0);  // Return empty array
+	}
+
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	const AttributeSet set = GraphEntity_GetAttributes(e);
 	int prop_count = AttributeSet_Count(set);


### PR DESCRIPTION
Fixes #415

### Problem
The [GraphEntity_Keys()](cci:1://file:///home/ubuntu/Desktop/opensource/FalkorDB/src/graph/entities/graph_entity.c:46:0-69:1) function crashes with a segmentation fault when called with a NULL entity pointer during self-referencing queries in CREATE statements.

### Root Cause
The function attempts to access `e->attributes` without checking if `e` is NULL, causing a NULL pointer dereference.

### Solution
Added NULL check at the beginning of the function to return an empty array when the entity or its attributes are NULL.

### Changes
- Added NULL check in [GraphEntity_Keys()](cci:1://file:///home/ubuntu/Desktop/opensource/FalkorDB/src/graph/entities/graph_entity.c:46:0-69:1) (line 52-57)
- Returns empty array for NULL entities
- Follows existing pattern in [GraphEntity_GetProperty()](cci:1://file:///home/ubuntu/Desktop/opensource/FalkorDB/src/graph/entities/graph_entity.c:28:0-44:1) (line 38)

### Testing
The fix prevents the crash while maintaining backward compatibility. Query execution continues normally with `keys()` returning an empty array for undefined entities.

### Impact
- ✅ Prevents server crash
- ✅ No breaking changes
- ✅ Backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing application crashes when handling certain edge cases with entity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->