### PR TITLE
Stabilize sanitizer CI: increase timeout and add retry

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   sanitize-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container: falkordb/falkordb-build:ubuntu
     steps:
 
@@ -96,7 +97,11 @@ jobs:
       id: flow_tests
       run: |
         . venv/bin/activate
-        make flow-tests CLEAR_LOGS=0 SAN=address
+        if ! make flow-tests CLEAR_LOGS=0 SAN=address; then
+          echo "::warning::Flow tests failed on first attempt, retrying..."
+          rm -rf tests/flow/logs
+          make flow-tests CLEAR_LOGS=0 SAN=address
+        fi
       continue-on-error: true
 
     - uses: actions/upload-artifact@v6
@@ -109,7 +114,11 @@ jobs:
       id: tck_tests
       run: |
         . venv/bin/activate
-        make tck-tests CLEAR_LOGS=0 SAN=address
+        if ! make tck-tests CLEAR_LOGS=0 SAN=address; then
+          echo "::warning::TCK tests failed on first attempt, retrying..."
+          rm -rf tests/tck/logs
+          make tck-tests CLEAR_LOGS=0 SAN=address
+        fi
       continue-on-error: true
 
     - uses: actions/upload-artifact@v6

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -99,7 +99,7 @@ jobs:
         . venv/bin/activate
         if ! make flow-tests CLEAR_LOGS=0 SAN=address; then
           echo "::warning::Flow tests failed on first attempt, retrying..."
-          mv tests/flow/logs tests/flow/logs.first-attempt
+          mv tests/flow/logs tests/flow/logs.first-attempt || true
           make flow-tests CLEAR_LOGS=0 SAN=address
         fi
       continue-on-error: true

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -99,15 +99,18 @@ jobs:
         . venv/bin/activate
         if ! make flow-tests CLEAR_LOGS=0 SAN=address; then
           echo "::warning::Flow tests failed on first attempt, retrying..."
-          rm -rf tests/flow/logs
+          mv tests/flow/logs tests/flow/logs.first-attempt
           make flow-tests CLEAR_LOGS=0 SAN=address
         fi
       continue-on-error: true
 
     - uses: actions/upload-artifact@v6
+      if: always()
       with:
         name: Upload flow tests logs
-        path: ${{ github.workspace }}/tests/flow/logs/
+        path: |
+          ${{ github.workspace }}/tests/flow/logs/
+          ${{ github.workspace }}/tests/flow/logs.first-attempt/
         retention-days: 7
 
     - name: TCK tests
@@ -116,15 +119,18 @@ jobs:
         . venv/bin/activate
         if ! make tck-tests CLEAR_LOGS=0 SAN=address; then
           echo "::warning::TCK tests failed on first attempt, retrying..."
-          rm -rf tests/tck/logs
+          mv tests/tck/logs tests/tck/logs.first-attempt
           make tck-tests CLEAR_LOGS=0 SAN=address
         fi
       continue-on-error: true
 
     - uses: actions/upload-artifact@v6
+      if: always()
       with:
         name: Upload TCK tests logs
-        path: ${{ github.workspace }}/tests/tck/logs/
+        path: |
+          ${{ github.workspace }}/tests/tck/logs/
+          ${{ github.workspace }}/tests/tck/logs.first-attempt/
         retention-days: 7
 
     - name: Check on failures

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -119,7 +119,7 @@ jobs:
         . venv/bin/activate
         if ! make tck-tests CLEAR_LOGS=0 SAN=address; then
           echo "::warning::TCK tests failed on first attempt, retrying..."
-          mv tests/tck/logs tests/tck/logs.first-attempt
+          mv tests/tck/logs tests/tck/logs.first-attempt || true
           make tck-tests CLEAR_LOGS=0 SAN=address
         fi
       continue-on-error: true

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -663,7 +663,7 @@ setup_rltest
 
 if [[ -n $SAN ]]; then
 	setup_clang_sanitizer
-	RLTEST_ARGS+=" --test-timeout 900"
+	RLTEST_ARGS+=" --test-timeout 1800"
 elif [[ $VG == 1 ]]; then
 	# no timeout for Valgrind tests
 	setup_valgrind


### PR DESCRIPTION
## Stabilize Sanitizer CI

### Problem
The sanitizer CI workflow (`sanitize.yml`) fails intermittently due to:

1. **Test timeout** — `test_constraint:testConstraintEdges` creates 500K entities, which consistently exceeds the 900-second timeout under AddressSanitizer (5-15x slower than normal execution)
2. **Flaky crashes** — Flow tests and TCK tests occasionally crash under ASAN due to timing-sensitive operations (async index creation, server initialization) that are exacerbated by ASAN's slowdown

### Evidence
- Master run [#22251429914](https://github.com/FalkorDB/FalkorDB/actions/runs/22251429914): `test_constraint:testConstraintEdges` timed out at 900s (took 1052s)
- PR runs: `test_index_create` async tests crash intermittently; TCK tests crash with "process is not alive"
- PR #1615 sanitizer run passed cleanly, showing the flakiness is not deterministic

### Changes
1. **`tests/flow/tests.sh`** — Increase `--test-timeout` from 900s to 1800s for sanitizer runs
   - The constraint test creates 500K entities; under ASAN overhead this takes >900s but <1800s
2. **`.github/workflows/sanitize.yml`** — Add retry logic for flow and TCK test steps
   - On first failure, clears logs and retries once to handle genuinely intermittent issues
   - Uses `::warning::` annotation to make retries visible in the workflow UI
3. **`.github/workflows/sanitize.yml`** — Add `timeout-minutes: 60` to prevent runaway jobs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI test reliability by adding automatic retry for transient failures; first-attempt failures emit warnings and are retried while preserving overall continue-on-error behavior.
  * Increased timeout for sanitizer/flow tests to reduce spurious timeouts.
  * CI artifact uploads now always run and include logs from both initial and retry attempts for easier debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->