### PR TITLE
Fix 4 crash-related issues: #1466, #1481, #1410, #1591

### DIFF
--- a/src/arithmetic/list_funcs/list_funcs.c
+++ b/src/arithmetic/list_funcs/list_funcs.c
@@ -70,22 +70,43 @@ static void _PopulateReduceCtx
 	Record outer_record
 ) {
 	rax *record_map = raxClone(outer_record->mapping);
+	int n_pad = 0;
 
 	//--------------------------------------------------------------------------
 	// map variable name
 	//--------------------------------------------------------------------------
 
 	intptr_t id = raxSize(record_map);
-	raxTryInsert(record_map, (unsigned char *)ctx->variable,
-				 strlen(ctx->variable), (void *)id, NULL);
+	if(!raxTryInsert(record_map, (unsigned char *)ctx->variable,
+				 strlen(ctx->variable), (void *)id, NULL)) {
+		// variable name shadows an outer scope variable
+		// overwrite to assign a new unique slot index
+		raxInsert(record_map, (unsigned char *)ctx->variable,
+				  strlen(ctx->variable), (void *)id, NULL);
+		n_pad++;
+	}
 
 	//--------------------------------------------------------------------------
 	// map accumulator name
 	//--------------------------------------------------------------------------
 
 	id++;
-	raxTryInsert(record_map, (unsigned char *)ctx->accumulator,
-				 strlen(ctx->accumulator), (void *)id, NULL);
+	if(!raxTryInsert(record_map, (unsigned char *)ctx->accumulator,
+				 strlen(ctx->accumulator), (void *)id, NULL)) {
+		raxInsert(record_map, (unsigned char *)ctx->accumulator,
+				  strlen(ctx->accumulator), (void *)id, NULL);
+		n_pad++;
+	}
+
+	// when names were shadowed, raxInsert overwrote entries without
+	// increasing raxSize, so the record would be too small for the new
+	// slot indices; add padding entries to ensure correct allocation
+	for(int i = 0; i < n_pad; i++) {
+		char pad[48];
+		snprintf(pad, sizeof(pad), "\x01_reduce_pad_%d_%p", i, (void *)ctx);
+		raxTryInsert(record_map, (unsigned char *)pad, strlen(pad),
+					 (void *)(intptr_t)0, NULL);
+	}
 
 	ctx->record = Record_New(record_map);
 
@@ -343,6 +364,14 @@ SIValue AR_RANGE(SIValue *argv, int argc, void *private_data) {
 	uint64_t size = 0;
 	if((end >= start && interval > 0) || (end <= start && interval < 0)) {
 		size = 1 + (end - start) / interval;
+	}
+
+	// cap range size to prevent OOM from queries like range(1, INT64_MAX)
+	if(size > 1000000) {
+		ErrorCtx_RaiseRuntimeException(
+			"range() maximum size exceeded: %llu elements requested, "
+			"limit is 1000000", (unsigned long long)size);
+		return SI_NullVal();
 	}
 
 	SIValue array = SI_Array(size);

--- a/tests/flow/test_access_del_entity.py
+++ b/tests/flow/test_access_del_entity.py
@@ -378,3 +378,17 @@ class testAccessDelEdge():
         self.env.assertEquals(edges[1].properties['v'], 2)
         self.env.assertEquals(edges[1].relation, 'R2')
 
+    def test09_uaf_via_dangling_list_reference(self):
+        # regression test for issue #1591
+        # collecting a node into a list, deleting it, then accessing
+        # the collected copy must not cause use-after-free
+        q = "CREATE (:A {payload: 123})"
+        self.graph.query(q)
+
+        q = """MATCH (n:A)
+               WITH collect(n) AS list
+               DETACH DELETE list[0]
+               RETURN list[0].payload"""
+        res = self.graph.query(q)
+        # the collected copy should still be accessible
+        self.env.assertEquals(res.result_set[0][0], 123)

--- a/tests/flow/test_comprehension_functions.py
+++ b/tests/flow/test_comprehension_functions.py
@@ -452,3 +452,12 @@ class testComprehensionFunctions(FlowTestsBase):
         expected_result = [[[1, 1]], [[2]], [[3]], [[]]]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
+    def test21_nested_reduce_shadowed_variables(self):
+        # regression test for issue #1481
+        # nested reduce with shadowed variable names must not corrupt
+        # outer scope record slots
+        query = """RETURN [x IN [1] |
+                     reduce(s=0, x IN [1] | s + [x IN [1] | x][0])
+                   ][0]"""
+        result = self.graph.query(query)
+        self.env.assertEquals(result.result_set[0][0], 1)

--- a/tests/flow/test_list.py
+++ b/tests/flow/test_list.py
@@ -1420,3 +1420,12 @@ class testList(FlowTestsBase):
         query = """RETURN list.dedup([3,[1,2],3,[1],[1,2]])"""
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0], expected_result)
+
+    def test14_range_size_limit(self):
+        # regression test for issue #1410
+        # range() with enormous size must return error, not OOM
+        try:
+            self.graph.query("RETURN range(1, 9223372036854775807)")
+            self.env.assertTrue(False, "Expected an error")
+        except ResponseError as e:
+            self.env.assertContains("range() maximum size exceeded", str(e))

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -278,3 +278,13 @@ class testPathFilter(FlowTestsBase):
 
         res = self.graph.query(q).result_set
         self.env.assertEqual(res[0][0], 1)
