### PR TITLE
Fix yield_reducible assignment to use 'reducible'

### DIFF
--- a/src/procedures/proc_functions.c
+++ b/src/procedures/proc_functions.c
@@ -167,7 +167,7 @@ SIValue *Proc_FunctionsStep
 
 	// yield reducible
 	if (pdata->yield_reducible != NULL) {
-		*pdata->yield_reducible = SI_BoolVal (f->internal) ;
+		*pdata->yield_reducible = SI_BoolVal (f->reducible) ;
 	}
 
 	// yield aggregation


### PR DESCRIPTION
fix https://github.com/FalkorDB/FalkorDB/issues/1524
 **PR Summary by Typo**
------------

#### Overview
This PR fixes a bug where the `yield_reducible` flag was incorrectly assigned based on the `internal` flag instead of the intended `reducible` flag within the `Proc_FunctionsStep` function.

#### Key Changes
- Corrected the assignment of `*pdata->yield_reducible` to use `SI_BoolVal(f->reducible)` instead of `SI_BoolVal(f->internal)` in `src/procedures/proc_functions.c`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Rework   | 1 (100.0%)    |
| Total Changes | 1         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reducibility assessment in procedure processing logic to ensure accurate control flow evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->