### PR TITLE
Update cost_base_label_scan.c

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -323,25 +323,22 @@ static void _costBaseLabelScan
 	OpBase *parent = op->parent;
 	while(OpBase_Type(parent) == OPType_FILTER) parent = parent->parent;
 	OPType t = OpBase_Type(parent);
-	ASSERT(t == OPType_CONDITIONAL_TRAVERSE || t == OPType_EXPAND_INTO);
 
 	AlgebraicExpression *ae = NULL;
-	if(t == OPType_CONDITIONAL_TRAVERSE) {
-		// GRAPH.EXPLAIN g "match (n:B:A:C)-[]->() RETURN n"
-		// 1) "Results"
-		// 2) "    Project"
-		// 3) "        Conditional Traverse | (n:B:C)->(@anon_0)"
-		// 4) "            Node By Label Scan | (n:A)"
-		OpCondTraverse *op_traverse = (OpCondTraverse*)parent;
-		ae = op_traverse->ae;
-	} else {
-		// GRAPH.EXPLAIN g "MATCH (n:B:A:C) RETURN n"
-		// 1) "Results"
-		// 2) "    Project"
-		// 3) "        Expand Into | (n:A:C)->(n:A:C)"
-		// 4) "            Node By Label Scan | (n:B)"
-		OpExpandInto *op_expand = (OpExpandInto*)parent;
-		ae = op_expand->ae;
+	switch(t) {
+		case OPType_CONDITIONAL_TRAVERSE:
+		case OPType_OPTIONAL_CONDITIONAL_TRAVERSE: {
+			OpCondTraverse *op_traverse = (OpCondTraverse*)parent;
+			ae = op_traverse->ae;
+			break;
+		}
+		case OPType_EXPAND_INTO: {
+			OpExpandInto *op_expand = (OpExpandInto*)parent;
+			ae = op_expand->ae;
+			break;
+		}
+		default:
+			return;
 	}
 
 	AlgebraicExpression *operand;


### PR DESCRIPTION
This PR addresses a segmentation fault (SIGSEGV) in the _costBaseLabelScan optimization logic, which was caused by an unguarded assumption of traversal types following a node scan.

The Problem:
The original logic used a restrictive ASSERT that only expected OPType_CONDITIONAL_TRAVERSE or OPType_EXPAND_INTO. When encountering optional patterns or variable-length traversals (which strip label operands during construction), the planner attempted to access a NULL algebraic expression pointer, leading to a crash.

The Solution:

Broadened Support: Replaced the ASSERT with a switch statement to explicitly handle OPType_CONDITIONAL_TRAVERSE, OPType_OPTIONAL_CONDITIONAL_TRAVERSE, and OPType_EXPAND_INTO.

Safety Bail-out: Implemented a default return path. This safely bypasses the optimization for complex patterns (like variable-length traversals) where the label operand cannot be safely repurposed in-place.

Verification Results:

Poison Query: MATCH (n:A)<-[*]-(n:Z) RETURN 1 no longer crashes the server and returns an empty set as expected.

Server Health: Confirmed server remains responsive (PONG) post-execution.

Regression Testing: make unit-tests passed with a 100% success rate.

Memory Safety: Valgrind audit confirmed zero new memory leaks or invalid reads in the modified logic.

Closes #636
/claim #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional conditional traversal operations in query processing.

* **Refactor**
  * Improved operation type handling logic for greater robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->