### PR TITLE
fix: skip cost-base label scan optimization for variable-length trave…

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -323,7 +323,15 @@ static void _costBaseLabelScan
 	OpBase *parent = op->parent;
 	while(OpBase_Type(parent) == OPType_FILTER) parent = parent->parent;
 	OPType t = OpBase_Type(parent);
-	ASSERT(t == OPType_CONDITIONAL_TRAVERSE || t == OPType_EXPAND_INTO);
+
+	// this optimization only supports conditional traverse and expand-into
+	// for variable-length traversal types we should not attempt to switch
+	// labels, as we should not construct a plan where a variable-length
+	// traversal has to resolve a node with multiple labels
+	// skip the optimization gracefully instead of crashing
+	if(t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+		return;
+	}
 
 	AlgebraicExpression *ae = NULL;
 	if(t == OPType_CONDITIONAL_TRAVERSE) {

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -250,5 +250,8 @@ class testMultiLabel():
             try:
                 self.graph.query(q)
             except Exception:
-                # query may return an error, but it should not crash
                 pass
+            # verify server is still alive after each query
+            # if the server crashed (SIGSEGV), this will fail
+            result = self.graph.query("RETURN 1")
+            self.env.assertEquals(result.result_set[0][0], 1)

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -233,3 +233,22 @@ class testMultiLabel():
         self.env.assertEquals(query_result.labels_added, 1)
         self.env.assertEquals(query_result.nodes_created, 1)
         self.env.assertEquals(query_result.result_set[0][0], ["L4"])
+
+    # Regression test for issue #636
+    # Variable-length traversal with multi-label nodes should not crash
+    def test06_varlen_traversal_multi_label_no_crash(self):
+        # This query previously caused a SIGSEGV crash because
+        # _costBaseLabelScan did not handle variable-length traversal
+        # operation types (e.g. OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO)
+        # The fix skips the cost-base label scan optimization for these types
+        queries = [
+            "MATCH (n:A)<-[*]-(n:Z) RETURN 1",
+            "MATCH (n:L0:L1)-[*]->(m:L1:L2) RETURN n, m",
+            "MATCH (n:L1)-[*0..3]->(m:L1:L2) RETURN n, m",
+        ]
+        for q in queries:
+            try:
+                self.graph.query(q)
+            except Exception:
+                # query may return an error, but it should not crash
+                pass


### PR DESCRIPTION
…rsals (#636)

Replace the ASSERT in _costBaseLabelScan that crashes when the parent operation is a variable-length traversal type (e.g. OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO) with a guard that gracefully skips the optimization for unsupported operation types.

This prevents the SIGSEGV crash reported in #636 when running queries like: MATCH (n:A)<-[*]-(n:Z) RETURN 1

The cost-base label scan optimization only makes sense for OPType_CONDITIONAL_TRAVERSE and OPType_EXPAND_INTO. For variable-length traversals, we should not attempt to switch labels, as noted by the maintainer: "We shouldn't construct a plan where a variable length traversal has to resolve a node with multiple labels."

Closes #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for variable-length traversal queries involving multiple labels by preventing an unsafe optimization path that could cause crashes; the engine now safely skips incompatible optimization steps.

* **Tests**
  * Added a regression test to verify multi-label variable-length traversal queries no longer crash and that the server remains responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->