### PR TITLE
1377 add text to cypher to the dockerimages

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -50,6 +50,8 @@ COPY --from=compiler /FalkorDB/bin/linux*/src/falkordb.so ${FALKORDB_BIN_PATH}/f
 
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}
 
+RUN rm ${FALKORDB_BROWSER_PATH}/text-to-cypher && rm -rf ${FALKORDB_BROWSER_PATH}/templates
+
 ENV ARCH=${TARGETPLATFORM}
 
 ENV TLS=0

--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -36,6 +36,8 @@ COPY --from=compiler /FalkorDB/bin/linux*/src/falkordb.so ${FALKORDB_BIN_PATH}/f
 # Copy browser files from the Alpine-based browser image
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}
 
+RUN rm ${FALKORDB_BROWSER_PATH}/text-to-cypher && rm -rf ${FALKORDB_BROWSER_PATH}/templates
+
 ENV ARCH=${TARGETPLATFORM}
 
 ENV TLS=0


### PR DESCRIPTION
fix #1377 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker container images by removing unnecessary browser assets, reducing overall image size for faster deployments.
  * Enhanced multi-platform Docker build support with improved architecture detection for better deployment flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR removes specific files and directories related to the 'text-to-cypher' feature from both the standard and Alpine FalkorDB Docker images. This cleanup ensures that these components are no longer included in the final Docker builds.

#### Key Changes
- Added `RUN rm` commands to `Dockerfile` and `Dockerfile.alpine` to remove the `text-to-cypher` executable.
- Added `RUN rm -rf` commands to `Dockerfile` and `Dockerfile.alpine` to remove the `templates` directory.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 4 (100.0%)    |
| Total Changes | 4             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>