### PR TITLE
fix(query): protect writer match phase with READ lock against defrag race

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -153,21 +153,24 @@ inline static bool _readonly_cmd_mode(CommandCtx *ctx) {
 // _ExecuteQuery accepts a GraphQueryCtx as an argument
 // it may be called directly by a reader thread or the Redis main thread,
 // or dispatched as a worker thread job when used for writing.
-static void _ExecuteQuery(void *args) {
-	ASSERT(args != NULL);
+static void _ExecuteQuery
+(
+	void *args
+) {
+	ASSERT (args != NULL) ;
 
-	GraphQueryCtx  *gq_ctx      = args;
-	QueryCtx       *query_ctx   = gq_ctx->query_ctx;
-	GraphContext   *gc          = gq_ctx->graph_ctx;
+	GraphQueryCtx  *gq_ctx      = args ;
+	QueryCtx       *query_ctx   = gq_ctx->query_ctx ;
+	GraphContext   *gc          = gq_ctx->graph_ctx ;
 	Graph          *g           = GraphContext_GetGraph (gc) ;
-	RedisModuleCtx *rm_ctx      = gq_ctx->rm_ctx;
-	ExecutionCtx   *exec_ctx    = gq_ctx->exec_ctx;
-	CommandCtx     *command_ctx = gq_ctx->command_ctx;
-	AST            *ast         = exec_ctx->ast;
-	ExecutionPlan  *plan        = exec_ctx->plan;
-	ExecutionType  exec_type    = exec_ctx->exec_type;
-	const bool     profile      = (query_ctx->flags & QueryExecutionTypeFlag_PROFILE);
-	const bool     readonly     = !(query_ctx->flags & QueryExecutionTypeFlag_WRITE);
+	RedisModuleCtx *rm_ctx      = gq_ctx->rm_ctx ;
+	ExecutionCtx   *exec_ctx    = gq_ctx->exec_ctx ;
+	CommandCtx     *command_ctx = gq_ctx->command_ctx ;
+	AST            *ast         = exec_ctx->ast ;
+	ExecutionPlan  *plan        = exec_ctx->plan ;
+	ExecutionType  exec_type    = exec_ctx->exec_type ;
+	const bool     profile      = (query_ctx->flags & QueryExecutionTypeFlag_PROFILE) ;
+	const bool     readonly     = !(query_ctx->flags & QueryExecutionTypeFlag_WRITE) ;
 
 	// if we have migrated to a writer thread,
 	// update thread-local storage and track the CommandCtx
@@ -180,44 +183,45 @@ static void _ExecuteQuery(void *args) {
 	}
 
 	// instantiate the query ResultSet
-	bool bolt    = command_ctx->bolt_client != NULL;
-	bool compact = command_ctx->compact;
+	bool bolt    = command_ctx->bolt_client != NULL ;
+	bool compact = command_ctx->compact ;
+
 	// replicated command don't need to return result
 	ResultSetFormatterType resultset_format =
-		profile || command_ctx->replicated_command
-		? FORMATTER_NOP
-		: (bolt)
-			? FORMATTER_BOLT
-			: (compact)
-				? FORMATTER_COMPACT
-				: FORMATTER_VERBOSE;
-	ResultSet *result_set = NewResultSet(rm_ctx, command_ctx->bolt_client, resultset_format);
-	if(exec_ctx->cached) {
-		ResultSet_CachedExecution(result_set); // indicate a cached execution
+		(profile || command_ctx->replicated_command) ?
+			FORMATTER_NOP :
+				(bolt) ?
+					FORMATTER_BOLT :
+					(compact) ?
+						FORMATTER_COMPACT :
+						FORMATTER_VERBOSE ;
+
+	ResultSet *result_set =
+		NewResultSet (rm_ctx, command_ctx->bolt_client, resultset_format) ;
+
+	if (exec_ctx->cached) {
+		ResultSet_CachedExecution (result_set) ; // indicate a cached execution
 	}
 
-	QueryCtx_SetResultSet(result_set);
+	QueryCtx_SetResultSet (result_set) ;
 
 	// acquire the appropriate lock
-	if(readonly) {
-		Graph_AcquireReadLock(g);
-	} else {
+	if (!readonly) {
 		// if this is a writer query we need to re-open the graph key with
 		// write flag this notifies Redis that the key is "dirty" any watcher
 		// on that key will be notified
 		// must happen before READ lock to avoid deadlock:
 		//   worker: READ → GIL  vs  main thread: GIL → WRITE
-		CommandCtx_ThreadSafeContextLock(command_ctx);
+		CommandCtx_ThreadSafeContextLock (command_ctx) ;
 		{
-			GraphContext_MarkWriter(rm_ctx, gc);
+			GraphContext_MarkWriter (rm_ctx, gc) ;
 		}
-		CommandCtx_ThreadSafeContextUnlock(command_ctx);
-
-		// acquire graph READ lock to protect match phase from concurrent
-		// memory modifications by defrag or GRAPH.EFFECT on main thread
-		Graph_AcquireReadLock(g);
-		query_ctx->internal_exec_ctx.read_locked = true;
+		CommandCtx_ThreadSafeContextUnlock (command_ctx) ;
 	}
+
+	// acquire graph READ lock to protect match phase from concurrent
+	// memory modifications by defrag or GRAPH.EFFECT on main thread
+	QueryCtx_AcquireReadLock () ;
 
 	if(exec_type == EXECUTION_TYPE_QUERY) {  // query operation
 		// set policy after lock acquisition,
@@ -281,12 +285,10 @@ static void _ExecuteQuery(void *args) {
 				rm_free(effects);
 			} else {
 				// replicate original query
-				QueryCtx_Replicate(query_ctx);
+				QueryCtx_Replicate (query_ctx) ;
 			}
 		}
 	}
-
-	QueryCtx_UnlockCommit();
 
 	if(!profile || ErrorCtx_EncounteredError()) {
 		// if we encountered an error, ResultSet_Reply will emit the error
@@ -299,14 +301,7 @@ static void _ExecuteQuery(void *args) {
 		QueryCtx_AdvanceStage(query_ctx);
 	}
 
-	if (readonly) {
-		Graph_ReleaseLock(g) ; // release read lock
-	} else if(query_ctx->internal_exec_ctx.read_locked) {
-		// writer that never committed (e.g. read-only MERGE match)
-		// still holds READ lock from match-phase protection
-		Graph_ReleaseLock(g);
-		query_ctx->internal_exec_ctx.read_locked = false;
-	}
+	QueryCtx_ReleaseLock () ;
 
 	//--------------------------------------------------------------------------
 	// log query to slowlog
@@ -370,12 +365,12 @@ static void enter_writer_loop
 	while (true) {
 		// drain the queue
 		GraphQueryCtx *gq_ctx;
-		while ((gq_ctx = (GraphQueryCtx *)GraphContext_DequeueWriteQuery(gc))) {
-			_ExecuteQuery(gq_ctx);
+		while ((gq_ctx = (GraphQueryCtx *)GraphContext_DequeueWriteQuery (gc))) {
+			_ExecuteQuery (gq_ctx) ;
 		}
 
 		// release write access
-		GraphContext_ExitWrite(gc);
+		GraphContext_ExitWrite (gc) ;
 
 		// race condition handling: after releasing write access, another thread
 		// may have enqueued a query
@@ -383,10 +378,11 @@ static void enter_writer_loop
 		// to reacquire write access
 		// if we succeed, continue processing
 		// if we fail, another thread is now the writer and will handle the queue
-		if(GraphContext_WriteQueueEmpty(gc) || !GraphContext_TryEnterWrite(gc)) {
+		if (GraphContext_WriteQueueEmpty (gc) ||
+			!GraphContext_TryEnterWrite  (gc)) {
 			// either the queue is empty
 			// or the another thread became a writer
-			break;
+			break ;
 		}
 	}
 }
@@ -428,108 +424,109 @@ void _query
 	// NOTE: acquiring this lock at this point in time might be a bit too early
 	// as we should push it into `ExecutionCtx_FromQuery` some time after
 	// query parsing
-	Graph_AcquireReadLock (g) ;
+	QueryCtx_AcquireReadLock () ;
 
 	// parse query parameters and build an execution plan
 	// or retrieve it from the cache
-	exec_ctx = ExecutionCtx_FromQuery(command_ctx);
+	exec_ctx = ExecutionCtx_FromQuery (command_ctx) ;
 
 	// release graph READ lock
-	Graph_ReleaseLock (g) ;
+	QueryCtx_ReleaseLock () ;
 
-	if(exec_ctx == NULL || ErrorCtx_EncounteredError()) {
-		goto cleanup;
+	if (exec_ctx == NULL || ErrorCtx_EncounteredError ()) {
+		goto cleanup ;
 	}
 
 	// update cached flag
-	QueryCtx_SetUtilizedCache(query_ctx, exec_ctx->cached);
+	QueryCtx_SetUtilizedCache (query_ctx, exec_ctx->cached) ;
 
-	ExecutionType exec_type = exec_ctx->exec_type;
-	bool readonly = AST_ReadOnly(exec_ctx->ast->root);
+	ExecutionType exec_type = exec_ctx->exec_type ;
+	bool readonly = AST_ReadOnly (exec_ctx->ast->root) ;
 	bool index_op = (exec_type == EXECUTION_TYPE_INDEX_CREATE ||
-	     exec_type == EXECUTION_TYPE_INDEX_DROP);
+	     exec_type == EXECUTION_TYPE_INDEX_DROP) ;
 
-	if(profile && index_op) {
-		RedisModule_ReplyWithError(ctx, "Can't profile index operations.");
-		goto cleanup;
+	if (profile && index_op) {
+		RedisModule_ReplyWithError (ctx, "Can't profile index operations.") ;
+		goto cleanup ;
 	}
 
 	// write query executing via GRAPH.RO_QUERY isn't allowed
-	if(!profile && !readonly && _readonly_cmd_mode(command_ctx)) {
-		ErrorCtx_SetError(EMSG_MISUSE_GRAPH_ROQUERY);
-		goto cleanup;
+	if (!profile && !readonly && _readonly_cmd_mode (command_ctx)) {
+		ErrorCtx_SetError (EMSG_MISUSE_GRAPH_ROQUERY) ;
+		goto cleanup ;
 	}
 
-	CronTaskHandle timeout_task = 0;
+	CronTaskHandle timeout_task = 0 ;
 
 	// enforce specified timeout when query is readonly
 	// or timeout applies to both read and write
-	bool enforce_timeout = command_ctx->timeout != 0 && !index_op &&
-		(readonly || command_ctx->timeout_rw) &&
-		!command_ctx->replicated_command;
-	if(enforce_timeout) {
-		timeout_task = Query_SetTimeOut(command_ctx->timeout, exec_ctx->plan);
+	bool enforce_timeout = command_ctx->timeout != 0             &&
+						   !index_op                             &&
+						   (readonly || command_ctx->timeout_rw) &&
+						   !command_ctx->replicated_command ;
+	if (enforce_timeout) {
+		timeout_task = Query_SetTimeOut (command_ctx->timeout, exec_ctx->plan) ;
 	}
 
 	// populate the container struct for invoking _ExecuteQuery.
-	QueryExecutionTypeFlag flags = QueryExecutionTypeFlag_READ;
+	QueryExecutionTypeFlag flags = QueryExecutionTypeFlag_READ ;
 	if (!readonly) {
-		flags |= QueryExecutionTypeFlag_WRITE;
+		flags |= QueryExecutionTypeFlag_WRITE ;
 	}
 	if (profile) {
-		flags |= QueryExecutionTypeFlag_PROFILE;
+		flags |= QueryExecutionTypeFlag_PROFILE ;
 	}
-	GraphQueryCtx *gq_ctx = GraphQueryCtx_New(gc, ctx, exec_ctx, command_ctx,
-											  flags, timeout_task);
+	GraphQueryCtx *gq_ctx =
+		GraphQueryCtx_New (gc, ctx, exec_ctx, command_ctx, flags, timeout_task) ;
 
 	// if 'thread' is redis main thread, continue running
 	// if readonly is true we're executing on a worker thread from
 	// the read-only threadpool
-	if(readonly || command_ctx->thread == EXEC_THREAD_MAIN) {
-		_ExecuteQuery(gq_ctx);
+	if (readonly || command_ctx->thread == EXEC_THREAD_MAIN) {
+		_ExecuteQuery (gq_ctx) ;
 	} else {
 		// increase graph ref count, guard against the graph context
 		// being free too early as the writer need access to the graph's
 		// pending queries queue and the writer's flag
-		GraphContext_IncreaseRefCount(gc);
+		GraphContext_IncreaseRefCount (gc) ;
 
 		// thread failed getting exclusive write access to graph
 		// delegate query to current writer
-		if(!_DelegateQuery(gc, gq_ctx)) {
-			ErrorCtx_SetError(EMSG_WRITE_QUEUE_FULL);
+		if (!_DelegateQuery (gc, gq_ctx)) {
+			ErrorCtx_SetError (EMSG_WRITE_QUEUE_FULL) ;
 
 			// counter to GraphContext_IncreaseRefCount just above
-			GraphContext_DecreaseRefCount(gc);
-			goto cleanup;
+			GraphContext_DecreaseRefCount (gc) ;
+			goto cleanup ;
 		}
 
 		// try to acquire exclusive write access to graph
-		if(GraphContext_TryEnterWrite(gc)) {
+		if (GraphContext_TryEnterWrite (gc)) {
 			// thread has exclusive write access to graph
 			// go ahead and run the query
-			enter_writer_loop(gc);
+			enter_writer_loop (gc) ;
 		}
 
 		// counter to GraphContext_IncreaseRefCount just above
-		GraphContext_DecreaseRefCount(gc);
+		GraphContext_DecreaseRefCount (gc) ;
 	}
 
-	return;
+	return ;
 
 cleanup:
 	// if there were any query compile time errors, report them
-	if(ErrorCtx_EncounteredError()) {
-		ErrorCtx_EmitException();
+	if (ErrorCtx_EncounteredError ()) {
+		ErrorCtx_EmitException () ;
 	}
 
 	// cleanup routine invoked after encountering errors in this function
-	ExecutionCtx_Free(exec_ctx);
-	GraphContext_DecreaseRefCount(gc);
-	Globals_UntrackCommandCtx(command_ctx);
-	CommandCtx_UnblockClient(command_ctx);
-	CommandCtx_Free(command_ctx);
-	QueryCtx_Free(); // reset the QueryCtx and free its allocations
-	ErrorCtx_Clear();
+	ExecutionCtx_Free (exec_ctx) ;
+	GraphContext_DecreaseRefCount (gc) ;
+	Globals_UntrackCommandCtx (command_ctx) ;
+	CommandCtx_UnblockClient (command_ctx) ;
+	CommandCtx_Free (command_ctx) ;
+	QueryCtx_Free () ; // reset the QueryCtx and free its allocations
+	ErrorCtx_Clear () ;
 }
 
 void Graph_Profile(void *args) {

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -202,14 +202,21 @@ static void _ExecuteQuery(void *args) {
 	if(readonly) {
 		Graph_AcquireReadLock(g);
 	} else {
-		// if this is a writer query `we need to re-open the graph key with write flag
-		// this notifies Redis that the key is "dirty" any watcher on that key will
-		// be notified
+		// if this is a writer query we need to re-open the graph key with
+		// write flag this notifies Redis that the key is "dirty" any watcher
+		// on that key will be notified
+		// must happen before READ lock to avoid deadlock:
+		//   worker: READ → GIL  vs  main thread: GIL → WRITE
 		CommandCtx_ThreadSafeContextLock(command_ctx);
 		{
 			GraphContext_MarkWriter(rm_ctx, gc);
 		}
 		CommandCtx_ThreadSafeContextUnlock(command_ctx);
+
+		// acquire graph READ lock to protect match phase from concurrent
+		// memory modifications by defrag or GRAPH.EFFECT on main thread
+		Graph_AcquireReadLock(g);
+		query_ctx->internal_exec_ctx.read_locked = true;
 	}
 
 	if(exec_type == EXECUTION_TYPE_QUERY) {  // query operation
@@ -294,6 +301,11 @@ static void _ExecuteQuery(void *args) {
 
 	if (readonly) {
 		Graph_ReleaseLock(g) ; // release read lock
+	} else if(query_ctx->internal_exec_ctx.read_locked) {
+		// writer that never committed (e.g. read-only MERGE match)
+		// still holds READ lock from match-phase protection
+		Graph_ReleaseLock(g);
+		query_ctx->internal_exec_ctx.read_locked = false;
 	}
 
 	//--------------------------------------------------------------------------

--- a/src/commands/index_operations.c
+++ b/src/commands/index_operations.c
@@ -137,7 +137,7 @@ static bool index_delete
 	//--------------------------------------------------------------------------
 
 	// lock
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	if(is_node) {
 		// try deleting node index
@@ -435,7 +435,7 @@ static void index_create
 		   idx_type == INDEX_FLD_VECTOR);
 
 	// lock
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	Index idx = NULL;
 	ResultSet *result_set = QueryCtx_GetResultSet();

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -80,7 +80,7 @@ static void _BulkDeleteEntities
 	ASSERT ((node_count + total_edge_count) > 0) ;
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	// NOTE: delete edges before nodes
 	// required as a deleted node must be detached
@@ -179,7 +179,7 @@ static void _DeleteEntities
 	}
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 	// NOTE: delete edges before nodes
 	// required as a deleted node must be detached
 

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -471,7 +471,7 @@ static Record MergeConsume
 	OpBase_PropagateReset (op->match_stream) ;
 
 	// lock everything
-	QueryCtx_LockForCommit ();
+	QueryCtx_AcquireWriteLock ();
 
 	// in cases such as:
 	// MERGE (n) ON MATCH SET n:L ON CREATE n:M

--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -138,7 +138,9 @@ static Record ProcCallConsume
 		// introduced
 
 		// lock if procedure can modify the graph
-		if(!Procedure_IsReadOnly(op->procedure)) QueryCtx_LockForCommit();
+		if (!Procedure_IsReadOnly (op->procedure)) {
+			QueryCtx_AcquireWriteLock () ;
+		}
 
 		ProcedureResult res = Proc_Invoke(op->procedure, op->args, op->output);
 

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -116,7 +116,7 @@ static Record UpdateConsume
 		OpBase_PropagateReset (child) ;
 
 		// lock everything
-		QueryCtx_LockForCommit () ;
+		QueryCtx_AcquireWriteLock () ;
 
 		// in cases such as:
 		// MATCH (n) SET n:L

--- a/src/execution_plan/ops/shared/create_functions.c
+++ b/src/execution_plan/ops/shared/create_functions.c
@@ -268,7 +268,7 @@ void CommitNewEntities
 	}
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	//--------------------------------------------------------------------------
 	// commit nodes

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -23,7 +23,7 @@ static inline QueryCtx *_QueryCtx_GetCreateCtx(void) {
 
 	if(ctx == NULL) {
 		// set a new thread-local QueryCtx if one has not been created
-		ctx = rm_calloc(1, sizeof(QueryCtx));
+		ctx = rm_calloc (1, sizeof(QueryCtx)) ;
 
 		// created lazily only when needed
 		ctx->undo_log       = NULL ;
@@ -351,14 +351,18 @@ void QueryCtx_PrintQuery(void) {
 	printf("%s\n", ctx->query_data.query);
 }
 
+//------------------------------------------------------------------------------
+// Lock management
+//------------------------------------------------------------------------------
+
 static void _QueryCtx_ThreadSafeContextLock
 (
 	QueryCtx *ctx
 ) {
 	// acquire GIL if we're running with a blocked client
 	// implicates we're running on a worker thread and not on Redis main thread
-	if(ctx->global_exec_ctx.bc) {
-		RedisModule_ThreadSafeContextLock(ctx->global_exec_ctx.redis_ctx);
+	if (ctx->global_exec_ctx.bc) {
+		RedisModule_ThreadSafeContextLock (ctx->global_exec_ctx.redis_ctx) ;
 	} else {
 		// no blocked client, most likely we're running on Redis main thread
 		// ASSERT(pthread_equal(Globals_Get_MainThreadId(), pthread_self()) != 0);
@@ -368,8 +372,8 @@ static void _QueryCtx_ThreadSafeContextLock
 		// to alow Redis to reply to PING requests we should yield execution
 		// giving Redis the opportunity to process commands
 		// see RedisModule_Yield docs
-		RedisModule_Yield(ctx->global_exec_ctx.redis_ctx,
-				REDISMODULE_YIELD_FLAG_CLIENTS, NULL);
+		RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
+				REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
 	}
 }
 
@@ -377,36 +381,64 @@ static void _QueryCtx_ThreadSafeContextUnlock
 (
 	QueryCtx *ctx
 ) {
-	if(ctx->global_exec_ctx.bc) RedisModule_ThreadSafeContextUnlock(ctx->global_exec_ctx.redis_ctx);
+	if (ctx->global_exec_ctx.bc != NULL) {
+		RedisModule_ThreadSafeContextUnlock (ctx->global_exec_ctx.redis_ctx) ;
+	}
 }
 
-// starts a locking flow before commiting changes
-// Locking flow:
-// 1. lock GIL
-// 2. open key with `write` flag
-// 3. graph R/W lock with write flag
-// since 2PL protocal is implemented, the method returns true if
-// it managed to achieve locks in this call or a previous call
-// in case that the locks are already locked, there will be no attempt to lock
-// them again this method returns false if the key has changed
-// from the current graph, and sets the relevant error message
-bool QueryCtx_LockForCommit (void) {
+// acquire graph's read lock
+void QueryCtx_AcquireReadLock (void) {
 	QueryCtx *ctx = _QueryCtx_GetCreateCtx () ;
-	if (ctx->internal_exec_ctx.locked_for_commit) {
+
+	// shouldn't try to acquire write lock when read lock is held
+	ASSERT (ctx->internal_exec_ctx.write_locked == false) ;
+
+	// return if we've already acquired read lock
+	if (ctx->internal_exec_ctx.read_locked == true) {
+		return ;
+	}
+
+	// acquire read lock
+	// TODO: change to TryAcquireReadLock with the appropriate timeout
+	Graph_AcquireReadLock (QueryCtx_GetGraph ()) ;
+	ctx->internal_exec_ctx.read_locked = true ;
+}
+
+// acquire graph's write lock
+bool QueryCtx_AcquireWriteLock (void) {
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx () ;
+
+	// return if we've already acquired write lock
+	if (ctx->internal_exec_ctx.write_locked == true) {
+		ASSERT (ctx->internal_exec_ctx.read_locked == false) ;
 		return true ;
 	}
 
-	// release graph READ lock if held by writer
+	// locking flow:
+	// 1. release read lock
+	// 2. lock GIL
+	// 3. open key with `write` flag
+	// 4. graph R/W lock with write flag
+	// since 2PL protocal is implemented, the method returns true if
+	// it managed to achieve locks in this call or a previous call
+	// in case that the locks are already locked, there will be no attempt to lock
+	// them again this method returns false if the key has changed
+	// from the current graph, and sets the relevant error message
+
+	// release graph READ lock if held
 	// writer queries hold a READ lock during the match phase to prevent
-	// concurrent memory modifications by defrag or GRAPH.EFFECT
+	// concurrent memory modifications by defrag
 	// must release before acquiring GIL to avoid deadlock:
 	//   worker: READ lock → GIL  vs  main thread: GIL → WRITE lock
-	if (ctx->internal_exec_ctx.read_locked) {
+	if (ctx->internal_exec_ctx.read_locked == true) {
 		Graph_ReleaseLock (GraphContext_GetGraph (ctx->gc)) ;
 		ctx->internal_exec_ctx.read_locked = false ;
 	}
 
+	//--------------------------------------------------------------------------
 	// lock GIL
+	//--------------------------------------------------------------------------
+
 	GraphContext   *gc         = ctx->gc ;
 	RedisModuleCtx *redis_ctx  = ctx->global_exec_ctx.redis_ctx ;
 	const char     *graph_name = GraphContext_GetName (gc) ;
@@ -416,7 +448,10 @@ bool QueryCtx_LockForCommit (void) {
 
 	_QueryCtx_ThreadSafeContextLock (ctx) ;
 
-	// open key and verify
+	//--------------------------------------------------------------------------
+	// make sure graph key exists
+	//--------------------------------------------------------------------------
+
 	RedisModuleKey *key = RedisModule_OpenKey (redis_ctx, graphID,
 			REDISMODULE_WRITE) ;
 	RedisModule_FreeString (redis_ctx, graphID) ;
@@ -429,7 +464,6 @@ bool QueryCtx_LockForCommit (void) {
 	if (RedisModule_ModuleTypeGetType (key) != GraphContextRedisModuleType) {
 		ErrorCtx_SetError (EMSG_NON_GRAPH_KEY, graph_name) ;
 		goto clean_up ;
-
 	}
 
 	if (gc != RedisModule_ModuleTypeGetValue (key)) {
@@ -440,8 +474,10 @@ bool QueryCtx_LockForCommit (void) {
 	ctx->internal_exec_ctx.key = key ;
 
 	// acquire graph write lock
+	// TODO: change to TryAcquireWriteLock with the appropriate timeout
 	Graph_AcquireWriteLock (GraphContext_GetGraph (gc)) ;
-	ctx->internal_exec_ctx.locked_for_commit = true ;
+	ctx->internal_exec_ctx.write_locked = true ;
+	ASSERT (ctx->internal_exec_ctx.read_locked == false) ;
 
 	return true ;
 
@@ -452,45 +488,43 @@ clean_up:
 	// unlock GIL
 	_QueryCtx_ThreadSafeContextUnlock (ctx) ;
 
-	// if there is a break point for runtime exception, raise it, otherwise return false
+	// if there is a break point for runtime exception, raise it
+	// otherwise return false
 	ErrorCtx_RaiseRuntimeException (NULL) ;
 	return false ;
 }
 
-static void _QueryCtx_UnlockCommit
-(
-	QueryCtx *ctx
-) {
-	GraphContext *gc = ctx->gc ;
+// release graph's lock
+void QueryCtx_ReleaseLock (void) {
+	QueryCtx *ctx = _QueryCtx_GetCtx () ;
+	ASSERT (ctx != NULL) ;
 
-	ctx->internal_exec_ctx.locked_for_commit = false ;
-	// release graph R/W lock
-	Graph_ReleaseLock (GraphContext_GetGraph (gc)) ;
+	// return if neither lock is held
+	if (ctx->internal_exec_ctx.write_locked == false &&
+		ctx->internal_exec_ctx.read_locked  == false) {
+		return ;
+	}
 
-	// close Key
-	RedisModule_CloseKey (ctx->internal_exec_ctx.key) ;
+	// starts an ulocking flow
+	// Unlocking flow:
+	// 1. unlock graph R/W lock
+	// 2. close key
+	// 3. unlock GIL
 
-	// unlock GIL
-	_QueryCtx_ThreadSafeContextUnlock (ctx) ;
-}
+	// release graph lock
+	Graph_ReleaseLock (QueryCtx_GetGraph ()) ;
 
-// starts an ulocking flow and notifies Redis after commiting changes
-// the only writer which allow to perform the unlock and commit (replicate)
-// is the last_writer the method get an OpBase and compares it to
-// the last writer, if they are equal then the commit and unlock flow will start
-// Unlocking flow:
-// 1. replicate
-// 2. unlock graph R/W lock
-// 3. close key
-// 4. unlock GIL
-void QueryCtx_UnlockCommit() {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(!ctx) return;
+	// release WRITE lock
+	if (ctx->internal_exec_ctx.write_locked == true) {
+		// close Key
+		RedisModule_CloseKey (ctx->internal_exec_ctx.key) ;
 
-	// already unlocked?
-	if(!ctx->internal_exec_ctx.locked_for_commit) return;
+		// unlock GIL
+		_QueryCtx_ThreadSafeContextUnlock (ctx) ;
+	}
 
-	_QueryCtx_UnlockCommit(ctx);
+	ctx->internal_exec_ctx.read_locked  = false ;
+	ctx->internal_exec_ctx.write_locked = false ;
 }
 
 // replicate command to AOF/Replicas
@@ -527,8 +561,8 @@ uint64_t QueryCtx_GetReceivedTS (void) {
 
 // free the allocations within the QueryCtx and reset it for the next query
 void QueryCtx_Free(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ASSERT(ctx != NULL);
+	QueryCtx *ctx = _QueryCtx_GetCtx () ;
+	ASSERT (ctx != NULL) ;
 
 	if (ctx->undo_log) {
 		UndoLog_Free (ctx->undo_log) ;

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -396,6 +396,16 @@ bool QueryCtx_LockForCommit (void) {
 		return true ;
 	}
 
+	// release graph READ lock if held by writer
+	// writer queries hold a READ lock during the match phase to prevent
+	// concurrent memory modifications by defrag or GRAPH.EFFECT
+	// must release before acquiring GIL to avoid deadlock:
+	//   worker: READ lock → GIL  vs  main thread: GIL → WRITE lock
+	if (ctx->internal_exec_ctx.read_locked) {
+		Graph_ReleaseLock (GraphContext_GetGraph (ctx->gc)) ;
+		ctx->internal_exec_ctx.read_locked = false ;
+	}
+
 	// lock GIL
 	GraphContext   *gc         = ctx->gc ;
 	RedisModuleCtx *redis_ctx  = ctx->global_exec_ctx.redis_ctx ;

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -60,6 +60,7 @@ typedef struct {
 	RedisModuleKey *key;     // graph open key, for later extraction and closing
 	ResultSet *result_set;   // execution result set
 	bool locked_for_commit;  // indicates if QueryCtx_LockForCommit been called
+	bool read_locked;        // writer holds graph READ lock for match-phase protection
 } QueryCtx_InternalExecCtx;
 
 typedef struct {

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -59,8 +59,8 @@ typedef struct {
 typedef struct {
 	RedisModuleKey *key;     // graph open key, for later extraction and closing
 	ResultSet *result_set;   // execution result set
-	bool locked_for_commit;  // indicates if QueryCtx_LockForCommit been called
-	bool read_locked;        // writer holds graph READ lock for match-phase protection
+	bool read_locked;        // thread holds graph READ lock
+	bool write_locked;       // thread holds graph WRITE lock
 } QueryCtx_InternalExecCtx;
 
 typedef struct {
@@ -221,28 +221,18 @@ ResultSetStatistics *QueryCtx_GetResultSetStatistics(void);
 // print the current query
 void QueryCtx_PrintQuery(void);
 
-// starts a locking flow before commiting changes
-// Locking flow:
-// 1. lock GIL
-// 2. open key with `write` flag
-// 3. graph R/W lock with write flag
-// since 2PL protocal is implemented, the method returns true if
-// it managed to achieve locks in this call or a previous call
-// in case that the locks are already locked, there will be no attempt to lock
-// them again this method returns false if the key has changed
-// from the current graph, and sets the relevant error message
-bool QueryCtx_LockForCommit(void);
+//------------------------------------------------------------------------------
+// Lock management
+//------------------------------------------------------------------------------
 
-// starts an ulocking flow and notifies Redis after commiting changes
-// the only writer which allow to perform the unlock and commit (replicate)
-// is the last_writer the method get an OpBase and compares it to
-// the last writer, if they are equal then the commit and unlock flow will start
-// Unlocking flow:
-// 1. replicate
-// 2. unlock graph R/W lock
-// 3. close key
-// 4. unlock GIL
-void QueryCtx_UnlockCommit(void);
+// acquire graph's read lock
+void QueryCtx_AcquireReadLock (void) ;
+
+// acquire graph's write lock
+bool QueryCtx_AcquireWriteLock (void) ;
+
+// release graph's lock
+void QueryCtx_ReleaseLock (void) ;
 
 // replicate command to AOF/Replicas
 void QueryCtx_Replicate

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -278,8 +278,7 @@ class testDefrag():
 
             # verify no connection-lost errors (would indicate a crash)
             crash_errors = [e for e in errors if "crash" in e.lower()]
-            self.env.assertEquals(len(crash_errors), 0,
-                f"Server crashed during concurrent defrag+writes: {crash_errors}")
+            self.env.assertEquals(len(crash_errors), 0)
 
         finally:
             #------------------------------------------------------------------

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -2,6 +2,7 @@ import time
 import redis
 import random
 import datetime
+import threading
 from dateutil.relativedelta import relativedelta
 from common import *
 
@@ -161,3 +162,136 @@ class testDefrag():
             self.env.assertEquals(props, row[0])
             self.env.assertEquals(props, row[1])
 
+    def test_concurrent_writers_during_defrag(self):
+        """Regression test for issue #1831: writer queries must hold a graph
+        READ lock during the match phase to prevent active defrag from
+        relocating entity memory mid-execution."""
+
+        conn = self.env.getConnection()
+
+        #----------------------------------------------------------------------
+        # 1. Seed the graph with data to defragment
+        #----------------------------------------------------------------------
+
+        g = self.db.select_graph("defrag_race")
+
+        # create nodes with properties to give defrag something to relocate
+        g.query("""UNWIND range(0, 500) AS i
+                   CREATE (:Item {id: i, name: 'item_' + toString(i),
+                                  value: i * 1.5, tag: 'bulk'})""")
+
+        # delete half to create fragmentation
+        g.query("MATCH (n:Item) WHERE n.id % 2 = 0 DELETE n")
+        conn.execute_command("MEMORY PURGE")
+
+        #----------------------------------------------------------------------
+        # 2. Enable aggressive active defrag
+        #----------------------------------------------------------------------
+
+        keys = [
+            "activedefrag",
+            "active-defrag-threshold-lower",
+            "active-defrag-threshold-upper",
+            "active-defrag-ignore-bytes",
+        ]
+
+        original_cfg = {}
+        for k in keys:
+            original_cfg.update(conn.config_get(k))
+
+        try:
+            conn.config_set("activedefrag", "yes")
+            conn.config_set("active-defrag-threshold-lower", "1")
+            conn.config_set("active-defrag-threshold-upper", "1")
+            conn.config_set("active-defrag-ignore-bytes", "1")
+        except ResponseError:
+            self.env.skip()
+            return
+
+        #----------------------------------------------------------------------
+        # 3. Run concurrent MERGE+SET writers while defrag is active
+        #----------------------------------------------------------------------
+
+        errors = []
+        stop_event = threading.Event()
+
+        def writer_thread(thread_id):
+            """Run MERGE+SET queries concurrently with defrag."""
+            try:
+                tg = self.db.select_graph("defrag_race")
+                i = 0
+                while not stop_event.is_set():
+                    try:
+                        tg.query(
+                            "UNWIND $rows AS row "
+                            "MERGE (n:Item {id: row.id}) "
+                            "SET n.name = row.name, n.value = row.value",
+                            {"rows": [
+                                {"id": thread_id * 1000 + i,
+                                 "name": f"t{thread_id}_{i}",
+                                 "value": float(i)},
+                                {"id": thread_id * 1000 + i + 1,
+                                 "name": f"t{thread_id}_{i+1}",
+                                 "value": float(i + 1)},
+                            ]}
+                        )
+                    except Exception as e:
+                        err_str = str(e)
+                        if "connection" not in err_str.lower():
+                            errors.append(f"Thread {thread_id}: {e}")
+                        else:
+                            # server crash — connection lost
+                            errors.append(f"Thread {thread_id}: server crashed: {e}")
+                            return
+                    i += 2
+            except Exception as e:
+                errors.append(f"Thread {thread_id} setup: {e}")
+
+        # start writer threads
+        num_threads = 4
+        threads = []
+        for t in range(num_threads):
+            th = threading.Thread(target=writer_thread, args=(t,))
+            th.daemon = True
+            th.start()
+            threads.append(th)
+
+        try:
+            # let writers and defrag run concurrently
+            time.sleep(3)
+
+            # signal threads to stop
+            stop_event.set()
+            for th in threads:
+                th.join(timeout=5)
+
+            #------------------------------------------------------------------
+            # 4. Verify server is alive and data is consistent
+            #------------------------------------------------------------------
+
+            # server should still respond
+            self.env.assertTrue(conn.ping())
+
+            # query should return valid results
+            res = g.query("MATCH (n:Item) RETURN count(n)").result_set
+            self.env.assertGreater(res[0][0], 0)
+
+            # verify no connection-lost errors (would indicate a crash)
+            crash_errors = [e for e in errors if "crash" in e.lower()]
+            self.env.assertEquals(len(crash_errors), 0,
+                f"Server crashed during concurrent defrag+writes: {crash_errors}")
+
+        finally:
+            #------------------------------------------------------------------
+            # 5. Restore original config
+            #------------------------------------------------------------------
+
+            stop_event.set()
+            for th in threads:
+                th.join(timeout=5)
+
+            for k, v in original_cfg.items():
+                try:
+                    conn.config_set(k, v)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

Fix a race condition where writer queries execute their match phase (entity scanning, property reads) without any graph lock, allowing concurrent memory modifications by active defrag or `GRAPH.EFFECT` on the main thread to invalidate entity pointers mid-execution, causing heap corruption and SIGSEGV crashes in production.

## Changes

- **`src/query_ctx.h`**: Add `read_locked` field to `QueryCtx_InternalExecCtx` to track whether a writer holds a graph READ lock for match-phase protection.
- **`src/query_ctx.c`**: In `QueryCtx_LockForCommit`, release the READ lock before acquiring the GIL to prevent deadlock (worker: READ→GIL vs main thread: GIL→WRITE).
- **`src/commands/cmd_query.c`**: Writer queries now acquire a graph READ lock after `MarkWriter` and before execution begins. The READ lock is released either by `LockForCommit` (at commit time) or after execution completes (if commit never happened).

### Lock flow for writers (after fix):
1. `MarkWriter` under GIL (no graph lock — avoids READ→GIL deadlock)
2. Acquire graph READ lock (protects match phase)
3. Execute query (match phase protected by READ lock)
4. `LockForCommit`: release READ → acquire GIL → acquire WRITE
5. Commit changes under WRITE lock
6. `UnlockCommit`: release WRITE + GIL
7. If commit never happened: release READ lock after `ResultSet_Reply`

## Root Cause

The `_ExecuteQuery` function in `cmd_query.c` acquires **no graph lock** for writer queries before calling `ExecutionPlan_Execute`. The graph WRITE lock is only acquired later inside `QueryCtx_LockForCommit`, which is called from individual ops (op_merge, op_create, etc.) when they need to commit changes.

During this unprotected match phase, the Redis main thread can:
- Run **active defrag** callbacks that acquire a graph WRITE lock and move `AttributeSet` memory via `RedisModule_DefragAlloc`
- Execute **`GRAPH.EFFECT`** commands that acquire a graph WRITE lock and mutate graph storage

This causes use-after-free / stale pointer access in the worker thread, leading to heap corruption and crashes.

## Testing

- Reproduced reliably with `repro_defrag_race.py` (crashes unpatched server in ~10-20s)
- Compilation verified with zero warnings
- Full CI test suite (65 checks)

## Memory / Performance Impact

- **Memory**: One additional `bool` field in `QueryCtx_InternalExecCtx` (negligible)
- **Performance**: Writer queries now hold a graph READ lock during match phase. This is the same lock readers already hold. Multiple READ locks can coexist, so reader throughput is unaffected. The only contention is between writer match phases and defrag/EFFECT write operations, which is exactly the race we are fixing.

## Known Limitations

1. **Brief gap during lock transition**: Between READ lock release and WRITE lock acquire in `LockForCommit`, there is a microsecond-scale window where no lock is held. This is orders of magnitude smaller than the current unprotected window (entire execution), but not zero. The GIL prevents most main-thread operations during this gap.

2. **Reply path for committed writers**: `ResultSet_Reply` runs after `UnlockCommit` for writers that committed changes. Result formatters may dereference entity data without lock protection. This is a **pre-existing issue** not introduced or worsened by this fix.

## Related Issues

Closes #1831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling for writer executions so transient read locks are tracked and reliably released during commit/teardown, reducing lock contention and preventing stale read-locks.

* **Tests**
  * Added a regression stress test that runs concurrent writers during active defragmentation to validate stability, responsiveness, and absence of errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->