+
+    def test16_xor_with_path_filter(self):
+        # regression test for issue #1466
+        # XOR combined with a path filter must return an error, not crash
+        try:
+            self.graph.query(
+                "MATCH (n) WHERE NOT((()--()) XOR TRUE) RETURN n")
+            self.env.assertTrue(False, "Expected an error")
+        except ResponseError as e:
+            self.env.assertContains("XOR", str(e))


### PR DESCRIPTION
## Summary

Fix 4 crash-related issues with surgical code changes and regression tests.

## Issues Fixed

### #1466 — XOR + path filter triggers `ASSERT(false)`

**Root cause:** `_ReduceFilterToOp()` passes the filter operator to `NewApplyMultiplexerOp()`, which only supports `OP_AND`/`OP_OR`. Using `XOR` (or `XNOR`) with a path filter reaches an `ASSERT(false)` at `op_apply_multiplexer.c:51`.

**Fix:** Validate the operator before creating the multiplexer. Unsupported operators now produce a compile-time error (`"FalkorDB does not currently support combining path filters with XOR"`) and fall back to a regular filter op.

**File:** `src/execution_plan/execution_plan_build/reduce_to_apply.c`

---

### #1481 — Nested `reduce()` with shadowed variable crashes (SIGSEGV)

**Root cause:** `_PopulateReduceCtx` clones the outer record's rax mapping and calls `raxTryInsert` to add the variable/accumulator names. When the inner `reduce` reuses the same variable name as the outer scope (e.g., `x`), `raxTryInsert` silently fails (returns 0) because the key already exists. This causes the inner reduce to share the outer's record slot, corrupting data and leading to a segfault.

**Fix:** Detect when `raxTryInsert` fails (name collision) and use `raxInsert` to overwrite with a new unique slot index. Since `raxInsert` overwrites without increasing `raxSize`, padding entries are added so `Record_New` allocates enough slots for the new indices.

**File:** `src/arithmetic/list_funcs/list_funcs.c`

---

### #1410 — `range(1, 9223372036854775807)` causes OOM abort

**Root cause:** `AR_RANGE` computes the result size as `1 + (end - start) / interval` with no upper bound. Extreme values attempt to allocate arrays with billions of entries, exhausting memory.

**Fix:** Cap the range output at 1,000,000 elements. Exceeding this limit raises a runtime exception with a clear error message.

**File:** `src/arithmetic/list_funcs/list_funcs.c`

---

### #1591 — Use-after-free via dangling list reference (CVE)

**Root cause:** `SI_CloneValue` for `T_NODE`/`T_EDGE` does a `memcpy` of the entity struct, which copies the `attributes` pointer as-is. This pointer points into the graph's `DataBlock`. When the original entity is deleted (e.g., via `DETACH DELETE`), the `DataBlock` slot is freed, leaving the clone's `attributes` pointer dangling. The same issue exists in `SIPath_New` → `Path_Clone`, which shallow-copies node/edge arrays.

**Fix:**
- **`SI_CloneValue`**: After `memcpy`, allocate a new `AttributeSet*` and deep-copy via `AttributeSet_Clone`.
- **`SIPath_New`**: After `Path_Clone`, iterate all nodes and edges in the cloned path and deep-copy their attributes.
- **`SIValue_Free`** and **`SIPath_Free`**: Free the owned attribute copies before freeing the entity/path struct.

This is safe because only `M_SELF` values (clones) reach the free path; graph-owned entities use `M_NONE`/`M_CONST`.

**Files:** `src/value.c`, `src/datatypes/path/sipath.c`

## Regression Tests

| Test File | Test Name | Issue |
|-----------|-----------|-------|
| `test_path_filter.py` | `test16_xor_with_path_filter` | #1466 |
| `test_comprehension_functions.py` | `test21_nested_reduce_shadowed_variables` | #1481 |
| `test_list.py` | `test14_range_size_limit` | #1410 |
| `test_access_del_entity.py` | `test09_uaf_via_dangling_list_reference` | #1591 |

## Not Fixed (documented)

- **#1580, #1486, #1485, #1484, #1483, #1482** — All 6 OOM issues share the same root cause: `QUERY_MEM_CAPACITY` defaults to `UINT64_MAX` (no per-query memory limit). This is an architectural/policy decision requiring memory tracking integration.
- **#1548** — VLP multi-label crash requires major refactoring of the VLP traversal subsystem (confirmed by team).

Closes #1466, closes #1481, closes #1410, closes #1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed memory safety issues with attribute handling in path and value operations
  * Added range size limit (1,000,000 maximum elements) with error handling to prevent out-of-memory conditions
  * Added error handling for unsupported XOR/XNOR operations with path filters

* **Tests**
  * Added regression tests for edge cases including shadowed variables, deleted entities, and range limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->