### PR TITLE
Add zstd library support for Alpine/musl builds in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,8 @@ CC_C_STD=gnu11
 CC_OPENMP=1
 
 # Add zstd library for Alpine/musl builds (libcurl dependency)
-# On Alpine and other musl-based systems, libcurl is often built with zstd support
-# and we need to explicitly link it. Detect both via OSNICK and libc.
-USING_MUSL := $(shell ldd --version 2>&1 | grep -q musl && echo 1 || echo 0)
+# Detect via OSNICK and libc probe; allow manual override.
+USING_MUSL ?= $(shell ldd 2>&1 | head -1 | grep -qi musl && echo 1 || echo 0)
 ifeq ($(USING_MUSL),1)
 LD_LIBS.ext += zstd
 else ifeq ($(findstring alpine,$(OSNICK)),alpine)


### PR DESCRIPTION
fix #1439 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build compatibility on Alpine and musl-based systems by ensuring the zstd library is linked during builds, preventing missing-dependency failures when libcurl or related components require it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->