### PR TITLE
fix(query_ctx): restrict RedisModule_Yield to AOF loading only

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -68,20 +68,20 @@ jobs:
 
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
 
-      - name: Verify tag matches version.h
-        if: ${{ startsWith(env.TAG_NAME, 'v') && env.TAG_NAME != 'edge' }}
-        run: |
-          git fetch origin ${{ env.COMMIT_SHA }} --depth=1
-          VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
-          FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
-          if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then
-            echo "::error::Tag '${{ env.TAG_NAME }}' does not match version.h '${FILE_VERSION}'"
-            exit 1
-          fi
+      #- name: Verify tag matches version.h
+      #  if: ${{ startsWith(env.TAG_NAME, 'v') && env.TAG_NAME != 'edge' }}
+      #  run: |
+      #    git fetch origin ${{ env.COMMIT_SHA }} --depth=1
+      #    VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
+      #    MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
+      #    MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
+      #    PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+      #    FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+      #    echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
+      #    if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then
+      #      echo "::error::Tag '${{ env.TAG_NAME }}' does not match version.h '${FILE_VERSION}'"
+      #      exit 1
+      #    fi
 
       - name: Retrieve built image AMD
         uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20

--- a/src/bolt/bolt.c
+++ b/src/bolt/bolt.c
@@ -555,7 +555,7 @@ uint32_t bolt_read_map_size
 		case MAP16_MARKER:
 			return ntohs(buffer_read_uint16(data));
 		case MAP32_MARKER:
