### PR TITLE
Fix cache path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             os: rhel
             arch: amd64
             machine_label: ubuntu-latest
-            cache_path: rhel-x64
+            cache_path: linux-x64
             build_variants: [release]
             use_docker: true
           - name: rhel8-x64
@@ -87,7 +87,7 @@ jobs:
             os: rhel8
             arch: amd64
             machine_label: ubuntu-latest
-            cache_path: rhel8-x64
+            cache_path: linux-x64
             build_variants: [release]
             use_docker: true
           # macOS builds


### PR DESCRIPTION
fix #936 
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow cache path configuration to use consistent versioning across dependency caches, improving build consistency and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue with cache paths in the GitHub Actions build workflow by standardizing the naming convention for Linux-based caches and ensuring consistent build type usage in cache paths.

#### Key Changes
- Standardized `cache_path` for RHEL platforms from `rhel-x64` and `rhel8-x64` to `linux-x64`.
- Modified cache restore and save steps to explicitly use `-release` in the path, rather than a dynamic `build_type` variable.
- Updated a conditional clean step to reflect the new `-release` suffix in the path check.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Rework      | 25 (100.0%)   |
| Total Changes | 25          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>