### PR TITLE
fix(docker): restore ca-certificates for HTTPS LOAD CSV

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN ln -s ${FALKORDB_BIN_PATH} /FalkorDB/build/docker && \
     ln -s ${FALKORDB_DATA_PATH} /data
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgomp1 && \
+    apt-get install -y --no-install-recommends libgomp1 ca-certificates && \
     apt-get upgrade -y && \
     # Remove packages not needed at runtime to reduce CVE surface
     (apt-get purge -y python3.11 python3.11-minimal libpython3.11-minimal libpython3.11-stdlib || true) && \

--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -24,8 +24,9 @@ ENV FALKORDB_TLS_PATH=${FALKORDB_HOME}/tls
 
 ENV FALKORDB_BROWSER_PATH=${FALKORDB_HOME}/browser
 
-# Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS)
-RUN apk add --no-cache libgomp openssl
+# Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS,
+# ca-certificates for HTTPS in LOAD CSV)
+RUN apk add --no-cache libgomp openssl ca-certificates
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/build/docker/Dockerfile.alpine-server
+++ b/build/docker/Dockerfile.alpine-server
@@ -16,8 +16,9 @@ ENV FALKORDB_IMPORT_PATH=${FALKORDB_HOME}/import
 
 ENV FALKORDB_TLS_PATH=${FALKORDB_HOME}/tls
 
-# Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS)
-RUN apk add --no-cache libgomp openssl
+# Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS,
+# ca-certificates for HTTPS in LOAD CSV)
+RUN apk add --no-cache libgomp openssl ca-certificates
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/build/docker/Dockerfile.server
+++ b/build/docker/Dockerfile.server
@@ -26,7 +26,7 @@ RUN ln -s ${FALKORDB_BIN_PATH} /FalkorDB/build/docker && \
     ln -s ${FALKORDB_DATA_PATH} /data
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgomp1 && \
+    apt-get install -y --no-install-recommends libgomp1 ca-certificates && \
     apt-get upgrade -y && \
     # Remove packages not needed at runtime to reduce CVE surface
     (apt-get purge -y python3.11 python3.11-minimal libpython3.11-minimal libpython3.11-stdlib || true) && \

--- a/src/curl_session/curl_session.c
+++ b/src/curl_session/curl_session.c
@@ -117,7 +117,9 @@ static void *_curl_thread
 	session->stream = NULL;
 
 	if(res != CURLE_OK && !session->abort) {
-		// if download was not aborted, set thread exit code to 'res'
+		// log curl error for diagnostics
+		RedisModule_Log(NULL, "warning",
+			"curl download failed: %s", curl_easy_strerror(res));
 		return (void *)(intptr_t)res;
 	}
 


### PR DESCRIPTION
## Summary
Restores `ca-certificates` package to all Docker images, fixing broken LOAD CSV from HTTPS URLs.

## Root Cause
Commit 1ed48e9f removed the `curl` package from Docker images to reduce CVE surface. However, `curl` was the package that pulled in `ca-certificates` as a dependency. Without CA certificates at `/etc/ssl/certs/ca-certificates.crt` (the path compiled into the statically-linked libcurl), HTTPS certificate verification silently fails, causing `LOAD CSV FROM 'https://...'` to return empty results instead of data.

## Changes
- **Dockerfile** (Debian browser): add `ca-certificates` to `apt-get install`
- **Dockerfile.server** (Debian server): add `ca-certificates` to `apt-get install`
- **Dockerfile.alpine** (Alpine browser): add `ca-certificates` to `apk add`
- **Dockerfile.alpine-server** (Alpine server): add `ca-certificates` to `apk add`
- **curl_session.c**: log the actual libcurl error message when downloads fail, so future HTTPS issues produce diagnostics in the Redis log instead of failing silently

## Testing
- Build verified: `make -j4` succeeds
- To reproduce the bug: run `GRAPH.QUERY a "LOAD CSV FROM 'https://raw.githubusercontent.com/FalkorDB/FalkorDB/refs/heads/master/demo/social/resources/person.csv' AS row RETURN row"` in the edge Docker image — returns empty array without this fix
- After fix: the Docker image includes CA certificates and HTTPS downloads work again

## Memory / Performance Impact
N/A — only adds the `ca-certificates` package (~200KB) and a log call on error path.

## Related Issues
Closes #1774
Regression from #1761