### PR TITLE
Potential fixes for 3 code quality findings

### DIFF
--- a/src/cron/cron.c
+++ b/src/cron/cron.c
@@ -63,11 +63,20 @@ static int cmp_timespec
 	struct timespec a,
 	struct timespec b
 ) {
-	if (a.tv_sec == b.tv_sec) {
-		return a.tv_nsec - b.tv_nsec ;
-	} else {
-		return a.tv_sec - b.tv_sec ;
+	if (a.tv_sec < b.tv_sec) {
+		return -1 ;
+	} else if (a.tv_sec > b.tv_sec) {
+		return 1 ;
 	}
+
+	// seconds are equal; compare nanoseconds
+	if (a.tv_nsec < b.tv_nsec) {
+		return -1 ;
+	} else if (a.tv_nsec > b.tv_nsec) {
+		return 1 ;
+	}
+
+	return 0 ;
 }
 
 // minimum heap sort function


### PR DESCRIPTION
_This PR applies 3/5 suggestions from code quality [AI findings](https://github.com/FalkorDB/FalkorDB/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._

1. **Unsafe timespec comparator (`cmp_timespec`)**: Uses `a.tv_sec - b.tv_sec` / `a.tv_nsec - b.tv_nsec` subtraction pattern which can overflow for large `time_t` / `long` values, producing wrong sort order in the cron task heap. Should use the safe three-way comparison pattern (`< → -1`, `> → 1`, `== → 0`).
2. **Typo in comment**: `miliseconds` → `milliseconds` in `Cron_AddTask` parameter doc.
3. **Typo in comment**: `wan't` → `wasn't` in `Cron_AbortTask`.


Closes #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of task scheduling by fixing the time comparison mechanism to prevent potential arithmetic issues and ensure consistent ordering of scheduled tasks.

* **Documentation**
  * Corrected spelling errors in code comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->