### PR TITLE
test(reproducer): cache-eviction UAF reproducer for issue #1823 [DRAFT, no fix]

### DIFF
--- a/tests/reproducers/README.md
+++ b/tests/reproducers/README.md
@@ -1,0 +1,79 @@
+# Crash reproducers
+
+Standalone scripts for reproducing customer-reported crashes outside the regular
+test suite. These are intentionally NOT wired into CI because they intentionally
+crash the server.
+
+## issue_1823_uaf_reproducer.py
+
+Reproduces the `QGEdge_RelationID` use-after-free reported in
+[issue #1823](https://github.com/FalkorDB/FalkorDB/issues/1823).
+
+Crash signature (from customer log):
+
+```
+SIGSEGV (signal 11), si_code 1, accessing address (nil)
+falkordb.so(QGEdge_RelationID+0xb)
+falkordb.so(EdgeTraverseCtx_CollectEdges+0xdf)
+```
+
+### Mechanism
+
+When the execution-plan cache evicts a cached entry, a clone of that plan may
+still be running on a thread-pool worker. `QGEdge` and `QGNode` instances held
+by the clone borrow alias / label / reltype string pointers that originated in
+the source plan's AST and sub-query-graph. Eviction tears those down, and the
+in-flight clone dereferences the freed memory the next time it touches
+`e->reltypeIDs`.
+
+### Reproducing
+
+Build FalkorDB with ASan:
+
+```
+./build.sh SAN=address
+```
+
+Start a server with a tiny cache and several worker threads (small cache size
+maximizes eviction pressure):
+
+```
+LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libasan.so.8 /lib/x86_64-linux-gnu/libzstd.so.1" \
+  redis-server --loadmodule bin/linux-x64-debug-asan/falkordb.so \
+    CACHE_SIZE 1 THREAD_COUNT 8 --port 6399
+```
+
+Drive load:
+
+```
+python3 tests/reproducers/issue_1823_uaf_reproducer.py 127.0.0.1 6399
+```
+
+Expected outcome on master (commit 0f1552e24, 2026-04): SIGSEGV in
+`QGEdge_RelationID` from a `thread-pool-thr` within ~30 seconds.
+
+### Status
+
+A first-pass fix was attempted in the closed
+[PR #1824](https://github.com/FalkorDB/FalkorDB/pull/1824) (deep-copying alias
+and reltype strings into `QGNode`/`QGEdge` themselves). Cherry-picking that PR
+locally:
+
+* removes the original SIGSEGV, but
+* introduces silent wrong-result regressions in `tests/flow/test_cache.py`
+  (test_05/06/07/08/09/10 fail) because many downstream consumers (NodeScanCtx,
+  AllNodeScan, AE operands, NodeCreateCtx, EdgeCreateCtx, merge ops, ...) keep
+  borrowed pointers into the per-MATCH `sub_qg` that `buildMatchOpTree` frees
+  eagerly. PR #1824's deep copy moves ownership into that short-lived sub_qg,
+  so all those borrowed pointers now dangle right after each MATCH is built.
+
+A complete fix needs to either
+
+1. extend ownership end-to-end across all op constructors and clone/free paths,
+   or
+2. attach `sub_qg` to the parent `ExecutionPlan` so it lives as long as the
+   plan, AND keep PR #1824's ownership change so cloned cached plans survive
+   eviction of the source plan.
+
+Either route requires a careful design pass plus a broad flow-test sweep
+(cache, index_scans, optimizations_plan, traversal_construction, merge, ...).

--- a/tests/reproducers/issue_1823_uaf_reproducer.py
+++ b/tests/reproducers/issue_1823_uaf_reproducer.py
@@ -1,0 +1,40 @@
+import threading, random, sys
+from falkordb import FalkorDB
+HOST=sys.argv[1] if len(sys.argv)>1 else '127.0.0.1'
+PORT=int(sys.argv[2]) if len(sys.argv)>2 else 6399
+
+db = FalkorDB(host=HOST, port=PORT)
+g = db.select_graph('uaf')
+try: g.delete()
+except: pass
+g.query("UNWIND range(1,500) AS i CREATE (a:City {id:i, name:'C'+toString(i)})-[:JOINED {ts:i}]->(b:Member {id:i, name:'M'+toString(i)})")
+
+# Generate many distinct edge types and labels
+def worker(tid):
+    g2 = db.select_graph('uaf')
+    for k in range(5000):
+        # Mix of writer queries with OPTIONAL MATCH and CALL{} subqueries (matches customer crash pattern)
+        l1=f'L{(tid*7+k)%30}'; l2=f'L{(tid*5+k)%30}'; r=f'R{(tid*3+k)%30}'
+        try:
+            choice = k % 6
+            if choice==0:
+                g2.query(f"MATCH (this:City) WHERE this.id={k%500} CALL {{ WITH this OPTIONAL MATCH (this)<-[u0:JOINED]-(u1:Member) DELETE u0 RETURN count(u0) AS d }} RETURN d")
+            elif choice==1:
+                g2.query(f"MATCH (this:City) WHERE this.id={k%500} OPTIONAL MATCH (this)<-[u0:JOINED]-(u1:Member) RETURN this.id, count(u0)")
+            elif choice==2:
+                g2.query(f"MATCH (a:City)-[e:JOINED]->(b:Member) WHERE a.id={k%500} RETURN e.ts LIMIT 1")
+            elif choice==3:
+                # unique query to churn cache
+                g2.query(f"MATCH (a:{l1})-[e:{r}]->(b:{l2}) RETURN count(*)")
+            elif choice==4:
+                g2.query(f"MATCH (a:City) WHERE a.id<{k%500} OPTIONAL MATCH (a)-[e:JOINED]->(m:Member {{id:a.id}}) RETURN count(m) LIMIT 5")
+            else:
+                g2.query(f"MATCH (a:City {{id:{k%500}}})-[e:JOINED]->(b:Member) CREATE (a)-[:NEW{tid%5} {{k:{k}}}]->(b)")
+        except Exception as ex:
+            pass
+
+T=24
+threads=[threading.Thread(target=worker,args=(i,)) for i in range(T)]
+for t in threads: t.start()
+for t in threads: t.join()
+print("done")


### PR DESCRIPTION
## Summary

Investigation of customer crash https://github.com/FalkorDB/FalkorDB/issues/1823 (`QGEdge_RelationID+0xb` SIGSEGV from `EdgeTraverseCtx_CollectEdges` on a thread-pool worker), with a reliable reproducer that triggers the UAF on master under ASan.

## Reproducer

`tests/reproducers/issue_1823_uaf_reproducer.py` — 24 threads × 5000 unique queries (mix of `OPTIONAL MATCH` + `CALL{}` + `DELETE`) against `CACHE_SIZE=1`. Reproduces the original SIGSEGV at `QGEdge_RelationID` in <30s on master with ASan.

## Root cause

Cached `ExecutionPlan` clones via `ExecutionCtx_Clone` borrow many string pointers that originate in either:
1. The libcypher AST (kept alive via `AST_ShallowCopy` ref-count — generally OK)
2. The per-MATCH `sub_qg` / `connectedComponents` `QueryGraph` clones inside `buildMatchOpTree` (freed at the end of build)
3. The `QueryGraph_Clone(qg)` inside `algebraic_expression_construction.c` (freed at the end of construction)

`QGNode`/`QGEdge` historically store the *AST* string pointer directly into their `alias`/`labels`/`reltypes` arrays, then `QGEdge`/`QGNode` clones do shallow `memcpy`. Cache evictions of the source plan, combined with active executing clones, expose dangling reads in `QGEdge_RelationID`, `QGEdge_ResolveUnknownRelIDS`, and similar.

## Status of fix exploration

WIP fix branch: https://github.com/FalkorDB/FalkorDB/tree/fix/qgedge-qgnode-ast-uaf

That branch combines:
* PR #1824 cherry-pick (QGNode/QGEdge own their alias/label/reltype strings)
* `ExecutionPlan` retains per-MATCH `sub_qg` and `connectedComponents` for deferred free
* `AlgebraicExpression` operand owns src/dest/edge/label via `owned_strings` flag
* `NodeScanCtx` anchors its alias/label borrows on the cloned `QGNode`

**Result**: original `QGEdge_RelationID` SIGSEGV no longer reproduced in smoke runs, but the reproducer still triggers a related UAF at `QGEdge_ResolveUnknownRelIDS` under sustained concurrency, and `test_cache.py` test_05/06/07/10/13/14 regress with silent wrong-results in cached MERGE / path-filter / multi-pattern flows. This indicates additional shallow-cloned ops (op_merge, op_create, EntityUpdateEvalCtx, scan ctxs, etc.) still hold borrowed pointers.

A more robust direction may be a refcounted `ExecutionPlan` so the source plan stays alive until all clones release, eliminating the per-op string-ownership work. Capturing the analysis here so a maintainer can pick the preferred direction.

## Changes (this PR)

* Added `tests/reproducers/issue_1823_uaf_reproducer.py` and README documenting the reproducer.

## Testing

Reproducer reliably triggers original UAF under ASan on master `0f1552e24` in <30s.

## Related Issues

References #1823, #1824 (closed/superseded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reproducer guide including build instructions, server configuration steps, and crash diagnostics for investigating specific server issues.

* **Tests**
  * Added standalone reproducer script that executes concurrent Cypher queries across multiple threads to help validate fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->