### PR TITLE
fix: update cache paths for Alpine builds to use more generic naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,8 +348,8 @@ jobs:
           outputs: type=docker,dest=/tmp/falkordb-tests-${{ matrix.platform.suffix }}.tar
           tags: falkordb/falkordb-tests-${{ matrix.platform.suffix }}
           platforms: linux/${{ matrix.platform.arch }}
-          cache-from: type=gha,scope=tests-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
-          cache-to: type=gha,mode=max,scope=tests-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
+          cache-from: type=gha,scope=tests-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
+          cache-to: type=gha,mode=max,scope=tests-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
           build-args: |
             BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler-${{ matrix.platform.suffix }}
             TARGETPLATFORM=linux/${{ matrix.platform.arch }}
@@ -373,8 +373,8 @@ jobs:
           platforms: linux/${{ matrix.platform.arch }}
           outputs: type=docker,dest=/tmp/falkordb-${{ matrix.platform.suffix }}.tar
           tags: falkordb/falkordb-${{ matrix.platform.suffix }}
-          cache-from: type=gha,scope=base-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
-          cache-to: type=gha,mode=max,scope=base-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
+          cache-from: type=gha,scope=base-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
+          cache-to: type=gha,mode=max,scope=base-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
           build-args: |
             BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler-${{ matrix.platform.suffix }}
             TARGETPLATFORM=linux/${{ matrix.platform.arch }}
@@ -402,8 +402,8 @@ jobs:
           platforms: linux/${{ matrix.platform.arch }}
           outputs: type=docker,dest=/tmp/falkordb-server-${{ matrix.platform.suffix }}.tar
           tags: falkordb/falkordb-server-${{ matrix.platform.suffix }}
-          cache-from: type=gha,scope=server-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
-          cache-to: type=gha,mode=max,scope=server-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}
+          cache-from: type=gha,scope=server-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
+          cache-to: type=gha,mode=max,scope=server-${{ matrix.platform.os }}-${{ matrix.platform.cache_path }}-${{ matrix.build_type }}
           build-args: |
             BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler-${{ matrix.platform.suffix }}
             TARGETPLATFORM=linux/${{ matrix.platform.arch }}


### PR DESCRIPTION
fix #1476 
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build caching: cache keys and paths now include OS and build type, enabling more reliable cross-OS cache restores and faster incremental builds.
  * Extended cache scoping across image build and test stages (including Docker/Buildx), reducing redundant rebuilds and speeding workflows.
  * Refined handling for Alpine and macOS variants to ensure consistent, efficient caching across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the CI/CD workflow to use more generic naming conventions for cache paths in Alpine Linux builds, standardizing them under a `linux-*` scheme. This change aims to improve cache management and consistency across different Linux distributions.

#### Key Changes
- Renamed `cache_path` variables for Alpine builds from `alpine-x64` to `linux-x64` and `alpine-arm64v8` to `linux-arm64v8`.
- Modified cache keys and restore keys in GitHub Actions caching steps to include `matrix.platform.os` and `matrix.build_type` for more precise cache identification.
- Updated Docker buildx cache scopes (`cache-from`, `cache-to`) to also incorporate `matrix.platform.os` and `matrix.build_type`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (2.8%)      |
| Rework      | 35 (97.2%)    |
| Total Changes | 36            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>