### PR TITLE
batch backport workflow

### DIFF
--- a/.github/workflows/batch-backport.yml
+++ b/.github/workflows/batch-backport.yml
@@ -167,6 +167,24 @@ jobs:
 
           echo "Cherry-pick summary: $SUCCESS_COUNT successful, $FAIL_COUNT failed"
 
+      - name: Bump patch version
+        run: |
+          TAG="${{ steps.find_tag.outputs.LATEST_TAG }}"
+          # Parse version components from tag (e.g., v4.16.2)
+          MAJOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$TAG" | sed 's/^v//' | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+
+          echo "Bumping version: ${MAJOR}.${MINOR}.${PATCH} -> ${MAJOR}.${MINOR}.${NEW_PATCH}"
+
+          sed -i "s/#define FALKOR_VERSION_MAJOR .*/#define FALKOR_VERSION_MAJOR ${MAJOR}/" src/version.h
+          sed -i "s/#define FALKOR_VERSION_MINOR .*/#define FALKOR_VERSION_MINOR ${MINOR}/" src/version.h
+          sed -i "s/#define FALKOR_VERSION_PATCH .*/#define FALKOR_VERSION_PATCH ${NEW_PATCH}/" src/version.h
+
+          git add src/version.h
+          git commit -m "Bump version to ${MAJOR}.${MINOR}.${NEW_PATCH}"
+
       - name: Push branch
         run: |
           git push origin "${{ steps.create_branch.outputs.BRANCH_NAME }}"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -42,6 +42,47 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set tag name
+        id: set_tag
+        run: |
+          # If the event is a release, use the release tag name
+          if [ "${{ github.event_name }}" == "release" ]; then
+            TAG_NAME=${{ github.event.release.tag_name }}
+            echo "IS_LATEST=1" >> $GITHUB_ENV
+          fi
+
+          # If the event is a workflow_dispatch, use the input value
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG_NAME=${{ github.event.inputs.tag }}
+          fi
+
+          # If the event is a workflow_run, and branch is master, set to "edge"
+          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" == "master" ]; then
+            TAG_NAME="edge"
+          fi
+
+          # If the event is a workflow_run, and branch is not master, set to the branch name
+          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" != "master" ]; then
+            TAG_NAME="v${{ github.event.workflow_run.head_branch }}"
+          fi
+
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+
+      - name: Verify tag matches version.h
+        if: ${{ startsWith(env.TAG_NAME, 'v') && env.TAG_NAME != 'edge' }}
+        run: |
+          git fetch origin ${{ env.COMMIT_SHA }} --depth=1
+          VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
+          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
+          if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then
+            echo "::error::Tag '${{ env.TAG_NAME }}' does not match version.h '${FILE_VERSION}'"
+            exit 1
+          fi
+
       - name: Retrieve built image AMD
         uses: dawidd6/action-download-artifact@v11
         with:
@@ -320,32 +361,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set tag name
-        id: set_tag
-        run: |
-          # If the event is a release, use the release tag name
-          if [ "${{ github.event_name }}" == "release" ]; then
-            TAG_NAME=${{ github.event.release.tag_name }}
-            echo "IS_LATEST=1" >> $GITHUB_ENV
-          fi
-
-          # If the event is a workflow_dispatch, use the input value
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG_NAME=${{ github.event.inputs.tag }}
-          fi
-
-          # If the event is a workflow_run, and branch is master, set to "edge"
-          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" == "master" ]; then
-            TAG_NAME="edge"
-          fi
-
-          # If the event is a workflow_run, and branch is not master, set to the branch name
-          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" != "master" ]; then
-            TAG_NAME="v${{ github.event.workflow_run.head_branch }}"
-          fi
-
-          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
 
       - name: Tag x64, ARM, and rhel-x64 images
         run: |

--- a/.github/workflows/release-ramp.yml
+++ b/.github/workflows/release-ramp.yml
@@ -40,6 +40,21 @@ jobs:
           echo "SEMVER=${SEMVER}" >> $GITHUB_OUTPUT
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
 
+      - name: Verify tag matches version.h
+        run: |
+          git fetch origin ${{ env.COMMIT_SHA }} --depth=1
+          VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
+          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          TAG="${{ steps.set_semver.outputs.TAG_NAME }}"
+          echo "Tag: ${TAG}, version.h: ${FILE_VERSION}"
+          if [ "${TAG}" != "${FILE_VERSION}" ]; then
+            echo "::error::Tag '${TAG}' does not match version.h '${FILE_VERSION}'"
+            exit 1
+          fi
+
       - name: Download rhel8 ramp file
         uses: dawidd6/action-download-artifact@v11
         with:


### PR DESCRIPTION
Closes #1840

- Add batch backport workflow that automates cherry-picking commits from `master` to version branches based on PR labels

  ## How It Works
  1. Trigger manually via `workflow_dispatch` with a version branch (e.g., `4.16`)
  2. Finds the latest tag for that version (e.g., `v4.16.2`)
  3. Searches for merged PRs with the version label since that tag
  4. Cherry-picks each merge commit to a new backport branch
  5. Creates a PR with a summary of successful and failed cherry-picks

  ## Usage
  1. Add a version label (e.g., `4.16`) to PRs that should be backported
  2. Run the workflow from Actions tab with the target version branch
  3. Review and merge the generated backport PR

  ## Conflict Handling
  - On conflict: aborts that cherry-pick, continues with remaining commits
  - PR body lists failed cherry-picks for manual resolution
  - Workflow fails only if ALL cherry-picks fail or no labeled PRs exist