### PR TITLE
fix: add version script to hide dict* symbols from Redis 8.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,17 +150,8 @@ add_compile_options(-fno-strict-aliasing)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_LD_FLAGS} ${CMAKE_EXE_LD_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_LD_FLAGS} ${CMAKE_SO_LD_FLAGS}")
 
-# -Bsymbolic and -Bsymbolic-functions: Resolve internal references to global symbols locally,
-# preventing symbol interposition from the host process (Redis). This is critical because
-# RediSearch has its own dict implementation with the same symbol names as Redis's
-# internal dict (dictCreate, dictAdd, etc.), but with a different dictType structure.
-# Without these flags, RediSearch's code would call Redis's dict functions instead
-# of its own, causing crashes due to ABI incompatibility (Redis 8.x dictType has
-# more fields than RediSearch's dictType).
-# Note: Both flags are used together as in the original readies build system.
-if(NOT APPLE)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic,-Bsymbolic-functions")
-endif()
+# Symbol isolation flags are applied per-target below (after add_library).
+# See the target_link_options(falkordb ...) block near line 320.
 
 # Set C standard
 set(CMAKE_C_STANDARD 11)
@@ -309,6 +300,41 @@ add_dependencies(falkordb redisearch-static)
 
 target_link_options(falkordb PRIVATE ${CMAKE_LD_FLAGS_LIST} ${CMAKE_SO_LD_FLAGS_LIST})
 target_link_libraries(falkordb PRIVATE ${FALKORDB_LIBS} ${CMAKE_LD_LIBS})
+
+# Symbol isolation: prevent RediSearch's dict symbols from clashing with Redis's.
+#
+# RediSearch has its own dict implementation (dictCreate, dictAdd, dictFind, etc.)
+# with the same symbol names as Redis's dict API but a different dictType layout.
+# On Redis 8.x, dictType has 12+ fields vs RediSearch's 6 — without isolation,
+# the dynamic linker resolves RediSearch's internal dict calls to Redis's versions,
+# causing ABI mismatches and SEGFAULT in UNIQUE constraint enforcement.
+#
+# Two layers of defense (applied to the falkordb target only):
+# 1. -Bsymbolic: tells the linker to bind internal references locally
+# 2. Version script (src/falkordb.ver): explicitly hides dict* from dynamic export
+#
+# Both are needed because -Bsymbolic alone may not set DF_SYMBOLIC on all
+# toolchains (observed with Clang 19 + binutils 2.42 on complex builds).
+if(NOT APPLE)
+    target_link_options(falkordb PRIVATE
+        -Wl,-Bsymbolic,-Bsymbolic-functions)
+    set(FALKORDB_VERSION_SCRIPT "${CMAKE_SOURCE_DIR}/src/falkordb.ver")
+    if(EXISTS "${FALKORDB_VERSION_SCRIPT}")
+        target_link_options(falkordb PRIVATE
+            -Wl,--version-script=${FALKORDB_VERSION_SCRIPT})
+    endif()
+endif()
+
+# Post-build verification: ensure dict* symbols are not dynamically exported.
+# If any dict symbol leaks through, the module will crash on Redis 8.x.
+if(NOT APPLE)
+    add_custom_command(TARGET falkordb POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Verifying dict symbol isolation..."
+        COMMAND /bin/sh -c "if nm -D $<TARGET_FILE:falkordb> 2>/dev/null | grep -q ' [TBD] dict'; then echo 'ERROR: dict* symbols are dynamically exported — Redis 8.x ABI crash risk!' && exit 1; else echo 'OK: dict* symbols are hidden'; fi"
+        COMMENT "Checking that dict* symbols are hidden from dynamic export"
+        VERBATIM
+    )
+endif()
 
 if(APPLE)
     add_library(falkordb_static STATIC $<TARGET_OBJECTS:falkordb>)

