### PR TITLE
Fix nested reduce() scope corruption crash (#1481)

### DIFF
--- a/tests/flow/test_comprehension_functions.py
+++ b/tests/flow/test_comprehension_functions.py
@@ -452,3 +452,12 @@ class testComprehensionFunctions(FlowTestsBase):
         expected_result = [[[1, 1]], [[2]], [[3]], [[]]]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
+    def test21_nested_reduce_shadowed_variables(self):
+        # regression test for issue #1481
+        # nested reduce with shadowed variable names must not corrupt
+        # outer scope record slots
+        query = """RETURN [x IN [1] |
+                     reduce(s=0, x IN [1] | s + [x IN [1] | x][0])
+                   ][0]"""
+        result = self.graph.query(query)
+        self.env.assertEquals(result.result_set[0][0], 1)


### PR DESCRIPTION
## Problem

Nested `reduce()` with shadowed variable names causes a SIGSEGV:

```cypher
RETURN [x IN [1] | reduce(s=0, x IN [1] | s + [x IN [1] | x][0])][0]
```

## Root Cause

`_PopulateReduceCtx` in `list_funcs.c` clones the outer record's rax mapping and calls `raxTryInsert` to add variable/accumulator names. When the inner `reduce` reuses the same variable name (`x`) as the outer scope, `raxTryInsert` silently fails (returns 0) because the key already exists. This causes the inner reduce to share the outer's record slot, corrupting data and leading to a segfault.

## Fix

1. Detect when `raxTryInsert` fails (name collision) and use `raxInsert` to overwrite with a new unique slot index
2. Add padding entries to the rax so `Record_New` (which allocates based on `raxSize`) creates a record large enough for the new indices

**File:** `src/arithmetic/list_funcs/list_funcs.c`

## Regression Test

`test21_nested_reduce_shadowed_variables` in `tests/flow/test_comprehension_functions.py`

Closes #1481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where nested reduce operations with shadowed variable names could corrupt outer scope data.

* **Tests**
  * Added regression test for nested reduce operations with shadowed variables to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->