### PR TITLE
fix(query): free heap instead of buffer in SortReset

### DIFF
--- a/src/execution_plan/ops/op_sort.c
+++ b/src/execution_plan/ops/op_sort.c
@@ -270,8 +270,8 @@ static OpResult SortReset
 			Record r = (Record)Heap_poll (op->heap) ;
 			OpBase_DeleteRecord (&r) ;
 		}
-		arr_free (op->buffer) ;
-		op->buffer = NULL ;
+		Heap_free (op->heap) ;
+		op->heap = NULL ;
 	}
 
 	op->first = true ;


### PR DESCRIPTION
## Summary

Fix memory leak and wrong-variable free in `SortReset` (`src/execution_plan/ops/op_sort.c`).

## Changes

- Replace `arr_free(op->buffer); op->buffer = NULL;` with `Heap_free(op->heap); op->heap = NULL;` in the heap cleanup block of `SortReset` (lines 273-274)

## Root Cause

Inside `SortReset`, the `if (op->heap)` block incorrectly freed `op->buffer` instead of `op->heap`:
- `op->heap` was never freed → **memory leak** on every sort reset
- `op->buffer` was freed inside the wrong block (may have already been cleared at lines 258-265)

The correct pattern is already used in `SortFree()` (lines 336-337).

## Testing

- Build passes (`make -j8`)
- The fix is a direct copy of the pattern from `SortFree`, which is known to be correct

## Memory / Performance Impact

Eliminates a memory leak proportional to the number of sort resets. Queries with `ORDER BY` + `LIMIT` in `OPTIONAL MATCH` or subqueries will no longer leak heap memory on reset.

## Related Issues

Closes #1811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed memory cleanup in sort operations to ensure proper deallocation of internal data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->