### PR TITLE
Update RHEL image version to 9-v20241210 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
             machine_type: e2-standard-4
             runner_label: rhel-build-${{ github.run_id }}-${{ github.run_number }}
             arm: false
-            image: projects/rhel-cloud/global/images/rhel-10-v20251209
+            image: projects/rhel-cloud/global/images/rhel-9-v20241210
           - name: rhel8-build
             machine_type: e2-standard-4
             runner_label: rhel8-build-${{ github.run_id }}-${{ github.run_number }}
             arm: false
-            image: projects/rhel-cloud/global/images/rhel-10-v20251209
+            image: projects/rhel-cloud/global/images/rhel-9-v20241210
     runs-on: ubuntu-latest
     steps:
       - name: Create runners


### PR DESCRIPTION
fix #1456 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated RHEL build base images for both RHEL build variants to the rhel-9-v20241210 release; build steps, matrix structure, and behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->