### PR TITLE
fix: update COMMIT_SHA logic to use sha for release events

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -439,7 +439,7 @@ jobs:
   trigger-falkordb-cloud-update:
     needs: release
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event.inputs.run_falkordb_cloud_update != 'true'
+    if: github.event_name == 'release' || github.event.inputs.run_falkordb_cloud_update == 'true'
     steps:
       - name: Trigger FalkorDB Cloud version update
         uses: peter-evans/repository-dispatch@v4
@@ -452,7 +452,7 @@ jobs:
   trigger-testflight-workflow:
     needs: release
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event.inputs.run_testflight_workflow != 'true'
+    if: github.event_name == 'release' || github.event.inputs.run_testflight_workflow == 'true'
     steps:
       - name: Trigger Redis Enterprise tests in FalkorDB/testflight
         uses: peter-evans/repository-dispatch@v4


### PR DESCRIPTION
fix #1502 
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow controls: added options to opt in/out of FalkorDB Cloud and Testflight update steps and made release-trigger behavior more reliable when tag or input values are missing.
  * Adjusted payload selection so automated update triggers prefer an explicit tag input when a release tag isn't present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the logic for determining the `COMMIT_SHA` in the `release-image.yml` workflow, specifically for release events, to use the direct `sha` instead of `target_commitish`. It also enhances the workflow dispatch capabilities by adding new inputs to conditionally trigger downstream workflows.

#### Key Changes
- Modified the `COMMIT_SHA` environment variable logic to use `github.sha` for release events.
- Introduced new `workflow_dispatch` inputs: `run_falkordb_cloud_update` and `run_testflight_workflow`, both defaulting to `true`.
- Updated the `if` conditions for the `trigger-falkordb-cloud-update` and `trigger-testflight-workflow` jobs to respect these new `workflow_dispatch` inputs.
- Adjusted the `client-payload` for these triggers to fall back to `github.event.inputs.tag` if `github.event.release.tag_name` is not available.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 8 (57.1%)     |
| Rework      | 6 (42.9%)     |
| Total Changes | 14            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>