### PR TITLE
graph query allowed while busy

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -209,7 +209,7 @@ int RedisModule_OnLoad
 	if(RedisModule_CreateCommand(ctx,
 				"graph.QUERY",
 				CommandDispatch,
-				"write deny-oom deny-script blocking",
+				"write deny-oom deny-script blocking allow-busy",
 				1, 1, 1) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
@@ -217,7 +217,7 @@ int RedisModule_OnLoad
 	if(RedisModule_CreateCommand(ctx,
 				"graph.RO_QUERY",
 				CommandDispatch,
-				"readonly deny-script blocking",
+				"readonly deny-script blocking allow-busy",
 				1, 1, 1) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command execution flags for `graph.QUERY` and `graph.RO_QUERY` to allow these commands to run when the server is busy, improving reliability and availability during high-load periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->