### PR TITLE
fix(query_ctx): restrict RedisModule_Yield to AOF loading only

### DIFF
--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -367,13 +367,19 @@ static void _QueryCtx_ThreadSafeContextLock
 		// no blocked client, most likely we're running on Redis main thread
 		// ASSERT(pthread_equal(Globals_Get_MainThreadId(), pthread_self()) != 0);
 
-		// it likely we're here because of an execution of a write query
-		// e.g. loading from AOF
-		// to alow Redis to reply to PING requests we should yield execution
-		// giving Redis the opportunity to process commands
-		// see RedisModule_Yield docs
-		RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
-				REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+		// yield only during AOF/RDB loading so that Redis can respond to
+		// health-check PINGs (e.g. from Sentinel or external monitors)
+		// while replaying potentially long-running write commands.
+		//
+		// we must NOT yield during replication or MULTI/EXEC because
+		// RedisModule_Yield with REDISMODULE_YIELD_FLAG_CLIENTS puts
+		// Redis into a "busy" state, causing other clients to receive
+		// BUSY errors (JedisBusyException)
+		int flags = RedisModule_GetContextFlags (ctx->global_exec_ctx.redis_ctx) ;
+		if (flags & REDISMODULE_CTX_FLAGS_LOADING) {
+			RedisModule_Yield (ctx->global_exec_ctx.redis_ctx,
+					REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Restricts `RedisModule_Yield(REDISMODULE_YIELD_FLAG_CLIENTS)` in `_QueryCtx_ThreadSafeContextLock` to only fire during AOF/RDB loading (`REDISMODULE_CTX_FLAGS_LOADING`). Previously it was called unconditionally whenever a write query ran on the main thread, which also covers replication, MULTI/EXEC, and Lua contexts.

## Problem

Since v4.16.0 (commit 90a1312c9, PR #1166), `RedisModule_Yield` was enabled in `_QueryCtx_ThreadSafeContextLock`. This call puts Redis into a "busy" state, causing concurrent clients to receive `BUSY` errors (`JedisBusyException` in Java clients). Customers reported this regression when upgrading from v4.14.x to v4.18.1.

### Root Cause

`_QueryCtx_ThreadSafeContextLock` is called every time a write query acquires the GIL on the main thread. The main thread path (`bc == NULL`) runs during:
- **AOF/RDB loading** at startup (`REDISMODULE_CTX_FLAGS_LOADING`)
- **Replication** on replicas (`REDISMODULE_CTX_FLAGS_REPLICATED`)
- **MULTI/EXEC** transactions (`REDISMODULE_CTX_FLAGS_MULTI`)
- **Lua scripts** (`REDISMODULE_CTX_FLAGS_LUA`)

`RedisModule_Yield(REDISMODULE_YIELD_FLAG_CLIENTS)` tells Redis to process client commands during yield but return `BUSY` to non-allowed commands — the same mechanism used by Lua scripts.

## Changes

- Guard the `RedisModule_Yield` call with `REDISMODULE_CTX_FLAGS_LOADING` check
- Yield only fires during AOF/RDB loading (where PING responsiveness for health checks is needed)
- No yield during replication, MULTI/EXEC, or Lua — eliminates BUSY errors

## Testing

- Verified via reproduction scripts that replicated write commands no longer trigger BUSY
- AOF loading path still yields to allow Sentinel/monitor PING responses

## Memory / Performance Impact

N/A — no changes to data structures or query execution.

## Related Issues

- PR #1166 — `allow ping while aof loading` (introduced the Yield call)
- PR #1819 — `disable yield` (disabled Yield in `_ForkPrepare` only, not `query_ctx`)
- PR #1876 — previous version targeting 4.18 (closed)
- https://github.com/redis/redis/issues/14266 — Related Redis module yield bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent operations on the Redis main thread to enhance stability and responsiveness during specific operational states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->