### PR TITLE
fix(serializer): use destination key name during DUMP/RESTORE decode

### DIFF
--- a/src/serializers/decoders/current/v18/decode_graph.c
+++ b/src/serializers/decoders/current/v18/decode_graph.c
@@ -71,21 +71,22 @@ static void _ComputeTransposeMatrices
 static GraphContext *_GetOrCreateGraphContext
 (
 	const char *key_name,  // destination key name (from Redis)
-	char *graph_name       // embedded graph name (from serialized payload)
+	char *graph_name,      // embedded graph name (from serialized payload)
+	uint64_t key_number    // total number of virtual keys for this graph
 ) {
-	// try to find a GraphContext with the embedded graph name
 	GraphContext *gc = GraphContext_UnsafeGetGraphContext (graph_name) ;
 
+	// detect a single-key RESTORE to a different key name
+	// e.g. DUMP a | RESTORE c — payload embeds "a" but dest is "c"
+	bool renamed_single_key =
+		(key_number == 1 && strcmp(key_name, graph_name) != 0) ;
+
 	if (gc != NULL) {
-		// found an existing graph with this embedded name
-		// check if this is a multi-key continuation (processed > 0)
-		// or a RESTORE to a different key (processed == 0, names differ)
 		uint64_t processed =
 			GraphDecodeContext_GetProcessedKeyCount(gc->decoding_context);
-		if (processed == 0 && strcmp(key_name, graph_name) != 0) {
+		if (processed == 0 && renamed_single_key) {
 			// a fully-loaded graph exists under the embedded name,
 			// but the destination key is different
-			// this is a RESTORE / DUMP scenario
 			// create a new GraphContext with the destination key name
 			gc = NULL ;
 		}
@@ -94,8 +95,9 @@ static GraphContext *_GetOrCreateGraphContext
 
 	if (gc == NULL) {
 		// new graph is being decoded
-		// inform the module and create new graph context
-		gc = GraphContext_New (key_name) ;
+		// use destination key name for renamed single-key restores
+		// otherwise use the embedded graph name (for multi-key decodes)
+		gc = GraphContext_New (renamed_single_key ? key_name : graph_name) ;
 
 		// while loading the graph
 		// minimize matrix realloc and synchronization calls
@@ -168,7 +170,8 @@ static GraphContext *_DecodeHeader
 	// total keys representing the graph
 	uint64_t key_number = SerializerIO_ReadUnsigned(rdb);
 
-	GraphContext *gc = _GetOrCreateGraphContext(key_name, graph_name);
+	GraphContext *gc = _GetOrCreateGraphContext(key_name, graph_name,
+			key_number);
 	Graph *g = gc->g;
 
 	// if it is the first key of this graph,

--- a/src/serializers/decoders/current/v18/decode_graph.c
+++ b/src/serializers/decoders/current/v18/decode_graph.c
@@ -70,13 +70,32 @@ static void _ComputeTransposeMatrices
 
 static GraphContext *_GetOrCreateGraphContext
 (
-	char *graph_name
+	const char *key_name,  // destination key name (from Redis)
+	char *graph_name       // embedded graph name (from serialized payload)
 ) {
+	// try to find a GraphContext with the embedded graph name
 	GraphContext *gc = GraphContext_UnsafeGetGraphContext (graph_name) ;
-	if (!gc) {
+
+	if (gc != NULL) {
+		// found an existing graph with this embedded name
+		// check if this is a multi-key continuation (processed > 0)
+		// or a RESTORE to a different key (processed == 0, names differ)
+		uint64_t processed =
+			GraphDecodeContext_GetProcessedKeyCount(gc->decoding_context);
+		if (processed == 0 && strcmp(key_name, graph_name) != 0) {
+			// a fully-loaded graph exists under the embedded name,
+			// but the destination key is different
+			// this is a RESTORE / DUMP scenario
+			// create a new GraphContext with the destination key name
+			gc = NULL ;
+		}
+		// else: multi-key continuation, reuse existing gc
+	}
+
+	if (gc == NULL) {
 		// new graph is being decoded
 		// inform the module and create new graph context
-		gc = GraphContext_New (graph_name) ;
+		gc = GraphContext_New (key_name) ;
 
 		// while loading the graph
 		// minimize matrix realloc and synchronization calls
@@ -114,7 +133,8 @@ static void _InitGraphDataStructure
 
 static GraphContext *_DecodeHeader
 (
-	SerializerIO rdb
+	SerializerIO rdb,
+	const char *key_name  // destination key name (from Redis)
 ) {
 	// Header format:
 	// Graph name
@@ -148,7 +168,7 @@ static GraphContext *_DecodeHeader
 	// total keys representing the graph
 	uint64_t key_number = SerializerIO_ReadUnsigned(rdb);
 
-	GraphContext *gc = _GetOrCreateGraphContext(graph_name);
+	GraphContext *gc = _GetOrCreateGraphContext(key_name, graph_name);
 	Graph *g = gc->g;
 
 	// if it is the first key of this graph,
@@ -224,7 +244,8 @@ GraphContext *RdbLoadGraphContext_latest
 	//      Entities in payload
 	//  Payload(s) X N
 
-	GraphContext *gc = _DecodeHeader(rdb);
+	const char *key_name = RedisModule_StringPtrLen(rm_key_name, NULL);
+	GraphContext *gc = _DecodeHeader(rdb, key_name);
 	Graph        *g  = gc->g;
 
 	// log progress
@@ -339,8 +360,6 @@ GraphContext *RdbLoadGraphContext_latest
 	GraphDecodeContext_IncreaseProcessedKeyCount(gc->decoding_context);
 
 	// before finalizing keep encountered meta keys names, for future deletion
-	const char *key_name = RedisModule_StringPtrLen(rm_key_name, NULL);
-
 	// the virtual key name is not equal the graph name
 	if(strcmp(key_name, gc->graph_name) != 0) {
 		GraphDecodeContext_AddMetaKey(gc->decoding_context, key_name);

--- a/tests/flow/test_dump_restore.py
+++ b/tests/flow/test_dump_restore.py
@@ -1,5 +1,6 @@
 from graph_utils import graph_eq
-from common import Env, SANITIZER
+from index_utils import wait_for_indices_to_sync
+from common import Env
 
 
 GRAPH_ID = "dump_restore"
@@ -134,9 +135,7 @@ class testDumpRestore():
         src_graph = self.db.select_graph(src_id)
         src_graph.query("CREATE (:Person {name: 'Alice', age: 30})")
         src_graph.query("CREATE INDEX FOR (n:Person) ON (n.name)")
-
-        # wait for index to be populated
-        src_graph.query("MATCH (n:Person) WHERE n.name = 'Alice' RETURN n")
+        wait_for_indices_to_sync(src_graph)
 
         payload = self.conn.dump(src_id)
         self.conn.restore(dest_id, 0, payload)

--- a/tests/flow/test_dump_restore.py
+++ b/tests/flow/test_dump_restore.py
@@ -1,0 +1,246 @@
+from graph_utils import graph_eq
+from common import Env, SANITIZER
+
+
+GRAPH_ID = "dump_restore"
+
+
+# tests Redis DUMP / RESTORE with FalkorDB graph keys
+class testDumpRestore():
+    def __init__(self):
+        self.env, self.db = Env(enableDebugCommand=True)
+        self.conn = self.env.getConnection()
+
+    def test_01_dump_restore_simple(self):
+        """DUMP/RESTORE a graph to a different key produces an independent copy"""
+
+        src_id  = "src_simple"
+        dest_id = "dest_simple"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:Person {name: 'Alice'})")
+
+        # DUMP src and RESTORE to dest
+        payload = self.conn.dump(src_id)
+        self.env.assertIsNotNone(payload)
+
+        self.conn.restore(dest_id, 0, payload)
+
+        dest_graph = self.db.select_graph(dest_id)
+
+        # both graphs should be queryable and equal
+        self.env.assertTrue(graph_eq(src_graph, dest_graph))
+
+        # src should still have exactly 1 node (not 2)
+        src_count = src_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(src_count, 1)
+
+        # dest should have exactly 1 node
+        dest_count = dest_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(dest_count, 1)
+
+        # clean up
+        src_graph.delete()
+        dest_graph.delete()
+
+    def test_02_dump_restore_graph_list(self):
+        """Restored graph appears in GRAPH.LIST"""
+
+        src_id  = "src_list"
+        dest_id = "dest_list"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:X)")
+
+        # DUMP and RESTORE
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        # GRAPH.LIST should contain both graphs
+        graphs = self.conn.execute_command("GRAPH.LIST")
+        self.env.assertContains(src_id, graphs)
+        self.env.assertContains(dest_id, graphs)
+
+        # clean up
+        src_graph.delete()
+        dest_graph = self.db.select_graph(dest_id)
+        dest_graph.delete()
+
+    def test_03_dump_restore_independence(self):
+        """Mutating the restored graph does not affect the source"""
+
+        src_id  = "src_indep"
+        dest_id = "dest_indep"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:Person {name: 'Alice'})")
+
+        # DUMP and RESTORE
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        dest_graph = self.db.select_graph(dest_id)
+
+        # mutate dest only
+        dest_graph.query("CREATE (:Person {name: 'Bob'})")
+
+        # src should still have 1 node
+        src_count = src_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(src_count, 1)
+
+        # dest should have 2 nodes
+        dest_count = dest_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(dest_count, 2)
+
+        # clean up
+        src_graph.delete()
+        dest_graph.delete()
+
+    def test_04_dump_restore_with_edges(self):
+        """DUMP/RESTORE preserves nodes, edges, and properties"""
+
+        src_id  = "src_edges"
+        dest_id = "dest_edges"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query(
+            "CREATE (:A {v:1})-[:R {w:2}]->(:B {v:3})"
+        )
+
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        dest_graph = self.db.select_graph(dest_id)
+        self.env.assertTrue(graph_eq(src_graph, dest_graph))
+
+        # clean up
+        src_graph.delete()
+        dest_graph.delete()
+
+    def test_05_dump_restore_with_index(self):
+        """DUMP/RESTORE preserves indices"""
+
+        src_id  = "src_idx"
+        dest_id = "dest_idx"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:Person {name: 'Alice', age: 30})")
+        src_graph.query("CREATE INDEX FOR (n:Person) ON (n.name)")
+
+        # wait for index to be populated
+        src_graph.query("MATCH (n:Person) WHERE n.name = 'Alice' RETURN n")
+
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        dest_graph = self.db.select_graph(dest_id)
+        self.env.assertTrue(graph_eq(src_graph, dest_graph))
+
+        # clean up
+        src_graph.delete()
+        dest_graph.delete()
+
+    def test_06_dump_restore_multiple_times(self):
+        """DUMP the same graph and RESTORE it to multiple keys"""
+
+        src_id = "src_multi"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:N {v:1})-[:E]->(:N {v:2})")
+
+        payload = self.conn.dump(src_id)
+
+        copies = []
+        for i in range(3):
+            dest_id = f"dest_multi_{i}"
+            self.conn.restore(dest_id, 0, payload)
+            copies.append(dest_id)
+
+        # all copies should match the source
+        for dest_id in copies:
+            dest_graph = self.db.select_graph(dest_id)
+            self.env.assertTrue(graph_eq(src_graph, dest_graph))
+
+        # src should still have exactly 2 nodes
+        src_count = src_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(src_count, 2)
+
+        # GRAPH.LIST should contain all graphs
+        graphs = self.conn.execute_command("GRAPH.LIST")
+        self.env.assertContains(src_id, graphs)
+        for dest_id in copies:
+            self.env.assertContains(dest_id, graphs)
+
+        # clean up
+        src_graph.delete()
+        for dest_id in copies:
+            g = self.db.select_graph(dest_id)
+            g.delete()
+
+    def test_07_dump_restore_with_existing_graphs(self):
+        """DUMP/RESTORE works correctly when other graphs already exist"""
+
+        other_id = "other_graph"
+        src_id   = "src_existing"
+        dest_id  = "dest_existing"
+
+        # create another graph first
+        other_graph = self.db.select_graph(other_id)
+        other_graph.query("CREATE (:Dummy {v: 42})")
+
+        # create src graph
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:Person {name: 'Alice'})")
+
+        # DUMP and RESTORE
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        dest_graph = self.db.select_graph(dest_id)
+
+        # dest should match src
+        self.env.assertTrue(graph_eq(src_graph, dest_graph))
+
+        # other graph should be unaffected
+        other_count = other_graph.query(
+            "MATCH (n) RETURN count(n)"
+        ).result_set[0][0]
+        self.env.assertEqual(other_count, 1)
+
+        # clean up
+        other_graph.delete()
+        src_graph.delete()
+        dest_graph.delete()
+
+    def test_08_dump_restore_reload(self):
+        """Restored graph survives DEBUG RELOAD"""
+
+        src_id  = "src_reload"
+        dest_id = "dest_reload"
+
+        src_graph = self.db.select_graph(src_id)
+        src_graph.query("CREATE (:A {v:1})-[:R {w:2}]->(:B {v:3})")
+
+        payload = self.conn.dump(src_id)
+        self.conn.restore(dest_id, 0, payload)
+
+        # reload keyspace
+        self.conn.execute_command("DEBUG", "RELOAD")
+
+        # both graphs should survive reload and be equal
+        self.env.assertTrue(graph_eq(src_graph, self.db.select_graph(dest_id)))
+
+        # clean up
+        src_graph.delete()
+        dest_graph = self.db.select_graph(dest_id)
+        dest_graph.delete()


### PR DESCRIPTION
## Summary
When restoring a graph via `DUMP`/`RESTORE` to a different key name, the decoder used the embedded graph name from the serialized payload instead of the destination key name. This caused data corruption: the source graph was modified, the restored graph was not independent, and `GRAPH.LIST` did not show the new key.

## Changes
- Pass the destination key name (from `RedisModule_GetKeyNameFromIO` / `rm_key_name`) through `_DecodeHeader` into `_GetOrCreateGraphContext`
- When the embedded name matches an existing fully-loaded graph but the destination key differs (`processed == 0 && key_name != graph_name`), create a new `GraphContext` with the destination key name instead of reusing the existing one
- Multi-key RDB loading is unaffected: meta-keys still find the primary graph via the embedded name when `processed > 0`
- Added comprehensive test suite (`test_dump_restore.py`) covering basic copy, graph list visibility, independence, edges/properties, indices, multiple restores, coexistence with other graphs, and reload persistence

## Testing
New test file: `tests/flow/test_dump_restore.py` with 8 tests:
1. Simple DUMP/RESTORE produces correct copy
2. Restored graph appears in GRAPH.LIST
3. Mutations to copy don't affect source
4. Edges and properties preserved
5. Indices preserved
6. Multiple RESTORE from same DUMP payload
7. Works alongside existing graphs
8. Survives DEBUG RELOAD

Manual test:
```
GRAPH.QUERY a "CREATE (:Person {name: 'Alice'})"
redis-cli --raw DUMP a | head -c -1 | redis-cli -x RESTORE c 0
```

Before fix:
- Graph `a` had 2 nodes (doubled)
- Graph `c` pointed to same GraphContext as `a`
- `GRAPH.LIST` did not show `c`

After fix:
- ✅ Graph `a` retains 1 node
- ✅ Graph `c` has 1 node (independent copy)
- ✅ `GRAPH.LIST` shows both `a` and `c`
- ✅ Mutations to `c` do not affect `a`

## Memory / Performance Impact
No additional allocations on the normal RDB load path. RESTORE creates one additional `GraphContext` as expected.

## Related Issues
Closes #170
Closes #1204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored graphs now correctly create independent, queryable graph instances when dumped data is restored to a different Redis key, avoiding collisions with already-loaded graphs and preserving multi-key behavior.

* **Tests**
  * Added comprehensive DUMP/RESTORE tests verifying copy fidelity, independence, index preservation, multiple restores, coexistence with other graphs, graph listing, and persistence across reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->