### PR TITLE
fix(ci): add pull-requests write permission to security-scan job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           # change this so it uses a pattern to download all group_* artifacts
           pattern: ${{ github.head_ref || github.ref_name }}-benchmark-group_*-results
@@ -189,7 +189,7 @@ jobs:
           mkdir -p tests/benchmarks/compare/master
 
       - name: Download artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.head_ref }}-benchmark-results
           path: tests/benchmarks/compare/${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,7 @@ jobs:
         test_type: [unit, flow, tck, fuzz]
     steps:
       - name: Download test image
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: falkordb-tests-${{ matrix.platform.suffix }}
           path: /tmp
@@ -486,7 +486,7 @@ jobs:
         uses: actions/checkout@v6
         
       - name: Download image
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: falkordb-${{ matrix.platform.suffix }}
           path: /tmp
@@ -566,7 +566,7 @@ jobs:
             machine_label: ubuntu-24.04-arm
     steps:
       - name: Download test image
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: falkordb-tests-${{ matrix.platform.suffix }}
           path: /tmp


### PR DESCRIPTION
The `marocchino/sticky-pull-request-comment` action needs `pull-requests: write` permission to post Trivy scan results as PR comments. Without it, all security-scan matrix jobs fail with:

```
Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

This adds `permissions: pull-requests: write` to the `security-scan` job.

Fixes the security-scan failures seen in #1652 and other PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to use the latest artifact download action version.
  * Enhanced workflow permissions for security scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->