--- a/src/falkordb.ver
+++ b/src/falkordb.ver
@@ -1,0 +1,25 @@
+/*
+ * FalkorDB symbol version script
+ *
+ * Hides internal dict* symbols to prevent dynamic symbol interposition
+ * when loaded as a Redis module. This is necessary because RediSearch's
+ * internal dict implementation (dictCreate, dictAdd, dictFind, etc.)
+ * uses the same symbol names as Redis's dict API, but with a different
+ * dictType struct layout.
+ *
+ * On Redis 8.x, dictType has 12+ fields while RediSearch's has 6.
+ * Without symbol hiding, the dynamic linker may resolve RediSearch's
+ * dict calls to Redis's implementations, causing ABI mismatches and
+ * crashes (SEGFAULT in EnforceUniqueEntity during UNIQUE constraint
+ * enforcement).
+ *
+ * This version script provides reliable symbol isolation even when
+ * -Bsymbolic does not produce DF_SYMBOLIC in the final binary
+ * (observed with Clang 19 on complex CMake builds).
+ */
+{
+    global:
+        RedisModule_OnLoad;
+    local:
+        dict*;
+};


### PR DESCRIPTION
## Summary

Fixes Redis 8.x ABI-incompatible symbol interposition that causes SEGFAULT during UNIQUE constraint enforcement.

RediSearch's internal dict uses the same symbol names (`dictCreate`, `dictAdd`, `dictFind`) as Redis's dict API, but with a different `dictType` struct layout (6 fields vs 12+ on Redis 8.x). Without symbol isolation, the dynamic linker resolves RediSearch's dict calls to Redis's implementations, causing null pointer dereferences.

## Changes

### 1. Version script (`src/falkordb.ver`)
Exports only `RedisModule_OnLoad`, hides all `dict*` symbols from dynamic export:
```
{ global: RedisModule_OnLoad; local: dict*; };
```

### 2. Target-scoped linker flags (`CMakeLists.txt`)
Moves `-Bsymbolic` from global `CMAKE_SHARED_LINKER_FLAGS` to `target_link_options(falkordb PRIVATE ...)`:
- Better CMake practice — flags only affect the `falkordb` target, not other shared libraries
- Adds `--version-script` as a second layer of defense alongside `-Bsymbolic`

### 3. Post-build verification (`CMakeLists.txt`)
Adds a `POST_BUILD` custom command that runs `nm -D` and **fails the build** if any `dict*` symbol is still dynamically exported. This catches regressions automatically — if a future build change accidentally exposes dict symbols, CI will catch it.

## Why `-Bsymbolic` alone isn't enough

The existing `-Wl,-Bsymbolic,-Bsymbolic-functions` flags are correct in principle but may not produce `DF_SYMBOLIC` in the final binary on all toolchains. We observed this with Clang 19 + binutils 2.42 on Ubuntu 24.04:
- The flag IS present in the actual link command
- `readelf -d falkordb.so` does NOT show `SYMBOLIC`
- `nm -D falkordb.so | grep dictCreate` shows the symbol globally exported
- A standalone test with the same linker works fine — the issue appears specific to the complex FalkorDB build

The version script provides reliable symbol isolation regardless of `-Bsymbolic` behavior. Both mechanisms are kept as defense in depth.

## Verification

After building with this change:
```bash
# dict symbols should be hidden
$ nm -D falkordb.so | grep dictCreate
(no output)

# Module entry point should be exported
$ nm -D falkordb.so | grep RedisModule_OnLoad
... T RedisModule_OnLoad

# The post-build step prints:
# Verifying dict symbol isolation...
# OK: dict* symbols are hidden
```

Tested on Redis 8.6.1: UNIQUE constraints work correctly, all graph operations functional.

## Test plan

- [ ] Build on Linux x64 (Ubuntu) — verify post-build check passes
- [ ] Build on Linux arm64 — verify post-build check passes
- [ ] Build on macOS — verify version script is correctly skipped (macOS uses two-level namespace)
- [ ] Load module on Redis 8.x and create UNIQUE constraint — no SEGFAULT
- [ ] Run full regression test suite
- [ ] Verify `nm -D falkordb.so | grep dict` returns nothing

Fixes #1642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved linker configuration to apply symbol isolation per build target on non-Apple platforms.
  * Added a symbol version script to restrict which symbols are exported when the module is loaded.
  * Added a post-build verification step that emits a check and fails the build if restricted symbols are exported.
  * Retained existing behavior on Apple platforms; overall build structure preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->