### PR TITLE
fix(graph): prevent UAF when cached execution plan is evicted while a clone is running (#1823)

### DIFF
--- a/src/execution_plan/ops/shared/traverse_functions.c
+++ b/src/execution_plan/ops/shared/traverse_functions.c
@@ -74,7 +74,12 @@ EdgeTraverseCtx *EdgeTraverseCtx_New
 
 	EdgeTraverseCtx *edge_ctx = rm_malloc (sizeof (EdgeTraverseCtx)) ;
 
-	edge_ctx->e = e ;
+	// own a deep clone of the QGEdge to decouple our lifetime from the
+	// plan's QueryGraph (issue #1823)
+	// the source plan's QGEdge can be freed by LRU cache eviction while a
+	// cloned ExecutionPlan that borrows the same pointer is still executing
+	// on a worker thread
+	edge_ctx->e = QGEdge_Clone (e) ;
 	edge_ctx->edges = arr_new (Edge, 32) ;   // instantiate array to collect matching edges
 
 	edge_ctx->edgeRecIdx = idx ;
@@ -179,6 +184,7 @@ void EdgeTraverseCtx_Free
 	}
 
 	arr_free (edge_ctx->edges) ;
+	QGEdge_Free (edge_ctx->e) ;
 	rm_free (edge_ctx) ;
 }
 


### PR DESCRIPTION
## Summary
Fix SIGSEGV in `QGEdge_RelationID` / `QGEdge_ResolveUnknownRelIDS` reported in #1823, triggered under heavy concurrent load when the LRU plan cache evicts a source ExecutionPlan whose QGEdge is still borrowed by a cloned plan running on a worker thread.

## Root cause
`EdgeTraverseCtx` was borrowing a raw pointer to `plan->query_graph->edges[i]` (set in `op_conditional_traverse.c` and `op_expand_into.c`). Under heavy concurrent load with a small `CACHE_SIZE`, that QGEdge pointer could become dangling, and `EdgeTraverseCtx_Reset` (which calls `QGEdge_ResolveUnknownRelIDS(edge_ctx->e)`) would crash on the freed memory.

## Changes
- `src/execution_plan/ops/shared/traverse_functions.c`:
  - `EdgeTraverseCtx_New`: store `QGEdge_Clone(e)` instead of borrowing `e`.
  - `EdgeTraverseCtx_Free`: `QGEdge_Free(edge_ctx->e)` before freeing the ctx.

`QGEdge_Clone` deep-copies `reltypes[]` / `reltypeIDs[]` (independent arrays). The reltype string pointers still alias AST memory but the AST is held alive for the entire ExecutionPlan via `ExecutionCtx_Clone`'s `AST_ShallowCopy` refcount, so this is safe and `QGEdge_Free` does not touch the strings.

## Testing
- Reproduced the original SIGSEGV on `master` using a 24-thread stress workload (OPTIONAL MATCH + CALL{} subqueries) against `CACHE_SIZE 4`. Crash stack matches the customer trace (`EdgeTraverseCtx_CollectEdges → QGEdge_RelationID`).
- Verified the same workload no longer crashes with the fix, both in release and ASan builds.
- Existing flow tests pass: `test_create_clause`, `test_optional_match`, `test_variable_length_traversals`, `test_optimizations_plan`, `test_bidirectional_traversals`, `test_multiple_edges`, `test_traversal_construction`, `test_edge_index_scans`.

## Memory / Performance Impact
One extra small allocation (clone of QGEdge plus its reltype arrays) per traverse op instance. Negligible in practice; bounded by the number of edge traverse operators in the plan.

## Related Issues
Closes #1823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated edge object handling in traversal contexts to maintain independent copies rather than external references, enabling traversal contexts to operate independently of the original structure's lifetime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->