### PR TITLE
1502 fix release pipeline sha

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -402,7 +402,19 @@ jobs:
           docker buildx imagetools inspect falkordb/falkordb-server:${{ env.TAG_NAME }}
           docker buildx imagetools inspect falkordb/falkordb-server:${{ env.TAG_NAME }}-alpine
 
+      - name: Check if release exists
+        id: check_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view ${{ env.TAG_NAME }} > /dev/null 2>&1; then
+            echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
+          else
+            echo "RELEASE_EXISTS=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload falkordb.so files to release
+        if: steps.check_release.outputs.RELEASE_EXISTS == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
fix #1502 
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline: added a release-existence check and adjusted upload behavior to run only when a release is present.
  * Standardized the release identifier usage and upload paths across all platforms and build variants to ensure consistent artifact handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses an issue in the release pipeline by ensuring that `.so` files are uploaded to an existing GitHub release using a consistent tag name. The changes prevent upload failures by first verifying the release's existence and then using an environment variable for the tag.

#### Key Changes
- Replaced `github.event.release.tag_name` with `env.TAG_NAME` in all `gh release upload` commands for consistency.
- Introduced a new step to check if a release with `env.TAG_NAME` exists using `gh release view`.
- Modified the `Upload falkordb.so files to release` step to execute only if the release is confirmed to exist, preventing errors during asset uploads.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 11 (40.7%)      |
| Rework      | 16 (59.3%)      |
| Total Changes | 27         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>