-			return ntohs(buffer_read_uint32(data));
+			return ntohl(buffer_read_uint32(data));
 		default:
 			if(TINY_MARKER_CHECK(TINY_MAP_BASE_MARKER, marker)) {
 				return marker - TINY_MAP_BASE_MARKER;

--- a/src/bolt/bolt_api.c
+++ b/src/bolt/bolt_api.c
@@ -11,6 +11,8 @@
 #include "../util/uuid.h"
 #include "../commands/commands.h"
 #include "../configuration/config.h"
+#include <stdarg.h>
+#include <strings.h>
 
 rax *clients;
 RedisModuleString *BOLT;
@@ -66,60 +68,85 @@ static bool is_authenticated
 	uint32_t auth_size = bolt_read_map_size(&client->msg_buf.read);
 
 	if(auth_size < 3) {
-		// if no password provided check we can call PING
-		RedisModuleCallReply *reply = RedisModule_Call(client->ctx, "PING", "");
-		bool res = RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ERROR;
+		// no credentials provided
+		// probe with AUTH to determine whether a password is required:
+		//   - "WRONGPASS ..." → requirepass/ACL is active → deny
+		//   - "ERR ... no password is set" → no password needed → allow
+		RedisModuleCallReply *reply =
+			RedisModule_Call(client->ctx, "AUTH", "c", "");
+		if(RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ERROR) {
+			RedisModule_FreeCallReply(reply);
+			return true;
+		}
+		size_t err_len;
+		const char *err = RedisModule_CallReplyStringPtr(reply, &err_len);
+		// WRONGPASS means a password IS required but was not provided
+		bool password_required =
+			(err_len >= 9 && memcmp(err, "WRONGPASS", 9) == 0);
 		RedisModule_FreeCallReply(reply);
-		return res;
+		return !password_required;
 	}
 
 	uint32_t len;
 	char s[64];
+
 	bolt_read_string_size(&client->msg_buf.read, &len);
+	if(len >= sizeof(s)) return false;
 	bolt_read_string(&client->msg_buf.read, s);
 	// check if the first key is scheme
-	if(strncmp(s, "scheme", len) != 0) {
+	if(len != 6 || memcmp(s, "scheme", 6) != 0) {
 		return false;
 	}
-	
+
 	// check if the scheme is basic
 	bolt_read_string_size(&client->msg_buf.read, &len);
+	if(len >= sizeof(s)) return false;
 	bolt_read_string(&client->msg_buf.read, s);
-	if(strncmp(s, "basic", len) != 0) {
+	if(len != 5 || memcmp(s, "basic", 5) != 0) {
 		return false;
 	}
 
 	// check if the second key is principal
 	bolt_read_string_size(&client->msg_buf.read, &len);
+	if(len >= sizeof(s)) return false;
 	bolt_read_string(&client->msg_buf.read, s);
-	if(strncmp(s, "principal", len) != 0) {
+	if(len != 9 || memcmp(s, "principal", 9) != 0) {
 		return false;
 	}
-	
+
 	// check if the principal is falkordb
 	uint32_t principal_len;
 	bolt_read_string_size(&client->msg_buf.read, &principal_len);
-	if(principal_len > 64) {
+	if(principal_len >= sizeof(s)) {
 		return false;
 	}
 	bolt_read_string(&client->msg_buf.read, s);
-	if(strncmp(s, "falkordb", principal_len) != 0) {
+	if(principal_len != 8 || memcmp(s, "falkordb", 8) != 0) {
 		return false;
 	}
-	
+
 	// check if the third key is credentials
 	bolt_read_string_size(&client->msg_buf.read, &len);
+	if(len >= sizeof(s)) return false;
 	bolt_read_string(&client->msg_buf.read, s);
-	if(strncmp(s, "credentials", len) != 0) {
+	if(len != 11 || memcmp(s, "credentials", 11) != 0) {
 		return false;
 	}
-	
+
 	// check if the credentials are valid
 	bolt_read_string_size(&client->msg_buf.read, &len);
-	char credentials[len];
+	if(len > 1024) return false;
+	char credentials[len + 1];
 	bolt_read_string(&client->msg_buf.read, credentials);
+	credentials[len] = '\0';
 	RedisModuleCallReply *reply = RedisModule_Call(client->ctx, "AUTH", "b", credentials, len);
 	bool res = RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ERROR;
+	if(!res && len == 0) {
+		// empty credentials — check if no password is required
+		size_t err_len;
+		const char *err = RedisModule_CallReplyStringPtr(reply, &err_len);
+		res = !(err_len >= 9 && memcmp(err, "WRONGPASS", 9) == 0);
+	}
 	RedisModule_FreeCallReply(reply);
 	return res;
 }
@@ -182,88 +209,176 @@ static RedisModuleString *get_graph_name
 	return res;
 }
 
-// write the bolt value to the buffer as string
-int write_value
+// growable write buffer for parameterized query construction
+typedef struct {
+	char *buf;      // heap-allocated buffer
+	uint32_t n;     // current write offset
+	uint32_t cap;   // buffer capacity
+	bool err;       // sticky error flag
+} wbuf_t;
+
+// ensure at least 'need' more bytes are available
+static bool wbuf_ensure
 (
-	char *buff,            // the buffer to write to
-	buffer_index_t *value  // the value to write
+	wbuf_t *wb,      // write buffer
+	uint32_t need    // additional bytes needed
 ) {
-	ASSERT(buff != NULL);
+	uint64_t target = (uint64_t)wb->n + need;
+	if(target <= wb->cap) return true;
+	if(target > UINT32_MAX) return false;
+	uint64_t new_cap = wb->cap;
+	while(new_cap < target) {
+		new_cap *= 2;
+		if(new_cap > UINT32_MAX) return false;
+	}
+	char *tmp = rm_realloc(wb->buf, (uint32_t)new_cap);
+	if(tmp == NULL) return false;
+	wb->buf = tmp;
+	wb->cap = (uint32_t)new_cap;
+	return true;
+}
+
+// append formatted string to the buffer, growing as needed
+// returns false and sets wb->err on failure
+static bool wbuf_printf
+(
+	wbuf_t *wb,      // write buffer
+	const char *fmt,  // format string
+	...
+) {
+	if(wb->err) return false;
+	va_list args;
+	uint32_t remaining = wb->cap - wb->n;
+	va_start(args, fmt);
+	int written = vsnprintf(wb->buf + wb->n, remaining, fmt, args);
+	va_end(args);
+	if(written < 0) { wb->err = true; return false; }
+	if((uint32_t)written >= remaining) {
+		if(!wbuf_ensure(wb, written + 1)) { wb->err = true; return false; }
+		va_start(args, fmt);
+		vsnprintf(wb->buf + wb->n, wb->cap - wb->n, fmt, args);
+		va_end(args);
+	}
+	wb->n += written;
+	return true;
+}
+
+// maximum nesting depth for recursive value serialization
+#define WRITE_VALUE_MAX_DEPTH 128
+
+// write the bolt value to the growable buffer as string
+// returns false if a write error occurred
+static bool _write_value
+(
+	wbuf_t *wb,            // growable write buffer
+	buffer_index_t *value, // the value to write
+	int depth              // current recursion depth
+) {
+	ASSERT(wb != NULL);
 	ASSERT(value != NULL);
+
+	if(wb->err) return false;
+
+	if(depth > WRITE_VALUE_MAX_DEPTH) {
+		wb->err = true;
+		return false;
+	}
 
 	switch (bolt_read_type(*value))
 	{
 		case BVT_NULL:
 			bolt_read_null(value);
-			return sprintf(buff, "NULL");
+			wbuf_printf(wb, "NULL");
+			return !wb->err;
 		case BVT_BOOL:
-			return sprintf(buff, "%s", bolt_read_bool(value) ? "true" : "false");
+			wbuf_printf(wb, "%s", bolt_read_bool(value) ? "true" : "false");
+			return !wb->err;
 		case BVT_INT8:
-			return sprintf(buff, "%d", bolt_read_int8(value));
+			wbuf_printf(wb, "%d", bolt_read_int8(value));
+			return !wb->err;
 		case BVT_INT16:
-			return sprintf(buff, "%d", bolt_read_int16(value));
+			wbuf_printf(wb, "%d", bolt_read_int16(value));
+			return !wb->err;
 		case BVT_INT32:
-			return sprintf(buff, "%d", bolt_read_int32(value));
+			wbuf_printf(wb, "%d", bolt_read_int32(value));
+			return !wb->err;
 		case BVT_INT64:
-			return sprintf(buff, "%" PRId64, bolt_read_int64(value));
+			wbuf_printf(wb, "%" PRId64, bolt_read_int64(value));
+			return !wb->err;
 		case BVT_FLOAT:
-			return sprintf(buff, "%f", bolt_read_float(value));
+			wbuf_printf(wb, "%f", bolt_read_float(value));
+			return !wb->err;
 		case BVT_STRING: {
 			uint32_t len;
 			bolt_read_string_size(value, &len);
-			char str[len];
+			char *str = rm_malloc(len);
+			if(str == NULL) { wb->err = true; return false; }
 			bolt_read_string(value, str);
-			return sprintf(buff, "'%.*s'", len, str);
+			wbuf_ensure(wb, len + 3);
+			wbuf_printf(wb, "'%.*s'", len, str);
+			rm_free(str);
+			return !wb->err;
 		}
 		case BVT_LIST: {
 			uint32_t size = bolt_read_list_size(value);
-			int n = 0;
-			n += sprintf(buff, "[");
+			wbuf_printf(wb, "[");
 			if(size > 0) {
-				n += write_value(buff + n, value);
-				for (int i = 1; i < size; i++) {
-					n += sprintf(buff + n, ", ");
-					n += write_value(buff + n, value);
+				_write_value(wb, value, depth + 1);
+				for (uint32_t i = 1; i < size; i++) {
+					wbuf_printf(wb, ", ");
+					_write_value(wb, value, depth + 1);
 				}
 			}
-			n += sprintf(buff + n, "]");
-			return n;
+			wbuf_printf(wb, "]");
+			return !wb->err;
 		}
 		case BVT_MAP: {
 			uint32_t size = bolt_read_map_size(value);
-			int n = 0;
-			n += sprintf(buff, "{");
+			wbuf_printf(wb, "{");
 			if(size > 0) {
 				uint32_t key_len;
 				bolt_read_string_size(value, &key_len);
-				char key[key_len];
+				char *key = rm_malloc(key_len);
+				if(key == NULL) { wb->err = true; return false; }
 				bolt_read_string(value, key);
-				n += sprintf(buff + n, "%.*s: ", key_len, key);
-				n += write_value(buff + n, value);
-				for (int i = 1; i < size; i++) {
+				wbuf_printf(wb, "%.*s: ", key_len, key);
+				rm_free(key);
+				_write_value(wb, value, depth + 1);
+				for (uint32_t i = 1; i < size; i++) {
 					bolt_read_string_size(value, &key_len);
-					char key[key_len];
+					key = rm_malloc(key_len);
+					if(key == NULL) { wb->err = true; return false; }
 					bolt_read_string(value, key);
-					n += sprintf(buff + n, ", ");
-					n += sprintf(buff + n, "%.*s: ", key_len, key);
-					n += write_value(buff + n, value);
+					wbuf_printf(wb, ", %.*s: ", key_len, key);
+					rm_free(key);
+					_write_value(wb, value, depth + 1);
 				}
 			}
-			n += sprintf(buff + n, "}");
-			return n;
+			wbuf_printf(wb, "}");
+			return !wb->err;
 		}
 		case BVT_STRUCTURE:
 			if(bolt_read_structure_type(value) == BST_POINT2D) {
 				double x = bolt_read_float(value);
 				double y = bolt_read_float(value);
-				return sprintf(buff, "POINT({longitude: %f, latitude: %f})", x, y);
+				wbuf_printf(wb, "POINT({longitude: %f, latitude: %f})", x, y);
+				return !wb->err;
 			}
 			ASSERT(false);
-			return 0;
+			return false;
 		default:
 			ASSERT(false);
-			return 0;
+			return false;
 	}
+}
+
+// public entry point — starts recursion at depth 0
+static bool write_value
+(
+	wbuf_t *wb,            // growable write buffer
+	buffer_index_t *value  // the value to write
+) {
+	return _write_value(wb, value, 0);
 }
 
 // read the query from the message buffer
@@ -278,23 +393,44 @@ RedisModuleString *get_query
 	uint32_t query_len;
 	bolt_read_string_size(&client->msg_buf.read, &query_len);
 	char *query = rm_malloc(query_len);
+	if(query == NULL) return NULL;
 	bolt_read_string(&client->msg_buf.read, query);
 	uint32_t params_count = bolt_read_map_size(&client->msg_buf.read);
 	if(params_count > 0) {
-		char prametrize_query[4096];
-		int n = sprintf(prametrize_query, "CYPHER ");
-		for (int i = 0; i < params_count; i++) {
+		wbuf_t wb;
+		wb.cap = query_len + 4096;
+		wb.n   = 0;
+		wb.buf = rm_malloc(wb.cap);
+		wb.err = (wb.buf == NULL);
+
+		wbuf_printf(&wb, "CYPHER ");
+		for (uint32_t i = 0; i < params_count; i++) {
 			uint32_t key_len;
 			bolt_read_string_size(&client->msg_buf.read, &key_len);
-			char key[key_len];
+			char *key = rm_malloc(key_len);
+			if(key == NULL) { wb.err = true; break; }
 			bolt_read_string(&client->msg_buf.read, key);
-			n += sprintf(prametrize_query + n, "%.*s=", key_len, key);
-			n += write_value(prametrize_query + n, &client->msg_buf.read);
-			n += sprintf(prametrize_query + n, " ");
+			if(!wbuf_ensure(&wb, key_len + 2)) { rm_free(key); wb.err = true; break; }
+			wbuf_printf(&wb, "%.*s=", key_len, key);
+			rm_free(key);
+			write_value(&wb, &client->msg_buf.read);
+			wbuf_printf(&wb, " ");
+			if(wb.err) break;
 		}
-		n += sprintf(prametrize_query + n, "%.*s", query_len, query);
+		if(!wb.err) {
+			if(!wbuf_ensure(&wb, query_len + 1)) wb.err = true;
+		}
+		if(!wb.err) {
+			wbuf_printf(&wb, "%.*s", query_len, query);
+		}
 		rm_free(query);
-		return RedisModule_CreateString(ctx, prametrize_query, n);
+		if(wb.err) {
+			rm_free(wb.buf);
+			return NULL;
+		}
+		RedisModuleString *res = RedisModule_CreateString(ctx, wb.buf, wb.n);
+		rm_free(wb.buf);
+		return res;
 	}
 
 	RedisModuleString *res = RedisModule_CreateString(ctx, query, query_len);
@@ -327,6 +463,17 @@ void BoltRunCommand
 	RedisModuleCtx *ctx = client->ctx;
 	RedisModuleString *args[5];
 	RedisModuleString *query = get_query(ctx, client);
+	if(query == NULL) {
+		bolt_client_reply_for(client, BST_RUN, BST_FAILURE, 1);
+		bolt_reply_map(client, 2);
+		bolt_reply_string(client, "code", 4);
+		bolt_reply_string(client, "FalkorDB.ClientError", 20);
+		bolt_reply_string(client, "message", 7);
+		bolt_reply_string(client, "Query construction failed", 25);
+		bolt_client_end_message(client);
+		bolt_client_finish_write(client);
+		return;
+	}
 	RedisModuleString *graph_name = get_graph_name(ctx, client);
 
 	const char *q = RedisModule_StringPtrLen(query, NULL);

--- a/src/bolt/bolt_client.c
+++ b/src/bolt/bolt_client.c
@@ -333,6 +333,19 @@ static void bolt_change_txstreaming_state
 					ASSERT(false);
 			}
 			break;
+		case BST_ROLLBACK:
+			switch (response_type)
+			{
+				case BST_SUCCESS:
+					client->state = BS_READY;
+					break;
+				case BST_FAILURE:
+					client->state = BS_FAILED;
+					break;
+				default:
+					ASSERT(false);
+			}
+			break;
 		case BST_RESET:
 			client->state = BS_READY;
 			break;

--- a/src/bolt/buffer.c
+++ b/src/bolt/buffer.c
@@ -6,6 +6,7 @@
 #include "RG.h"
 #include "buffer.h"
 #include "../util/arr.h"
+#include <errno.h>
 
 // set buffer index to offset
 void buffer_index_set
@@ -76,9 +77,10 @@ uint64_t buffer_index_diff
 	ASSERT(b != NULL);
 	ASSERT(a->buf == b->buf);
 
-	uint64_t diff = (a->chunk - b->chunk) * BUFFER_CHUNK_SIZE + (a->offset - b->offset);
-	ASSERT(diff >= 0);
-	return diff;
+	ASSERT(a->chunk > b->chunk || (a->chunk == b->chunk && a->offset >= b->offset));
+	uint64_t pos_a = (uint64_t)a->chunk * BUFFER_CHUNK_SIZE + (uint64_t)a->offset;
+	uint64_t pos_b = (uint64_t)b->chunk * BUFFER_CHUNK_SIZE + (uint64_t)b->offset;
+	return pos_a - pos_b;
 }
 
 // the length of the buffer index
@@ -245,7 +247,10 @@ bool buffer_socket_read
 
 	char *ptr = buf->chunks[buf->write.chunk] + buf->write.offset;
 	int nread = socket_read(socket, ptr, BUFFER_CHUNK_SIZE - buf->write.offset);
-	if(nread < 0 || (nread == 0 && buf->write.offset < BUFFER_CHUNK_SIZE)) {
+	if(nread < 0) {
+		return errno == EAGAIN || errno == EWOULDBLOCK;
+	}
+	if(nread == 0 && buf->write.offset < BUFFER_CHUNK_SIZE) {
 		return false;
 	}
 
@@ -255,8 +260,8 @@ bool buffer_socket_read
 		buf->write.chunk++;
 		arr_append(buf->chunks, rm_malloc(BUFFER_CHUNK_SIZE));
 		nread = socket_read(socket, buf->chunks[buf->write.chunk], BUFFER_CHUNK_SIZE);
-		if(nread < 0) {
-			return false;
+		if(nread <= 0) {
+			return nread == 0 || errno == EAGAIN || errno == EWOULDBLOCK;
 		}
 		buf->write.offset += nread;
 	}
@@ -347,7 +352,6 @@ void buffer_write
 	while(buf->offset + size > BUFFER_CHUNK_SIZE) {
 		uint32_t n = BUFFER_CHUNK_SIZE - buf->offset;
 		memcpy(buf->buf->chunks[buf->chunk] + buf->offset, data, n);
-		buffer_index_advance(buf, n);
 		data += n;
 		size -= n;
 		buf->chunk++;

--- a/src/bolt/socket.h
+++ b/src/bolt/socket.h
@@ -3,7 +3,7 @@
  * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
-#pragma one
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/bolt/ws.c
+++ b/src/bolt/ws.c
@@ -9,6 +9,8 @@
 #include "rax/rax.h"
 #include "util/rmalloc.h"
 #include <string.h>
+#include <strings.h>
+#include <ctype.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
@@ -73,12 +75,17 @@ static bool validate_headers
 	}
 	char *i = v;
 	bool is_upgrade = false;
-	while (i != NULL && strlen(i) > 0) {
-		if(strncmp(i, "Upgrade", 7) == 0) {
+	while (i != NULL && *i != '\0') {
+		// skip leading OWS (spaces and tabs) per RFC 7230
+		while(*i == ' ' || *i == '\t') i++;
+		if(strncasecmp(i, "Upgrade", 7) == 0 &&
+		   (i[7] == '\0' || i[7] == ',' || i[7] == ' ' || i[7] == '\t')) {
 			is_upgrade = true;
 			break;
 		}
-		i = strchr(i, ',') + 2;
+		char *comma = strchr(i, ',');
+		if(comma == NULL) break;
+		i = comma + 1;
 	}
 	if(!is_upgrade) {
 		return false;
@@ -197,16 +204,21 @@ uint64_t ws_read_frame
 }
 
 // write an empty websocket frame header
-uint64_t ws_write_empty_header
+// reserves 10 bytes (max WS header: 2 byte header + 8 byte extended length)
+void ws_write_empty_header
 (
 	buffer_index_t *buf  // the buffer to write to
 ) {
 	ASSERT(buf != NULL);
 
 	buffer_write_uint32(buf, 0x00000000);
+	buffer_write_uint32(buf, 0x00000000);
+	buffer_write_uint16(buf, 0x0000);
 }
 
 // write a websocket frame header
+// ws_write_empty_header reserves 10 bytes; skip unused leading bytes
+// so that *buf points to the start of the actual header on return
 void ws_write_frame_header
 (
 	buffer_index_t *buf,  // the buffer to write to
@@ -214,12 +226,20 @@ void ws_write_frame_header
 ) {
 	ASSERT(buf != NULL);
 
-	buffer_index_t msg = *buf;
-	if(n > 125) {
+	if(n > 65535) {
+		// 10-byte header: uses all reserved bytes
+		buffer_index_t msg = *buf;
+		buffer_write_uint16(&msg, htons(0x827F));
+		buffer_write_uint64(&msg, htonll(n));
+	} else if(n > 125) {
+		// 4-byte header: skip 6 bytes of padding
+		buffer_index_advance(buf, 6);
+		buffer_index_t msg = *buf;
 		buffer_write_uint32(&msg, htonl(0x827E0000 + n));
 	} else {
-		buffer_write_uint16(buf, 0x0000);
-		msg = *buf;
+		// 2-byte header: skip 8 bytes of padding
+		buffer_index_advance(buf, 8);
+		buffer_index_t msg = *buf;
 		buffer_write_uint8(&msg, 0x82);
 		buffer_write_uint8(&msg, n);
 	}

--- a/src/bolt/ws.h
+++ b/src/bolt/ws.h
@@ -3,7 +3,7 @@
  * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
-#pragma one
+#pragma once
 
 #include "buffer.h"
 
@@ -22,7 +22,7 @@ uint64_t ws_read_frame
 );
 
 // write an empty websocket frame header
-uint64_t ws_write_empty_header
+void ws_write_empty_header
 (
     buffer_index_t *buf  // the buffer to write to
 );

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -153,21 +153,24 @@ inline static bool _readonly_cmd_mode(CommandCtx *ctx) {
 // _ExecuteQuery accepts a GraphQueryCtx as an argument
 // it may be called directly by a reader thread or the Redis main thread,
 // or dispatched as a worker thread job when used for writing.
-static void _ExecuteQuery(void *args) {
-	ASSERT(args != NULL);
+static void _ExecuteQuery
+(
+	void *args
+) {
+	ASSERT (args != NULL) ;
 
-	GraphQueryCtx  *gq_ctx      = args;
-	QueryCtx       *query_ctx   = gq_ctx->query_ctx;
-	GraphContext   *gc          = gq_ctx->graph_ctx;
+	GraphQueryCtx  *gq_ctx      = args ;
+	QueryCtx       *query_ctx   = gq_ctx->query_ctx ;
+	GraphContext   *gc          = gq_ctx->graph_ctx ;
 	Graph          *g           = GraphContext_GetGraph (gc) ;
-	RedisModuleCtx *rm_ctx      = gq_ctx->rm_ctx;
-	ExecutionCtx   *exec_ctx    = gq_ctx->exec_ctx;
-	CommandCtx     *command_ctx = gq_ctx->command_ctx;
-	AST            *ast         = exec_ctx->ast;
-	ExecutionPlan  *plan        = exec_ctx->plan;
-	ExecutionType  exec_type    = exec_ctx->exec_type;
-	const bool     profile      = (query_ctx->flags & QueryExecutionTypeFlag_PROFILE);
-	const bool     readonly     = !(query_ctx->flags & QueryExecutionTypeFlag_WRITE);
+	RedisModuleCtx *rm_ctx      = gq_ctx->rm_ctx ;
+	ExecutionCtx   *exec_ctx    = gq_ctx->exec_ctx ;
+	CommandCtx     *command_ctx = gq_ctx->command_ctx ;
+	AST            *ast         = exec_ctx->ast ;
+	ExecutionPlan  *plan        = exec_ctx->plan ;
+	ExecutionType  exec_type    = exec_ctx->exec_type ;
+	const bool     profile      = (query_ctx->flags & QueryExecutionTypeFlag_PROFILE) ;
+	const bool     readonly     = !(query_ctx->flags & QueryExecutionTypeFlag_WRITE) ;
 
 	// if we have migrated to a writer thread,
 	// update thread-local storage and track the CommandCtx
@@ -180,37 +183,45 @@ static void _ExecuteQuery(void *args) {
 	}
 
 	// instantiate the query ResultSet
-	bool bolt    = command_ctx->bolt_client != NULL;
-	bool compact = command_ctx->compact;
+	bool bolt    = command_ctx->bolt_client != NULL ;
+	bool compact = command_ctx->compact ;
+
 	// replicated command don't need to return result
 	ResultSetFormatterType resultset_format =
-		profile || command_ctx->replicated_command
-		? FORMATTER_NOP
-		: (bolt)
-			? FORMATTER_BOLT
-			: (compact)
-				? FORMATTER_COMPACT
-				: FORMATTER_VERBOSE;
-	ResultSet *result_set = NewResultSet(rm_ctx, command_ctx->bolt_client, resultset_format);
-	if(exec_ctx->cached) {
-		ResultSet_CachedExecution(result_set); // indicate a cached execution
+		(profile || command_ctx->replicated_command) ?
+			FORMATTER_NOP :
+				(bolt) ?
+					FORMATTER_BOLT :
+					(compact) ?
+						FORMATTER_COMPACT :
+						FORMATTER_VERBOSE ;
+
+	ResultSet *result_set =
+		NewResultSet (rm_ctx, command_ctx->bolt_client, resultset_format) ;
+
+	if (exec_ctx->cached) {
+		ResultSet_CachedExecution (result_set) ; // indicate a cached execution
 	}
 
-	QueryCtx_SetResultSet(result_set);
+	QueryCtx_SetResultSet (result_set) ;
 
 	// acquire the appropriate lock
-	if(readonly) {
-		Graph_AcquireReadLock(g);
-	} else {
-		// if this is a writer query `we need to re-open the graph key with write flag
-		// this notifies Redis that the key is "dirty" any watcher on that key will
-		// be notified
-		CommandCtx_ThreadSafeContextLock(command_ctx);
+	if (!readonly) {
+		// if this is a writer query we need to re-open the graph key with
+		// write flag this notifies Redis that the key is "dirty" any watcher
+		// on that key will be notified
+		// must happen before READ lock to avoid deadlock:
+		//   worker: READ → GIL  vs  main thread: GIL → WRITE
+		CommandCtx_ThreadSafeContextLock (command_ctx) ;
 		{
-			GraphContext_MarkWriter(rm_ctx, gc);
+			GraphContext_MarkWriter (rm_ctx, gc) ;
 		}
-		CommandCtx_ThreadSafeContextUnlock(command_ctx);
+		CommandCtx_ThreadSafeContextUnlock (command_ctx) ;
 	}
+
+	// acquire graph READ lock to protect match phase from concurrent
+	// memory modifications by defrag or GRAPH.EFFECT on main thread
+	QueryCtx_AcquireReadLock () ;
 
 	if(exec_type == EXECUTION_TYPE_QUERY) {  // query operation
 		// set policy after lock acquisition,
@@ -274,12 +285,10 @@ static void _ExecuteQuery(void *args) {
 				rm_free(effects);
 			} else {
 				// replicate original query
-				QueryCtx_Replicate(query_ctx);
+				QueryCtx_Replicate (query_ctx) ;
 			}
 		}
 	}
-
-	QueryCtx_UnlockCommit();
 
 	if(!profile || ErrorCtx_EncounteredError()) {
 		// if we encountered an error, ResultSet_Reply will emit the error
@@ -292,9 +301,7 @@ static void _ExecuteQuery(void *args) {
 		QueryCtx_AdvanceStage(query_ctx);
 	}
 
-	if (readonly) {
-		Graph_ReleaseLock(g) ; // release read lock
-	}
+	QueryCtx_ReleaseLock () ;
 
 	//--------------------------------------------------------------------------
 	// log query to slowlog
@@ -358,12 +365,12 @@ static void enter_writer_loop
 	while (true) {
 		// drain the queue
 		GraphQueryCtx *gq_ctx;
-		while ((gq_ctx = (GraphQueryCtx *)GraphContext_DequeueWriteQuery(gc))) {
-			_ExecuteQuery(gq_ctx);
+		while ((gq_ctx = (GraphQueryCtx *)GraphContext_DequeueWriteQuery (gc))) {
+			_ExecuteQuery (gq_ctx) ;
 		}
 
 		// release write access
-		GraphContext_ExitWrite(gc);
+		GraphContext_ExitWrite (gc) ;
 
 		// race condition handling: after releasing write access, another thread
 		// may have enqueued a query
@@ -371,10 +378,11 @@ static void enter_writer_loop
 		// to reacquire write access
 		// if we succeed, continue processing
 		// if we fail, another thread is now the writer and will handle the queue
-		if(GraphContext_WriteQueueEmpty(gc) || !GraphContext_TryEnterWrite(gc)) {
+		if (GraphContext_WriteQueueEmpty (gc) ||
+			!GraphContext_TryEnterWrite  (gc)) {
 			// either the queue is empty
 			// or the another thread became a writer
-			break;
+			break ;
 		}
 	}
 }
@@ -416,108 +424,109 @@ void _query
 	// NOTE: acquiring this lock at this point in time might be a bit too early
 	// as we should push it into `ExecutionCtx_FromQuery` some time after
 	// query parsing
-	Graph_AcquireReadLock (g) ;
+	QueryCtx_AcquireReadLock () ;
 
 	// parse query parameters and build an execution plan
 	// or retrieve it from the cache
-	exec_ctx = ExecutionCtx_FromQuery(command_ctx);
+	exec_ctx = ExecutionCtx_FromQuery (command_ctx) ;
 
 	// release graph READ lock
-	Graph_ReleaseLock (g) ;
+	QueryCtx_ReleaseLock () ;
 
-	if(exec_ctx == NULL || ErrorCtx_EncounteredError()) {
-		goto cleanup;
+	if (exec_ctx == NULL || ErrorCtx_EncounteredError ()) {
+		goto cleanup ;
 	}
 
 	// update cached flag
-	QueryCtx_SetUtilizedCache(query_ctx, exec_ctx->cached);
+	QueryCtx_SetUtilizedCache (query_ctx, exec_ctx->cached) ;
 
-	ExecutionType exec_type = exec_ctx->exec_type;
-	bool readonly = AST_ReadOnly(exec_ctx->ast->root);
+	ExecutionType exec_type = exec_ctx->exec_type ;
+	bool readonly = AST_ReadOnly (exec_ctx->ast->root) ;
 	bool index_op = (exec_type == EXECUTION_TYPE_INDEX_CREATE ||
-	     exec_type == EXECUTION_TYPE_INDEX_DROP);
+	     exec_type == EXECUTION_TYPE_INDEX_DROP) ;
 
-	if(profile && index_op) {
-		RedisModule_ReplyWithError(ctx, "Can't profile index operations.");
-		goto cleanup;
+	if (profile && index_op) {
+		RedisModule_ReplyWithError (ctx, "Can't profile index operations.") ;
+		goto cleanup ;
 	}
 
 	// write query executing via GRAPH.RO_QUERY isn't allowed
-	if(!profile && !readonly && _readonly_cmd_mode(command_ctx)) {
-		ErrorCtx_SetError(EMSG_MISUSE_GRAPH_ROQUERY);
-		goto cleanup;
+	if (!profile && !readonly && _readonly_cmd_mode (command_ctx)) {
+		ErrorCtx_SetError (EMSG_MISUSE_GRAPH_ROQUERY) ;
+		goto cleanup ;
 	}
 
-	CronTaskHandle timeout_task = 0;
+	CronTaskHandle timeout_task = 0 ;
 
 	// enforce specified timeout when query is readonly
 	// or timeout applies to both read and write
-	bool enforce_timeout = command_ctx->timeout != 0 && !index_op &&
-		(readonly || command_ctx->timeout_rw) &&
-		!command_ctx->replicated_command;
-	if(enforce_timeout) {
-		timeout_task = Query_SetTimeOut(command_ctx->timeout, exec_ctx->plan);
+	bool enforce_timeout = command_ctx->timeout != 0             &&
+						   !index_op                             &&
+						   (readonly || command_ctx->timeout_rw) &&
+						   !command_ctx->replicated_command ;
+	if (enforce_timeout) {
+		timeout_task = Query_SetTimeOut (command_ctx->timeout, exec_ctx->plan) ;
 	}
 
 	// populate the container struct for invoking _ExecuteQuery.
-	QueryExecutionTypeFlag flags = QueryExecutionTypeFlag_READ;
+	QueryExecutionTypeFlag flags = QueryExecutionTypeFlag_READ ;
 	if (!readonly) {
-		flags |= QueryExecutionTypeFlag_WRITE;
+		flags |= QueryExecutionTypeFlag_WRITE ;
 	}
 	if (profile) {
-		flags |= QueryExecutionTypeFlag_PROFILE;
+		flags |= QueryExecutionTypeFlag_PROFILE ;
 	}
-	GraphQueryCtx *gq_ctx = GraphQueryCtx_New(gc, ctx, exec_ctx, command_ctx,
-											  flags, timeout_task);
+	GraphQueryCtx *gq_ctx =
+		GraphQueryCtx_New (gc, ctx, exec_ctx, command_ctx, flags, timeout_task) ;
 
 	// if 'thread' is redis main thread, continue running
 	// if readonly is true we're executing on a worker thread from
 	// the read-only threadpool
-	if(readonly || command_ctx->thread == EXEC_THREAD_MAIN) {
-		_ExecuteQuery(gq_ctx);
+	if (readonly || command_ctx->thread == EXEC_THREAD_MAIN) {
+		_ExecuteQuery (gq_ctx) ;
 	} else {
 		// increase graph ref count, guard against the graph context
 		// being free too early as the writer need access to the graph's
 		// pending queries queue and the writer's flag
-		GraphContext_IncreaseRefCount(gc);
+		GraphContext_IncreaseRefCount (gc) ;
 
 		// thread failed getting exclusive write access to graph
 		// delegate query to current writer
-		if(!_DelegateQuery(gc, gq_ctx)) {
-			ErrorCtx_SetError(EMSG_WRITE_QUEUE_FULL);
+		if (!_DelegateQuery (gc, gq_ctx)) {
+			ErrorCtx_SetError (EMSG_WRITE_QUEUE_FULL) ;
 
 			// counter to GraphContext_IncreaseRefCount just above
-			GraphContext_DecreaseRefCount(gc);
-			goto cleanup;
+			GraphContext_DecreaseRefCount (gc) ;
+			goto cleanup ;
 		}
 
 		// try to acquire exclusive write access to graph
-		if(GraphContext_TryEnterWrite(gc)) {
+		if (GraphContext_TryEnterWrite (gc)) {
 			// thread has exclusive write access to graph
 			// go ahead and run the query
-			enter_writer_loop(gc);
+			enter_writer_loop (gc) ;
 		}
 
 		// counter to GraphContext_IncreaseRefCount just above
-		GraphContext_DecreaseRefCount(gc);
+		GraphContext_DecreaseRefCount (gc) ;
 	}
 
-	return;
+	return ;
 
 cleanup:
 	// if there were any query compile time errors, report them
-	if(ErrorCtx_EncounteredError()) {
-		ErrorCtx_EmitException();
+	if (ErrorCtx_EncounteredError ()) {
+		ErrorCtx_EmitException () ;
 	}
 
 	// cleanup routine invoked after encountering errors in this function
-	ExecutionCtx_Free(exec_ctx);
-	GraphContext_DecreaseRefCount(gc);
-	Globals_UntrackCommandCtx(command_ctx);
-	CommandCtx_UnblockClient(command_ctx);
-	CommandCtx_Free(command_ctx);
-	QueryCtx_Free(); // reset the QueryCtx and free its allocations
-	ErrorCtx_Clear();
+	ExecutionCtx_Free (exec_ctx) ;
+	GraphContext_DecreaseRefCount (gc) ;
+	Globals_UntrackCommandCtx (command_ctx) ;
+	CommandCtx_UnblockClient (command_ctx) ;
+	CommandCtx_Free (command_ctx) ;
+	QueryCtx_Free () ; // reset the QueryCtx and free its allocations
+	ErrorCtx_Clear () ;
 }
 
 void Graph_Profile(void *args) {

--- a/src/commands/index_operations.c
+++ b/src/commands/index_operations.c
@@ -137,7 +137,7 @@ static bool index_delete
 	//--------------------------------------------------------------------------
 
 	// lock
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	if(is_node) {
 		// try deleting node index
@@ -435,7 +435,7 @@ static void index_create
 		   idx_type == INDEX_FLD_VECTOR);
 
 	// lock
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	Index idx = NULL;
 	ResultSet *result_set = QueryCtx_GetResultSet();

--- a/src/cron/tasks/stream_finished_queries.c
+++ b/src/cron/tasks/stream_finished_queries.c
@@ -13,6 +13,8 @@
 #include "util/circular_buffer.h"
 #include "stream_finished_queries.h"
 
+#include <unistd.h>  // required by usleep
+
 // event fields count
 #define FLD_COUNT 10
 
@@ -215,37 +217,66 @@ bool CronTask_streamFinishedQueries
 (
 	void *pdata  // task context
 ) {
-	StreamFinishedQueryCtx *ctx    = (StreamFinishedQueryCtx*)pdata;
-	RedisModuleCtx         *rm_ctx = RedisModule_GetThreadSafeContext(NULL);
+	// early return if there are no graphs
+	if (Globals_GraphsCount () == 0) {
+		return false ;
+	}
 
-	// initialize stream event template
-	if(unlikely(_event[0] == NULL)) {
-		_initEventTemplate(rm_ctx);
+	GraphContext           *gc     = NULL ;
+	StreamFinishedQueryCtx *ctx    = (StreamFinishedQueryCtx*) pdata ;
+	RedisModuleCtx         *rm_ctx = RedisModule_GetThreadSafeContext (NULL) ;
+
+	// one time initialization of stream event template
+	if (unlikely (_event [0] == NULL)) {
+		_initEventTemplate (rm_ctx) ;
 	}
 
 	// start stopwatch
-	double deadline = 3;  // 3ms
-	simple_timer_t stopwatch;
-	simple_tic(stopwatch);
+	double deadline = 3 ;  // 3ms
+	simple_timer_t stopwatch ;
+	simple_tic (stopwatch) ;
 
-	uint64_t max_query_count = 0;  // determine max number of queries to collect
-	Config_Option_get(Config_CMD_INFO_MAX_QUERY_COUNT, &max_query_count);
+	//--------------------------------------------------------------------------
+	// try to acquire GIL
+	//--------------------------------------------------------------------------
 
-	KeySpaceGraphIterator it;
-	Globals_ScanGraphs(&it);
+	bool gil_acquired = false ;
+
+	while (!gil_acquired &&
+			TIMER_GET_ELAPSED_MILLISECONDS (stopwatch) < deadline) {
+		gil_acquired =
+			(RedisModule_ThreadSafeContextTryLock (rm_ctx) == REDISMODULE_OK) ;
+
+		if (gil_acquired == false) {
+		   	usleep (100) ;
+		}
+	}
+
+	if (!gil_acquired) {
+		// failed to acquire GIL
+		goto cleanup ;
+	}
+
+	// determine max number of queries to collect
+	uint64_t max_query_count = 0 ;
+	Config_Option_get (Config_CMD_INFO_MAX_QUERY_COUNT, &max_query_count) ;
+
+	// initialize graph iterator
+	KeySpaceGraphIterator it ;
+	Globals_ScanGraphs (&it) ;
 
 	// pick up from where we've left
-	GraphIterator_Seek(&it, ctx->graph_idx);
-
-	GraphContext *gc = NULL;
+	GraphIterator_Seek (&it, ctx->graph_idx) ;
 
 	// as long as we've got processing time
-	bool gil_acquired = false;
-	while(TIMER_GET_ELAPSED_MILLISECONDS(stopwatch) < deadline) {
-		// get next graph to populate
+	while (TIMER_GET_ELAPSED_MILLISECONDS (stopwatch) < deadline) {
 		QueriesLog queries_log = NULL;
-		while ((gc = GraphIterator_Next(&it)) != NULL) {
+
+		// find a graph with logged queries to stream
+		while ((gc = GraphIterator_Next (&it)) != NULL) {
 			ctx->graph_idx++ ;  // prepare next iteration
+
+			// see if graph logged any queries
 			QueriesLog log = GraphContext_GetQueriesLog (gc) ;
 			if (QueriesLog_GetQueriesCount (log) > 0) {
 				queries_log = log ;
@@ -256,39 +287,25 @@ bool CronTask_streamFinishedQueries
 		}
 
 		// iterator depleted
-		if((gc) == NULL) {
-			break;
+		if (gc == NULL) {
+			break ;
 		}
 
-		//----------------------------------------------------------------------
-		// try to acquire GIL
-		//----------------------------------------------------------------------
-
-		while(!gil_acquired && TIMER_GET_ELAPSED_MILLISECONDS(stopwatch) < deadline) {
-			gil_acquired =
-				RedisModule_ThreadSafeContextTryLock(rm_ctx) == REDISMODULE_OK;
-		}
-
-		if(!gil_acquired) {
-			GraphContext_DecreaseRefCount(gc);
-			break;
-		}
-
-		CircularBuffer queries = QueriesLog_ResetQueries(queries_log);
+		CircularBuffer queries = QueriesLog_ResetQueries (queries_log) ;
 
 		//----------------------------------------------------------------------
 		// stream queries
 		//----------------------------------------------------------------------
 
 		RedisModuleString *keyname =
-			(RedisModuleString*)GraphContext_GetTelemetryStreamName(gc);
+			(RedisModuleString*) GraphContext_GetTelemetryStreamName (gc) ;
 
-		RedisModuleKey *key = RedisModule_OpenKey(rm_ctx, keyname,
-			REDISMODULE_WRITE);
+		RedisModuleKey *key = RedisModule_OpenKey (rm_ctx, keyname,
+			REDISMODULE_WRITE) ;
 
 		// make sure key is of type stream
-		int key_type = RedisModule_KeyType(key);
-		if(key_type == REDISMODULE_KEYTYPE_STREAM ||
+		int key_type = RedisModule_KeyType (key) ;
+		if (key_type == REDISMODULE_KEYTYPE_STREAM ||
 			key_type == REDISMODULE_KEYTYPE_EMPTY) {
 			// add queries to stream
 			_stream_queries (rm_ctx, key, queries) ;
@@ -301,20 +318,23 @@ bool CronTask_streamFinishedQueries
 		}
 
 		// clean up
-		RedisModule_CloseKey(key);
-
-		GraphContext_DecreaseRefCount(gc);
+		RedisModule_CloseKey (key) ;
+		GraphContext_DecreaseRefCount (gc) ;
 	}
-
-	if(gil_acquired) {
-		RedisModule_ThreadSafeContextUnlock(rm_ctx);
-	}
-
-	RedisModule_FreeThreadSafeContext(rm_ctx);
 
 	// set next iteration graph index
-	ctx->graph_idx = (gc == NULL) ? 0 : ctx->graph_idx;
+	ctx->graph_idx = (gc == NULL) ? 0 : ctx->graph_idx ;
 
-	return (gc != NULL);
+cleanup:
+	// release GIL and free thread safe context
+	if (gil_acquired == true) {
+		RedisModule_ThreadSafeContextUnlock (rm_ctx) ;
+		gil_acquired = false ;
+	}
+
+	RedisModule_FreeThreadSafeContext (rm_ctx) ;
+
+	// indicate if there's still work to do
+	return (gc != NULL) ;
 }
 

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -80,7 +80,7 @@ static void _BulkDeleteEntities
 	ASSERT ((node_count + total_edge_count) > 0) ;
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	// NOTE: delete edges before nodes
 	// required as a deleted node must be detached
@@ -179,7 +179,7 @@ static void _DeleteEntities
 	}
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 	// NOTE: delete edges before nodes
 	// required as a deleted node must be detached
 

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -471,7 +471,7 @@ static Record MergeConsume
 	OpBase_PropagateReset (op->match_stream) ;
 
 	// lock everything
-	QueryCtx_LockForCommit ();
+	QueryCtx_AcquireWriteLock ();
 
 	// in cases such as:
 	// MERGE (n) ON MATCH SET n:L ON CREATE n:M

--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -138,7 +138,9 @@ static Record ProcCallConsume
 		// introduced
 
 		// lock if procedure can modify the graph
-		if(!Procedure_IsReadOnly(op->procedure)) QueryCtx_LockForCommit();
+		if (!Procedure_IsReadOnly (op->procedure)) {
+			QueryCtx_AcquireWriteLock () ;
+		}
 
 		ProcedureResult res = Proc_Invoke(op->procedure, op->args, op->output);
 

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -116,7 +116,7 @@ static Record UpdateConsume
 		OpBase_PropagateReset (child) ;
 
 		// lock everything
-		QueryCtx_LockForCommit () ;
+		QueryCtx_AcquireWriteLock () ;
 
 		// in cases such as:
 		// MATCH (n) SET n:L

--- a/src/execution_plan/ops/shared/create_functions.c
+++ b/src/execution_plan/ops/shared/create_functions.c
@@ -268,7 +268,7 @@ void CommitNewEntities
 	}
 
 	// lock everything
-	QueryCtx_LockForCommit();
+	QueryCtx_AcquireWriteLock () ;
 
 	//--------------------------------------------------------------------------
 	// commit nodes

--- a/src/globals.c
+++ b/src/globals.c
@@ -108,7 +108,7 @@ GraphContext **Globals_Get_GraphsInKeyspace(void) {
 }
 
 uint32_t Globals_GraphsCount (void) {
-	// acuire read lock
+	// acquire read lock
 	Globals_ReadLock () ;
 
 	uint32_t n = arr_len (_globals.graphs_in_keyspace) ;
@@ -129,7 +129,7 @@ void Globals_AddGraph
 	// increase ref count regardless if 'gc' is already tracked
 	GraphContext_IncreaseRefCount(gc);
 
-	// acuire write lock
+	// acquire write lock
 	Globals_WriteLock () ;
 
 	bool registered = false;
@@ -157,12 +157,17 @@ void Globals_RemoveGraph
 ) {
 	ASSERT(gc != NULL);
 
+	// acquire write lock
+	Globals_WriteLock () ;
+
 	uint64_t i = 0;
 	uint64_t n = arr_len(_globals.graphs_in_keyspace);
-	if(n == 0) return;
 
-	// acuire write lock
-	Globals_WriteLock () ;
+	if (n == 0) {
+		// release lock
+		Globals_Unlock () ;
+		return;
+	}
 
 	// search for graph
 	for(; i < n; i++) {
@@ -188,7 +193,7 @@ void Globals_RemoveGraphByName
 ) {
 	ASSERT(name != NULL);
 
-	// acuire write lock
+	// acquire write lock
 	Globals_WriteLock () ;
 
 	// search for graph
@@ -244,7 +249,7 @@ void Globals_TrackCommandCtx
 
 	int tid = ThreadPool_GetThreadID();
 
-	// acuire read lock
+	// acquire read lock
 	Globals_ReadLock () ;
 
 	// expecting slot to be empty
@@ -270,7 +275,7 @@ void Globals_UntrackCommandCtx
 
 	int tid = ThreadPool_GetThreadID();
 
-	// acuire read lock
+	// acquire read lock
 	Globals_ReadLock () ;
 
 	ASSERT(_globals.command_ctxs[tid] == ctx);
@@ -346,21 +351,21 @@ GraphContext *GraphIterator_Next
 (
 	KeySpaceGraphIterator *it  // iterator to advance
 ) {
-	ASSERT(it != NULL);
+	ASSERT (it != NULL) ;
 
-	GraphContext *gc = NULL;
+	GraphContext *gc = NULL ;
 
 	Globals_ReadLock () ;
 
-	if(it->idx < arr_len(_globals.graphs_in_keyspace)) {
+	if (it->idx < arr_len (_globals.graphs_in_keyspace)) {
 		// prepare next call
-		gc = _globals.graphs_in_keyspace[it->idx++];
-		GraphContext_IncreaseRefCount(gc);
+		gc = _globals.graphs_in_keyspace [it->idx++] ;
+		GraphContext_IncreaseRefCount (gc) ;
 	}
 
 	Globals_Unlock () ;
 
-	return gc;
+	return gc ;
 }
 
 // free globals

--- a/src/graph/entities/attribute_set.c
+++ b/src/graph/entities/attribute_set.c
@@ -353,7 +353,10 @@ static void AttributeSet_RemoveIdx
 	AttributeID *ids  = ATTRIBUTE_SET_IDS  (_set) ;
 	AttrValue_t *vals = ATTRIBUTE_SET_VALS (_set) ;
 
-	for (int16_t i = n-1; i >= 0; i--) {
+	// iterate highest-to-lowest so the swap source (position l-1)
+	// is never a slot scheduled for removal in a later iteration,
+	// preventing a use-after-free of heap-owning attribute values
+	for (uint16_t i = 0; i < n; i++) {
 		// free attribute
 		uint16_t idx = indices[i] ;
 		AttrValue_t *attr = vals + idx ;

--- a/src/graph/graph_delete_edges.c
+++ b/src/graph/graph_delete_edges.c
@@ -34,12 +34,12 @@ static int _edge_cmp
 
 	// same relationship-type, different source node ID
 	if (as != bs) {
-		return as - bs ;
+		return (as > bs) - (as < bs) ;
 	}
 
 	// same relationship-type and src node ID
 	// compare base on destination node ID
-	return at - bt ;
+	return (at > bt) - (at < bt) ;
 }
 
 static void _clear_adj

--- a/src/graph/tensor/tensor.c
+++ b/src/graph/tensor/tensor.c
@@ -505,7 +505,7 @@ static int _value_cmp
 	Edge *eb = (Edge *)b;
 	uint64_t a_id = ENTITY_GET_ID(ea);  // A's value
 	uint64_t b_id = ENTITY_GET_ID(eb);  // B's value
-	return a_id - b_id;
+	return (a_id > b_id) - (a_id < b_id);
 }
 
 // remove multiple entries

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -23,7 +23,7 @@ static inline QueryCtx *_QueryCtx_GetCreateCtx(void) {
 
 	if(ctx == NULL) {
 		// set a new thread-local QueryCtx if one has not been created
-		ctx = rm_calloc(1, sizeof(QueryCtx));
+		ctx = rm_calloc (1, sizeof(QueryCtx)) ;
 
 		// created lazily only when needed
 		ctx->undo_log       = NULL ;
@@ -351,14 +351,18 @@ void QueryCtx_PrintQuery(void) {
 	printf("%s\n", ctx->query_data.query);
 }
 
+//------------------------------------------------------------------------------
+// Lock management
+//------------------------------------------------------------------------------
+
 static void _QueryCtx_ThreadSafeContextLock
 (
 	QueryCtx *ctx
 ) {
 	// acquire GIL if we're running with a blocked client
 	// implicates we're running on a worker thread and not on Redis main thread
-	if(ctx->global_exec_ctx.bc) {
-		RedisModule_ThreadSafeContextLock(ctx->global_exec_ctx.redis_ctx);
+	if (ctx->global_exec_ctx.bc) {
+		RedisModule_ThreadSafeContextLock (ctx->global_exec_ctx.redis_ctx) ;
 	} else {
 		// no blocked client, most likely we're running on Redis main thread
 		// ASSERT(pthread_equal(Globals_Get_MainThreadId(), pthread_self()) != 0);
@@ -368,8 +372,8 @@ static void _QueryCtx_ThreadSafeContextLock
 		// to alow Redis to reply to PING requests we should yield execution
 		// giving Redis the opportunity to process commands
 		// see RedisModule_Yield docs
-		RedisModule_Yield(ctx->global_exec_ctx.redis_ctx,
-				REDISMODULE_YIELD_FLAG_CLIENTS, NULL);
+		RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
+				REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
 	}
 }
 
@@ -377,26 +381,64 @@ static void _QueryCtx_ThreadSafeContextUnlock
 (
 	QueryCtx *ctx
 ) {
-	if(ctx->global_exec_ctx.bc) RedisModule_ThreadSafeContextUnlock(ctx->global_exec_ctx.redis_ctx);
+	if (ctx->global_exec_ctx.bc != NULL) {
+		RedisModule_ThreadSafeContextUnlock (ctx->global_exec_ctx.redis_ctx) ;
+	}
 }
 
-// starts a locking flow before commiting changes
-// Locking flow:
-// 1. lock GIL
-// 2. open key with `write` flag
-// 3. graph R/W lock with write flag
-// since 2PL protocal is implemented, the method returns true if
-// it managed to achieve locks in this call or a previous call
-// in case that the locks are already locked, there will be no attempt to lock
-// them again this method returns false if the key has changed
-// from the current graph, and sets the relevant error message
-bool QueryCtx_LockForCommit (void) {
+// acquire graph's read lock
+void QueryCtx_AcquireReadLock (void) {
 	QueryCtx *ctx = _QueryCtx_GetCreateCtx () ;
-	if (ctx->internal_exec_ctx.locked_for_commit) {
+
+	// shouldn't try to acquire write lock when read lock is held
+	ASSERT (ctx->internal_exec_ctx.write_locked == false) ;
+
+	// return if we've already acquired read lock
+	if (ctx->internal_exec_ctx.read_locked == true) {
+		return ;
+	}
+
+	// acquire read lock
+	// TODO: change to TryAcquireReadLock with the appropriate timeout
+	Graph_AcquireReadLock (QueryCtx_GetGraph ()) ;
+	ctx->internal_exec_ctx.read_locked = true ;
+}
+
+// acquire graph's write lock
+bool QueryCtx_AcquireWriteLock (void) {
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx () ;
+
+	// return if we've already acquired write lock
+	if (ctx->internal_exec_ctx.write_locked == true) {
+		ASSERT (ctx->internal_exec_ctx.read_locked == false) ;
 		return true ;
 	}
 
+	// locking flow:
+	// 1. release read lock
+	// 2. lock GIL
+	// 3. open key with `write` flag
+	// 4. graph R/W lock with write flag
+	// since 2PL protocal is implemented, the method returns true if
+	// it managed to achieve locks in this call or a previous call
+	// in case that the locks are already locked, there will be no attempt to lock
+	// them again this method returns false if the key has changed
+	// from the current graph, and sets the relevant error message
+
+	// release graph READ lock if held
+	// writer queries hold a READ lock during the match phase to prevent
+	// concurrent memory modifications by defrag
+	// must release before acquiring GIL to avoid deadlock:
+	//   worker: READ lock → GIL  vs  main thread: GIL → WRITE lock
+	if (ctx->internal_exec_ctx.read_locked == true) {
+		Graph_ReleaseLock (GraphContext_GetGraph (ctx->gc)) ;
+		ctx->internal_exec_ctx.read_locked = false ;
+	}
+
+	//--------------------------------------------------------------------------
 	// lock GIL
+	//--------------------------------------------------------------------------
+
 	GraphContext   *gc         = ctx->gc ;
 	RedisModuleCtx *redis_ctx  = ctx->global_exec_ctx.redis_ctx ;
 	const char     *graph_name = GraphContext_GetName (gc) ;
@@ -406,7 +448,10 @@ bool QueryCtx_LockForCommit (void) {
 
 	_QueryCtx_ThreadSafeContextLock (ctx) ;
 
-	// open key and verify
+	//--------------------------------------------------------------------------
+	// make sure graph key exists
+	//--------------------------------------------------------------------------
+
 	RedisModuleKey *key = RedisModule_OpenKey (redis_ctx, graphID,
 			REDISMODULE_WRITE) ;
 	RedisModule_FreeString (redis_ctx, graphID) ;
@@ -419,7 +464,6 @@ bool QueryCtx_LockForCommit (void) {
 	if (RedisModule_ModuleTypeGetType (key) != GraphContextRedisModuleType) {
 		ErrorCtx_SetError (EMSG_NON_GRAPH_KEY, graph_name) ;
 		goto clean_up ;
-
 	}
 
 	if (gc != RedisModule_ModuleTypeGetValue (key)) {
@@ -430,8 +474,10 @@ bool QueryCtx_LockForCommit (void) {
 	ctx->internal_exec_ctx.key = key ;
 
 	// acquire graph write lock
+	// TODO: change to TryAcquireWriteLock with the appropriate timeout
 	Graph_AcquireWriteLock (GraphContext_GetGraph (gc)) ;
-	ctx->internal_exec_ctx.locked_for_commit = true ;
+	ctx->internal_exec_ctx.write_locked = true ;
+	ASSERT (ctx->internal_exec_ctx.read_locked == false) ;
 
 	return true ;
 
@@ -442,45 +488,43 @@ clean_up:
 	// unlock GIL
 	_QueryCtx_ThreadSafeContextUnlock (ctx) ;
 
-	// if there is a break point for runtime exception, raise it, otherwise return false
+	// if there is a break point for runtime exception, raise it
+	// otherwise return false
 	ErrorCtx_RaiseRuntimeException (NULL) ;
 	return false ;
 }
 
-static void _QueryCtx_UnlockCommit
-(
-	QueryCtx *ctx
-) {
-	GraphContext *gc = ctx->gc ;
+// release graph's lock
+void QueryCtx_ReleaseLock (void) {
+	QueryCtx *ctx = _QueryCtx_GetCtx () ;
+	ASSERT (ctx != NULL) ;
 
-	ctx->internal_exec_ctx.locked_for_commit = false ;
-	// release graph R/W lock
-	Graph_ReleaseLock (GraphContext_GetGraph (gc)) ;
+	// return if neither lock is held
+	if (ctx->internal_exec_ctx.write_locked == false &&
+		ctx->internal_exec_ctx.read_locked  == false) {
+		return ;
+	}
 
-	// close Key
-	RedisModule_CloseKey (ctx->internal_exec_ctx.key) ;
+	// starts an ulocking flow
+	// Unlocking flow:
+	// 1. unlock graph R/W lock
+	// 2. close key
+	// 3. unlock GIL
 
-	// unlock GIL
-	_QueryCtx_ThreadSafeContextUnlock (ctx) ;
-}
+	// release graph lock
+	Graph_ReleaseLock (QueryCtx_GetGraph ()) ;
 
-// starts an ulocking flow and notifies Redis after commiting changes
-// the only writer which allow to perform the unlock and commit (replicate)
-// is the last_writer the method get an OpBase and compares it to
-// the last writer, if they are equal then the commit and unlock flow will start
-// Unlocking flow:
-// 1. replicate
-// 2. unlock graph R/W lock
-// 3. close key
-// 4. unlock GIL
-void QueryCtx_UnlockCommit() {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(!ctx) return;
+	// release WRITE lock
+	if (ctx->internal_exec_ctx.write_locked == true) {
+		// close Key
+		RedisModule_CloseKey (ctx->internal_exec_ctx.key) ;
 
-	// already unlocked?
-	if(!ctx->internal_exec_ctx.locked_for_commit) return;
+		// unlock GIL
+		_QueryCtx_ThreadSafeContextUnlock (ctx) ;
+	}
 
-	_QueryCtx_UnlockCommit(ctx);
+	ctx->internal_exec_ctx.read_locked  = false ;
+	ctx->internal_exec_ctx.write_locked = false ;
 }
 
 // replicate command to AOF/Replicas
@@ -517,8 +561,8 @@ uint64_t QueryCtx_GetReceivedTS (void) {
 
 // free the allocations within the QueryCtx and reset it for the next query
 void QueryCtx_Free(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ASSERT(ctx != NULL);
+	QueryCtx *ctx = _QueryCtx_GetCtx () ;
+	ASSERT (ctx != NULL) ;
 
 	if (ctx->undo_log) {
 		UndoLog_Free (ctx->undo_log) ;

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -367,13 +367,19 @@ static void _QueryCtx_ThreadSafeContextLock
 		// no blocked client, most likely we're running on Redis main thread
 		// ASSERT(pthread_equal(Globals_Get_MainThreadId(), pthread_self()) != 0);
 
-		// it likely we're here because of an execution of a write query
-		// e.g. loading from AOF
-		// to alow Redis to reply to PING requests we should yield execution
-		// giving Redis the opportunity to process commands
-		// see RedisModule_Yield docs
-		RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
-				REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+		// yield only during AOF/RDB loading so that Redis can respond to
+		// health-check PINGs (e.g. from Sentinel or external monitors)
+		// while replaying potentially long-running write commands.
+		//
+		// we must NOT yield during replication or MULTI/EXEC because
+		// RedisModule_Yield with REDISMODULE_YIELD_FLAG_CLIENTS puts
+		// Redis into a "busy" state, causing other clients to receive
+		// BUSY errors (JedisBusyException)
+		int flags = RedisModule_GetContextFlags (ctx->global_exec_ctx.redis_ctx) ;
+		if (flags & REDISMODULE_CTX_FLAGS_LOADING) {
+			RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
+					REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+		}
 	}
 }
 

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -59,7 +59,8 @@ typedef struct {
 typedef struct {
 	RedisModuleKey *key;     // graph open key, for later extraction and closing
 	ResultSet *result_set;   // execution result set
-	bool locked_for_commit;  // indicates if QueryCtx_LockForCommit been called
+	bool read_locked;        // thread holds graph READ lock
+	bool write_locked;       // thread holds graph WRITE lock
 } QueryCtx_InternalExecCtx;
 
 typedef struct {
@@ -220,28 +221,18 @@ ResultSetStatistics *QueryCtx_GetResultSetStatistics(void);
 // print the current query
 void QueryCtx_PrintQuery(void);
 
-// starts a locking flow before commiting changes
-// Locking flow:
-// 1. lock GIL
-// 2. open key with `write` flag
-// 3. graph R/W lock with write flag
-// since 2PL protocal is implemented, the method returns true if
-// it managed to achieve locks in this call or a previous call
-// in case that the locks are already locked, there will be no attempt to lock
-// them again this method returns false if the key has changed
-// from the current graph, and sets the relevant error message
-bool QueryCtx_LockForCommit(void);
+//------------------------------------------------------------------------------
+// Lock management
+//------------------------------------------------------------------------------
 
-// starts an ulocking flow and notifies Redis after commiting changes
-// the only writer which allow to perform the unlock and commit (replicate)
-// is the last_writer the method get an OpBase and compares it to
-// the last writer, if they are equal then the commit and unlock flow will start
-// Unlocking flow:
-// 1. replicate
-// 2. unlock graph R/W lock
-// 3. close key
-// 4. unlock GIL
-void QueryCtx_UnlockCommit(void);
+// acquire graph's read lock
+void QueryCtx_AcquireReadLock (void) ;
+
+// acquire graph's write lock
+bool QueryCtx_AcquireWriteLock (void) ;
+
+// release graph's lock
+void QueryCtx_ReleaseLock (void) ;
 
 // replicate command to AOF/Replicas
 void QueryCtx_Replicate

--- a/src/resultset/formatters/resultset_replybolt.c
+++ b/src/resultset/formatters/resultset_replybolt.c
@@ -86,7 +86,6 @@ void _ResultSet_BoltReplyWithSIValue
 		bolt_reply_int64(client, 4326);
 		bolt_reply_float(client, v.point.longitude);
 		bolt_reply_float(client, v.point.latitude);
-		bolt_reply_null(client);
 		break;
 	case T_VECTOR_F32: {
 		uint32_t dim = SIVector_Dim(v);

--- a/src/serializers/decoders/current/v19/decode_graph_entities.c
+++ b/src/serializers/decoders/current/v19/decode_graph_entities.c
@@ -200,13 +200,16 @@ void RdbLoadDeletedNodes_v19
 	size_t n;
 	NodeID *deleted_nodes_list = (NodeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	// validate buffer alignment
-	if (n % sizeof(NodeID) != 0) {
-		rm_free (deleted_nodes_list) ;
-		ASSERT (false && "corrupted deleted nodes buffer") ;
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(NodeID) != 0 ||
+		n / sizeof(NodeID) != deleted_node_count) {
+		rm_free(deleted_nodes_list);
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted nodes buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_node_count);
+		RedisModule_Assert(false);
 	}
-
-	ASSERT((n / sizeof(NodeID)) == deleted_node_count);
 
 	// mark each node id as deleted
 	for(uint64_t i = 0; i < deleted_node_count; i++) {
@@ -268,13 +271,16 @@ void RdbLoadDeletedEdges_v19
 	size_t n;
 	EdgeID *deleted_edges_list = (EdgeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	// validate buffer alignment
-	if (n % sizeof(EdgeID) != 0) {
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(EdgeID) != 0 ||
+		n / sizeof(EdgeID) != deleted_edge_count) {
 		rm_free(deleted_edges_list);
-		ASSERT(false && "corrupted deleted edges buffer");
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted edges buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_edge_count);
+		RedisModule_Assert(false);
 	}
-
-	ASSERT((n / sizeof(EdgeID)) == deleted_edge_count);
 
 	// mark each edge id as deleted
 	for(uint64_t i = 0; i < deleted_edge_count; i++) {

--- a/src/serializers/decoders/prev/v17/decode_graph_entities.c
+++ b/src/serializers/decoders/prev/v17/decode_graph_entities.c
@@ -175,7 +175,16 @@ void RdbLoadDeletedNodes_v17
 	size_t n;
 	NodeID *deleted_nodes_list = (NodeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	ASSERT((n / sizeof(NodeID)) == deleted_node_count);
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(NodeID) != 0 ||
+		n / sizeof(NodeID) != deleted_node_count) {
+		rm_free(deleted_nodes_list);
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted nodes buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_node_count);
+		RedisModule_Assert(false);
+	}
 
 	// mark each node id as deleted
 	for(uint64_t i = 0; i < deleted_node_count; i++) {
@@ -237,7 +246,16 @@ void RdbLoadDeletedEdges_v17
 	size_t n;
 	EdgeID *deleted_edges_list = (EdgeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	ASSERT((n / sizeof(EdgeID)) == deleted_edge_count);
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(EdgeID) != 0 ||
+		n / sizeof(EdgeID) != deleted_edge_count) {
+		rm_free(deleted_edges_list);
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted edges buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_edge_count);
+		RedisModule_Assert(false);
+	}
 
 	// mark each edge id as deleted
 	for(uint64_t i = 0; i < deleted_edge_count; i++) {

--- a/src/serializers/decoders/prev/v18/decode_graph_entities.c
+++ b/src/serializers/decoders/prev/v18/decode_graph_entities.c
@@ -200,13 +200,16 @@ void RdbLoadDeletedNodes_v18
 	size_t n;
 	NodeID *deleted_nodes_list = (NodeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	// validate buffer alignment
-	if (n % sizeof(NodeID) != 0) {
-		rm_free (deleted_nodes_list) ;
-		ASSERT (false && "corrupted deleted nodes buffer") ;
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(NodeID) != 0 ||
+		n / sizeof(NodeID) != deleted_node_count) {
+		rm_free(deleted_nodes_list);
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted nodes buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_node_count);
+		RedisModule_Assert(false);
 	}
-
-	ASSERT((n / sizeof(NodeID)) == deleted_node_count);
 
 	// mark each node id as deleted
 	for(uint64_t i = 0; i < deleted_node_count; i++) {
@@ -268,13 +271,16 @@ void RdbLoadDeletedEdges_v18
 	size_t n;
 	EdgeID *deleted_edges_list = (EdgeID*)SerializerIO_ReadBuffer(rdb, &n);
 
-	// validate buffer alignment
-	if (n % sizeof(EdgeID) != 0) {
+	// validate buffer: must be aligned and match expected count
+	if (n % sizeof(EdgeID) != 0 ||
+		n / sizeof(EdgeID) != deleted_edge_count) {
 		rm_free(deleted_edges_list);
-		ASSERT(false && "corrupted deleted edges buffer");
+		RedisModule_Log(NULL, "warning",
+			"Malformed RDB: deleted edges buffer size %zu "
+			"is not aligned or does not match expected count %" PRIu64,
+			n, deleted_edge_count);
+		RedisModule_Assert(false);
 	}
-
-	ASSERT((n / sizeof(EdgeID)) == deleted_edge_count);
 
 	// mark each edge id as deleted
 	for(uint64_t i = 0; i < deleted_edge_count; i++) {

--- a/src/value.c
+++ b/src/value.c
@@ -876,7 +876,11 @@ int SIValue_Compare
 
 		case T_NODE:
 		case T_EDGE:
-			return ENTITY_GET_ID((GraphEntity *)a.ptrval) - ENTITY_GET_ID((GraphEntity *)b.ptrval);
+		{
+			EntityID a_id = ENTITY_GET_ID((GraphEntity *)a.ptrval);
+			EntityID b_id = ENTITY_GET_ID((GraphEntity *)b.ptrval);
+			return (a_id > b_id) - (a_id < b_id);
+		}
 
 		case T_ARRAY:
 			return SIArray_Compare(a, b, disjointOrNull);

--- a/src/version.h
+++ b/src/version.h
@@ -8,7 +8,7 @@
 
 #define FALKOR_VERSION_MAJOR 4
 #define FALKOR_VERSION_MINOR 18
-#define FALKOR_VERSION_PATCH 0
+#define FALKOR_VERSION_PATCH 1
 
 #define FALKOR_SEMANTIC_VERSION(major, minor, patch) \
   (major * 10000 + minor * 100 + patch)

--- a/src/version.h
+++ b/src/version.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#define FALKOR_VERSION_MAJOR 99
-#define FALKOR_VERSION_MINOR 99
-#define FALKOR_VERSION_PATCH 99
+#define FALKOR_VERSION_MAJOR 4
+#define FALKOR_VERSION_MINOR 18
+#define FALKOR_VERSION_PATCH 0
 
 #define FALKOR_SEMANTIC_VERSION(major, minor, patch) \
   (major * 10000 + minor * 100 + patch)

--- a/tests/flow/test_bolt.py
+++ b/tests/flow/test_bolt.py
@@ -2,26 +2,75 @@ from common import *
 from neo4j import GraphDatabase
 from neo4j.spatial import WGS84Point
 import neo4j.graph
-# from neo4j.debug import watch
+import socket
+import struct
+import base64
+import os
+import time
+import websocket
 
-bolt_con = None
+BOLT_PORT = 7687
+
+def _bolt_setup(env_self):
+    """Shared setup: start server and create bolt driver."""
+    env_self.env, _ = Env(moduleArgs=f"BOLT_PORT {BOLT_PORT}")
+    # limit pool size so idle connections don't consume all server threads
+    env_self.bolt_con = GraphDatabase.driver(
+        f"bolt://localhost:{BOLT_PORT}", auth=("falkordb", ""),
+        max_connection_pool_size=1)
+
+def _bolt_teardown(env_self):
+    """Shared teardown: close bolt driver to release connections."""
+    if hasattr(env_self, 'bolt_con') and env_self.bolt_con is not None:
+        env_self.bolt_con.close()
+
+def _ws_create_connection(port, retries=3):
+    """Open a WebSocket connection to the Bolt port using websocket-client.
+    Retries on timeout to handle slow server thread release (e.g. ASAN).
+    Returns (ws, True) on success, (None, False) on failure."""
+    for attempt in range(retries):
+        try:
+            ws = websocket.create_connection(
+                f"ws://127.0.0.1:{port}/", timeout=10)
+            return ws, True
+        except (websocket.WebSocketTimeoutException,
+                websocket.WebSocketException, ConnectionRefusedError):
+            if attempt < retries - 1:
+                time.sleep(2)
+    return None, False
+
+def _bolt_handshake_over_ws(ws):
+    """Send the Bolt handshake over an established WebSocket connection.
+    Returns the server version response bytes."""
+    time.sleep(0.1)
+    # Bolt magic preamble (0x6060B017) + 4 version proposals
+    handshake = struct.pack('>I', 0x6060B017)
+    # version proposals: [5.7, 5.1, 0, 0]
+    # each proposal is 4 raw bytes: [patch, range, minor, major]
+    handshake += struct.pack('>I', 0x00000705)
+    handshake += struct.pack('>I', 0x00000105)
+    handshake += struct.pack('>I', 0x00000000)
+    handshake += struct.pack('>I', 0x00000000)
+    ws.send_binary(handshake)
+    _, response = ws.recv_data()
+    return response
+
 
 class testBolt():
     def __init__(self):
-        global bolt_con
-        bolt_port = 7687
-        self.env,_ = Env(moduleArgs=f"BOLT_PORT {bolt_port}")
-        bolt_con = GraphDatabase.driver(f"bolt://localhost:{bolt_port}", auth=("falkordb", ""))
-        # self.watcher = watch("neo4j")
+        _bolt_setup(self)
+
+    def __del__(self):
+        _bolt_teardown(self)
 
     def test01_null(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN null, $v", {"v": None})
             record = result.single()
             self.env.assertEquals(record[0], None)
 
     def test02_boolean(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN true, false, $v_true, $v_false", {"v_true": True, "v_false": False})
             record = result.single()
             self.env.assertEquals(record[0], True)
@@ -30,7 +79,7 @@ class testBolt():
             self.env.assertEquals(record[3], False)
 
     def test03_integer(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN -1, 0, 1, 2, $v", {"v": 3})
             record = result.single()
             self.env.assertEquals(record[0], -1)
@@ -66,14 +115,14 @@ class testBolt():
             self.env.assertEquals(record[1], 9223372036854775807)
 
     def test04_float(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN 1.23, $v", {"v": 4.56})
             record = result.single()
             self.env.assertEquals(record[0], 1.23)
             self.env.assertEquals(record[1], 4.56)
 
     def test05_string(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN '', 'Hello, World!', $v8, $v16", {"v8": 'A' * 255, "v16": 'A' * 256})
             record = result.single()
             self.env.assertEquals(record[0], '')
@@ -82,7 +131,7 @@ class testBolt():
             self.env.assertEquals(record[3], 'A' * 256)
 
     def test06_list(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
             result = session.run("RETURN [], [1,2,3], $v8, $v16", {"v8": [1] * 255, "v16": [1] * 256})
             record = result.single()
             self.env.assertEquals(record[0], [])
@@ -91,7 +140,7 @@ class testBolt():
             self.env.assertEquals(record[3], [1] * 256)
 
     def test07_map(self):
-        with bolt_con.session() as session:
+        with self.bolt_con.session() as session:
              result = session.run("RETURN {}, {foo:'bar'}, $v8", {"v8": {'foo':'bar'} })
              record = result.single()
              self.env.assertEquals(record[0], {})
@@ -99,13 +148,13 @@ class testBolt():
              self.env.assertEquals(record[2], {'foo':'bar'})
 
     def test08_point(self):
-         with bolt_con.session() as session:
+         with self.bolt_con.session() as session:
              result = session.run("RETURN POINT({longitude:1, latitude:2})")
              record = result.single()
              self.env.assertEquals(record[0], WGS84Point((1, 2)))
 
     def test09_graph_entities_values(self):
-         with bolt_con.session() as session:
+         with self.bolt_con.session() as session:
              result = session.run("""CREATE (a:A {v: 1})-[r1:R1]->(b:B)<-[r2:R2]-(c:C) RETURN a, r1, b, r2, c""")
              record = result.single()
              a:neo4j.graph.Node = record[0]
@@ -157,3 +206,358 @@ class testBolt():
              self.env.assertEquals(p.nodes[2].labels, set(['C']))
              self.env.assertEquals(p.relationships[0].type, 'R1')
              self.env.assertEquals(p.relationships[1].type, 'R2')
+
+    def test10_tiny_int_negative_range(self):
+        """Verify tiny int encoding for the full range -16..127.
+        Before the fix, bolt_reply_int never used the tiny int path
+        because the comparison used the unsigned constant 0xF0 (240)."""
+        with self.bolt_con.session() as session:
+            # test all negative tiny ints: -16 to -1
+            vals = list(range(-16, 0))
+            placeholders = ', '.join(f'${f"n{abs(v)}"}' for v in vals)
+            params = {f"n{abs(v)}": v for v in vals}
+            result = session.run(f"RETURN {placeholders}", params)
+            record = result.single()
+            for i, v in enumerate(vals):
+                self.env.assertEquals(record[i], v)
+
+            # test boundaries around tiny int range
+            result = session.run("RETURN $a, $b, $c, $d",
+                                 {"a": -16, "b": -17, "c": 127, "d": 128})
+            record = result.single()
+            self.env.assertEquals(record[0], -16)
+            self.env.assertEquals(record[1], -17)
+            self.env.assertEquals(record[2], 127)
+            self.env.assertEquals(record[3], 128)
+
+    def test11_negative_integer_boundaries(self):
+        """Test negative values at int8/int16/int32/int64 boundaries."""
+        with self.bolt_con.session() as session:
+            result = session.run(
+                "RETURN $a, $b, $c, $d, $e, $f",
+                {"a": -128, "b": -129, "c": -32768,
+                 "d": -32769, "e": -2147483648, "f": -2147483649})
+            record = result.single()
+            self.env.assertEquals(record[0], -128)     # int8 min
+            self.env.assertEquals(record[1], -129)     # int16
+            self.env.assertEquals(record[2], -32768)   # int16 min
+            self.env.assertEquals(record[3], -32769)   # int32
+            self.env.assertEquals(record[4], -2147483648)   # int32 min
+            self.env.assertEquals(record[5], -2147483649)   # int64
+
+    def test12_point_followed_by_values(self):
+        """Verify Point2D doesn't corrupt subsequent values in the record.
+        Before the fix, an extra bolt_reply_null shifted all following data."""
+        with self.bolt_con.session() as session:
+            result = session.run(
+                "RETURN POINT({longitude:1.5, latitude:2.5}), 42, 'hello'")
+            record = result.single()
+            self.env.assertEquals(record[0], WGS84Point((1.5, 2.5)))
+            self.env.assertEquals(record[1], 42)
+            self.env.assertEquals(record[2], 'hello')
+
+    def test13_multiple_points(self):
+        """Test returning multiple Point2D values with float coordinates.
+        Uses float32-exact values (multiples of powers of 2) to exercise
+        the float serialization path without precision mismatch."""
+        with self.bolt_con.session() as session:
+            result = session.run(
+                "RETURN POINT({longitude:10.5, latitude:20.25}), "
+                "POINT({longitude:-30.125, latitude:40.75}), "
+                "POINT({longitude:-50.5, latitude:60.875})")
+            record = result.single()
+            self.env.assertEquals(record[0], WGS84Point((10.5, 20.25)))
+            self.env.assertEquals(record[1], WGS84Point((-30.125, 40.75)))
+            self.env.assertEquals(record[2], WGS84Point((-50.5, 60.875)))
+
+    def test14_large_string_parameter(self):
+        """Test queries with large string parameters.
+        Before the fix, a fixed 4096-byte stack buffer could overflow."""
+        with self.bolt_con.session() as session:
+            large_str = 'X' * 8000
+            result = session.run("RETURN $v", {"v": large_str})
+            record = result.single()
+            self.env.assertEquals(record[0], large_str)
+
+    def test15_many_parameters(self):
+        """Test a query with many parameters to stress the parameterized
+        query buffer allocation."""
+        with self.bolt_con.session() as session:
+            params = {f"p{i}": i for i in range(100)}
+            placeholders = ', '.join(f'${k}' for k in params)
+            result = session.run(f"RETURN {placeholders}", params)
+            record = result.single()
+            for i in range(100):
+                self.env.assertEquals(record[i], i)
+
+    def test16_int16_string16_list16_serialization(self):
+        """Verify int16/string16/list16 serialization works correctly."""
+        with self.bolt_con.session() as session:
+            # int16 range: 128..32767 and -128..-17
+            result = session.run("RETURN $a, $b, $c, $d",
+                                 {"a": 200, "b": 32767, "c": -100, "d": -32768})
+            record = result.single()
+            self.env.assertEquals(record[0], 200)
+            self.env.assertEquals(record[1], 32767)
+            self.env.assertEquals(record[2], -100)
+            self.env.assertEquals(record[3], -32768)
+
+            # string16: string with length 256 (requires 16-bit size header)
+            s16 = 'B' * 256
+            result = session.run("RETURN $v", {"v": s16})
+            record = result.single()
+            self.env.assertEquals(record[0], s16)
+
+            # list16: list with 256 elements (requires 16-bit size header)
+            l16 = list(range(256))
+            result = session.run("RETURN $v", {"v": l16})
+            record = result.single()
+            self.env.assertEquals(record[0], l16)
+
+    def test17_int32_int64_serialization(self):
+        """Verify int32/int64 serialization at boundary values."""
+        with self.bolt_con.session() as session:
+            # int32 range
+            result = session.run("RETURN $a, $b, $c, $d",
+                                 {"a": 100000, "b": 2147483647,
+                                  "c": -100000, "d": -2147483648})
+            record = result.single()
+            self.env.assertEquals(record[0], 100000)
+            self.env.assertEquals(record[1], 2147483647)
+            self.env.assertEquals(record[2], -100000)
+            self.env.assertEquals(record[3], -2147483648)
+
+            # int64 range
+            result = session.run("RETURN $a, $b",
+                                 {"a": 9223372036854775807,
+                                  "b": -9223372036854775808})
+            record = result.single()
+            self.env.assertEquals(record[0], 9223372036854775807)
+            self.env.assertEquals(record[1], -9223372036854775808)
+
+    def test18_reset_during_session(self):
+        """Verify RESET handling works correctly.
+        Before the fix, raw pointer arithmetic in the RESET message removal
+        could corrupt memory when data spanned buffer chunk boundaries.
+        session.reset() sends a RESET message through the bolt protocol."""
+        with self.bolt_con.session() as session:
+            # run a query, then reset, then run another query
+            result = session.run("RETURN 1")
+            record = result.single()
+            self.env.assertEquals(record[0], 1)
+
+        # after closing and reopening a session, the connection is reused
+        # but the state is reset
+        with self.bolt_con.session() as session:
+            result = session.run("RETURN 'after_reset'")
+            record = result.single()
+            self.env.assertEquals(record[0], 'after_reset')
+
+    def test19_reset_with_pipelined_queries(self):
+        """Test that RESET works correctly when interleaved with queries.
+        Uses explicit transaction begin/rollback to trigger RESET."""
+        with self.bolt_con.session() as session:
+            # begin a transaction then roll it back (triggers RESET-like behavior)
+            tx = session.begin_transaction()
+            tx.run("RETURN 1").consume()
+            tx.rollback()
+
+            # subsequent query on the same session should work correctly
+            result = session.run("RETURN 42")
+            record = result.single()
+            self.env.assertEquals(record[0], 42)
+
+    def test20_rapid_session_cycling(self):
+        """Rapidly open/close sessions to stress RESET handling.
+        Each session close sends RESET on the pooled connection."""
+        for i in range(5):
+            with self.bolt_con.session() as session:
+                result = session.run("RETURN $i", {"i": i})
+                record = result.single()
+                self.env.assertEquals(record[0], i)
+
+    def test21_large_string_parameter_value(self):
+        """Test parameterized query where write_value must serialize a very
+        large string value. Before the fix, write_value wrote into a fixed
+        buffer that could overflow; now it uses a growable wbuf_t."""
+        with self.bolt_con.session() as session:
+            large = 'Z' * 8192
+            result = session.run("RETURN $v", {"v": large})
+            record = result.single()
+            self.env.assertEquals(record[0], large)
+
+    def test22_large_list_parameter_value(self):
+        """Test parameterized query with a large list value that forces
+        write_value to grow the buffer during recursive serialization."""
+        with self.bolt_con.session() as session:
+            large_list = list(range(200))
+            result = session.run("RETURN $v", {"v": large_list})
+            record = result.single()
+            self.env.assertEquals(record[0], large_list)
+
+    def test23_nested_map_parameter(self):
+        """Test parameterized query with a nested map to exercise
+        write_value's recursive map serialization with heap-allocated keys."""
+        with self.bolt_con.session() as session:
+            nested = {"outer_key": {"inner_key": "inner_value"}}
+            result = session.run("RETURN $v", {"v": nested})
+            record = result.single()
+            self.env.assertEquals(record[0], nested)
+
+    def test24_many_large_parameters(self):
+        """Combine many parameters with large values to stress the
+        growable query buffer across multiple write_value calls."""
+        with self.bolt_con.session() as session:
+            params = {f"p{i}": 'V' * 500 for i in range(15)}
+            placeholders = ', '.join(f'${k}' for k in params)
+            result = session.run(f"RETURN {placeholders}", params)
+            record = result.single()
+            for i in range(15):
+                self.env.assertEquals(record[i], 'V' * 500)
+
+    def test25_multiple_consecutive_rollbacks(self):
+        """Test that multiple consecutive transaction rollbacks within the
+        same session work correctly. Each rollback sends a RESET-like message;
+        the RESET scan loop must continue past the first removed frame to
+        handle any subsequent ones in the buffer."""
+        with self.bolt_con.session() as session:
+            for i in range(3):
+                tx = session.begin_transaction()
+                tx.run("RETURN $i", {"i": i}).consume()
+                tx.rollback()
+
+            # after all rollbacks, the session must still be usable
+            result = session.run("RETURN 'after_rollbacks'")
+            record = result.single()
+            self.env.assertEquals(record[0], 'after_rollbacks')
+
+    def test26_interleaved_rollback_and_queries(self):
+        """Stress the RESET scan loop by interleaving rollbacks with
+        queries on the same session. Verifies the buffer state is
+        consistent after each RESET removal."""
+        with self.bolt_con.session() as session:
+            for i in range(3):
+                # rollback a transaction
+                tx = session.begin_transaction()
+                tx.run("RETURN 1").consume()
+                tx.rollback()
+
+                # immediately run a normal query
+                result = session.run("RETURN $v", {"v": i * 100})
+                record = result.single()
+                self.env.assertEquals(record[0], i * 100)
+
+    def test27_auth_empty_credentials_no_password(self):
+        """Verify that authentication with empty credentials still works
+        when no requirepass is configured. Before the fix, PING was used
+        which always succeeds even when requirepass IS set. Now AUTH with
+        empty string is used, which correctly reflects server config."""
+        # the test env has no requirepass, so empty auth should still succeed
+        driver = GraphDatabase.driver(
+            f"bolt://localhost:{BOLT_PORT}", auth=("falkordb", ""))
+        with driver.session() as session:
+            result = session.run("RETURN 1")
+            record = result.single()
+            self.env.assertEquals(record[0], 1)
+        driver.close()
+
+    def test28_deeply_nested_map_parameter_rejected(self):
+        """Test that deeply nested parameters beyond the recursion limit
+        cause query construction to fail gracefully rather than crash.
+        Before the fix, write_value had no recursion depth limit; a deeply
+        nested structure would overflow the C stack."""
+        # build a map nested 200 levels deep (exceeds WRITE_VALUE_MAX_DEPTH=128)
+        nested = "inner_value"
+        for i in range(200):
+            nested = {"k": nested}
+        with self.bolt_con.session() as session:
+            try:
+                result = session.run("RETURN $v", {"v": nested})
+                result.consume()
+                # if server handled it gracefully (returned error), that's fine
+            except Exception:
+                # a client or server error is acceptable — crash is not
+                pass
+        # verify the server is still alive after the deeply nested param
+        with self.bolt_con.session() as session:
+            result = session.run("RETURN 'alive'")
+            record = result.single()
+            self.env.assertEquals(record[0], 'alive')
+
+    def test29_moderately_nested_map_parameter_succeeds(self):
+        """Verify that moderately nested parameters (within the depth
+        limit) still work correctly after the recursion limit was added."""
+        # 50 levels deep — well within WRITE_VALUE_MAX_DEPTH=128
+        nested = "leaf"
+        for i in range(50):
+            nested = {"k": nested}
+        with self.bolt_con.session() as session:
+            result = session.run("RETURN $v", {"v": nested})
+            record = result.single()
+            # verify the innermost value survived the round-trip
+            val = record[0]
+            for i in range(50):
+                self.env.assertContains("k", val)
+                val = val["k"]
+            self.env.assertEquals(val, "leaf")
+
+    def test30_ws_handshake_and_bolt(self):
+        """Test WebSocket upgrade and Bolt protocol handshake over WS.
+        Verifies that the server accepts a WS upgrade (HTTP 101) and then
+        successfully negotiates a Bolt version over the WS transport."""
+        ws, ok = _ws_create_connection(BOLT_PORT)
+        self.env.assertTrue(ok)
+        response = _bolt_handshake_over_ws(ws)
+        # response should be 4 bytes: 2 zero bytes + minor + major
+        self.env.assertGreaterEqual(len(response), 4)
+        if len(response) >= 4:
+            # Bolt version 5.x expected
+            self.env.assertEquals(response[-1], 5)
+            self.env.assertGreaterEqual(response[-2], 1)
+        ws.close(timeout=0)
+
+    def test31_ws_reject_invalid_upgrade(self):
+        """Test that the server rejects a non-WebSocket, non-Bolt connection
+        by closing the socket."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(10)
+        s.connect(('127.0.0.1', BOLT_PORT))
+        # send garbage that's neither Bolt handshake nor WS upgrade
+        s.sendall(b'INVALID REQUEST\r\n\r\n')
+        try:
+            data = s.recv(4096)
+            # empty response or connection reset both acceptable
+            self.env.assertTrue(len(data) == 0 or data == b'')
+        except (ConnectionResetError, socket.timeout):
+            pass  # expected: server closes connection
+        s.close()
+
+    def test32_ws_connection_header_variants(self):
+        """Test that WebSocket upgrade works with different Connection
+        header formats (comma-separated tokens, mixed case)."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(10)
+        s.connect(('127.0.0.1', BOLT_PORT))
+        key = base64.b64encode(os.urandom(16)).decode()
+        request = (
+            "GET / HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{BOLT_PORT}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: keep-alive, Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            f"Origin: http://127.0.0.1:{BOLT_PORT}\r\n"
+            "\r\n"
+        )
+        s.sendall(request.encode())
+        response = b''
+        try:
+            while b'\r\n\r\n' not in response:
+                b = s.recv(1)
+                if not b:
+                    break
+                response += b
+            self.env.assertTrue(response.startswith(b'HTTP/1.1 101'))
+        except socket.timeout:
+            self.env.assertTrue(False, "Timeout waiting for WS upgrade response")
+        s.close()

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -2,6 +2,7 @@ import time
 import redis
 import random
 import datetime
+import threading
 from dateutil.relativedelta import relativedelta
 from common import *
 
@@ -161,3 +162,135 @@ class testDefrag():
             self.env.assertEquals(props, row[0])
             self.env.assertEquals(props, row[1])
 
+    def test_concurrent_writers_during_defrag(self):
+        """Regression test for issue #1831: writer queries must hold a graph
+        READ lock during the match phase to prevent active defrag from
+        relocating entity memory mid-execution."""
+
+        conn = self.env.getConnection()
+
+        #----------------------------------------------------------------------
+        # 1. Seed the graph with data to defragment
+        #----------------------------------------------------------------------
+
+        g = self.db.select_graph("defrag_race")
+
+        # create nodes with properties to give defrag something to relocate
+        g.query("""UNWIND range(0, 500) AS i
+                   CREATE (:Item {id: i, name: 'item_' + toString(i),
+                                  value: i * 1.5, tag: 'bulk'})""")
+
+        # delete half to create fragmentation
+        g.query("MATCH (n:Item) WHERE n.id % 2 = 0 DELETE n")
+        conn.execute_command("MEMORY PURGE")
+
+        #----------------------------------------------------------------------
+        # 2. Enable aggressive active defrag
+        #----------------------------------------------------------------------
+
+        keys = [
+            "activedefrag",
+            "active-defrag-threshold-lower",
+            "active-defrag-threshold-upper",
+            "active-defrag-ignore-bytes",
+        ]
+
+        original_cfg = {}
+        for k in keys:
+            original_cfg.update(conn.config_get(k))
+
+        try:
+            conn.config_set("activedefrag", "yes")
+            conn.config_set("active-defrag-threshold-lower", "1")
+            conn.config_set("active-defrag-threshold-upper", "1")
+            conn.config_set("active-defrag-ignore-bytes", "1")
+        except ResponseError:
+            self.env.skip()
+            return
+
+        #----------------------------------------------------------------------
+        # 3. Run concurrent MERGE+SET writers while defrag is active
+        #----------------------------------------------------------------------
+
+        errors = []
+        stop_event = threading.Event()
+
+        def writer_thread(thread_id):
+            """Run MERGE+SET queries concurrently with defrag."""
+            try:
+                tg = self.db.select_graph("defrag_race")
+                i = 0
+                while not stop_event.is_set():
+                    try:
+                        tg.query(
+                            "UNWIND $rows AS row "
+                            "MERGE (n:Item {id: row.id}) "
+                            "SET n.name = row.name, n.value = row.value",
+                            {"rows": [
+                                {"id": thread_id * 1000 + i,
+                                 "name": f"t{thread_id}_{i}",
+                                 "value": float(i)},
+                                {"id": thread_id * 1000 + i + 1,
+                                 "name": f"t{thread_id}_{i+1}",
+                                 "value": float(i + 1)},
+                            ]}
+                        )
+                    except Exception as e:
+                        err_str = str(e)
+                        if "connection" not in err_str.lower():
+                            errors.append(f"Thread {thread_id}: {e}")
+                        else:
+                            # server crash — connection lost
+                            errors.append(f"Thread {thread_id}: server crashed: {e}")
+                            return
+                    i += 2
+            except Exception as e:
+                errors.append(f"Thread {thread_id} setup: {e}")
+
+        # start writer threads
+        num_threads = 4
+        threads = []
+        for t in range(num_threads):
+            th = threading.Thread(target=writer_thread, args=(t,))
+            th.daemon = True
+            th.start()
+            threads.append(th)
+
+        try:
+            # let writers and defrag run concurrently
+            time.sleep(3)
+
+            # signal threads to stop
+            stop_event.set()
+            for th in threads:
+                th.join(timeout=5)
+
+            #------------------------------------------------------------------
+            # 4. Verify server is alive and data is consistent
+            #------------------------------------------------------------------
+
+            # server should still respond
+            self.env.assertTrue(conn.ping())
+
+            # query should return valid results
+            res = g.query("MATCH (n:Item) RETURN count(n)").result_set
+            self.env.assertGreater(res[0][0], 0)
+
+            # verify no connection-lost errors (would indicate a crash)
+            crash_errors = [e for e in errors if "crash" in e.lower()]
+            self.env.assertEquals(len(crash_errors), 0)
+
+        finally:
+            #------------------------------------------------------------------
+            # 5. Restore original config
+            #------------------------------------------------------------------
+
+            stop_event.set()
+            for th in threads:
+                th.join(timeout=5)
+
+            for k, v in original_cfg.items():
+                try:
+                    conn.config_set(k, v)
+                except Exception:
+                    pass

--- a/tests/flow/test_encode_decode.py
+++ b/tests/flow/test_encode_decode.py
@@ -30,7 +30,13 @@ class test_encode_decode(FlowTestsBase):
         self.graph = self.db.select_graph(GRAPH_ID)
 
     def tearDown(self):
-        self.graph.delete()
+        try:
+            self.graph.delete()
+        except Exception as e:
+            # tolerate missing graph key and dead server (e.g. ASAN timeout)
+            msg = str(e).lower()
+            if "empty key" not in msg and "connection" not in msg:
+                raise
 
     def test_01_nodes_over_multiple_keys(self):
         # Create 3 nodes meta keys
@@ -341,3 +347,83 @@ class test_encode_decode(FlowTestsBase):
             self.env, nodes_before.result_set, nodes_after.result_set
         )
         self.env.assertEquals(edges_before.result_set, edges_after.result_set)
+
+    def test_15_varied_label_sizes(self):
+        # verify that a graph with multiple labels of different sizes
+        # and cross-label edges survives encode / decode
+        sizes = {"S": 10, "M": 100, "L": 1000, "XL": 2000}
+        for label, count in sizes.items():
+            self.graph.query(
+                f"UNWIND range(1, {count}) AS id CREATE (:{label} {{id:id}})"
+            )
+
+        # connect nodes across labels
+        self.graph.query(
+            "MATCH (a:S), (b:M) WHERE a.id = b.id CREATE (a)-[:R]->(b)"
+        )
+
+        expected = {}
+        for label in sizes:
+            expected[label] = self.graph.query(
+                f"MATCH (n:{label}) RETURN count(n)"
+            )
+        expected_edges = self.graph.query("MATCH ()-[e:R]->() RETURN count(e)")
+
+        # Save RDB & Load from RDB
+        self.redis_con.execute_command("DEBUG", "RELOAD")
+
+        for label in sizes:
+            actual = self.graph.query(f"MATCH (n:{label}) RETURN count(n)")
+            self.env.assertEquals(expected[label].result_set, actual.result_set)
+        actual_edges = self.graph.query("MATCH ()-[e:R]->() RETURN count(e)")
+        self.env.assertEquals(expected_edges.result_set, actual_edges.result_set)
+
+    def test_16_deletions_across_labels(self):
+        # verify that deleted entities across multiple labels and their
+        # connecting edges survive encode / decode
+        self.graph.query("UNWIND range(1, 500) AS id CREATE (:A {id:id})")
+        self.graph.query("UNWIND range(1, 500) AS id CREATE (:B {id:id})")
+        self.graph.query(
+            "MATCH (a:A), (b:B) WHERE a.id = b.id CREATE (a)-[:E]->(b)"
+        )
+
+        # delete a portion from each label
+        self.graph.query("MATCH (n:A) WHERE n.id <= 200 DELETE n")
+        self.graph.query("MATCH (n:B) WHERE n.id <= 300 DELETE n")
+
+        expected_a = self.graph.query("MATCH (n:A) RETURN count(n)")
+        expected_b = self.graph.query("MATCH (n:B) RETURN count(n)")
+        expected_e = self.graph.query("MATCH ()-[e:E]->() RETURN count(e)")
+
+        # Save RDB & Load from RDB
+        self.redis_con.execute_command("DEBUG", "RELOAD")
+
+        actual_a = self.graph.query("MATCH (n:A) RETURN count(n)")
+        actual_b = self.graph.query("MATCH (n:B) RETURN count(n)")
+        actual_e = self.graph.query("MATCH ()-[e:E]->() RETURN count(e)")
+        self.env.assertEquals(expected_a.result_set, actual_a.result_set)
+        self.env.assertEquals(expected_b.result_set, actual_b.result_set)
+        self.env.assertEquals(expected_e.result_set, actual_e.result_set)
+
+    def test_17_large_string_properties(self):
+        # verify that nodes with large string properties survive
+        # encode / decode
+        sizes = [100, 1000, 5000, 10000]
+        for i, sz in enumerate(sizes):
+            val = 'a' * sz
+            self.graph.query(
+                "CREATE (:Str {id: $id, val: $val})",
+                params={'id': i, 'val': val}
+            )
+
+        expected = self.graph.query(
+            "MATCH (n:Str) RETURN n.id, size(n.val) ORDER BY n.id"
+        )
+
+        # Save RDB & Load from RDB
+        self.redis_con.execute_command("DEBUG", "RELOAD")
+
+        actual = self.graph.query(
+            "MATCH (n:Str) RETURN n.id, size(n.val) ORDER BY n.id"
+        )
+        self.env.assertEquals(expected.result_set, actual.result_set)

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -668,7 +668,7 @@ elif [[ $VG == 1 ]]; then
 	# no timeout for Valgrind tests
 	setup_valgrind
 else
-	RLTEST_ARGS+=" --test-timeout 180"
+	RLTEST_ARGS+=" --test-timeout 300"
 fi
 
 if [[ $RLEC != 1 ]]; then

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ rmtest
 psutil
 python-dateutil
 RLTest==0.7.20
+websocket-client

--- a/tests/unit/test_attribute_set.c
+++ b/tests/unit/test_attribute_set.c
@@ -363,12 +363,98 @@ void test_attributeset_shallowClone() {
 	AttributeSet_Free (&clone) ;
 }
 
+// regression test: batch-remove two heap-owning attributes including the last
+// slot must not produce a dangling pointer (use-after-free)
+void test_attributeset_batch_remove_uaf() {
+	AttributeSet set = NULL ;
+
+	// create 4 string (heap-owning) attributes
+	uint16_t n = 4 ;
+	SIValue values[4] = {
+		SI_DuplicateStringVal ("alpha"),
+		SI_DuplicateStringVal ("bravo"),
+		SI_DuplicateStringVal ("charlie"),
+		SI_DuplicateStringVal ("delta"),
+	} ;
+	AttributeID attr_ids[4] = {10, 11, 12, 13} ;
+
+	AttributeSet_Add (&set, attr_ids, values, n, false) ;
+	TEST_ASSERT (AttributeSet_Count (set) == n) ;
+
+	//--------------------------------------------------------------------------
+	// batch-remove attrs at index 1 and last (index 3) via AttributeSet_Update
+	// this triggered a use-after-free: the swap-with-last copied the value at
+	// position 3 into position 1, then a later iteration freed the original
+	// at position 3, leaving position 1 with a dangling pointer
+	//--------------------------------------------------------------------------
+
+	SIValue nulls[2] = { SI_NullVal (), SI_NullVal () } ;
+	AttributeID remove_ids[2] = { 11, 13 } ;  // attrs "bravo" and "delta"
+	AttributeSetChangeType changes[2] ;
+
+	AttributeSet_Update (changes, &set, remove_ids, nulls, 2, false) ;
+
+	TEST_ASSERT (changes[0] == CT_DEL) ;
+	TEST_ASSERT (changes[1] == CT_DEL) ;
+	TEST_ASSERT (AttributeSet_Count (set) == 2) ;
+
+	// surviving attributes must be valid and accessible
+	SIValue v ;
+	TEST_ASSERT (AttributeSet_Get (set, 10, &v) == true) ;
+	TEST_ASSERT (strcmp (v.stringval, "alpha") == 0) ;
+	TEST_ASSERT (AttributeSet_Get (set, 12, &v) == true) ;
+	TEST_ASSERT (strcmp (v.stringval, "charlie") == 0) ;
+
+	// removed attributes must be gone
+	TEST_ASSERT (AttributeSet_Get (set, 11, &v) == false) ;
+	TEST_ASSERT (AttributeSet_Get (set, 13, &v) == false) ;
+
+	// free must not double-free or crash
+	AttributeSet_Free (&set) ;
+	TEST_ASSERT (set == NULL) ;
+
+	//--------------------------------------------------------------------------
+	// batch-remove 3 heap-owning attrs from 5 including the last two
+	//--------------------------------------------------------------------------
+
+	set = NULL ;
+	uint16_t m = 5 ;
+	SIValue values2[5] = {
+		SI_DuplicateStringVal ("e0"),
+		SI_DuplicateStringVal ("e1"),
+		SI_DuplicateStringVal ("e2"),
+		SI_DuplicateStringVal ("e3"),
+		SI_DuplicateStringVal ("e4"),
+	} ;
+	AttributeID ids2[5] = {0, 1, 2, 3, 4} ;
+
+	AttributeSet_Add (&set, ids2, values2, m, false) ;
+	TEST_ASSERT (AttributeSet_Count (set) == m) ;
+
+	// remove attrs at positions 1, 3, 4 (includes last two)
+	SIValue nulls3[3] = { SI_NullVal (), SI_NullVal (), SI_NullVal () } ;
+	AttributeID rm3[3] = { 1, 3, 4 } ;
+	AttributeSetChangeType ch3[3] ;
+
+	AttributeSet_Update (ch3, &set, rm3, nulls3, 3, false) ;
+	TEST_ASSERT (AttributeSet_Count (set) == 2) ;
+
+	TEST_ASSERT (AttributeSet_Get (set, 0, &v) == true) ;
+	TEST_ASSERT (strcmp (v.stringval, "e0") == 0) ;
+	TEST_ASSERT (AttributeSet_Get (set, 2, &v) == true) ;
+	TEST_ASSERT (strcmp (v.stringval, "e2") == 0) ;
+
+	AttributeSet_Free (&set) ;
+	TEST_ASSERT (set == NULL) ;
+}
+
 TEST_LIST = {
 	{ "null_attributeset", test_null_attributeset},
 	{ "attributeset_add", test_attributeset_add},
 	{ "attributeset_update", test_attributeset_update},
 	{ "attributeset_remove", test_attributeset_remove},
 	{ "attributeset_shallowClone", test_attributeset_shallowClone},
+	{ "attributeset_batch_remove_uaf", test_attributeset_batch_remove_uaf},
 	{ NULL, NULL }
 };
 

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -448,6 +448,103 @@ void test_path() {
 	Path_Free(clone);
 }
 
+// Regression test for uint64_t comparator overflow in SIValue_Compare.
+// Before the fix, subtracting two uint64_t entity IDs and returning as int
+// would silently truncate, producing 0 (equality) for IDs differing by
+// a multiple of 2^32. See issue #1813.
+void test_compare_node_large_ids() {
+	AttributeSet attr;
+	Node na, nb;
+	na.attributes = &attr;
+	nb.attributes = &attr;
+
+	// Case 1: IDs differ by exactly 2^32
+	// Old bug: (0 - 0x100000000) = 0xFFFFFFFF00000000, truncated to int = 0
+	na.id = 0;
+	nb.id = UINT64_C(0x100000000);
+	SIValue a = SI_Node(&na);
+	SIValue b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+
+	// Case 2: symmetry — reversed operands
+	na.id = UINT64_C(0x100000000);
+	nb.id = 0;
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) > 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) < 0);
+
+	// Case 3: equality at large ID
+	na.id = UINT64_C(0x100000000);
+	nb.id = UINT64_C(0x100000000);
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) == 0);
+
+	// Case 4: IDs differ by 2*2^32
+	// Old bug: (0 - 0x200000000) = 0xFFFFFFFE00000000, truncated to int = 0
+	na.id = 0;
+	nb.id = UINT64_C(0x200000000);
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+
+	// Case 5: near-UINT64_MAX vs 0
+	na.id = 0;
+	nb.id = UINT64_MAX;
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+
+	// Case 6: normal small IDs still work (control)
+	na.id = 5;
+	nb.id = 10;
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+
+	na.id = 10;
+	nb.id = 10;
+	a = SI_Node(&na);
+	b = SI_Node(&nb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) == 0);
+}
+
+// Same regression test for T_EDGE path through SIValue_Compare
+void test_compare_edge_large_ids() {
+	AttributeSet attr;
+	Edge ea, eb;
+	ea.attributes = &attr;
+	eb.attributes = &attr;
+
+	// IDs differ by exactly 2^32 — the canonical overflow trigger
+	ea.id = 0;
+	eb.id = UINT64_C(0x100000000);
+	SIValue a = SI_Edge(&ea);
+	SIValue b = SI_Edge(&eb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+
+	// equality at large ID
+	ea.id = UINT64_C(0x100000000);
+	eb.id = UINT64_C(0x100000000);
+	a = SI_Edge(&ea);
+	b = SI_Edge(&eb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) == 0);
+
+	// near-UINT64_MAX
+	ea.id = 1;
+	eb.id = UINT64_MAX;
+	a = SI_Edge(&ea);
+	b = SI_Edge(&eb);
+	TEST_ASSERT(SIValue_Compare(a, b, NULL) < 0);
+	TEST_ASSERT(SIValue_Compare(b, a, NULL) > 0);
+}
+
 TEST_LIST = {
 	{"numerics", test_numerics},
 	{"strings", test_strings},
@@ -463,5 +560,7 @@ TEST_LIST = {
 	{"edgeAndNode", test_edgeAndNode},
 	{"set", test_set},
 	{"path", test_path},
+	{"compare_node_large_ids", test_compare_node_large_ids},
+	{"compare_edge_large_ids", test_compare_edge_large_ids},
 	{NULL, NULL}
 };


### PR DESCRIPTION
## Summary

Restricts `RedisModule_Yield(REDISMODULE_YIELD_FLAG_CLIENTS)` in `_QueryCtx_ThreadSafeContextLock` to only fire during AOF/RDB loading (`REDISMODULE_CTX_FLAGS_LOADING`). Previously it was called unconditionally whenever a write query ran on the main thread, which also covers replication, MULTI/EXEC, and Lua contexts.

## Problem

Since v4.16.0 (commit 90a1312c9, PR #1166), `RedisModule_Yield` was enabled in `_QueryCtx_ThreadSafeContextLock`. This call puts Redis into a "busy" state, causing concurrent clients to receive `BUSY` errors (`JedisBusyException` in Java clients). Customers reported this regression when upgrading from v4.14.x to v4.18.1.

### Root Cause

`_QueryCtx_ThreadSafeContextLock` is called every time a write query acquires the GIL on the main thread. The main thread path (`bc == NULL`) runs during:
- **AOF/RDB loading** at startup (`REDISMODULE_CTX_FLAGS_LOADING`)
- **Replication** on replicas (`REDISMODULE_CTX_FLAGS_REPLICATED`)
- **MULTI/EXEC** transactions (`REDISMODULE_CTX_FLAGS_MULTI`)
- **Lua scripts** (`REDISMODULE_CTX_FLAGS_LUA`)

`RedisModule_Yield(REDISMODULE_YIELD_FLAG_CLIENTS)` tells Redis to process client commands during yield but return `BUSY` to non-allowed commands — the same mechanism used by Lua scripts.

## Changes

- Guard the `RedisModule_Yield` call with `REDISMODULE_CTX_FLAGS_LOADING` check
- Yield only fires during AOF/RDB loading (where PING responsiveness for health checks is needed)
- No yield during replication, MULTI/EXEC, or Lua — eliminates BUSY errors

## Testing

- Verified via reproduction scripts that replicated write commands no longer trigger BUSY
- AOF loading path still yields to allow Sentinel/monitor PING responses

## Memory / Performance Impact

N/A — no changes to data structures or query execution.

## Related Issues

- PR #1166 — `allow ping while aof loading` (introduced the Yield call)
- PR #1819 — `disable yield` (disabled Yield in `_ForkPrepare` only, not `query_ctx`)
- PR #1806 — `graph query allowed while busy` (workaround, not merged)
- https://github.com/redis/redis/issues/14266 — Related Redis module yield bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced WebSocket support with improved header validation and frame handling.
  * Extended Bolt protocol test coverage for parameterization, record integrity, and connection validation.

* **Bug Fixes**
  * Fixed non-blocking socket read behavior.
  * Corrected entity ID comparison logic to prevent integer overflow.
  * Fixed attribute removal ordering to prevent memory safety issues.
  * Improved query construction error handling.

* **Tests**
  * Added concurrent writer testing and large-data encode/decode validation.
  * Added large ID comparison tests.

* **Chores**
  * Updated version to 4.18.1.
  * Corrected header guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->