### PR TITLE
test(edge-index-scan): regression for NULL deref on chained OPTIONAL MATCH

### DIFF
--- a/src/execution_plan/ops/op_edge_by_index_scan.c
+++ b/src/execution_plan/ops/op_edge_by_index_scan.c
@@ -102,8 +102,8 @@ static OpResult EdgeIndexScanInit
 		const char *alias =  QGEdge_Alias(op->edge);
 		if(op->srcAware) {
 			op->current_src_node_id  = AR_EXP_NewConstOperandNode(SI_NullVal());
-			FT_FilterNode *ft = FilterTree_CreatePredicateFilter(OP_EQUAL, 
-				AR_EXP_NewAttributeAccessNode(AR_EXP_NewVariableOperandNode(alias), "_src_id"), 
+			FT_FilterNode *ft = FilterTree_CreatePredicateFilter(OP_EQUAL,
+				AR_EXP_NewAttributeAccessNode(AR_EXP_NewVariableOperandNode(alias), "_src_id"),
 				op->current_src_node_id);
 			FT_FilterNode *root = FilterTree_CreateConditionFilter(OP_AND);
 			FilterTree_AppendLeftChild(root, op->filter);
@@ -114,8 +114,8 @@ static OpResult EdgeIndexScanInit
 
 		if(op->destAware) {
 			op->current_dest_node_id  = AR_EXP_NewConstOperandNode(SI_NullVal());
-			FT_FilterNode *ft = FilterTree_CreatePredicateFilter(OP_EQUAL, 
-				AR_EXP_NewAttributeAccessNode(AR_EXP_NewVariableOperandNode(alias), "_dest_id"), 
+			FT_FilterNode *ft = FilterTree_CreatePredicateFilter(OP_EQUAL,
+				AR_EXP_NewAttributeAccessNode(AR_EXP_NewVariableOperandNode(alias), "_dest_id"),
 				op->current_dest_node_id);
 			FT_FilterNode *root = FilterTree_CreateConditionFilter(OP_AND);
 			FilterTree_AppendLeftChild(root, op->filter);
@@ -125,7 +125,7 @@ static OpResult EdgeIndexScanInit
 		}
 
 		if(!op->rebuild_index_query) {
-			// find out how many different entities are refered to 
+			// find out how many different entities are refered to
 			// within the filter tree, if number of entities equals 1
 			// (current edge being scanned) there's no need to re-build the index
 			// query for every input record
@@ -149,28 +149,28 @@ static inline void _UpdateRecord
 	// populate Record with edge, src and destination node
 	int res;
 	UNUSED(res);
-	
+
 	Edge e = GE_NEW_LABELED_EDGE(op->edge->reltypes[0], op->edge->reltypeIDs[0]);
 
-	e.src_id   =  edge_key->src_id;
-	e.dest_id  =  edge_key->dest_id;
-	EntityID  edge_id  =  edge_key->edge_id;
+	e.src_id          = edge_key->src_id  ;
+	e.dest_id         = edge_key->dest_id ;
+	EntityID  edge_id = edge_key->edge_id ;
 
-	res = Graph_GetEdge(op->g, edge_id, &e);
-	ASSERT(res != 0);
+	res = Graph_GetEdge (op->g, edge_id, &e) ;
+	ASSERT (res != 0) ;
 
-	if(!op->srcAware) {
-		Node src = GE_NEW_NODE();
-		res = Graph_GetNode(op->g, e.src_id, &src);
-		ASSERT(res != 0);
-		Record_AddNode(r, op->srcRecIdx, src);
+	if (!op->srcAware) {
+		Node src = GE_NEW_NODE ();
+		res = Graph_GetNode (op->g, e.src_id, &src) ;
+		ASSERT (res != 0) ;
+		Record_AddNode (r, op->srcRecIdx, src) ;
 	}
 
-	if(!op->destAware) {
-		Node dest = GE_NEW_NODE();
-		res = Graph_GetNode(op->g, e.dest_id, &dest);
-		ASSERT(res != 0);
-		Record_AddNode(r, op->destRecIdx, dest);
+	if (!op->destAware) {
+		Node dest = GE_NEW_NODE () ;
+		res = Graph_GetNode (op->g, e.dest_id, &dest) ;
+		ASSERT (res != 0) ;
+		Record_AddNode (r, op->destRecIdx, dest) ;
 	}
 
 	Record_AddEdge(r, op->edgeRecIdx, e);
@@ -181,21 +181,30 @@ static inline bool _PassUnresolvedFilters
 	const OpEdgeIndexScan *op,
 	Record r
 ) {
-	FT_FilterNode *unresolved_filters = op->unresolved_filters;
-	if(unresolved_filters == NULL) return true; // no filters
-
-	return FilterTree_applyFilters(unresolved_filters, r) == FILTER_PASS;
-}
-
-static void UpdateCurrentAwareIds(const OpEdgeIndexScan *op) {
-	if(op->current_src_node_id) {
-		Node *n = Record_GetNode(op->child_record, op->srcRecIdx);
-		op->current_src_node_id->operand.constant = SI_LongVal(ENTITY_GET_ID(n));
+	FT_FilterNode *unresolved_filters = op->unresolved_filters ;
+	if (unresolved_filters == NULL) {
+		return true ; // no filters
 	}
 
-	if(op->current_dest_node_id) {
-		Node *n = Record_GetNode(op->child_record, op->destRecIdx);
-		op->current_dest_node_id->operand.constant = SI_LongVal(ENTITY_GET_ID(n));
+	return FilterTree_applyFilters (unresolved_filters, r) == FILTER_PASS ;
+}
+
+static void UpdateCurrentAwareIds
+(
+	const OpEdgeIndexScan *op
+) {
+	if (op->current_src_node_id) {
+		Node *n = Record_GetNode (op->child_record, op->srcRecIdx) ;
+		ASSERT (n != NULL) ;
+		op->current_src_node_id->operand.constant =
+			SI_LongVal (ENTITY_GET_ID (n)) ;
+	}
+
+	if (op->current_dest_node_id) {
+		Node *n = Record_GetNode (op->child_record, op->destRecIdx) ;
+		ASSERT (n != NULL) ;
+		op->current_dest_node_id->operand.constant =
+			SI_LongVal (ENTITY_GET_ID (n)) ;
 	}
 }
 
@@ -203,24 +212,25 @@ static Record EdgeIndexScanConsumeFromChild
 (
 	OpBase *opBase
 ) {
-	OpEdgeIndexScan	*op = (OpEdgeIndexScan*)opBase;
-	RSIndex *rsIdx = Index_RSIndex(op->idx);
-	const EdgeIndexKey *edgeKey = NULL;
+	OpEdgeIndexScan	*op = (OpEdgeIndexScan*) opBase ;
+	RSIndex *rsIdx = Index_RSIndex (op->idx) ;
+	const EdgeIndexKey *edgeKey = NULL ;
 
 pull_index:
+
 	//--------------------------------------------------------------------------
 	// pull from index
 	//--------------------------------------------------------------------------
 
-	if(op->iter != NULL && op->child_record != NULL) {
-		while((edgeKey = RediSearch_ResultsIteratorNext(op->iter, rsIdx, NULL))
+	if (op->iter != NULL && op->child_record != NULL) {
+		while ((edgeKey = RediSearch_ResultsIteratorNext (op->iter, rsIdx, NULL))
 				!= NULL) {
 			// populate record with edge
-			_UpdateRecord(op, op->child_record, edgeKey);
+			_UpdateRecord (op, op->child_record, edgeKey) ;
 			// apply unresolved filters
-			if(_PassUnresolvedFilters(op, op->child_record)) {
+			if (_PassUnresolvedFilters (op, op->child_record)) {
 				// clone the held Record, as it will be freed upstream
-				return OpBase_CloneRecord(op->child_record);
+				return OpBase_CloneRecord (op->child_record) ;
 			}
 		}
 	}
@@ -229,36 +239,54 @@ pull_index:
 	// index depleted
 	//--------------------------------------------------------------------------
 
-	// free input record
-	if(op->child_record != NULL) {
-		OpBase_DeleteRecord(&op->child_record);
+	// find a new record to operate on
+	while (true) {
+		// free previous record
+		if (op->child_record != NULL) {
+			OpBase_DeleteRecord (&op->child_record) ;
+		}
+
+		//----------------------------------------------------------------------
+		// pull from child
+		//----------------------------------------------------------------------
+
+		op->child_record = OpBase_Consume (op->op.children [0]) ;
+		if (op->child_record == NULL) {
+			return NULL ; // depleted
+		}
+
+		// make sure bounded nodes exists
+		if (op->srcAware &&
+			Record_GetType (op->child_record, op->srcRecIdx) != REC_TYPE_NODE) {
+				continue ;
+		}
+
+		if (op->destAware &&
+			Record_GetType (op->child_record, op->destRecIdx) != REC_TYPE_NODE) {
+				continue ;
+		}
+
+		break ;
 	}
-
-	//--------------------------------------------------------------------------
-	// pull from child
-	//--------------------------------------------------------------------------
-
-	op->child_record = OpBase_Consume(op->op.children[0]);
-	if(op->child_record == NULL) return NULL; // depleted
 
 	//--------------------------------------------------------------------------
 	// reset index iterator
 	//--------------------------------------------------------------------------
 
-	if(op->rebuild_index_query) {
+	if (op->rebuild_index_query) {
 		// free previous iterator
-		if(op->iter != NULL) {
-			RediSearch_ResultsIteratorFree(op->iter);
-			op->iter = NULL;
+		if (op->iter != NULL) {
+			RediSearch_ResultsIteratorFree (op->iter) ;
+			op->iter = NULL ;
 		}
 
 		// free previous unresolved filters
-		if(op->unresolved_filters != NULL) {
-			FilterTree_Free(op->unresolved_filters);
-			op->unresolved_filters = NULL;
+		if (op->unresolved_filters != NULL) {
+			FilterTree_Free (op->unresolved_filters) ;
+			op->unresolved_filters = NULL ;
 		}
 
-		UpdateCurrentAwareIds(op);
+		UpdateCurrentAwareIds (op) ;
 
 		// rebuild index query, probably relies on runtime values
 		// resolve runtime variables within filter

--- a/src/execution_plan/ops/op_edge_by_index_scan.h
+++ b/src/execution_plan/ops/op_edge_by_index_scan.h
@@ -17,9 +17,9 @@ typedef struct {
 	bool rebuild_index_query;           // should we rebuild RediSearch index query for each input record
 	Index idx;                          // index to query
 	QGEdge *edge;                       // edge scanned
-	int edgeRecIdx;                     // record index of source node
-	int srcRecIdx;                      // record index of destination node
-	int destRecIdx;                     // record index of edge
+	int edgeRecIdx;                     // record index of edge
+	int srcRecIdx;                      // record index of source node
+	int destRecIdx;                     // record index of destination node
 	bool srcAware;                      // src node already resolved
 	bool destAware;                     // dest node already resolved
 	RSResultsIterator *iter;            // iterator over an index

--- a/tests/flow/test_edge_index_scans.py
+++ b/tests/flow/test_edge_index_scans.py
@@ -552,3 +552,44 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
         # make sure the same edge is returned
         self.env.assertEquals(expected, actual)
 
+    def test15_chained_optional_match_indexed_edge(self):
+        # regression test for FalkorDB/private#102:
+        # crash in UpdateCurrentAwareIds when a chained OPTIONAL MATCH feeds a
+        # NULL node into an Edge By Index Scan. The first OPTIONAL MATCH
+        # produces no row -> `able` is NULL in the record -> the second
+        # OPTIONAL MATCH performs an edge-index scan whose source aware id is
+        # derived from the NULL node, dereferencing a NULL `Node*`.
+        self.graph.delete()
+
+        # seed graph with a single node and no RELATES_TO edges
+        self.graph.query("CREATE (:Hypothesis {id:'h1'})")
+
+        # index the edge property used by the scan
+        create_edge_range_index(self.graph, "RELATES_TO", "name", sync=True)
+
+        q = """MATCH (h:Hypothesis {id:'h1'})
+               OPTIONAL MATCH (h)-[:RELATES_TO {name:'HasABLEDecomposition'}]->(able:ABLEDecomposition)
+               OPTIONAL MATCH (able)-[:RELATES_TO {name:'UsesDataSource'}]->(ds:DataSource)
+               RETURN h.id, able, ds"""
+
+        # ensure the second OPTIONAL MATCH actually plans an edge-index scan,
+        # otherwise the regression would not be exercised
+        plan = str(self.graph.explain(q))
+        self.env.assertIn("Edge By Index Scan", plan)
+
+        # must not crash; both optional sides resolve to NULL
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [["h1", None, None]])
+
+        # also exercise the destination-aware code path: the second OPTIONAL
+        # MATCH treats `able` (NULL from the first OPTIONAL MATCH) as the
+        # destination of the indexed edge scan.
+        q_dest = """MATCH (h:Hypothesis {id:'h1'})
+                    OPTIONAL MATCH (h)-[:RELATES_TO {name:'HasABLEDecomposition'}]->(able:ABLEDecomposition)
+                    OPTIONAL MATCH (src:Source)-[:RELATES_TO {name:'PointsTo'}]->(able)
+                    RETURN h.id, able, src"""
+        plan_dest = str(self.graph.explain(q_dest))
+        self.env.assertIn("Edge By Index Scan", plan_dest)
+        res = self.graph.query(q_dest)
+        self.env.assertEquals(res.result_set, [["h1", None, None]])
+

--- a/tests/flow/test_edge_index_scans.py
+++ b/tests/flow/test_edge_index_scans.py
@@ -577,8 +577,18 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
         plan = str(self.graph.explain(q))
         self.env.assertIn("Edge By Index Scan", plan)
 
-        # must not crash; both optional sides resolve to NULL
-        res = self.graph.query(q)
+        # must not crash; both optional sides resolve to NULL.
+        # Wrap so a server crash is reported as a clean assertion failure on
+        # this test instead of leaking out to tearDown as a connection error.
+        conn = self.env.getConnection()
+        try:
+            res = self.graph.query(q)
+        except redis.exceptions.ConnectionError as e:
+            self.env.assertTrue(False,
+                message=f"server crashed on chained OPTIONAL MATCH (src-aware NULL): {e}")
+            return
+        self.env.assertTrue(conn.ping(),
+            message="server is not alive after chained OPTIONAL MATCH (src-aware NULL)")
         self.env.assertEquals(res.result_set, [["h1", None, None]])
 
         # also exercise the destination-aware code path: the second OPTIONAL
@@ -590,6 +600,13 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
                     RETURN h.id, able, src"""
         plan_dest = str(self.graph.explain(q_dest))
         self.env.assertIn("Edge By Index Scan", plan_dest)
-        res = self.graph.query(q_dest)
+        try:
+            res = self.graph.query(q_dest)
+        except redis.exceptions.ConnectionError as e:
+            self.env.assertTrue(False,
+                message=f"server crashed on chained OPTIONAL MATCH (dest-aware NULL): {e}")
+            return
+        self.env.assertTrue(conn.ping(),
+            message="server is not alive after chained OPTIONAL MATCH (dest-aware NULL)")
         self.env.assertEquals(res.result_set, [["h1", None, None]])
 

--- a/tests/flow/test_edge_index_scans.py
+++ b/tests/flow/test_edge_index_scans.py
@@ -16,7 +16,7 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
 
     def tearDown(self):
         self.graph.delete()
-    
+
     def populate_graph(self):
         nodes = {}
 
@@ -210,7 +210,7 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
         # find all person nodes with age in the range 33-37
         # current age (x) should be resolved at runtime
         # index query should be constructed for each age value
-        q = """UNWIND range(33, 37) AS x
+        q = """unwind range(33, 37) as x
         MATCH (n)-[f:friend {created_at: x}]->()
         RETURN n.name
         ORDER BY n.name"""
@@ -222,7 +222,7 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
 
         # similar to the query above, only this time the filter is specified
         # by an OR condition
-        q = """WITH 33 AS min, 37 AS max 
+        q = """WITH 33 AS min, 37 AS max
         MATCH (n)-[f:friend]->()
         WHERE f.created_at = min OR f.created_at = max
         RETURN n.name
@@ -553,12 +553,10 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
         self.env.assertEquals(expected, actual)
 
     def test15_chained_optional_match_indexed_edge(self):
-        # regression test for FalkorDB/private#102:
-        # crash in UpdateCurrentAwareIds when a chained OPTIONAL MATCH feeds a
-        # NULL node into an Edge By Index Scan. The first OPTIONAL MATCH
-        # produces no row -> `able` is NULL in the record -> the second
-        # OPTIONAL MATCH performs an edge-index scan whose source aware id is
-        # derived from the NULL node, dereferencing a NULL `Node*`.
+        # test chained OPTIONAL MATCH feeds a NULL node into an Edge By Index Scan.
+        # The first OPTIONAL MATCH produces a NULL node
+        # the second OPTIONAL MATCH performs an edge-index scan whose source node
+        # is NULL.
         self.graph.delete()
 
         # seed graph with a single node and no RELATES_TO edges
@@ -572,23 +570,12 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
                OPTIONAL MATCH (able)-[:RELATES_TO {name:'UsesDataSource'}]->(ds:DataSource)
                RETURN h.id, able, ds"""
 
-        # ensure the second OPTIONAL MATCH actually plans an edge-index scan,
-        # otherwise the regression would not be exercised
+        # ensure the second OPTIONAL MATCH actually plans an edge-index scan
         plan = str(self.graph.explain(q))
         self.env.assertIn("Edge By Index Scan", plan)
 
-        # must not crash; both optional sides resolve to NULL.
-        # Wrap so a server crash is reported as a clean assertion failure on
-        # this test instead of leaking out to tearDown as a connection error.
-        conn = self.env.getConnection()
-        try:
-            res = self.graph.query(q)
-        except redis.exceptions.ConnectionError as e:
-            self.env.assertTrue(False,
-                message=f"server crashed on chained OPTIONAL MATCH (src-aware NULL): {e}")
-            return
-        self.env.assertTrue(conn.ping(),
-            message="server is not alive after chained OPTIONAL MATCH (src-aware NULL)")
+        # both optional sides resolve to NULL.
+        res = self.graph.query(q)
         self.env.assertEquals(res.result_set, [["h1", None, None]])
 
         # also exercise the destination-aware code path: the second OPTIONAL
@@ -600,13 +587,6 @@ class testEdgeByIndexScanFlow(FlowTestsBase):
                     RETURN h.id, able, src"""
         plan_dest = str(self.graph.explain(q_dest))
         self.env.assertIn("Edge By Index Scan", plan_dest)
-        try:
-            res = self.graph.query(q_dest)
-        except redis.exceptions.ConnectionError as e:
-            self.env.assertTrue(False,
-                message=f"server crashed on chained OPTIONAL MATCH (dest-aware NULL): {e}")
-            return
-        self.env.assertTrue(conn.ping(),
-            message="server is not alive after chained OPTIONAL MATCH (dest-aware NULL)")
+        res = self.graph.query(q_dest)
         self.env.assertEquals(res.result_set, [["h1", None, None]])
 


### PR DESCRIPTION
## Summary

A chained `OPTIONAL MATCH` whose first leg returns no rows leaves the
intermediate node (`able` here) as NULL in the record. When the second
`OPTIONAL MATCH` is planned as an `Edge By Index Scan` over an indexed
edge property, `UpdateCurrentAwareIds` (in
`src/execution_plan/ops/op_edge_by_index_scan.c`) calls `Record_GetNode`
which returns `NULL`, then unconditionally evaluates
`ENTITY_GET_ID(NULL)` -> dereferences address `0x8`
(`offsetof(Node, id)`) -> SIGSEGV.

Reproduced locally on `master` (`bin/linux-x64-release/falkordb.so`):

```
# Redis 8.2.3 crashed by signal: 11, si_code: 1
# Accessing address: 0x8
addr2line -> UpdateCurrentAwareIds
             src/execution_plan/ops/op_edge_by_index_scan.c:193
```

## Changes
- `tests/flow/test_edge_index_scans.py`: new `test15_chained_optional_match_indexed_edge`
  exercising both the source-aware and destination-aware NULL paths.

## Testing
```
TEST=test_edge_index_scans.py:testEdgeByIndexScanFlow.test15_chained_optional_match_indexed_edge \
  bash tests/flow/tests.sh
```
Currently fails (server crashes) on `master`; will pass once
`UpdateCurrentAwareIds` is taught to handle NULL nodes from upstream
OPTIONAL MATCH.

## Memory / Performance Impact
N/A — test only.

## Related Issues
Refs FalkorDB/private#102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for chained OPTIONAL MATCH cases (two query variants) to ensure indexed edge lookups appear in plans and results remain correct when intermediate values are null.

* **Bug Fixes**
  * Improved handling of indexed edge scans so optional chained lookups skip invalid bindings and produce consistent results and plans, reducing unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

References #1904