### PR TITLE
Fix crash in planner for self-referential variable-length MATCH patterns

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -78,40 +78,50 @@ static OpBase *_ExecutionPlan_ProcessQueryGraph
 		orderExpressions(qg, exps, &expCount, ft, bound_vars);
 
 		// create a SCAN operation that will be the tail of the traversal chain
-		QGNode *src = QueryGraph_GetNodeByAlias (qg,
-				AlgebraicExpression_Src (exps[0])) ;
+		const char *src_alias  = AlgebraicExpression_Src(exps[0]);
+		const char *dest_alias = AlgebraicExpression_Dest(exps[0]);
 
-		uint label_count = QGNode_LabelCount (src) ;
+		QGNode *src = QueryGraph_GetNodeByAlias(qg, src_alias);
+		uint label_count = QGNode_LabelCount(src);
 
-		if (label_count > 0) {
+		// self-referential traversals like:
+		// MATCH (n:A)<-[*..]-(n:B)
+		// must not be opened by removing the source operand, as this can
+		// leave a degenerate traversal expression for later optimizer passes
+		bool self_referential =
+			(src_alias != NULL && dest_alias != NULL &&
+			 strcmp(src_alias, dest_alias) == 0);
+
+		if(label_count > 0 && !self_referential) {
 			AlgebraicExpression *ae_src =
-				AlgebraicExpression_RemoveSource (&exps[0]) ;
-			ASSERT(AlgebraicExpression_DiagonalOperand (ae_src, 0)) ;
+				AlgebraicExpression_RemoveSource(&exps[0]);
+			ASSERT(AlgebraicExpression_DiagonalOperand(ae_src, 0));
 
-			const char *label = AlgebraicExpression_Label (ae_src) ;
-			const char *alias = AlgebraicExpression_Src (ae_src) ;
-			ASSERT (label != NULL) ;
-			ASSERT (alias != NULL) ;
+			const char *label = AlgebraicExpression_Label(ae_src);
+			const char *alias = AlgebraicExpression_Src(ae_src);
+			ASSERT(label != NULL);
+			ASSERT(alias != NULL);
 
-			int label_id = GRAPH_UNKNOWN_LABEL ;
-			Schema *s = GraphContext_GetSchema (gc, label, SCHEMA_NODE) ;
-			if (s != NULL) {
+			int label_id = GRAPH_UNKNOWN_LABEL;
+			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
+			if(s != NULL) {
 				label_id = Schema_GetID(s);
 			}
 
 			// resolve source node by performing label scan
-			NodeScanCtx *ctx = NodeScanCtx_New (alias, label, label_id, src);
+			NodeScanCtx *ctx = NodeScanCtx_New(alias, label, label_id, src);
 			root = tail = NewNodeByLabelScanOp(plan, ctx);
 
 			// first operand has been converted into a label scan op
 			AlgebraicExpression_Free(ae_src);
 		} else {
 			root = tail = NewAllNodeScanOp(plan, src->alias);
-			// free expression source
-			// in-case there are additional patterns to traverse
+
+			// free expression source only for isolated node scans;
+			// keep self-referential traversal expressions intact
 			if(array_len(cc->edges) == 0) {
 				AlgebraicExpression_Free(
-						AlgebraicExpression_RemoveSource(&exps[0]));
+					AlgebraicExpression_RemoveSource(&exps[0]));
 			}
 		}
 

--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -98,26 +98,22 @@ static OpBase *_ExecutionPlan_ProcessQueryGraph
 			ASSERT(AlgebraicExpression_DiagonalOperand(ae_src, 0));
 
 			const char *label = AlgebraicExpression_Label(ae_src);
-            const char *alias = AlgebraicExpression_Src(ae_src);
-            ASSERT(label != NULL);
-            ASSERT(alias != NULL);
-            
-            // copy before freeing expression
-            char *label_copy = rm_strdup(label);
-            char *alias_copy = rm_strdup(alias);
-            
-            int label_id = GRAPH_UNKNOWN_LABEL;
-            Schema *s = GraphContext_GetSchema(gc, label_copy, SCHEMA_NODE);
-            if(s != NULL) {
-                label_id = Schema_GetID(s);
-            }
-            
-            // resolve source node by performing label scan
-            NodeScanCtx *ctx = NodeScanCtx_New(alias_copy, label_copy, label_id, src);
-            root = tail = NewNodeByLabelScanOp(plan, ctx);
-            
-            // first operand has been converted into a label scan op
-            AlgebraicExpression_Free(ae_src);
+			const char *alias = AlgebraicExpression_Src(ae_src);
+			ASSERT(label != NULL);
+			ASSERT(alias != NULL);
+
+			int label_id = GRAPH_UNKNOWN_LABEL;
+			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
+			if(s != NULL) {
+				label_id = Schema_GetID(s);
+			}
+
+			// resolve source node by performing label scan
+			NodeScanCtx *ctx = NodeScanCtx_New(alias, label, label_id, src);
+			root = tail = NewNodeByLabelScanOp(plan, ctx);
+
+			// first operand has been converted into a label scan op
+			AlgebraicExpression_Free(ae_src);
 		} else {
 			root = tail = NewAllNodeScanOp(plan, src->alias);
 

--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -77,7 +77,7 @@ static OpBase *_ExecutionPlan_ProcessQueryGraph
 		// reorder exps, to the most performant arrangement of evaluation
 		orderExpressions(qg, exps, &expCount, ft, bound_vars);
 
-		// create a SCAN operation that will be the tail of the traversal chain
+				// create a SCAN operation that will be the tail of the traversal chain
 		const char *src_alias  = AlgebraicExpression_Src(exps[0]);
 		const char *dest_alias = AlgebraicExpression_Dest(exps[0]);
 
@@ -98,22 +98,26 @@ static OpBase *_ExecutionPlan_ProcessQueryGraph
 			ASSERT(AlgebraicExpression_DiagonalOperand(ae_src, 0));
 
 			const char *label = AlgebraicExpression_Label(ae_src);
-			const char *alias = AlgebraicExpression_Src(ae_src);
-			ASSERT(label != NULL);
-			ASSERT(alias != NULL);
-
-			int label_id = GRAPH_UNKNOWN_LABEL;
-			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
-			if(s != NULL) {
-				label_id = Schema_GetID(s);
-			}
-
-			// resolve source node by performing label scan
-			NodeScanCtx *ctx = NodeScanCtx_New(alias, label, label_id, src);
-			root = tail = NewNodeByLabelScanOp(plan, ctx);
-
-			// first operand has been converted into a label scan op
-			AlgebraicExpression_Free(ae_src);
+            const char *alias = AlgebraicExpression_Src(ae_src);
+            ASSERT(label != NULL);
+            ASSERT(alias != NULL);
+            
+            // copy before freeing expression
+            char *label_copy = rm_strdup(label);
+            char *alias_copy = rm_strdup(alias);
+            
+            int label_id = GRAPH_UNKNOWN_LABEL;
+            Schema *s = GraphContext_GetSchema(gc, label_copy, SCHEMA_NODE);
+            if(s != NULL) {
+                label_id = Schema_GetID(s);
+            }
+            
+            // resolve source node by performing label scan
+            NodeScanCtx *ctx = NodeScanCtx_New(alias_copy, label_copy, label_id, src);
+            root = tail = NewNodeByLabelScanOp(plan, ctx);
+            
+            // first operand has been converted into a label scan op
+            AlgebraicExpression_Free(ae_src);
 		} else {
 			root = tail = NewAllNodeScanOp(plan, src->alias);
 

--- a/src/execution_plan/ops/shared/scan_functions.c
+++ b/src/execution_plan/ops/shared/scan_functions.c
@@ -23,8 +23,8 @@ NodeScanCtx *NodeScanCtx_New
 
     NodeScanCtx *ctx = rm_malloc(sizeof(NodeScanCtx));
 
-	ctx->alias    = alias;
-	ctx->label    = label;
+	ctx->alias    = rm_strdup(alias);
+	ctx->label    = rm_strdup(label);
 	ctx->label_id = label_id;
 	ctx->n        = QGNode_Clone(n);
 
@@ -41,6 +41,8 @@ NodeScanCtx *NodeScanCtx_Clone
 
     NodeScanCtx *clone = rm_malloc(sizeof(NodeScanCtx));
     memcpy(clone, ctx, sizeof(NodeScanCtx));
+    clone->alias = rm_strdup(ctx->alias);
+    clone->label = rm_strdup(ctx->label);
     clone->n = QGNode_Clone(ctx->n);
 
     return clone;
@@ -53,7 +55,8 @@ void NodeScanCtx_Free
 ) {
     ASSERT(ctx != NULL);
     ASSERT(ctx->n != NULL);
-    
+    rm_free(ctx->alias);
+    rm_free(ctx->label);
     QGNode_Free(ctx->n);
 
     rm_free(ctx);

--- a/src/execution_plan/ops/shared/scan_functions.h
+++ b/src/execution_plan/ops/shared/scan_functions.h
@@ -13,8 +13,8 @@
 typedef struct {
 	QGNode *n;          // node to scan (might hold multiple labels)
 	LabelID label_id;   // label ID of the node being traversed
-	const char *alias;  // alias of the node being traversed
-	const char *label;  // label of the node being traversed
+	char *alias;        // alias of the node being traversed (owned)
+	char *label;        // label of the node being traversed (owned)
 } NodeScanCtx;
 
 // allocates and returns a new context


### PR DESCRIPTION
**Bug status**: fixed for issue #636 repro
**Fix type**: planner-level prevention of degenerate self-referential traversal expression
**Observed behavior after fix**: empty result instead of segfault
```
root@DESKTOP-6QN3GRE:~/FalkorDB# redis-cli
127.0.0.1:6379> GRAPH.QUERY test "MERGE (:label8) MERGE (:label2{})<-[:reltype5]-(node_0{})<-[:reltype7]-({})"
1) 1) "Cached execution: 1"
   2) "Query internal execution time: 0.722686 milliseconds"
127.0.0.1:6379> GRAPH.QUERY test "MATCH (node_0:label8{})<-[*..]-(node_0:label9) WHERE node_0.prop7 = [ FALSE ] RETURN *"
1) 1) "node_0"
2) (empty array)
3) 1) "Cached execution: 1"
   2) "Query internal execution time: 0.123640 milliseconds"
127.0.0.1:6379> GRAPH.QUERY test "MATCH (node_0:label8{})<-[*..]-(node_0:label9) RETURN *"
1) 1) "node_0"
2) (empty array)
3) 1) "Cached execution: 1"
   2) "Query internal execution time: 0.353553 milliseconds"
127.0.0.1:6379> 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved node-scan and traversal initialization to more reliably build execution plans, including converting eligible expressions into label-based scans.
  * Made string ownership explicit for scan contexts to ensure safe copies of aliases and labels.

* **Bug Fixes**
  * Corrected handling of self-referential traversals to avoid incorrect plan alterations.
  * Adjusted cleanup rules to free resources only when appropriate, reducing memory leaks and preserving valid traversal expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->