### PR TITLE
Revert "Fix Alpine CI cache"

### DIFF
--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -31,7 +31,7 @@ COPY ./build/docker/run.sh ${FALKORDB_BIN_PATH}/run.sh
 COPY ./build/docker/gen-certs.sh ${FALKORDB_BIN_PATH}/gen-certs.sh
 
 # Copy the compiled FalkorDB module from the Alpine compiler
-COPY --from=compiler /FalkorDB/bin/alpine*/src/falkordb.so ${FALKORDB_BIN_PATH}/falkordb.so
+COPY --from=compiler /FalkorDB/bin/linux*/src/falkordb.so ${FALKORDB_BIN_PATH}/falkordb.so
 
 # Copy browser files from the Alpine-based browser image
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}

--- a/build/docker/Dockerfile.alpine-server
+++ b/build/docker/Dockerfile.alpine-server
@@ -25,7 +25,7 @@ COPY ./build/docker/run.sh ${FALKORDB_BIN_PATH}/run.sh
 COPY ./build/docker/gen-certs.sh ${FALKORDB_BIN_PATH}/gen-certs.sh
 
 # Copy the compiled FalkorDB module from the Alpine compiler
-COPY --from=compiler /FalkorDB/bin/alpine*/src/falkordb.so ${FALKORDB_BIN_PATH}/falkordb.so
+COPY --from=compiler /FalkorDB/bin/linux*/src/falkordb.so ${FALKORDB_BIN_PATH}/falkordb.so
 
 ENV ARCH=${TARGETPLATFORM}
 

--- a/build/docker/Dockerfile.compiler
+++ b/build/docker/Dockerfile.compiler
@@ -7,15 +7,12 @@ ARG BASE_IMAGE_VERSION=1.0.0
 FROM falkordb/falkordb-build:$OS-${BASE_IMAGE_VERSION} AS builder
 
 ARG DEBUG=0
-ARG OS=ubuntu
 
 WORKDIR /FalkorDB
 
 COPY . /FalkorDB
 
-# Pass OS to make to override platform detection
-# This ensures Alpine builds output to alpine-x64-release instead of linux-x64-release
-RUN make DEBUG=$DEBUG OS=$OS
+RUN make DEBUG=$DEBUG
 
 RUN mkdir -p /FalkorDB/bin/src \
- && find /FalkorDB/bin -type f -name "falkordb.so" -path "*/src/falkordb.so" -exec cp {} /FalkorDB/bin/src/ \;
+ && find /FalkorDB/bin -type f -path "/FalkorDB/bin/linux*/src/falkordb.so" -exec cp {} /FalkorDB/bin/src/ \;


### PR DESCRIPTION
Reverts FalkorDB/FalkorDB#1476
 
 **PR Summary by Typo**
------------

#### Overview
This PR reverts a previous change intended to fix the Alpine CI cache. The revert restores the build process to use `linux*/src/falkordb.so` paths instead of `alpine*/src/falkordb.so` for copying compiled modules, indicating the prior fix was either incorrect or introduced new issues.

#### Key Changes
- Restored `COPY` commands in `Dockerfile.alpine` and `Dockerfile.alpine-server` to reference `linux*/src/falkordb.so`.
- Removed the explicit `OS=$OS` argument from the `make` command in `Dockerfile.compiler`, allowing `make` to use its default platform detection.
- Adjusted the `find` command in `Dockerfile.compiler` to locate `falkordb.so` within `linux*/src/` directories.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Churn       | 3 (42.9%)     |
| Rework      | 4 (57.1%)     |
| Total Changes | 7             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to use standardized binary sources across Alpine and standard Linux environments.
  * Simplified compiler build parameters by removing platform-specific argument handling.
  * Modified artifact copying logic to consistently source from a unified binary location during containerization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->