### PR TITLE
swith to redis host config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1481,7 +1481,16 @@ run_flow_tests() {
     elif [[ "$SLOW" == "1" ]]; then
         export PARALLEL=0
     else
-        export PARALLEL=1
+        # Default to serial execution for stability.
+        # RLTest multiprocessing may terminate early under the current
+        # Python/RLTest combination.
+        export PARALLEL=0
+    fi
+
+    # Randomize test ports by default to avoid collisions between concurrent
+    # RLTest workers and any lingering local Redis instances.
+    if [[ -z "${RANDPORTS:-}" ]]; then
+        export RANDPORTS=1
     fi
 
     # Set test options

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -109,11 +109,29 @@ bool AST_ReadOnly
 	if(root == NULL) return true;
 
 	cypher_astnode_type_t type = cypher_astnode_type(root);
+	if(type == CYPHER_AST_STATEMENT) {
+		return AST_ReadOnly(cypher_ast_statement_get_body(root));
+	}
+
+	if(type == CYPHER_AST_QUERY) {
+		uint n_clauses = cypher_ast_query_nclauses(root);
+		for(uint i = 0; i < n_clauses; i++) {
+			const cypher_astnode_t *clause = cypher_ast_query_get_clause(root, i);
+			if(!AST_ReadOnly(clause)) return false;
+		}
+		return true;
+	}
+
+	if(type == CYPHER_AST_CALL_SUBQUERY) {
+		return AST_ReadOnly(cypher_ast_call_subquery_get_query(root));
+	}
+
 	if(type == CYPHER_AST_CREATE                     ||
 	   type == CYPHER_AST_MERGE                      ||
 	   type == CYPHER_AST_DELETE                     ||
 	   type == CYPHER_AST_SET                        ||
 	   type == CYPHER_AST_REMOVE                     ||
+	   type == CYPHER_AST_FOREACH                    ||
 	   type == CYPHER_AST_CREATE_NODE_PROPS_INDEX    ||
 	   type == CYPHER_AST_CREATE_PATTERN_PROPS_INDEX ||
 	   type == CYPHER_AST_DROP_PROPS_INDEX           ||
@@ -131,12 +149,6 @@ bool AST_ReadOnly
 		Proc_Free(proc);
 
 		if(!read_only) return false;
-	}
-
-	uint num_children = cypher_astnode_nchildren(root);
-	for(uint i = 0; i < num_children; i ++) {
-		const cypher_astnode_t *child = cypher_astnode_get_child(root, i);
-		if(!AST_ReadOnly(child)) return false;
 	}
 
 	return true;

--- a/src/bolt/bolt_api.c
+++ b/src/bolt/bolt_api.c
@@ -780,10 +780,10 @@ void BoltAcceptHandler
 // checks if bolt is enabled
 static bool _bolt_enabled
 (
-	int16_t *port  // [output] the bolt port
+	int32_t *port  // [output] the bolt port
 ) {
 	// get bolt port from configuration
-	int16_t p;
+	int32_t p;
 	Config_Option_get(Config_BOLT_PORT, &p);
 
 	// bolt is disabled if port is -1
@@ -803,7 +803,7 @@ int BoltApi_Register
 (
     RedisModuleCtx *ctx  // redis context
 ) {
-	int16_t port;
+	int32_t port;
 
 	// quick return if bolt is disabled
 	if(!_bolt_enabled(&port)) {
@@ -815,7 +815,13 @@ int BoltApi_Register
 		return REDISMODULE_OK;
 	}
 
-    socket_t bolt = socket_bind(port);
+	// out of range for TCP port
+	if(port < 0 || port > UINT16_MAX) {
+		RedisModule_Log(ctx, "warning", "Invalid bolt port: %d", (int)port);
+		return REDISMODULE_ERR;
+	}
+
+	socket_t bolt = socket_bind((uint16_t)port);
 	if(bolt == -1) {
 		RedisModule_Log(ctx, "warning", "Failed to bind to port %d", port);
 		return REDISMODULE_ERR;

--- a/src/commands/cmd_config.c
+++ b/src/commands/cmd_config.c
@@ -5,8 +5,77 @@
  */
 
 #include <string.h>
+#include <limits.h>
 #include "RG.h"
 #include "configuration/config.h"
+
+static bool _Config_GetNumericValue(Config_Option_Field field, long long *value) {
+	ASSERT(value != NULL);
+
+	switch(field) {
+	case Config_TIMEOUT:
+	case Config_TIMEOUT_DEFAULT:
+	case Config_TIMEOUT_MAX:
+	case Config_CACHE_SIZE:
+	case Config_OPENMP_NTHREAD:
+	case Config_THREAD_POOL_SIZE:
+	case Config_VKEY_MAX_ENTITY_COUNT:
+	case Config_MAX_QUEUED_QUERIES:
+	case Config_NODE_CREATION_BUFFER:
+	case Config_CMD_INFO_MAX_QUERY_COUNT:
+	case Config_EFFECTS_THRESHOLD: {
+		uint64_t n = 0;
+		bool res = Config_Option_get(field, &n);
+		if(!res) return false;
+		ASSERT(n <= (uint64_t)LLONG_MAX);
+		*value = (long long)n;
+		return true;
+	}
+
+	case Config_RESULTSET_MAX_SIZE: {
+		uint64_t n = 0;
+		bool res = Config_Option_get(field, &n);
+		if(!res) return false;
+		if(n == RESULTSET_SIZE_UNLIMITED) {
+			*value = -1;
+			return true;
+		}
+		ASSERT(n <= (uint64_t)LLONG_MAX);
+		*value = (long long)n;
+		return true;
+	}
+
+	case Config_QUERY_MEM_CAPACITY:
+	case Config_DELTA_MAX_PENDING_CHANGES: {
+		int64_t n = 0;
+		bool res = Config_Option_get(field, &n);
+		if(!res) return false;
+		*value = (long long)n;
+		return true;
+	}
+
+	case Config_BOLT_PORT: {
+		int32_t n = 0;
+		bool res = Config_Option_get(field, &n);
+		if(!res) return false;
+		*value = (long long)n;
+		return true;
+	}
+
+	case Config_JS_HEAP_SIZE:
+	case Config_JS_STACK_SIZE: {
+		size_t n = 0;
+		bool res = Config_Option_get(field, &n);
+		if(!res) return false;
+		ASSERT(n <= (size_t)LLONG_MAX);
+		*value = (long long)n;
+		return true;
+	}
+
+	default:
+		return false;
+	}
+}
 
 // emit config field name and value
 static void _Emit_config
@@ -36,7 +105,7 @@ static void _Emit_config
 			break;
 
 		case T_INT64:
-			res = Config_Option_get(field, &numeric_value);
+				res = _Config_GetNumericValue(field, &numeric_value);
 			ASSERT(res == true);
 
 			RedisModule_ReplyWithArray(ctx, 2);

--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -298,14 +298,14 @@ static RedisModuleString *_ModuleConfigGetString(const char *name,
 
 static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 	// numeric configs
-	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT, config.timeout,
+	if(RedisModule_RegisterNumericConfig(ctx, "timeout", config.timeout,
 		_Config_flags(Config_TIMEOUT, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
 		NULL, (void *)(intptr_t)Config_TIMEOUT) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT_DEFAULT,
+	if(RedisModule_RegisterNumericConfig(ctx, "timeout_default",
 		config.timeout_default,
 		_Config_flags(Config_TIMEOUT_DEFAULT, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -313,21 +313,21 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT_MAX, config.timeout_max,
+	if(RedisModule_RegisterNumericConfig(ctx, "timeout_max", config.timeout_max,
 		_Config_flags(Config_TIMEOUT_MAX, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
 		NULL, (void *)(intptr_t)Config_TIMEOUT_MAX) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, CACHE_SIZE, config.cache_size,
+	if(RedisModule_RegisterNumericConfig(ctx, "cache_size", config.cache_size,
 		_Config_flags(Config_CACHE_SIZE, false),
 		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
 		NULL, (void *)(intptr_t)Config_CACHE_SIZE) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, THREAD_COUNT,
+	if(RedisModule_RegisterNumericConfig(ctx, "thread_count",
 		config.thread_pool_size,
 		_Config_flags(Config_THREAD_POOL_SIZE, false),
 		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -335,7 +335,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, RESULTSET_SIZE,
+	if(RedisModule_RegisterNumericConfig(ctx, "resultset_size",
 		config.resultset_size,
 		_Config_flags(Config_RESULTSET_MAX_SIZE, false),
 		LLONG_MIN, LLONG_MAX, _ModuleConfigGetNumeric,
@@ -344,7 +344,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, OMP_THREAD_COUNT,
+	if(RedisModule_RegisterNumericConfig(ctx, "omp_thread_count",
 		config.omp_thread_count,
 		_Config_flags(Config_OPENMP_NTHREAD, false),
 		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -352,7 +352,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, VKEY_MAX_ENTITY_COUNT,
+	if(RedisModule_RegisterNumericConfig(ctx, "vkey_max_entity_count",
 		config.vkey_entity_count,
 		_Config_flags(Config_VKEY_MAX_ENTITY_COUNT, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -360,7 +360,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, MAX_QUEUED_QUERIES,
+	if(RedisModule_RegisterNumericConfig(ctx, "max_queued_queries",
 		config.max_queued_queries,
 		_Config_flags(Config_MAX_QUEUED_QUERIES, false),
 		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -368,7 +368,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, QUERY_MEM_CAPACITY,
+	if(RedisModule_RegisterNumericConfig(ctx, "query_mem_capacity",
 		config.query_mem_capacity,
 		_Config_flags(Config_QUERY_MEM_CAPACITY, true),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -376,7 +376,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, DELTA_MAX_PENDING_CHANGES,
+	if(RedisModule_RegisterNumericConfig(ctx, "delta_max_pending_changes",
 		config.delta_max_pending_changes,
 		_Config_flags(Config_DELTA_MAX_PENDING_CHANGES, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -384,7 +384,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, NODE_CREATION_BUFFER,
+	if(RedisModule_RegisterNumericConfig(ctx, "node_creation_buffer",
 		config.node_creation_buffer,
 		_Config_flags(Config_NODE_CREATION_BUFFER, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -392,7 +392,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, CMD_INFO_MAX_QUERIES_COUNT_OPTION_NAME,
+	if(RedisModule_RegisterNumericConfig(ctx, "max_info_queries",
 		config.max_info_queries_count,
 		_Config_flags(Config_CMD_INFO_MAX_QUERY_COUNT, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -400,7 +400,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, EFFECTS_THRESHOLD,
+	if(RedisModule_RegisterNumericConfig(ctx, "effects_threshold",
 		config.effects_threshold,
 		_Config_flags(Config_EFFECTS_THRESHOLD, false),
 		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -408,14 +408,14 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, BOLT_PORT, config.bolt_port,
+	if(RedisModule_RegisterNumericConfig(ctx, "bolt_port", config.bolt_port,
 		_Config_flags(Config_BOLT_PORT, false),
 		-1, 65535, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
 		NULL, (void *)(intptr_t)Config_BOLT_PORT) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, JS_HEAP_SIZE,
+	if(RedisModule_RegisterNumericConfig(ctx, "js_heap_size",
 		(long long)config.js_heap_size,
 		_Config_flags(Config_JS_HEAP_SIZE, true),
 		1048576, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -423,7 +423,7 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, JS_STACK_SIZE,
+	if(RedisModule_RegisterNumericConfig(ctx, "js_stack_size",
 		(long long)config.js_stack_size,
 		_Config_flags(Config_JS_STACK_SIZE, true),
 		1048576, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
@@ -432,21 +432,21 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 	}
 
 	// bool configs
-	if(RedisModule_RegisterBoolConfig(ctx, ASYNC_DELETE, config.async_delete,
+	if(RedisModule_RegisterBoolConfig(ctx, "async_delete", config.async_delete,
 		_Config_flags(Config_ASYNC_DELETE, false),
 		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
 		(void *)(intptr_t)Config_ASYNC_DELETE) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterBoolConfig(ctx, CMD_INFO, config.cmd_info_on,
+	if(RedisModule_RegisterBoolConfig(ctx, "cmd_info", config.cmd_info_on,
 		_Config_flags(Config_CMD_INFO, false),
 		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
 		(void *)(intptr_t)Config_CMD_INFO) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterBoolConfig(ctx, DELAY_INDEXING, config.delay_indexing,
+	if(RedisModule_RegisterBoolConfig(ctx, "delay_indexing", config.delay_indexing,
 		_Config_flags(Config_DELAY_INDEXING, false),
 		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
 		(void *)(intptr_t)Config_DELAY_INDEXING) == REDISMODULE_ERR) {
@@ -454,14 +454,14 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 	}
 
 	// string configs
-	if(RedisModule_RegisterStringConfig(ctx, IMPORT_FOLDER, config.import_folder,
+	if(RedisModule_RegisterStringConfig(ctx, "import_folder", config.import_folder,
 		_Config_flags(Config_IMPORT_FOLDER, false),
 		_ModuleConfigGetString, _ModuleConfigSetString, NULL,
 		(void *)(intptr_t)Config_IMPORT_FOLDER) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterStringConfig(ctx, TEMP_FOLDER, config.temp_folder,
+	if(RedisModule_RegisterStringConfig(ctx, "temp_folder", config.temp_folder,
 		_Config_flags(Config_TEMP_FOLDER, false),
 		_ModuleConfigGetString, _ModuleConfigSetString, NULL,
 		(void *)(intptr_t)Config_TEMP_FOLDER) == REDISMODULE_ERR) {
@@ -1331,6 +1331,14 @@ int Config_Init
 		RedisModule_Log(ctx, "warning",
 				"Failed to load module configuration");
 		return REDISMODULE_ERR;
+	}
+
+	if(argc > 0) {
+		RedisModule_Log(ctx, "warning",
+				"Passing FalkorDB configuration via loadmodule arguments is "
+				"deprecated and will be removed in a future release. "
+				"Use redis.conf module directives (for example: "
+				"graph.max_queued_queries 10) instead.");
 	}
 
 	if (argc % 2)

--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
+#include <stdint.h>
 #include <sys/stat.h>
 
 //-----------------------------------------------------------------------------
@@ -131,6 +132,344 @@ typedef struct
 } RG_Config;
 
 RG_Config config; // global module configuration
+
+//------------------------------------------------------------------------------
+// Redis module configuration registration helpers
+//------------------------------------------------------------------------------
+
+static bool _Config_is_runtime(Config_Option_Field field) {
+	for(size_t i = 0; i < RUNTIME_CONFIG_COUNT; i++) {
+		if(RUNTIME_CONFIGS[i] == field) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static unsigned int _Config_flags(Config_Option_Field field, bool memory) {
+	unsigned int flags = _Config_is_runtime(field) ?
+		REDISMODULE_CONFIG_DEFAULT : REDISMODULE_CONFIG_IMMUTABLE;
+	if(memory) flags |= REDISMODULE_CONFIG_MEMORY;
+	return flags;
+}
+
+static int _Config_set_from_string
+(
+	Config_Option_Field field,
+	const char *val,
+	RedisModuleString **err
+) {
+	char *error = NULL;
+	if(!Config_Option_set(field, val, &error)) {
+		if(err != NULL) {
+			const char *name = Config_Field_name(field);
+			if(error) {
+				*err = RedisModule_CreateString(NULL, error, strlen(error));
+			} else {
+				char buf[128];
+				snprintf(buf, sizeof(buf),
+					"Failed to set config value %s to %s", name, val);
+				*err = RedisModule_CreateString(NULL, buf, strlen(buf));
+			}
+		}
+		return REDISMODULE_ERR;
+	}
+	return REDISMODULE_OK;
+}
+
+static RedisModuleString *_Config_get_string_value(Config_Option_Field field) {
+	const char *value = NULL;
+	bool res = Config_Option_get(field, &value);
+	ASSERT(res);
+	return RedisModule_CreateString(NULL, value, strlen(value));
+}
+
+static int _ModuleConfigSetNumeric(const char *name, long long val,
+	void *privdata, RedisModuleString **err) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+	char buf[64];
+	snprintf(buf, sizeof(buf), "%lld", val);
+	return _Config_set_from_string(field, buf, err);
+}
+
+static long long _ModuleConfigGetNumeric(const char *name, void *privdata) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+
+	switch(field) {
+	case Config_TIMEOUT:
+	case Config_TIMEOUT_DEFAULT:
+	case Config_TIMEOUT_MAX:
+	case Config_CACHE_SIZE:
+	case Config_OPENMP_NTHREAD:
+	case Config_THREAD_POOL_SIZE:
+	case Config_RESULTSET_MAX_SIZE:
+	case Config_VKEY_MAX_ENTITY_COUNT:
+	case Config_MAX_QUEUED_QUERIES:
+	case Config_QUERY_MEM_CAPACITY:
+	case Config_DELTA_MAX_PENDING_CHANGES:
+	case Config_NODE_CREATION_BUFFER:
+	case Config_CMD_INFO_MAX_QUERY_COUNT:
+	case Config_EFFECTS_THRESHOLD:
+	case Config_BOLT_PORT:
+	case Config_IMPORT_FOLDER: // not numeric, handled below
+	case Config_TEMP_FOLDER:   // not numeric, handled below
+	case Config_JS_HEAP_SIZE:
+	case Config_JS_STACK_SIZE:
+	default:
+		break;
+	}
+
+	long long n = 0;
+
+	switch(field) {
+	case Config_TIMEOUT:
+	case Config_TIMEOUT_DEFAULT:
+	case Config_TIMEOUT_MAX:
+	case Config_MAX_QUEUED_QUERIES:
+	case Config_QUERY_MEM_CAPACITY:
+	case Config_DELTA_MAX_PENDING_CHANGES:
+	case Config_EFFECTS_THRESHOLD:
+	case Config_RESULTSET_MAX_SIZE:
+	case Config_VKEY_MAX_ENTITY_COUNT:
+	case Config_NODE_CREATION_BUFFER:
+	case Config_CMD_INFO_MAX_QUERY_COUNT:
+	case Config_CACHE_SIZE:
+	case Config_OPENMP_NTHREAD:
+	case Config_THREAD_POOL_SIZE:
+	case Config_JS_HEAP_SIZE:
+	case Config_JS_STACK_SIZE:
+		Config_Option_get(field, &n);
+		break;
+
+	case Config_BOLT_PORT: {
+		int16_t port;
+		Config_Option_get(field, &port);
+		n = port;
+		break;
+	}
+
+	default:
+		ASSERT(false && "invalid numeric config");
+	}
+
+	return n;
+}
+
+static int _ModuleConfigSetBool(const char *name, int val, void *privdata,
+	RedisModuleString **err) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+	const char *bool_str = val ? "yes" : "no";
+	return _Config_set_from_string(field, bool_str, err);
+}
+
+static int _ModuleConfigGetBool(const char *name, void *privdata) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+	bool flag = false;
+	Config_Option_get(field, &flag);
+	return flag ? 1 : 0;
+}
+
+static int _ModuleConfigSetString(const char *name, RedisModuleString *val,
+	void *privdata, RedisModuleString **err) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+
+	size_t len = 0;
+	const char *cstr = RedisModule_StringPtrLen(val, &len);
+	char *buf = rm_malloc(len + 1);
+	memcpy(buf, cstr, len);
+	buf[len] = '\0';
+
+	int rc = _Config_set_from_string(field, buf, err);
+	rm_free(buf);
+	return rc;
+}
+
+static RedisModuleString *_ModuleConfigGetString(const char *name,
+	void *privdata) {
+	UNUSED(name);
+	Config_Option_Field field = (Config_Option_Field)(intptr_t)privdata;
+	return _Config_get_string_value(field);
+}
+
+static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
+	// numeric configs
+	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT, config.timeout,
+		_Config_flags(Config_TIMEOUT, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_TIMEOUT) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT_DEFAULT,
+		config.timeout_default,
+		_Config_flags(Config_TIMEOUT_DEFAULT, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_TIMEOUT_DEFAULT) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, TIMEOUT_MAX, config.timeout_max,
+		_Config_flags(Config_TIMEOUT_MAX, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_TIMEOUT_MAX) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, CACHE_SIZE, config.cache_size,
+		_Config_flags(Config_CACHE_SIZE, false),
+		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_CACHE_SIZE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, THREAD_COUNT,
+		config.thread_pool_size,
+		_Config_flags(Config_THREAD_POOL_SIZE, false),
+		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_THREAD_POOL_SIZE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, RESULTSET_SIZE,
+		config.resultset_size,
+		_Config_flags(Config_RESULTSET_MAX_SIZE, false),
+		LLONG_MIN, LLONG_MAX, _ModuleConfigGetNumeric,
+		_ModuleConfigSetNumeric, NULL,
+		(void *)(intptr_t)Config_RESULTSET_MAX_SIZE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, OMP_THREAD_COUNT,
+		config.omp_thread_count,
+		_Config_flags(Config_OPENMP_NTHREAD, false),
+		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_OPENMP_NTHREAD) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, VKEY_MAX_ENTITY_COUNT,
+		config.vkey_entity_count,
+		_Config_flags(Config_VKEY_MAX_ENTITY_COUNT, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_VKEY_MAX_ENTITY_COUNT) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, MAX_QUEUED_QUERIES,
+		config.max_queued_queries,
+		_Config_flags(Config_MAX_QUEUED_QUERIES, false),
+		1, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_MAX_QUEUED_QUERIES) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, QUERY_MEM_CAPACITY,
+		config.query_mem_capacity,
+		_Config_flags(Config_QUERY_MEM_CAPACITY, true),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_QUERY_MEM_CAPACITY) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, DELTA_MAX_PENDING_CHANGES,
+		config.delta_max_pending_changes,
+		_Config_flags(Config_DELTA_MAX_PENDING_CHANGES, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_DELTA_MAX_PENDING_CHANGES) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, NODE_CREATION_BUFFER,
+		config.node_creation_buffer,
+		_Config_flags(Config_NODE_CREATION_BUFFER, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_NODE_CREATION_BUFFER) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, CMD_INFO_MAX_QUERIES_COUNT_OPTION_NAME,
+		config.max_info_queries_count,
+		_Config_flags(Config_CMD_INFO_MAX_QUERY_COUNT, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_CMD_INFO_MAX_QUERY_COUNT) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, EFFECTS_THRESHOLD,
+		config.effects_threshold,
+		_Config_flags(Config_EFFECTS_THRESHOLD, false),
+		0, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_EFFECTS_THRESHOLD) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, BOLT_PORT, config.bolt_port,
+		_Config_flags(Config_BOLT_PORT, false),
+		-1, 65535, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_BOLT_PORT) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, JS_HEAP_SIZE,
+		(long long)config.js_heap_size,
+		_Config_flags(Config_JS_HEAP_SIZE, true),
+		1048576, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_JS_HEAP_SIZE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterNumericConfig(ctx, JS_STACK_SIZE,
+		(long long)config.js_stack_size,
+		_Config_flags(Config_JS_STACK_SIZE, true),
+		1048576, LLONG_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		NULL, (void *)(intptr_t)Config_JS_STACK_SIZE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	// bool configs
+	if(RedisModule_RegisterBoolConfig(ctx, ASYNC_DELETE, config.async_delete,
+		_Config_flags(Config_ASYNC_DELETE, false),
+		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
+		(void *)(intptr_t)Config_ASYNC_DELETE) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterBoolConfig(ctx, CMD_INFO, config.cmd_info_on,
+		_Config_flags(Config_CMD_INFO, false),
+		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
+		(void *)(intptr_t)Config_CMD_INFO) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterBoolConfig(ctx, DELAY_INDEXING, config.delay_indexing,
+		_Config_flags(Config_DELAY_INDEXING, false),
+		_ModuleConfigGetBool, _ModuleConfigSetBool, NULL,
+		(void *)(intptr_t)Config_DELAY_INDEXING) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	// string configs
+	if(RedisModule_RegisterStringConfig(ctx, IMPORT_FOLDER, config.import_folder,
+		_Config_flags(Config_IMPORT_FOLDER, false),
+		_ModuleConfigGetString, _ModuleConfigSetString, NULL,
+		(void *)(intptr_t)Config_IMPORT_FOLDER) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	if(RedisModule_RegisterStringConfig(ctx, TEMP_FOLDER, config.temp_folder,
+		_Config_flags(Config_TEMP_FOLDER, false),
+		_ModuleConfigGetString, _ModuleConfigSetString, NULL,
+		(void *)(intptr_t)Config_TEMP_FOLDER) == REDISMODULE_ERR) {
+		return REDISMODULE_ERR;
+	}
+
+	return REDISMODULE_OK;
+}
 
 //------------------------------------------------------------------------------
 // config value parsing
@@ -976,6 +1315,20 @@ int Config_Init(
 	// initialize the configuration to its default values
 	_Config_SetToDefaults();
 
+	// register configurations with Redis CONFIG interface
+	if(_RegisterModuleConfigs(ctx) != REDISMODULE_OK) {
+		RedisModule_Log(ctx, "warning",
+				"Failed to register module configuration");
+		return REDISMODULE_ERR;
+	}
+
+	// apply configurations provided via MODULE LOADEX / redis.conf
+	if(RedisModule_LoadConfigs(ctx) != REDISMODULE_OK) {
+		RedisModule_Log(ctx, "warning",
+				"Failed to load module configuration");
+		return REDISMODULE_ERR;
+	}
+
 	if (argc % 2)
 	{
 		// emit an error if we received an odd number of arguments,
@@ -1804,4 +2157,3 @@ void Config_Subscribe_Changes(
 	ASSERT(cb != NULL);
 	config.cb = cb;
 }
-

--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -122,7 +122,7 @@ typedef struct
 	bool cmd_info_on;				   // if true, the GRAPH.INFO is enabled
 	uint64_t effects_threshold;		   // replicate via effects when runtime exceeds threshold
 	uint64_t max_info_queries_count;   // maximum number of query info elements
-	int16_t bolt_port;				   // bolt protocol port
+	int32_t bolt_port;				   // bolt protocol port
 	bool delay_indexing;			   // delay index construction when decoding
 	char *import_folder;			   // path to import folder, used for CSV loading
 	char *temp_folder;				   // path to temp folder, used for storing temporary files
@@ -201,60 +201,55 @@ static long long _ModuleConfigGetNumeric(const char *name, void *privdata) {
 	case Config_TIMEOUT:
 	case Config_TIMEOUT_DEFAULT:
 	case Config_TIMEOUT_MAX:
+	case Config_MAX_QUEUED_QUERIES:
+	case Config_VKEY_MAX_ENTITY_COUNT:
+	case Config_NODE_CREATION_BUFFER:
+	case Config_CMD_INFO_MAX_QUERY_COUNT:
 	case Config_CACHE_SIZE:
 	case Config_OPENMP_NTHREAD:
 	case Config_THREAD_POOL_SIZE:
-	case Config_RESULTSET_MAX_SIZE:
-	case Config_VKEY_MAX_ENTITY_COUNT:
-	case Config_MAX_QUEUED_QUERIES:
-	case Config_QUERY_MEM_CAPACITY:
-	case Config_DELTA_MAX_PENDING_CHANGES:
-	case Config_NODE_CREATION_BUFFER:
-	case Config_CMD_INFO_MAX_QUERY_COUNT:
-	case Config_EFFECTS_THRESHOLD:
-	case Config_BOLT_PORT:
-	case Config_IMPORT_FOLDER: // not numeric, handled below
-	case Config_TEMP_FOLDER:   // not numeric, handled below
-	case Config_JS_HEAP_SIZE:
-	case Config_JS_STACK_SIZE:
-	default:
-		break;
+	case Config_EFFECTS_THRESHOLD: {
+		uint64_t n = 0;
+		Config_Option_get(field, &n);
+		ASSERT(n <= (uint64_t)LLONG_MAX);
+		return (long long)n;
 	}
 
-	long long n = 0;
-
-	switch(field) {
-	case Config_TIMEOUT:
-	case Config_TIMEOUT_DEFAULT:
-	case Config_TIMEOUT_MAX:
-	case Config_MAX_QUEUED_QUERIES:
-	case Config_QUERY_MEM_CAPACITY:
-	case Config_DELTA_MAX_PENDING_CHANGES:
-	case Config_EFFECTS_THRESHOLD:
-	case Config_RESULTSET_MAX_SIZE:
-	case Config_VKEY_MAX_ENTITY_COUNT:
-	case Config_NODE_CREATION_BUFFER:
-	case Config_CMD_INFO_MAX_QUERY_COUNT:
-	case Config_CACHE_SIZE:
-	case Config_OPENMP_NTHREAD:
-	case Config_THREAD_POOL_SIZE:
-	case Config_JS_HEAP_SIZE:
-	case Config_JS_STACK_SIZE:
+	case Config_RESULTSET_MAX_SIZE: {
+		uint64_t n = 0;
 		Config_Option_get(field, &n);
-		break;
+		if(n == RESULTSET_SIZE_UNLIMITED) {
+			return -1;
+		}
+		ASSERT(n <= (uint64_t)LLONG_MAX);
+		return (long long)n;
+	}
+
+	case Config_QUERY_MEM_CAPACITY:
+	case Config_DELTA_MAX_PENDING_CHANGES: {
+		int64_t n = 0;
+		Config_Option_get(field, &n);
+		return (long long)n;
+	}
+
+	case Config_JS_HEAP_SIZE:
+	case Config_JS_STACK_SIZE: {
+		size_t n = 0;
+		Config_Option_get(field, &n);
+		ASSERT(n <= (size_t)LLONG_MAX);
+		return (long long)n;
+	}
 
 	case Config_BOLT_PORT: {
-		int16_t port;
-		Config_Option_get(field, &port);
-		n = port;
-		break;
+		int32_t n = 0;
+		Config_Option_get(field, &n);
+		return (long long)n;
 	}
 
 	default:
 		ASSERT(false && "invalid numeric config");
+		return 0;
 	}
-
-	return n;
 }
 
 static int _ModuleConfigSetBool(const char *name, int val, void *privdata,
@@ -408,9 +403,10 @@ static int _RegisterModuleConfigs(RedisModuleCtx *ctx) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_RegisterNumericConfig(ctx, "bolt_port", config.bolt_port,
+	if(RedisModule_RegisterNumericConfig(ctx, "bolt_port",
+		(long long)config.bolt_port,
 		_Config_flags(Config_BOLT_PORT, false),
-		-1, 65535, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
+		-1, UINT16_MAX, _ModuleConfigGetNumeric, _ModuleConfigSetNumeric,
 		NULL, (void *)(intptr_t)Config_BOLT_PORT) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
@@ -822,13 +818,13 @@ static uint64_t Config_effects_threshold_get(void)
 //------------------------------------------------------------------------------
 
 static void Config_bolt_port_set(
-	int16_t port)
+	int32_t port)
 {
-	int16_t p = (port < 0) ? BOLT_PROTOCOL_PORT_DEFAULT : port;
+	int32_t p = (port < 0) ? BOLT_PROTOCOL_PORT_DEFAULT : port;
 	config.bolt_port = p;
 }
 
-static int16_t Config_bolt_port_get(void)
+static int32_t Config_bolt_port_get(void)
 {
 	return config.bolt_port;
 }
@@ -1662,7 +1658,7 @@ bool Config_Option_get(
 	case Config_BOLT_PORT:
 	{
 		va_start(ap, field);
-		int16_t *bolt_port = va_arg(ap, int16_t *);
+		int32_t *bolt_port = va_arg(ap, int32_t *);
 		va_end(ap);
 
 		ASSERT(bolt_port != NULL);
@@ -2098,8 +2094,14 @@ bool Config_Option_set
 			if (!_Config_ParseInteger (val, &port)) {
 				return false ;
 			}
+			if (port < -1 || port > UINT16_MAX) {
+				if (err) {
+					*err = "BOLT_PORT must be between -1 and 65535";
+				}
+				return false;
+			}
 			if (Config_bolt_port_get () != port) {
-				Config_bolt_port_set (port) ;
+				Config_bolt_port_set ((int32_t)port) ;
 				updated = true ;
 			}
 		}

--- a/src/cron/cron.c
+++ b/src/cron/cron.c
@@ -265,6 +265,10 @@ void Cron_Stop(void) {
 	cron = NULL;
 }
 
+bool Cron_IsRunning(void) {
+	return cron != NULL && cron->alive;
+}
+
 // create a new CRON task
 CronTaskHandle Cron_AddTask
 (
@@ -314,4 +318,3 @@ bool Cron_AbortTask
 	// managed to abort task
 	return true;
 }
-

--- a/src/cron/cron.h
+++ b/src/cron/cron.h
@@ -33,6 +33,9 @@ void Cron_AddRecurringTasks(void);
 // add stream finished queries task
 void CronTask_AddStreamFinishedQueries();
 
+// returns true if cron thread is up
+bool Cron_IsRunning(void);
+
 // create a new CRON task
 CronTaskHandle Cron_AddTask
 (
@@ -49,4 +52,3 @@ bool Cron_AbortTask
 (
 	CronTaskHandle t
 );
-

--- a/src/cron/tasks.c
+++ b/src/cron/tasks.c
@@ -62,6 +62,9 @@ void CronTask_AddStreamFinishedQueries() {
 	// add query logging task
 	//--------------------------------------------------------------------------
 
+	// skip if cron isn't active yet (e.g., during module config load)
+	if(!Cron_IsRunning()) return;
+
 	// make sure info tracking is enabled
 	bool info_enabled = false;
 	if(Config_Option_get(Config_CMD_INFO, &info_enabled) && info_enabled) {
@@ -88,4 +91,3 @@ void CronTask_AddStreamFinishedQueries() {
 void Cron_AddRecurringTasks(void) {
 	CronTask_AddStreamFinishedQueries();
 }
-

--- a/src/udf/repository.c
+++ b/src/udf/repository.c
@@ -121,7 +121,9 @@ bool UDF_RepoInit(void) {
 // without changing its internal content, this will force each query execution
 // thread to reload a new quickjs runtime picking up on the new limits
 void UDF_RepoBumpVersion(void) {
-	ASSERT (udf_repo != NULL) ;
+	// During module startup configuration callbacks may fire before the repo is
+	// initialized, in which case there's nothing to bump yet.
+	if (udf_repo == NULL) return ;
 
 	// bump version
 	udf_repo->v++ ;
@@ -463,4 +465,3 @@ void UDF_RepoFree(void) {
 
 	rm_free (udf_repo) ;
 }
-

--- a/src/udf/repository.c
+++ b/src/udf/repository.c
@@ -120,13 +120,23 @@ bool UDF_RepoInit(void) {
 // size limit the configuration handler would bump the UDFs repo version
 // without changing its internal content, this will force each query execution
 // thread to reload a new quickjs runtime picking up on the new limits
+static inline void UDF_RepoBumpVersionLocked(void) {
+	ASSERT (udf_repo != NULL) ;
+	udf_repo->v++ ;
+}
+
 void UDF_RepoBumpVersion(void) {
 	// During module startup configuration callbacks may fire before the repo is
 	// initialized, in which case there's nothing to bump yet.
 	if (udf_repo == NULL) return ;
 
-	// bump version
-	udf_repo->v++ ;
+	// lock under WRITE
+	pthread_rwlock_wrlock (&udf_repo->rwlock) ;
+
+	UDF_RepoBumpVersionLocked () ;
+
+	// unlock
+	pthread_rwlock_unlock (&udf_repo->rwlock) ;
 }
 
 // return repo's version
@@ -409,7 +419,7 @@ bool UDF_RepoRemoveLib
 	array_del_fast (udf_repo->libs, idx);
 
 	// bump version
-	UDF_RepoBumpVersion ();
+	UDF_RepoBumpVersionLocked ();
 
 	// unlock
 	pthread_rwlock_unlock (&udf_repo->rwlock) ;

--- a/src/udf/repository.c
+++ b/src/udf/repository.c
@@ -393,13 +393,17 @@ bool UDF_RepoRemoveLib
 ) {
 	ASSERT (lib      != NULL) ;
 	ASSERT (udf_repo != NULL) ;
-	
+
+	// lock under WRITE
+	pthread_rwlock_wrlock (&udf_repo->rwlock) ;
+
 	// locate library
 	unsigned int idx ;
 	UDF_Lib *_lib = _UDF_RepoGetLib (lib, &idx) ;
 
 	// return if library doesn't exists
 	if (_lib == NULL) {
+		pthread_rwlock_unlock (&udf_repo->rwlock) ;
 		return false ;
 	}
 
@@ -408,9 +412,6 @@ bool UDF_RepoRemoveLib
 		*script = udf_repo->libs[idx].script ;
 		udf_repo->libs[idx].script = NULL ;
 	}
-
-	// lock under WRITE
-	pthread_rwlock_wrlock (&udf_repo->rwlock) ;
 
 	// free library
 	UDF_Lib_Free (_lib) ;

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -96,6 +96,11 @@ def Env(
     else:
         # Standard mode - direct port access
         port = env.envRunner.port
+
+    # Keep the exposed env.port aligned with the actual running port.
+    # This is critical when tests run with randomized ports.
+    env.port = port
+
     db = FalkorDB("localhost", port)
 
     if SANITIZER or VALGRIND:

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -101,6 +101,12 @@ def Env(
     # This is critical when tests run with randomized ports.
     env.port = port
 
+    if useSlaves:
+        slavePort = None
+        if hasattr(env.envRunner, 'slavePort'):
+            slavePort = env.envRunner.slavePort
+        env.slavePort = slavePort
+
     db = FalkorDB("localhost", port)
 
     if SANITIZER or VALGRIND:

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -343,6 +343,23 @@ class testConfig(FlowTestsBase):
         expected_response = 1024
         self.env.assertEqual(creation_buffer_size, expected_response)
 
+    def test12_config_commands_available_via_redis_config(self):
+        timeout_key = "graph.TIMEOUT"
+
+        # ensure CONFIG GET exposes module configs
+        cfg = self.redis_con.config_get("graph.*")
+        self.env.assertIn(timeout_key, cfg)
+
+        # set via CONFIG SET and validate through GRAPH.CONFIG path
+        self.redis_con.config_set(timeout_key, 2)
+        self.env.assertEqual(self.db.config_get("TIMEOUT"), 2)
+
+        cfg = self.redis_con.config_get(timeout_key)
+        self.env.assertEqual(int(cfg[timeout_key]), 2)
+
+        # reset
+        self.redis_con.config_set(timeout_key, 0)
+
 import stat
 import shutil
 import tempfile
@@ -430,4 +447,3 @@ class testConfigTempFolder:
         finally:
             # clean up
             shutil.rmtree(valid_dir)
-

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -37,6 +37,8 @@ class testConfig(FlowTestsBase):
             try:
                 self.db.config_set(name, value)
             except redis.exceptions.ResponseError:
+                # Best-effort cleanup: some configs may be unavailable or immutable
+                # in certain Redis/module versions, but teardown should not fail.
                 pass
 
     def test01_config_get(self):
@@ -495,6 +497,8 @@ class testConfigRewritePersist:
             try:
                 self.db.config_set(name, value)
             except Exception:
+                # Best-effort reset before/after tests: ignore failures so that
+                # missing/unsupported configs do not cause the test to error.
                 pass
 
     def teardown_method(self):
@@ -505,8 +509,9 @@ class testConfigRewritePersist:
         if hasattr(self, "redis_proc") and self.redis_proc:
             try:
                 self.redis_con.shutdown()
-            except Exception:
-                pass
+            except Exception as e:
+                # Ignore shutdown exceptions during teardown, but log for diagnostics.
+                print(f"Warning: redis_con.shutdown() failed during teardown: {e}")
             self.redis_proc.terminate()
             try:
                 self.redis_proc.wait(timeout=5)

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -1,5 +1,7 @@
 import os
 import inspect
+import subprocess
+import time
 from common import *
 
 GRAPH_ID = "config"
@@ -453,6 +455,16 @@ class testConfigRewritePersist:
     def teardown_method(self):
         if hasattr(self, "env"):
             self.env.stop()
+        if hasattr(self, "redis_proc") and self.redis_proc:
+            try:
+                self.redis_con.shutdown()
+            except Exception:
+                pass
+            self.redis_proc.terminate()
+            try:
+                self.redis_proc.wait(timeout=5)
+            except Exception:
+                self.redis_proc.kill()
         if hasattr(self, "cfg_path") and os.path.exists(self.cfg_path):
             os.remove(self.cfg_path)
 
@@ -476,11 +488,35 @@ class testConfigRewritePersist:
             env_kwargs["redisConfigPath"] = self.cfg_path
         elif "redisConfig" in params:
             env_kwargs["redisConfig"] = self.cfg_path
-        else:
-            raise RuntimeError("Env is missing a redis config file parameter")
 
-        self.env, self.db = Env(**env_kwargs)
-        self.redis_con = self.env.getConnection()
+        if env_kwargs:
+            self.env, self.db = Env(**env_kwargs)
+            self.redis_con = self.env.getConnection()
+            self.redis_proc = None
+        else:
+            # RLTest version does not support passing a config file; launch Redis
+            # manually using the same binary/module args RLTest would use.
+            self.env, _ = Env()
+            runner = self.env.envRunner
+            port = runner.port
+            # stop the RLTest-managed instance so we can reuse the port/args
+            self.env.stop()
+
+            cmd = [runner.redisBinaryPath, self.cfg_path] + runner.masterCmdArgs[1:]
+            self.redis_proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )
+
+            self.redis_con = redis.StrictRedis(
+                "localhost", port, decode_responses=True
+            )
+            for _ in range(100):
+                try:
+                    if self.redis_con.ping():
+                        break
+                except Exception:
+                    time.sleep(0.05)
+            self.db = FalkorDB("localhost", port)
 
         # values should load from config file
         self.env.assertEqual(self.db.config_get("TIMEOUT"), 7)

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -13,6 +13,32 @@ class testConfig(FlowTestsBase):
         self.redis_con = self.env.getConnection()
         self.graph = self.db.select_graph(GRAPH_ID)
 
+    def tearDown(self):
+        # Reset mutable runtime configs to defaults so changes in one test
+        # don't leak into subsequent flow tests sharing the same Redis process.
+        defaults = {
+            "TIMEOUT": 0,
+            "TIMEOUT_DEFAULT": 0,
+            "TIMEOUT_MAX": 0,
+            "RESULTSET_SIZE": -1,
+            "MAX_QUEUED_QUERIES": 4294967295,
+            "QUERY_MEM_CAPACITY": 0,
+            "DELTA_MAX_PENDING_CHANGES": 10000,
+            "VKEY_MAX_ENTITY_COUNT": 100000,
+            "CMD_INFO": 1,
+            "MAX_INFO_QUERIES": 1000,
+            "EFFECTS_THRESHOLD": 300,
+            "DELAY_INDEXING": 0,
+            "JS_HEAP_SIZE": 256 * 1024 * 1024,
+            "JS_STACK_SIZE": 1024 * 1024,
+        }
+
+        for name, value in defaults.items():
+            try:
+                self.db.config_set(name, value)
+            except redis.exceptions.ResponseError:
+                pass
+
     def test01_config_get(self):
         # Try reading 'QUERY_MEM_CAPACITY' from config
         config_name = "QUERY_MEM_CAPACITY"
@@ -34,7 +60,8 @@ class testConfig(FlowTestsBase):
                 ("TIMEOUT_MAX",  0),
                 ("CACHE_SIZE", 25),
                 ("ASYNC_DELETE", [0,1]), # could be either 0 or 1 depending on load time config
-                ("OMP_THREAD_COUNT", os.cpu_count()),
+                # OMP thread count can be 1 when OpenMP is unavailable.
+                ("OMP_THREAD_COUNT", [1, os.cpu_count()]),
                 ("THREAD_COUNT", os.cpu_count()),
                 ("RESULTSET_SIZE", -1),
                 ("VKEY_MAX_ENTITY_COUNT", 100000),
@@ -452,7 +479,27 @@ class testConfigTempFolder:
             shutil.rmtree(valid_dir)
 
 class testConfigRewritePersist:
+    def _reset_runtime_configs(self):
+        if not hasattr(self, "db"):
+            return
+
+        defaults = {
+            "TIMEOUT": 0,
+            "TIMEOUT_DEFAULT": 0,
+            "TIMEOUT_MAX": 0,
+            "RESULTSET_SIZE": -1,
+            "CMD_INFO": 1,
+        }
+
+        for name, value in defaults.items():
+            try:
+                self.db.config_set(name, value)
+            except Exception:
+                pass
+
     def teardown_method(self):
+        self._reset_runtime_configs()
+
         if hasattr(self, "env"):
             self.env.stop()
         if hasattr(self, "redis_proc") and self.redis_proc:
@@ -549,7 +596,8 @@ class testConfigRewritePersist:
         self.env.assertEqual(self.db.config_get("CMD_INFO"), 0)
 
         # rewrite and ensure persisted in file
-        self.env.assertEqual(self.redis_con.config_rewrite(), True)
+        rewrite_result = self.redis_con.config_rewrite()
+        self.env.assertIn(rewrite_result, [True, "OK"])
         with open(self.cfg_path, "r") as cfg:
             contents = cfg.read().lower()
 

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -3,6 +3,7 @@ import inspect
 import subprocess
 import time
 from common import *
+from redis.exceptions import BusyLoadingError, ConnectionError as RedisConnectionError
 
 GRAPH_ID = "config"
 NUMBER_OF_CONFIGURATIONS = 22 # number of configurations available
@@ -74,7 +75,7 @@ class testConfig(FlowTestsBase):
                 ("CMD_INFO", 1),
                 ("MAX_INFO_QUERIES", 1000),
                 ("EFFECTS_THRESHOLD", 300),
-                ("BOLT_PORT", 65535),
+                ("BOLT_PORT", -1),
                 ("DELAY_INDEXING", 0),
                 ("IMPORT_FOLDER", "/var/lib/FalkorDB/import/"),
                 ("TEMP_FOLDER", "/tmp"),
@@ -591,8 +592,10 @@ class testConfigRewritePersist:
                 try:
                     if self.redis_con.ping():
                         break
-                except Exception:
+                except (RedisConnectionError, BusyLoadingError):
                     time.sleep(0.05)
+            else:
+                raise RuntimeError(f"Redis failed to become ready on port {port}")
             self.db = FalkorDB("localhost", port)
 
         # values should load from config file

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -374,7 +374,7 @@ class testConfig(FlowTestsBase):
         self.env.assertEqual(creation_buffer_size, expected_response)
 
     def test12_config_commands_available_via_redis_config(self):
-        timeout_key = "graph.TIMEOUT"
+        timeout_key = "graph.timeout"
 
         # ensure CONFIG GET exposes module configs
         cfg = self.redis_con.config_get("graph.*")
@@ -518,9 +518,9 @@ class testConfigRewritePersist:
     def test_config_rewrite_roundtrip(self):
         # configure via redis.conf only, no module args
         cfg_lines = [
-            "graph.TIMEOUT 7",
-            "graph.RESULTSET_SIZE 4",
-            "graph.CMD_INFO no",
+            "graph.timeout 7",
+            "graph.resultset_size 4",
+            "graph.cmd_info no",
         ]
 
         fd, self.cfg_path = tempfile.mkstemp(prefix="falkordb-config-", suffix=".conf")

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -1,4 +1,5 @@
 import os
+import inspect
 from common import *
 
 GRAPH_ID = "config"
@@ -467,7 +468,18 @@ class testConfigRewritePersist:
         with os.fdopen(fd, "w") as cfg:
             cfg.write("\n".join(cfg_lines))
 
-        self.env, self.db = Env(redisConfigFile=self.cfg_path)
+        params = inspect.signature(Env).parameters
+        env_kwargs = {}
+        if "redisConfigFile" in params:
+            env_kwargs["redisConfigFile"] = self.cfg_path
+        elif "redisConfigPath" in params:
+            env_kwargs["redisConfigPath"] = self.cfg_path
+        elif "redisConfig" in params:
+            env_kwargs["redisConfig"] = self.cfg_path
+        else:
+            raise RuntimeError("Env is missing a redis config file parameter")
+
+        self.env, self.db = Env(**env_kwargs)
         self.redis_con = self.env.getConnection()
 
         # values should load from config file

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -499,10 +499,35 @@ class testConfigRewritePersist:
             self.env, _ = Env()
             runner = self.env.envRunner
             port = runner.port
+
+            # pull loadmodule directives from the RLTest command and move them into the config
+            loadmodule_lines = []
+            filtered_args = []
+            args = runner.masterCmdArgs[1:]  # skip redis-server binary
+            i = 0
+            while i < len(args):
+                if args[i] == "--loadmodule" and i + 1 < len(args):
+                    j = i + 2
+                    while j < len(args) and not args[j].startswith("--"):
+                        j += 1
+                    load_args = args[i + 1 : j]
+                    loadmodule_lines.append("loadmodule " + " ".join(load_args))
+                    i = j
+                else:
+                    filtered_args.append(args[i])
+                    i += 1
+
+            if loadmodule_lines:
+                with open(self.cfg_path, "r+") as cfg:
+                    existing = cfg.read()
+                    cfg.seek(0)
+                    cfg.write("\n".join(loadmodule_lines) + "\n" + existing)
+                    cfg.truncate()
+
             # stop the RLTest-managed instance so we can reuse the port/args
             self.env.stop()
 
-            cmd = [runner.redisBinaryPath, self.cfg_path] + runner.masterCmdArgs[1:]
+            cmd = [runner.redisBinaryPath, self.cfg_path] + filtered_args
             self.redis_proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             )

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -467,7 +467,7 @@ class testConfigRewritePersist:
         with os.fdopen(fd, "w") as cfg:
             cfg.write("\n".join(cfg_lines))
 
-        self.env, self.db = Env(redisConfigPath=self.cfg_path)
+        self.env, self.db = Env(redisConfigFile=self.cfg_path)
         self.redis_con = self.env.getConnection()
 
         # values should load from config file

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -467,7 +467,7 @@ class testConfigRewritePersist:
         with os.fdopen(fd, "w") as cfg:
             cfg.write("\n".join(cfg_lines))
 
-        self.env, self.db = Env(redisConfigFile=self.cfg_path)
+        self.env, self.db = Env(redisConfigPath=self.cfg_path)
         self.redis_con = self.env.getConnection()
 
         # values should load from config file

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -447,3 +447,44 @@ class testConfigTempFolder:
         finally:
             # clean up
             shutil.rmtree(valid_dir)
+
+class testConfigRewritePersist:
+    def teardown_method(self):
+        if hasattr(self, "env"):
+            self.env.stop()
+        if hasattr(self, "cfg_path") and os.path.exists(self.cfg_path):
+            os.remove(self.cfg_path)
+
+    def test_config_rewrite_roundtrip(self):
+        # configure via redis.conf only, no module args
+        cfg_lines = [
+            "graph.TIMEOUT 7",
+            "graph.RESULTSET_SIZE 4",
+            "graph.CMD_INFO no",
+        ]
+
+        fd, self.cfg_path = tempfile.mkstemp(prefix="falkordb-config-", suffix=".conf")
+        with os.fdopen(fd, "w") as cfg:
+            cfg.write("\n".join(cfg_lines))
+
+        self.env, self.db = Env(redisConfigFile=self.cfg_path)
+        self.redis_con = self.env.getConnection()
+
+        # values should load from config file
+        self.env.assertEqual(self.db.config_get("TIMEOUT"), 7)
+        self.env.assertEqual(self.db.config_get("RESULTSET_SIZE"), 4)
+        self.env.assertEqual(self.db.config_get("CMD_INFO"), 0)
+
+        # rewrite and ensure persisted in file
+        self.env.assertEqual(self.redis_con.config_rewrite(), True)
+        with open(self.cfg_path, "r") as cfg:
+            contents = cfg.read().lower()
+
+        for line in cfg_lines:
+            key, val = line.split()
+            self.env.assertIn(f"{key.lower()} {val.lower()}", contents)
+
+        # still reflected in the running config
+        self.env.assertEqual(self.db.config_get("TIMEOUT"), 7)
+        self.env.assertEqual(self.db.config_get("RESULTSET_SIZE"), 4)
+        self.env.assertEqual(self.db.config_get("CMD_INFO"), 0)

--- a/tests/flow/test_graph_copy.py
+++ b/tests/flow/test_graph_copy.py
@@ -315,8 +315,8 @@ class testGraphCopy():
         master_con.execute_command("WAIT", "1", "0")
 
         # make sure dest graph was replicated
-        # assuming replica port is env port+1
-        replica_db = FalkorDB("localhost", self.env.port+1)
+        replica_port = self.env.envRunner.slavePort
+        replica_db = FalkorDB("localhost", replica_port)
         replica_cloned_graph = replica_db.select_graph(copy_graph_id)
         
         # make sure src graph on master is the same as cloned graph on replica

--- a/tests/flow/test_slowlog.py
+++ b/tests/flow/test_slowlog.py
@@ -41,7 +41,7 @@ class testSlowLog():
             self.env.assertIn("Invalid graph operation on empty key", str(e))
 
         # issue the same query twice
-        q = "UNWIND range (0, 200000) AS x RETURN max(x)"
+        q = "UNWIND range(0, 450000) AS x WITH x WHERE x % 1 = 0 RETURN count(x)"
         self.graph.query(q)
         self.graph.query(q)
 
@@ -122,7 +122,7 @@ class testSlowLog():
         #-----------------------------------------------------------------------
 
         long_string = 'a' * 4000
-        query = f"WITH '{long_string}' AS str UNWIND range(0, 200000) AS x RETURN count(x)"
+        query = f"WITH '{long_string}' AS str UNWIND range(0, 2000000) AS x RETURN count(x)"
         self.graph.query(query)
 
         slowlog = self.graph.slowlog()
@@ -146,7 +146,7 @@ class testSlowLog():
         # clear slowlog
         self.redis_con.execute_command("GRAPH.SLOWLOG", GRAPH_ID, "RESET")
 
-        query = "WITH $long_string AS str UNWIND range(0, 200000) AS x RETURN count(x)"
+        query = "WITH $long_string AS str UNWIND range(0, 2000000) AS x RETURN count(x)"
         self.graph.query(query, {'long_string': long_string})
 
         slowlog = self.graph.slowlog()
@@ -170,7 +170,7 @@ class testSlowLog():
         # clear slowlog
         self.redis_con.execute_command("GRAPH.SLOWLOG", GRAPH_ID, "RESET")
 
-        query = f"WITH $long_string as long_param, '{long_string}' AS long_string UNWIND range(0, 200000) AS x RETURN count(x)"
+        query = f"WITH $long_string as long_param, '{long_string}' AS long_string UNWIND range(0, 2000000) AS x RETURN count(x)"
         self.graph.query(query, {'long_string': long_string})
 
         slowlog = self.graph.slowlog()
@@ -198,7 +198,7 @@ class testSlowLog():
         self.redis_con.execute_command("GRAPH.SLOWLOG", GRAPH_ID, "RESET")
 
         query = f"UNWIND range(0, $i) AS x RETURN count(x)"
-        self.graph.query(query, {'i': 200000})
+        self.graph.query(query, {'i': 2000000})
 
         slowlog = self.graph.slowlog()
         self.env.assertEquals(len(slowlog), 1)
@@ -210,7 +210,7 @@ class testSlowLog():
 
         # re-issue the same query but with different params
         query = f"UNWIND range(0, $i) AS x RETURN count(x)"
-        self.graph.query(query, {'i': 400000})
+        self.graph.query(query, {'i': 4000000})
 
         slowlog = self.graph.slowlog()
         self.env.assertEquals(len(slowlog), 1)
@@ -225,7 +225,7 @@ class testSlowLog():
 
         # expecting params to update
         self.env.assertNotEqual(p0, p1)
-        self.env.assertIn('400000', p1)
+        self.env.assertIn('4000000', p1)
 
     def test05_fast_queries(self):
         # make sure fast queries do not enter the slowlog
@@ -256,10 +256,10 @@ class testSlowLog():
         # issue 2 slower queries
         # expecting to have them replace existing entries
 
-        q0 = "UNWIND range(0, 450000) AS x WITH x WHERE x % 1 = 0 RETURN count(x)"
+        q0 = "UNWIND range(0, 2000000) AS x WITH x WHERE x % 1 = 0 RETURN count(x)"
         self.graph.query(q0)
 
-        q1 = "UNWIND range(0, 500000) AS x WITH x WHERE x % 1 = 0 RETURN count(x)"
+        q1 = "UNWIND range(0, 3000000) AS x WITH x WHERE x % 1 = 0 RETURN count(x)"
         self.graph.query(q1)
 
         entries = self.graph.slowlog()

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -1,5 +1,6 @@
 import asyncio
 from common import *
+from common import Env
 from index_utils import *
 from falkordb.asyncio import FalkorDB
 from redis.asyncio import BlockingConnectionPool

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -8,14 +8,23 @@ GRAPH_ID = "timeout"
 
 
 class testQueryTimeout():
+    def _reset_env(self, module_args=None):
+        if hasattr(self, 'env'):
+            self.env.stop()
+
+        env_kwargs = {}
+        if module_args is not None:
+            env_kwargs['moduleArgs'] = module_args
+
+        self.env, self.db = Env(**env_kwargs)
+        self.graph = self.db.select_graph(GRAPH_ID)
+
     def __init__(self):
-        self.env, self.db = Env(moduleArgs="TIMEOUT 1000")
+        self._reset_env("TIMEOUT 1000")
 
         # skip test if we're running under Valgrind
         if VALGRIND or SANITIZER:
             self.env.skip() # valgrind is not working correctly with replication
-
-        self.graph = self.db.select_graph(GRAPH_ID)
 
     def test01_read_write_query_timeout(self):
         query = "UNWIND range(0, 1000000) AS x WITH x AS x WHERE x = 10000 RETURN x"
@@ -136,7 +145,7 @@ class testQueryTimeout():
             self.env.assertTrue(True)
 
     def test06_error_timeout_default_higher_than_timeout_max(self):
-        self.env, self.db = Env(moduleArgs="TIMEOUT_DEFAULT 10 TIMEOUT_MAX 10")
+        self._reset_env("TIMEOUT_DEFAULT 10 TIMEOUT_MAX 10")
 
         # get current timeout configuration
         max_timeout = self.db.config_get("TIMEOUT_MAX")
@@ -214,8 +223,7 @@ class testQueryTimeout():
                 self.env.assertContains("The query TIMEOUT parameter value cannot exceed the TIMEOUT_MAX configuration parameter value", str(error))
 
     def test09_fallback(self):
-        self.env.stop()
-        self.env, self.db = Env(moduleArgs="TIMEOUT 1")
+        self._reset_env("TIMEOUT 1")
 
         configs = ["TIMEOUT_DEFAULT", "TIMEOUT_MAX"]
 
@@ -254,8 +262,7 @@ class testQueryTimeout():
     # should return to user
     def test11_profile_no_double_response(self):
         # reset timeout params to default
-        self.env.stop()
-        self.env, self.db = Env()
+        self._reset_env()
 
         # Set timeout parameters to small values (1 millisecond)
         self.db.config_set("TIMEOUT_MAX", 1)
@@ -277,8 +284,7 @@ class testQueryTimeout():
         self.env.assertEquals(res.result_set[0][0], 1)
 
     def test12_concurrent_timeout(self):
-        self.env.stop()
-        self.env, self.db = Env()
+        self._reset_env()
 
         self.graph.query("UNWIND range(1, 1000) AS x CREATE (:N {v:x})")
 

--- a/tests/flow/test_undo_log.py
+++ b/tests/flow/test_undo_log.py
@@ -58,8 +58,9 @@ class testUndoLog():
         # ensure a clean graph for this test
         try:
             graph.delete()
-        except:
-            pass
+        except ResponseError as e:
+            # Ignore attempts to delete an already-empty/nonexistent graph
+            self.env.assertContains("Invalid graph operation on empty key", str(e))
 
         # test undo create edge by creating endpoints first
         graph.query("CREATE (:N {v: 1}), (:N {v: 2})")

--- a/tests/flow/test_undo_log.py
+++ b/tests/flow/test_undo_log.py
@@ -7,10 +7,14 @@ class testUndoLog():
     def __init__(self):
         self.env, self.db = Env()
         self.conn = self.env.getConnection()
+        self.db.config_set("ASYNC_DELETE", "no")
         self.graph = self.db.select_graph(GRAPH_ID)
 
     def tearDown(self):
-        self.graph.delete()
+        try:
+            self.graph.delete()
+        except ResponseError as e:
+            self.env.assertContains("Invalid graph operation on empty key", str(e))
 
     def test00_undo_schema(self):
         try:
@@ -49,10 +53,18 @@ class testUndoLog():
 
 
     def test02_undo_create_edge(self):
-        # test undo create edge only by creating a node first so the schema is created
-        self.graph.query("CREATE (:N {v: 1})-[:R]->(:N {v: 2})")
+        graph = self.db.select_graph(f"{GRAPH_ID}-create-edge")
+
+        # ensure a clean graph for this test
         try:
-            self.graph.query("""MATCH (s:N {v: 1}), (t:N {v: 2})
+            graph.delete()
+        except:
+            pass
+
+        # test undo create edge by creating endpoints first
+        graph.query("CREATE (:N {v: 1}), (:N {v: 2})")
+        try:
+            graph.query("""MATCH (s:N {v: 1}), (t:N {v: 2})
                                 CREATE (s)-[r:R]->(t)
                                 WITH r
                                 RETURN 1 * r""")
@@ -61,9 +73,11 @@ class testUndoLog():
         except:
             pass
 
-        # edge [r:R] should have been removed
-        result = self.graph.query("MATCH ()-[r:R]->() RETURN r")
-        self.env.assertEquals(len(result.result_set), 1)
+        # no edge should exist, rollback should remove the created edge
+        result = graph.query("MATCH ()-[r:R]->() RETURN r")
+        self.env.assertEquals(len(result.result_set), 0)
+
+        graph.delete()
 
     def test03_undo_delete_node(self):
         self.graph.query("CREATE (:N)")

--- a/tests/flow/test_undo_log.py
+++ b/tests/flow/test_undo_log.py
@@ -1,5 +1,6 @@
 from common import *
 from index_utils import *
+from redis.exceptions import ResponseError
 
 GRAPH_ID = "undo-log"
 

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -55,6 +55,7 @@ help() {
 		GDB=1                 Enable interactive gdb debugging (in single-test mode)
 
 		RLTEST=path|'view'    Take RLTest from repo path or from local view
+		PYTHON=path           Python interpreter for RLTest (default: .venv/bin/python3, then python3)
 		RLTEST_DEBUG=1        Show debugging printouts from tests
 		RLTEST_ARGS=args      Extra RLTest args
 
@@ -381,6 +382,31 @@ setup_coverage() {
 
 #----------------------------------------------------------------------------------------------
 
+setup_python() {
+	if [[ -n "$PYTHON" ]]; then
+		TEST_PYTHON="$PYTHON"
+	elif [[ -x "$ROOT/.venv/bin/python3" ]]; then
+		TEST_PYTHON="$ROOT/.venv/bin/python3"
+	elif [[ -x "$ROOT/.venv/bin/python" ]]; then
+		TEST_PYTHON="$ROOT/.venv/bin/python"
+	elif is_command python3; then
+		TEST_PYTHON="python3"
+	elif is_command python; then
+		TEST_PYTHON="python"
+	else
+		eprint "No Python interpreter found. Set PYTHON=/path/to/python."
+		exit 1
+	fi
+
+	if ! "$TEST_PYTHON" -c 'from RLTest import Env' &>/dev/null; then
+		eprint "RLTest is not available for '$TEST_PYTHON'."
+		eprint "Install test dependencies with: $TEST_PYTHON -m pip install -r $ROOT/tests/requirements.txt"
+		exit 1
+	fi
+}
+
+#----------------------------------------------------------------------------------------------
+
 run_env() {
 	rltest_config=$(mktemp "${TMPDIR:-/tmp}/rltest.XXXXXXX")
 	rm -f $rltest_config
@@ -411,9 +437,9 @@ run_env() {
 
 	local E=0
 	if [[ $NOP != 1 ]]; then
-		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		{ $OP "$TEST_PYTHON" -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
-		$OP python3 -m RLTest @$rltest_config
+		$OP "$TEST_PYTHON" -m RLTest @$rltest_config
 	fi
 
 	[[ $KEEP != 1 ]] && rm -f $rltest_config
@@ -513,9 +539,9 @@ run_tests() {
 
 	local E=0
 	if [[ $NOP != 1 ]]; then
-		{ $OP python3 -m RLTest @$rltest_config; (( E |= $? )); } || true
+		{ $OP "$TEST_PYTHON" -m RLTest @$rltest_config; (( E |= $? )); } || true
 	else
-		$OP python3 -m RLTest @$rltest_config
+		$OP "$TEST_PYTHON" -m RLTest @$rltest_config
 	fi
 
 	[[ $KEEP != 1 ]] && rm -f $rltest_config
@@ -660,6 +686,7 @@ fi
 #----------------------------------------------------------------------------------------------
 
 setup_rltest
+setup_python
 
 if [[ -n $SAN ]]; then
 	setup_clang_sanitizer


### PR DESCRIPTION
fix #619 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module configuration is exposed via Redis CONFIG and can be persisted to redis.conf.
  * Added a cron status check to report whether the cron thread is running.

* **Bug Fixes**
  * Replica port detection in replication tests now uses the actual replica port.
  * Safer handling when repository/state is uninitialized to avoid startup issues.
  * Bolt port inputs validated to reject out-of-range values.

* **Improvements**
  * Test ports randomized by default to reduce collisions; test runner prefers discovered Python and defaults to serial execution when unspecified.
  * Expanded and hardened test setup/teardown and slowlog/config/timeout test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->