### PR TITLE
fix(docker): remove libsystemd0 to mitigate CVE-2026-29111

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -50,7 +50,10 @@ RUN apt-get update && \
     (dpkg --purge passwd || true) && \
     apt-get autoremove -y --purge 2>/dev/null || true && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    # Remove libsystemd0 AFTER all apt-get operations (apt depends on libsystemd0)
+    # CVE-2026-29111 HIGH - not needed, no systemd PID 1 inside container
+    (dpkg --force-remove-essential --force-depends --purge libsystemd0 || true)
 
 # Copy only Node.js runtime from official image (no npm, no curl/gnupg needed)
 COPY --from=node /usr/local/bin/node /usr/local/bin/


### PR DESCRIPTION
## Summary
Remove `libsystemd0` from the Debian-based Docker image to eliminate CVE-2026-29111 (HIGH severity — arbitrary code execution or denial of service via systemd cgroup path validation).

## Changes
- Added `dpkg --force-remove-essential --force-depends --purge libsystemd0` to the existing package cleanup block in `build/docker/Dockerfile`

## Testing
- The Alpine image (`Dockerfile.alpine`) is unaffected (no systemd)
- `libsystemd0` is the systemd client library (journald, sd-bus, sd-notify). It is unused inside Docker containers since there is no systemd PID 1 — calls no-op gracefully when systemd is absent
- Follows the same removal pattern already used for `libtinfo6`, `ncurses`, `bash`, and `perl-base`

## Memory / Performance Impact
N/A — removes an unused library, slightly reducing image size.

## Related Issues
Closes CVE-2026-29111 for the Debian Docker image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Further optimized Docker image by removing an additional system library to reduce runtime dependencies and image size, with the cleanup made resilient to removal failures to keep builds robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->