### PR TITLE
fix: skip cost-base label scan optimization for variable-length traversals

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -323,7 +323,10 @@ static void _costBaseLabelScan
 	OpBase *parent = op->parent;
 	while(OpBase_Type(parent) == OPType_FILTER) parent = parent->parent;
 	OPType t = OpBase_Type(parent);
-	ASSERT(t == OPType_CONDITIONAL_TRAVERSE || t == OPType_EXPAND_INTO);
+
+	if(t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+		return;
+	}
 
 	AlgebraicExpression *ae = NULL;
 	if(t == OPType_CONDITIONAL_TRAVERSE) {

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -462,4 +462,5 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.graph.delete()
 
         self.graph.query("MERGE (:A) MERGE (:B{})<-[:R]-(n0{})<-[:R]-({})")
-        self.graph.query("MATCH (n0:A{})<-[*..]-(n0:C) RETURN *")
+        res = self.graph.query("MATCH (n0:A{})<-[*..]-(n0:C) RETURN *")
+        self.env.assertEquals(len(res.result_set), 0)

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -456,3 +456,10 @@ class testVariableLengthTraversals(FlowTestsBase):
                 Node(2, labels=["C"], properties={"v": 5})],
             [Edge(0, "R", 1, 0, properties={"v": 2}), Edge(1, "R", 2, 1, properties={"v": 4})]
         ))
+    # regression test for issue #636
+    # variable-length traversal with multi-label nodes should not crash
+    def test16_varlen_multi_label_no_crash(self):
+        self.graph.delete()
+
+        self.graph.query("MERGE (:A) MERGE (:B{})<-[:R]-(n0{})<-[:R]-({})")
+        self.graph.query("MATCH (n0:A{})<-[*..]-(n0:C) RETURN *")


### PR DESCRIPTION
Fixes #636

The `ASSERT` in `_costBaseLabelScan` assumed the parent operation is always a conditional traverse or expand-into. Variable-length traversal types (e.g. `OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO`) triggered a SIGSEGV crash.

Replaced the assert with an early return to skip the optimization for unsupported operation types, matching the existing early-return pattern already used in the same function (lines 294, 318).

## Reproduction

```
GRAPH.QUERY g "MERGE (:label8) MERGE (:label2{})<-[:reltype5]-(node_0{})<-[:reltype7]-({})"
GRAPH.QUERY g "MATCH (node_0:label8{})<-[*..]-(node_0:label9) RETURN *"
```

Before fix: `Redis crashed by signal: 11` (SIGSEGV)
After fix: query returns results, server stays alive.

## Testing

Built from source, loaded module into Redis 8.0.2, ran all three reproducer queries from the issue. Server responds to PING after all queries.

Regression test added in `tests/flow/test_variable_length_traversals.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traversal handling to avoid aborts when unexpected parent traversal types are encountered, making variable-length and multi-label traversals more robust.

* **Tests**
  * Added a regression test to ensure multi-label variable-length traversals do not crash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->