### PR TITLE
fix: iterate backwards in fulltext drop to avoid array mutation during iteration

### DIFF
--- a/src/procedures/proc_fulltext_drop_index.c
+++ b/src/procedures/proc_fulltext_drop_index.c
@@ -52,7 +52,10 @@ ProcedureResult Proc_FulltextDropIndexInvoke
 	const IndexField *fields = Index_GetFields(idx);
 	int n = array_len((IndexField*)fields);
 	// drop only fulltext fields
-	for(int i = 0; i < n; i++) {
+	// iterate backwards: array_del_fast swaps deleted element with the last
+	// element, iterating forward corrupts the iteration when fields points
+	// to the same array being modified by Schema_RemoveIndex
+	for(int i = n - 1; i >= 0; i--) {
 		const IndexField *f = fields + i;
 		if(IndexField_GetType(f) & INDEX_FLD_FULLTEXT) {
 			int res = GraphContext_DeleteIndex(gc, SCHEMA_NODE, lbl,


### PR DESCRIPTION
## Problem

`Proc_FulltextDropIndexInvoke` iterates the `fields` array returned by `Index_GetFields()` while `Schema_RemoveIndex` (called via `GraphContext_DeleteIndex`) modifies the **same** array using `array_del_fast`.

`array_del_fast` swaps the deleted element with the last element and decrements length. Forward iteration causes:
- Elements to be skipped (swapped element lands behind the iterator)
- Out-of-bounds reads when the array shrinks below the original `n`

### Trace with 5 fields `[v1, v2, v3, v4, v5]`

| i | array state | access | action | result |
|---|-------------|--------|--------|--------|
| 0 | `[v1,v2,v3,v4,v5]` len=5 | v1 | delete, swap with v5 | `[v5,v2,v3,v4]` len=4 |
| 1 | `[v5,v2,v3,v4]` len=4 | v2 | delete, swap with v4 | `[v5,v4,v3]` len=3 |
| 2 | `[v5,v4,v3]` len=3 | v3 | delete (last element) | `[v5,v4]` len=2 |
| 3 | `[v5,v4]` len=2 | **OOB** | garbage read, skip | — |
| 4 | `[v5,v4]` len=2 | **OOB** | garbage read, skip | — |

**Result:** Only 3 fields deleted, v4 and v5 remain orphaned (`indices_deleted = 3` instead of 5).

### Why it's flaky

This only manifests when the index is still in **PENDING** state (building). In that case, `Schema_GetIndex(..., true)` returns the PENDING index, and `Schema_RemoveIndex` operates on the same object. When the index is **ACTIVE**, `Schema_RemoveIndex` clones it to create PENDING and modifies the clone, leaving the original `fields` array untouched.

## Fix

Iterate backwards (`for(int i = n-1; i >= 0; i--)`). `array_del_fast` on the last element is a no-op swap, and earlier elements at indices `< i` are never affected by the swap.

Closes #1622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with dropping fulltext indexes to ensure proper cleanup and prevent data integrity problems during the removal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->