### PR TITLE
fix(effects): detect schema desync on replica and exit cleanly

### DIFF
--- a/src/effects/effects_apply.c
+++ b/src/effects/effects_apply.c
@@ -9,6 +9,7 @@
 #include "../graph/graph_hub.h"
 
 #include <stdio.h>
+#include <unistd.h>
 
 // read effect type from stream
 static inline EffectType ReadEffectType
@@ -315,7 +316,7 @@ static void ApplyLabels
 					"ApplyLabels: label ID %d schema not found"
 					" - replica/primary schema desync detected, aborting",
 					l) ;
-			exit (1) ;
+			_exit (1) ;
 		}
 		lbl[i] = Schema_GetName (s) ;
 	}
@@ -661,7 +662,7 @@ void Effects_Apply
 	// validate effects version
 	if(ValidateVersion(stream) == false) {
 		// replica/primary out of sync
-		exit(1);
+		_exit(1);
 	}
 
 	// lock graph for writing

--- a/src/effects/effects_apply.c
+++ b/src/effects/effects_apply.c
@@ -308,7 +308,15 @@ static void ApplyLabels
 		LabelID l ;
 		fread_assert (&l, sizeof (LabelID), stream) ;
 		Schema *s = GraphContext_GetSchemaByID (gc, l, SCHEMA_NODE) ;
-		ASSERT (s != NULL) ;
+		if (s == NULL) {
+			// schema desync: label `l` does not exist locally - exit
+			// cleanly so Redis triggers a full RDB resync on restart
+			RedisModule_Log (NULL, "warning",
+					"ApplyLabels: label ID %d schema not found"
+					" - replica/primary schema desync detected, aborting",
+					l) ;
+			exit (1) ;
+		}
 		lbl[i] = Schema_GetName (s) ;
 	}
 

--- a/src/graph/graph_hub.c
+++ b/src/graph/graph_hub.c
@@ -153,10 +153,24 @@ void GraphHub_CreateEdges
 	ASSERT (gc    != NULL) ;
 	ASSERT (edges != NULL) ;
 
+	// validate that the relation schema exists locally BEFORE touching the
+	// graph. on a replica a GRAPH.EFFECT may reference a relation type that
+	// is missing from the replica's schema (e.g. master/replica state
+	// diverged). passing an out-of-range relation ID into Graph_CreateEdges
+	// would segfault inside Graph_GetRelationMatrix / Delta_Matrix_nrows.
+	// detect the desync, log a warning and exit cleanly so Redis triggers
+	// a full RDB resync on restart - matches the existing ValidateVersion
+	// pattern in Effects_Apply (effects_apply.c).
+	Schema *s = GraphContext_GetSchemaByID (gc, r, SCHEMA_EDGE) ;
+	if (s == NULL) {
+		RedisModule_Log (NULL, "warning",
+				"GraphHub_CreateEdges: relation ID %d schema not found"
+				" - replica/primary schema desync detected, aborting", r) ;
+		exit (1) ;
+	}
+
 	Graph_CreateEdges (GraphContext_GetGraph (gc), r, edges, sets) ;
 
-	Schema *s = GraphContext_GetSchemaByID (gc, r, SCHEMA_EDGE) ;
-	ASSERT (s != NULL) ;
 	bool has_indices = Schema_HasIndices (s) ;
 
 	if (has_indices || log) {

--- a/src/graph/graph_hub.c
+++ b/src/graph/graph_hub.c
@@ -7,6 +7,8 @@
 #include "graph_hub.h"
 #include "../query_ctx.h"
 
+#include <unistd.h>
+
 // create a node
 // set the node labels and attributes
 // add the node to the relevant indexes
@@ -166,7 +168,7 @@ void GraphHub_CreateEdges
 		RedisModule_Log (NULL, "warning",
 				"GraphHub_CreateEdges: relation ID %d schema not found"
 				" - replica/primary schema desync detected, aborting", r) ;
-		exit (1) ;
+		_exit (1) ;
 	}
 
 	Graph_CreateEdges (GraphContext_GetGraph (gc), r, edges, sets) ;

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -606,6 +606,18 @@ Schema *GraphContext_GetSchemaByID
 	Schema **schemas = (t == SCHEMA_NODE) ?
 		gc->node_schemas :
 		gc->relation_schemas ;
+
+	// bounds check: replica may receive a GRAPH.EFFECT referencing a schema
+	// ID that does not yet exist locally if master/replica state diverged
+	// (e.g. failed query rolled back schema on master but the EFFECT was
+	// already replicated, or a previous replication step was lost).
+	// returning NULL lets callers detect the desync instead of OOB-reading
+	// the schemas array and segfaulting.
+	if (id < 0 || (uint)id >= arr_len (schemas)) {
+		_GraphContext_UnLockSchemas (gc) ;
+		return NULL ;
+	}
+
 	Schema *s = schemas [id] ;
 
 	_GraphContext_UnLockSchemas (gc) ;

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -1,6 +1,7 @@
 import struct
 import time
 from common import *
+from graph_utils import graph_eq
 
 # ---------------------------------------------------------------------------
 # Regression: GRAPH.EFFECT crash on replica when a referenced relation/label
@@ -184,3 +185,191 @@ class testEffectSetLabelsOOBLabel():
             pass
 
         self.env.assertFalse(_server_alive(self.conn))
+
+
+# ---------------------------------------------------------------------------
+# Real master/replica integration test - reproduces the customer-reported
+# desync chain organically (no synthetic GRAPH.EFFECT payloads).
+#
+# Customer scenario (v4.18.1, prior to PR #1815 "rollback schema creation
+# for failing queries"):
+#
+#   1. A write query introduces a NEW schema as part of its plan but later
+#      raises an error (e.g. division by zero in a projection that runs
+#      AFTER the CREATE clause).
+#
+#   2. Pre-PR-#1815 behaviour: the rollback path did NOT undo the schema
+#      addition, and ResultSet_Clear suppressed any replication. The new
+#      schema therefore became an "orphan" present on the master only.
+#
+#   3. A subsequent successful write query that references a different,
+#      brand-new relation type was replicated as GRAPH.EFFECT (because
+#      EFFECTS_THRESHOLD is 0 on this deployment, so every write goes
+#      through the effects path).
+#
+#      The EFFECT stream contained:
+#        EFFECT_ADD_SCHEMA(name=<new relation>) - replica appends, gets the
+#        next sequential id locally.
+#        EFFECT_CREATE_EDGE(relation_id=<master's id>, ...) - master's id
+#        is one ahead of the replica's because of the orphan schema.
+#
+#   4. On the replica, GraphHub_CreateEdges resolved the (out-of-range)
+#      relation id via GraphContext_GetSchemaByID, which OOB-read the
+#      schemas array. Schema_HasIndices(NULL) then dereferenced NULL ->
+#      SIGSEGV at (nil) (the symbolicator pointed at QGEdge_RelationID,
+#      the nearest exported symbol in the stripped release build).
+#
+# The fix has two layers:
+#
+#   * PR #1815 makes the failing query roll back the schema, so master and
+#     replica stay aligned and no malformed EFFECT is ever produced.
+#
+#   * PR #1907 (this branch) hardens GraphContext_GetSchemaByID with a
+#     bounds check and makes GraphHub_CreateEdges / ApplyLabels detect a
+#     desync and exit(1) cleanly. exit(1) triggers a full RDB resync on
+#     restart - matching the existing ValidateVersion + exit(1) pattern in
+#     Effects_Apply (effects_apply.c:654-656). This prevents future regressions
+#     where some other code path leaves master and replica out of sync.
+#
+# This integration test runs an actual master + replica pair, drives the
+# failing-query scenario through the public Cypher API, and asserts that:
+#
+#   - the replica is still alive after the EFFECT replicates
+#   - the replica's view of the graph matches the master byte-for-byte
+#
+# Reverting either PR #1815 or PR #1907 will cause this test to fail
+# (replica process dies under SIGSEGV before the second assertion can
+# complete).
+# ---------------------------------------------------------------------------
+class testEffectSchemaDesyncReplica():
+    def __init__(self):
+        self.env, self.db = Env(env='oss', useSlaves=True)
+        self.master  = self.env.getConnection()
+        self.replica = self.env.getSlaveConnection()
+        # force every write to be replicated as GRAPH.EFFECT so that a
+        # schema-id mismatch between master and replica becomes observable
+        # exactly as in the customer's deployment
+        self.db.config_set("EFFECTS_THRESHOLD", 0)
+        # let the replica catch up on the config change
+        self.master.wait(1, 0)
+
+    def __del__(self):
+        try:
+            self.replica.shutdown()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # helper: run a query on master and wait for the replica to ack it
+    # ------------------------------------------------------------------
+    def _run_and_replicate(self, g, q):
+        res = g.query(q)
+        # wait up to 2s for at least one replica to ack
+        self.master.wait(1, 2000)
+        return res
+
+    def test01_failing_schema_query_then_effect_edge(self):
+        """
+        End-to-end reproduction of the v4.18.1 desync -> EFFECT crash chain.
+        The test must remain green: with PR #1815 the orphan schema is
+        rolled back on master, so the subsequent EFFECT-replicated edge
+        carries an in-range relation id and the replica stays alive.
+        """
+
+        graph_id = "effect_desync_repro"
+        master_g  = Graph(self.master,  graph_id)
+        replica_g = Graph(self.replica, graph_id)
+
+        # ----------------------------------------------------------------
+        # step 1 - failing query that would introduce edge schema R_BAD on
+        # master only, prior to PR #1815. The "/0" raises ArithmeticError
+        # AFTER the CREATE clause has registered the relation type.
+        # ----------------------------------------------------------------
+        try:
+            master_g.query(
+                "CREATE ()-[:R_BAD]->() WITH 1 AS x RETURN x / 0"
+            )
+            # the projection must raise; if we get here the test premise
+            # is broken (the query accidentally succeeded)
+            self.env.assertTrue(False)
+        except Exception:
+            pass
+
+        # ----------------------------------------------------------------
+        # step 2 - successful write that introduces a different brand-new
+        # relation type. With EFFECTS_THRESHOLD=0 this is replicated as
+        # GRAPH.EFFECT, carrying EFFECT_ADD_SCHEMA(R_GOOD) followed by
+        # EFFECT_CREATE_EDGE(relation_id=<master id for R_GOOD>, ...).
+        #
+        # Pre-PR-#1815: master id for R_GOOD == 1 (orphan R_BAD took id 0),
+        # replica appends and assigns id 0 locally -> EFFECT_CREATE_EDGE
+        # references a non-existent relation id 1 on the replica, crashing
+        # GraphHub_CreateEdges.
+        # ----------------------------------------------------------------
+        res = self._run_and_replicate(
+            master_g,
+            "CREATE ()-[:R_GOOD]->()"
+        )
+        self.env.assertEquals(res.relationships_created, 1)
+
+        # ----------------------------------------------------------------
+        # step 3 - replica must still be alive and consistent. If the
+        # replica had segfaulted, ping() would raise / the connection
+        # would be dead.
+        # ----------------------------------------------------------------
+        self.env.assertTrue(_server_alive(self.replica))
+
+        # cross-check: master and replica agree on the schema view
+        m_rels = master_g.ro_query("CALL db.relationshipTypes()").result_set
+        r_rels = replica_g.ro_query("CALL db.relationshipTypes()").result_set
+        self.env.assertEquals(m_rels, r_rels)
+
+        # cross-check: graph contents agree
+        self.env.assertTrue(graph_eq(master_g, replica_g))
+
+    def test02_repeated_failures_keep_replica_in_sync(self):
+        """
+        Stress the schema-rollback path by alternating failing schema-
+        introducing queries with successful EFFECT-replicated writes.
+        Every cycle adds a fresh failing query (different label name) so
+        the rollback path is exercised against a non-empty schema array,
+        which is exactly the situation that produced an off-by-one
+        relation id on the customer's deployment.
+        """
+
+        graph_id = "effect_desync_repeat"
+        master_g  = Graph(self.master,  graph_id)
+        replica_g = Graph(self.replica, graph_id)
+
+        # seed both sides with one successful relation so the schema array
+        # is non-empty before we start poking at it
+        self._run_and_replicate(master_g, "CREATE ()-[:SEED]->()")
+        self.env.assertTrue(_server_alive(self.replica))
+
+        for i in range(5):
+            # failing schema-introducing query - must roll back cleanly
+            try:
+                master_g.query(
+                    "CREATE ()-[:R_FAIL_%d]->() WITH 1 AS x RETURN x / 0" % i
+                )
+                self.env.assertTrue(False)
+            except Exception:
+                pass
+
+            # successful EFFECT-replicated write with a fresh relation
+            res = self._run_and_replicate(
+                master_g,
+                "CREATE ()-[:R_OK_%d]->()" % i
+            )
+            self.env.assertEquals(res.relationships_created, 1)
+
+            # replica must remain alive after every cycle
+            self.env.assertTrue(_server_alive(self.replica))
+
+        # final consistency check
+        m_rels = sorted(master_g.ro_query(
+            "CALL db.relationshipTypes()").result_set)
+        r_rels = sorted(replica_g.ro_query(
+            "CALL db.relationshipTypes()").result_set)
+        self.env.assertEquals(m_rels, r_rels)
+        self.env.assertTrue(graph_eq(master_g, replica_g))

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -191,55 +191,75 @@ class testEffectSetLabelsOOBLabel():
 # Real master/replica integration test - reproduces the customer-reported
 # desync chain organically (no synthetic GRAPH.EFFECT payloads).
 #
-# Customer scenario (v4.18.1, prior to PR #1815 "rollback schema creation
-# for failing queries"):
+# Two desync mechanisms were identified in v4.18.1:
 #
-#   1. A write query introduces a NEW schema as part of its plan but later
-#      raises an error (e.g. division by zero in a projection that runs
-#      AFTER the CREATE clause).
+# ── Mechanism 1: RedisModule_Yield interleaving (PRIMARY crash path) ────────
 #
-#   2. Pre-PR-#1815 behaviour: the rollback path did NOT undo the schema
-#      addition, and ResultSet_Clear suppressed any replication. The new
-#      schema therefore became an "orphan" present on the master only.
+#   In v4.18.1, _QueryCtx_ThreadSafeContextLock calls RedisModule_Yield
+#   (YIELD_FLAG_CLIENTS) whenever the query runs without a blocked client
+#   (i.e. every replicated GRAPH.QUERY on the replica's main thread).
+#   The Yield fires BETWEEN the READ-lock release and the WRITE-lock
+#   acquisition, opening a window where the Redis event loop can process
+#   the *next* command from the replication socket.
 #
-#   3. A subsequent successful write query that references a different,
-#      brand-new relation type was replicated as GRAPH.EFFECT (because
-#      EFFECTS_THRESHOLD is 0 on this deployment, so every write goes
-#      through the effects path).
+#   If that next command is a GRAPH.EFFECT that references a schema just
+#   about to be committed by the still-in-flight GRAPH.QUERY, the replica
+#   crashes:
 #
-#      The EFFECT stream contained:
-#        EFFECT_ADD_SCHEMA(name=<new relation>) - replica appends, gets the
-#        next sequential id locally.
-#        EFFECT_CREATE_EDGE(relation_id=<master's id>, ...) - master's id
-#        is one ahead of the replica's because of the orphan schema.
+#     Replica main thread:
+#       GRAPH.QUERY "CREATE ()-[:R1]->()"   ← fast (<threshold) → GRAPH.QUERY
+#         QueryCtx_AcquireWriteLock():
+#           Graph_ReleaseLock(READ)          ← R1 not yet committed
+#           _QueryCtx_ThreadSafeContextLock:
+#             RedisModule_Yield()            ← event loop runs here
+#               → processes replication socket
+#               → GRAPH.EFFECT [EFFECT_CREATE_EDGE(r_id=0)]
+#                   GraphHub_CreateEdges(r=0)
+#                   GraphContext_GetSchemaByID(gc,0,SCHEMA_EDGE) → NULL
+#                   Schema_HasIndices(NULL) → SIGSEGV   ← crash
+#           Graph_AcquireWriteLock()
+#           _CommitEdgesBlueprint()          ← creates R1 (too late)
 #
-#   4. On the replica, GraphHub_CreateEdges resolved the (out-of-range)
-#      relation id via GraphContext_GetSchemaByID, which OOB-read the
-#      schemas array. Schema_HasIndices(NULL) then dereferenced NULL ->
-#      SIGSEGV at (nil) (the symbolicator pointed at QGEdge_RelationID,
-#      the nearest exported symbol in the stripped release build).
+#   This race is closed by PR #1877 (already in master), which restricts
+#   the Yield to AOF-loading paths only. Because the timing is
+#   sub-millisecond, this race cannot be triggered deterministically from
+#   a Python test; it is documented here for completeness.
 #
-# The fix has two layers:
+# ── Mechanism 2: Failed-query orphan schema (before PR #1815) ───────────────
 #
-#   * PR #1815 makes the failing query roll back the schema, so master and
-#     replica stay aligned and no malformed EFFECT is ever produced.
+#   A write query introduces a NEW schema as part of its plan but later
+#   raises an error (e.g. division by zero in a projection that runs
+#   AFTER the CREATE clause).
 #
-#   * PR #1907 (this branch) hardens GraphContext_GetSchemaByID with a
-#     bounds check and makes GraphHub_CreateEdges / ApplyLabels detect a
-#     desync and exit(1) cleanly. exit(1) triggers a full RDB resync on
-#     restart - matching the existing ValidateVersion + exit(1) pattern in
-#     Effects_Apply (effects_apply.c:654-656). This prevents future regressions
-#     where some other code path leaves master and replica out of sync.
+#   Pre-PR-#1815: the rollback path did NOT undo the schema addition, and
+#   ResultSet_Clear suppressed any replication. The new schema became an
+#   "orphan" present on the master only.
 #
-# This integration test runs an actual master + replica pair, drives the
-# failing-query scenario through the public Cypher API, and asserts that:
+#   A subsequent successful write query referencing a different brand-new
+#   relation type was replicated as GRAPH.EFFECT (EFFECTS_THRESHOLD=0):
 #
-#   - the replica is still alive after the EFFECT replicates
-#   - the replica's view of the graph matches the master byte-for-byte
+#     EFFECT_ADD_SCHEMA(<new relation>) → replica appends, gets the next
+#       sequential id locally (one behind master's because of the orphan).
+#     EFFECT_CREATE_EDGE(relation_id=<master's id>) → master's id is one
+#       ahead of the replica's; GraphContext_GetSchemaByID OOB-reads the
+#       schemas array → Schema_HasIndices(garbage) → SIGSEGV.
 #
-# Reverting either PR #1815 or PR #1907 will cause this test to fail
-# (replica process dies under SIGSEGV before the second assertion can
-# complete).
+#   PR #1815 (f2a8531c3, in v4.18.0+) makes failing queries roll back the
+#   schema atomically, so the orphan can no longer form.
+#
+# ── Defensive hardening (this PR #1907) ─────────────────────────────────────
+#
+#   Regardless of *how* desync occurs, GraphContext_GetSchemaByID had no
+#   bounds check on the schema ID. This PR adds:
+#     - bounds check in GraphContext_GetSchemaByID (returns NULL for OOB id)
+#     - NULL check in GraphHub_CreateEdges BEFORE Graph_CreateEdges
+#     - NULL check in ApplyLabels
+#   On NULL: log a warning and exit(1), triggering a full RDB resync.
+#   This matches the existing ValidateVersion + exit(1) pattern in
+#   Effects_Apply (effects_apply.c:654-656).
+#
+# The integration tests below drive Mechanism 2 through the public Cypher API.
+# They pass on this branch. Reverting PR #1815 causes the replica to SIGSEGV.
 # ---------------------------------------------------------------------------
 class testEffectSchemaDesyncReplica():
     def __init__(self):

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -1,0 +1,186 @@
+import struct
+import time
+from common import *
+
+# ---------------------------------------------------------------------------
+# Regression: GRAPH.EFFECT crash on replica when a referenced relation/label
+# schema is missing locally (master/replica schema desync).
+#
+# Customer-reported crash chain (FalkorDB v4.18.1):
+#   replica receives GRAPH.EFFECT for an edge whose relation type does not
+#   exist in the replica's schema -> GraphHub_CreateEdges calls
+#   GraphContext_GetSchemaByID which OOB-reads the schemas array and
+#   returns garbage/NULL -> Schema_HasIndices(NULL) dereferences NULL ->
+#   SIGSEGV at (nil) (the symbolicator pointed at the nearest exported
+#   symbol, QGEdge_RelationID, in the stripped release build).
+#
+# Fix:
+#   - GraphContext_GetSchemaByID now bounds-checks `id` and returns NULL
+#     for out-of-range IDs.
+#   - GraphHub_CreateEdges and ApplyLabels detect a NULL schema, log a
+#     warning, and call exit(1) so Redis triggers a full RDB resync on
+#     restart - matching the existing ValidateVersion pattern in
+#     Effects_Apply (effects_apply.c:654-656).
+#
+# These tests craft GRAPH.EFFECT payloads with out-of-range relation/label
+# IDs and assert the server exits cleanly instead of crashing.
+# ---------------------------------------------------------------------------
+
+# Effects binary protocol constants (must match src/effects/effects.h)
+EFFECTS_VERSION    = 1
+EFFECT_CREATE_NODE = 3   # node creation
+EFFECT_CREATE_EDGE = 4   # edge creation
+EFFECT_SET_LABELS  = 7   # set labels
+EFFECT_ADD_SCHEMA  = 9   # schema addition
+
+# Schema types (must match src/schema/schema.h)
+SCHEMA_NODE = 0
+SCHEMA_EDGE = 1
+
+
+def _build_effects_payload(effects):
+    """Build a binary GRAPH.EFFECT payload from a list of effect tuples.
+
+    Supported effects (keep in sync with src/effects/effects.c writers):
+        ('add_schema',  schema_type, name_str)
+        ('create_node', [label_id, ...], attr_count)         # attr_count == 0
+        ('create_edge', relation_id, src_id, dest_id)        # 0 attributes
+        ('set_labels',  node_id, [label_id, ...])
+    """
+
+    buf = struct.pack('<B', EFFECTS_VERSION)  # version: uint8_t
+
+    for effect in effects:
+        kind = effect[0]
+        if kind == 'add_schema':
+            _, schema_type, name = effect
+            name_bytes = name.encode('utf-8') + b'\x00'
+            buf += struct.pack('<i', EFFECT_ADD_SCHEMA)      # EffectType
+            buf += struct.pack('<i', schema_type)            # SchemaType
+            buf += struct.pack('<Q', len(name_bytes))        # size_t
+            buf += name_bytes
+        elif kind == 'create_node':
+            _, label_ids, attr_count = effect
+            buf += struct.pack('<i', EFFECT_CREATE_NODE)
+            buf += struct.pack('<H', len(label_ids))         # uint16_t
+            for lid in label_ids:
+                buf += struct.pack('<i', lid)                # LabelID (int32)
+            buf += struct.pack('<H', attr_count)             # uint16_t
+        elif kind == 'create_edge':
+            _, rel_id, src_id, dest_id = effect
+            # packed struct: EffectType(int) + uint16_t rel_count + RelationID
+            # + NodeID src + NodeID dest
+            buf += struct.pack('<i', EFFECT_CREATE_EDGE)     # EffectType
+            buf += struct.pack('<H', 1)                      # rel_count
+            buf += struct.pack('<i', rel_id)                 # RelationID int32
+            buf += struct.pack('<Q', src_id)                 # NodeID uint64
+            buf += struct.pack('<Q', dest_id)                # NodeID uint64
+            buf += struct.pack('<H', 0)                      # attr_count == 0
+        elif kind == 'set_labels':
+            _, node_id, label_ids = effect
+            buf += struct.pack('<i', EFFECT_SET_LABELS)
+            buf += struct.pack('<Q', node_id)                # node ID
+            buf += struct.pack('<H', len(label_ids))         # label count
+            for lid in label_ids:
+                buf += struct.pack('<i', lid)                # LabelID
+        else:
+            raise ValueError("unknown effect kind: %s" % kind)
+
+    return buf
+
+
+def _server_alive(conn):
+    try:
+        time.sleep(0.5)
+        conn.ping()
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# EDGE: relation ID out of range -> clean exit (was SIGSEGV)
+# ---------------------------------------------------------------------------
+class testEffectOOBRelation():
+    def __init__(self):
+        self.env, self.db = Env()
+        self.conn = self.env.getConnection()
+
+    def test01_create_edge_unknown_relation_exits(self):
+        graph_id = "edge_oob_rel"
+        g = Graph(self.conn, graph_id)
+
+        # create two nodes so node IDs 0 and 1 exist on this server
+        g.query("CREATE (), ()")
+
+        # craft a GRAPH.EFFECT that creates an edge with relation_id = 100
+        # the graph has zero edge schemas - this is the customer's crash
+        payload = _build_effects_payload([
+            ('create_edge', 100, 0, 1),
+        ])
+
+        try:
+            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
+        except Exception:
+            pass
+
+        # the server must NOT have segfaulted - it must have exited cleanly
+        # in either case the connection is dead, but with the fix there is
+        # no SIGSEGV in the redis log (we cannot easily assert on the log
+        # from here, but a clean exit() triggers full RDB resync on restart)
+        self.env.assertFalse(_server_alive(self.conn))
+
+
+# ---------------------------------------------------------------------------
+# EDGE: relation_id = -1 (negative) -> clean exit (was OOB read / SIGSEGV)
+# ---------------------------------------------------------------------------
+class testEffectNegativeRelation():
+    def __init__(self):
+        self.env, self.db = Env()
+        self.conn = self.env.getConnection()
+
+    def test01_create_edge_negative_relation_exits(self):
+        graph_id = "edge_neg_rel"
+        g = Graph(self.conn, graph_id)
+
+        g.query("CREATE (), ()")
+
+        payload = _build_effects_payload([
+            ('create_edge', -5, 0, 1),
+        ])
+
+        try:
+            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
+        except Exception:
+            pass
+
+        self.env.assertFalse(_server_alive(self.conn))
+
+
+# ---------------------------------------------------------------------------
+# LABEL: SET_LABELS with a label_id beyond the local schema count must
+# trigger a clean exit instead of dereferencing a NULL Schema.
+# ---------------------------------------------------------------------------
+class testEffectSetLabelsOOBLabel():
+    def __init__(self):
+        self.env, self.db = Env()
+        self.conn = self.env.getConnection()
+
+    def test01_set_labels_unknown_label_exits(self):
+        graph_id = "set_label_oob"
+        g = Graph(self.conn, graph_id)
+
+        # create one node with label A -> node id 0, label id 0
+        g.query("CREATE (:A)")
+
+        # try to add label_id = 99 to node 0
+        payload = _build_effects_payload([
+            ('set_labels', 0, [99]),
+        ])
+
+        try:
+            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
+        except Exception:
+            pass
+
+        self.env.assertFalse(_server_alive(self.conn))

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -1,4 +1,3 @@
-import os
 import time
 from common import *
 from graph_utils import graph_eq
@@ -19,16 +18,50 @@ from graph_utils import graph_eq
 #   - GraphContext_GetSchemaByID now bounds-checks `id` and returns NULL
 #     for out-of-range IDs.
 #   - GraphHub_CreateEdges and ApplyLabels detect a NULL schema, log a
-#     warning, and call exit(1) so Redis triggers a full RDB resync on
+#     warning, and call _exit(1) so Redis triggers a full RDB resync on
 #     restart - matching the existing ValidateVersion pattern in
-#     Effects_Apply (effects_apply.c:654-656).
+#     Effects_Apply (effects_apply.c).
 #
-# The tests below reproduce the crash through the public Cypher API and
-# real master/replica replication - no direct GRAPH.EFFECT calls.
+# ============================================================================
+# IMPORTANT: With current master, NO realistic user operation can produce a
+# master/replica schema-id divergence anymore.  Both historical mechanisms are
+# closed:
+#
+#   * Mechanism 1 - RedisModule_Yield interleaving (PRIMARY cause of the
+#     customer's v4.18.1 crashes).  Closed by PR #1877 (39460fe8c) which
+#     restricts Yield to AOF/RDB loading only.  The race required
+#     sub-millisecond timing and the now-removed Yield call; it cannot be
+#     reproduced from a Python test on current master.
+#
+#   * Mechanism 2 - Failed-query orphan schema (pre-v4.18.0).  Closed by
+#     PR #1815 (f2a8531c3) which makes failing queries atomically roll back
+#     any schemas they introduced.  Reproducing the desync requires
+#     reverting that PR.
+#
+# This file therefore tests:
+#
+#   1. testEffectSchemaDesyncReplica - the PR #1815 regression scenario.
+#      Uses ONLY the public Cypher API and real master/replica replication.
+#      Passes today; reverting PR #1815 causes the replica to SIGSEGV
+#      (without PR #1907) or to exit(1) cleanly (with PR #1907).  Either
+#      way the test catches a regression in PR #1815's rollback path.
+#
+#   2. testEffectReplicationStability - positive smoke test that exercises
+#      the GRAPH.EFFECT path through normal Cypher writes and verifies
+#      that PR #1907's bounds-check does not produce false positives in
+#      day-to-day operation.
+#
+# The bounds-check itself (GraphContext_GetSchemaByID) is exercised by the
+# unit test tests/unit/test_graphcontext_schema_bounds.c which directly
+# constructs a GraphContext and calls the function with in-range, out-of-
+# range, and negative IDs.  That is the only way to exercise the defensive
+# code path without resorting to direct GRAPH.EFFECT injection or to
+# reverting the upstream fixes.
 # ---------------------------------------------------------------------------
 
 
 def _server_alive(conn):
+    """Return True if a redis connection still responds to PING."""
     try:
         time.sleep(0.5)
         conn.ping()
@@ -37,210 +70,13 @@ def _server_alive(conn):
         return False
 
 
-def _replica_log_has_desync_warning(runner):
-    """Return True if the replica log contains the PR #1907 clean-exit warning.
-
-    The warning is emitted by GraphHub_CreateEdges / ApplyLabels before
-    calling exit(1) when an OOB schema ID is detected:
-        "... schema desync detected, aborting"
-
-    When the server crashes via SIGSEGV instead, the log contains
-    "REDIS BUG REPORT START" / "Segmentation fault" instead.
-    Returns None when the log file cannot be found (non-fatal).
-    """
-    if runner.dbDirPath is None:
-        return None
-    # _getFileName(role, suffix): role='slave' matches the else branch
-    log_path = os.path.join(runner.dbDirPath,
-                            runner._getFileName('slave', '.log'))
-    try:
-        with open(log_path) as f:
-            content = f.read()
-        return "schema desync detected, aborting" in content
-    except FileNotFoundError:
-        return None
-
-
-# ---------------------------------------------------------------------------
-# Crash reproduction via real replication (PR #1907 defensive hardening).
-#
-# The synthetic-payload approach (direct GRAPH.EFFECT calls) is replaced by
-# an end-to-end replication scenario that never calls GRAPH.EFFECT from
-# test code - the server sends GRAPH.EFFECT automatically when
-# EFFECTS_THRESHOLD=0, matching the customer's production configuration.
-#
-# Scenario - edge relation OOB via replication:
-#
-#   1. Both master and replica build an identical graph with N edge schemas
-#      (R0..R(N-1) at IDs 0..N-1) through normal GRAPH.EFFECT replication.
-#
-#   2. The replica's copy of the graph is deleted locally (replica-read-only
-#      disabled briefly, then re-enabled). Master still has [R0..R(N-1)].
-#
-#   3. Master creates one more edge with a brand-new relation type R_NEW.
-#      Because EFFECTS_THRESHOLD=0 the server sends:
-#
-#        EFFECT_CREATE_NODE / EFFECT_CREATE_NODE (two anonymous endpoints)
-#        EFFECT_ADD_SCHEMA(R_NEW)           <- master assigns id=N locally
-#        EFFECT_CREATE_EDGE(relation_id=N)  <- references master's id for R_NEW
-#
-#   4. The replica receives the stream.  cmd_effect.c creates a fresh empty
-#      graph (GraphContext_Retrieve with shouldCreate=true).
-#      EFFECT_ADD_SCHEMA(R_NEW) assigns id=0 (first entry in the empty
-#      schemas array).
-#      EFFECT_CREATE_EDGE(relation_id=N):
-#        GraphHub_CreateEdges calls GraphContext_GetSchemaByID(gc, N, EDGE).
-#        N >= 1 (the replica's schema array has exactly one entry) ->
-#        bounds check returns NULL -> exit(1) + warning log.
-#
-# Without PR #1907 bounds check: OOB array access -> garbage schema pointer
-#   -> Schema_HasIndices(NULL/garbage) -> SIGSEGV.
-# With PR #1907: clean exit(1), Redis triggers a full RDB resync on restart.
-# ---------------------------------------------------------------------------
-class testEffectSchemaDesyncViaReplication():
-    def __init__(self):
-        self.env, self.db = Env(env='oss', useSlaves=True)
-        self.master  = self.env.getConnection()
-        self.replica = self.env.getSlaveConnection()
-        # Force all writes through GRAPH.EFFECT - matches customer deployment
-        self.db.config_set("EFFECTS_THRESHOLD", 0)
-        self.master.wait(1, 0)
-
-    def test01_oob_relation_triggers_clean_exit(self):
-        """
-        Trigger OOB relation-id via real GRAPH.EFFECT replication.
-
-        Three edge schemas are synced to both sides, the replica's graph is
-        deleted, then master creates R_NEW (local id=3).  The EFFECT stream
-        carries relation_id=3 which is out of range on the empty replica
-        (R_NEW would be id=0 there) -> bounds check -> exit(1).
-
-        Without PR #1907: SIGSEGV.
-        With PR #1907: clean exit(1) + "schema desync detected" warning log.
-        """
-        GRAPH_ID = "desync_edge_crash"
-        N = 3  # number of pre-existing edge schemas to create first
-        master_g = Graph(self.master, GRAPH_ID)
-
-        # ------------------------------------------------------------------
-        # Step 1: create N edge schemas on BOTH master and replica via
-        # GRAPH.EFFECT replication.  After this both sides are identical.
-        # ------------------------------------------------------------------
-        for i in range(N):
-            master_g.query("CREATE ()-[:R%d]->()" % i)
-        self.master.wait(1, 2000)
-
-        r_types = master_g.ro_query("CALL db.relationshipTypes()").result_set
-        self.env.assertEquals(len(r_types), N)
-
-        # ------------------------------------------------------------------
-        # Step 2: delete the graph from the REPLICA ONLY to create a schema
-        # desync: master has N schemas, replica has an empty / no graph.
-        # ------------------------------------------------------------------
-        self.replica.execute_command("CONFIG", "SET", "replica-read-only", "no")
-        self.replica.execute_command("DEL", GRAPH_ID)
-        self.replica.execute_command("CONFIG", "SET", "replica-read-only", "yes")
-
-        # ------------------------------------------------------------------
-        # Step 3: create a new edge with a brand-new relation type.
-        # EFFECTS_THRESHOLD=0 makes the master send GRAPH.EFFECT:
-        #   EFFECT_ADD_SCHEMA(R_NEW)           <- id=N on master
-        #   EFFECT_CREATE_EDGE(relation_id=N)  <- OOB on empty replica
-        # ------------------------------------------------------------------
-        res = master_g.query("CREATE ()-[:R_NEW]->()")
-        self.env.assertEquals(res.relationships_created, 1)
-
-        # ------------------------------------------------------------------
-        # Step 4: replica must be dead.
-        #   _server_alive() already waits 0.5s for the EFFECT to propagate.
-        #   exit(1) with PR #1907; SIGSEGV without it.
-        # ------------------------------------------------------------------
-        self.env.assertFalse(_server_alive(self.replica))
-
-        # ------------------------------------------------------------------
-        # Step 5: verify the replica exited cleanly (PR #1907 fix) rather
-        # than crashing with a SIGSEGV.  Check the replica log for the
-        # "schema desync detected, aborting" warning written before exit(1).
-        # (Non-fatal if the log file is not available in this environment.)
-        # ------------------------------------------------------------------
-        clean = _replica_log_has_desync_warning(self.env.envRunner)
-        if clean is not None:
-            self.env.assertTrue(clean)
-
-
 # ---------------------------------------------------------------------------
 # Real master/replica integration test - reproduces the customer-reported
-# desync chain organically (no synthetic GRAPH.EFFECT payloads).
-#
-# Two desync mechanisms were identified in v4.18.1:
-#
-# ── Mechanism 1: RedisModule_Yield interleaving (PRIMARY crash path) ────────
-#
-#   In v4.18.1, _QueryCtx_ThreadSafeContextLock calls RedisModule_Yield
-#   (YIELD_FLAG_CLIENTS) whenever the query runs without a blocked client
-#   (i.e. every replicated GRAPH.QUERY on the replica's main thread).
-#   The Yield fires BETWEEN the READ-lock release and the WRITE-lock
-#   acquisition, opening a window where the Redis event loop can process
-#   the *next* command from the replication socket.
-#
-#   If that next command is a GRAPH.EFFECT that references a schema just
-#   about to be committed by the still-in-flight GRAPH.QUERY, the replica
-#   crashes:
-#
-#     Replica main thread:
-#       GRAPH.QUERY "CREATE ()-[:R1]->()"   ← fast (<threshold) → GRAPH.QUERY
-#         QueryCtx_AcquireWriteLock():
-#           Graph_ReleaseLock(READ)          ← R1 not yet committed
-#           _QueryCtx_ThreadSafeContextLock:
-#             RedisModule_Yield()            ← event loop runs here
-#               → processes replication socket
-#               → GRAPH.EFFECT [EFFECT_CREATE_EDGE(r_id=0)]
-#                   GraphHub_CreateEdges(r=0)
-#                   GraphContext_GetSchemaByID(gc,0,SCHEMA_EDGE) → NULL
-#                   Schema_HasIndices(NULL) → SIGSEGV   ← crash
-#           Graph_AcquireWriteLock()
-#           _CommitEdgesBlueprint()          ← creates R1 (too late)
-#
-#   This race is closed by PR #1877 (already in master), which restricts
-#   the Yield to AOF-loading paths only. Because the timing is
-#   sub-millisecond, this race cannot be triggered deterministically from
-#   a Python test; it is documented here for completeness.
-#
-# ── Mechanism 2: Failed-query orphan schema (before PR #1815) ───────────────
-#
-#   A write query introduces a NEW schema as part of its plan but later
-#   raises an error (e.g. division by zero in a projection that runs
-#   AFTER the CREATE clause).
-#
-#   Pre-PR-#1815: the rollback path did NOT undo the schema addition, and
-#   ResultSet_Clear suppressed any replication. The new schema became an
-#   "orphan" present on the master only.
-#
-#   A subsequent successful write query referencing a different brand-new
-#   relation type was replicated as GRAPH.EFFECT (EFFECTS_THRESHOLD=0):
-#
-#     EFFECT_ADD_SCHEMA(<new relation>) → replica appends, gets the next
-#       sequential id locally (one behind master's because of the orphan).
-#     EFFECT_CREATE_EDGE(relation_id=<master's id>) → master's id is one
-#       ahead of the replica's; GraphContext_GetSchemaByID OOB-reads the
-#       schemas array → Schema_HasIndices(garbage) → SIGSEGV.
-#
-#   PR #1815 (f2a8531c3, in v4.18.0+) makes failing queries roll back the
-#   schema atomically, so the orphan can no longer form.
-#
-# ── Defensive hardening (this PR #1907) ─────────────────────────────────────
-#
-#   Regardless of *how* desync occurs, GraphContext_GetSchemaByID had no
-#   bounds check on the schema ID. This PR adds:
-#     - bounds check in GraphContext_GetSchemaByID (returns NULL for OOB id)
-#     - NULL check in GraphHub_CreateEdges BEFORE Graph_CreateEdges
-#     - NULL check in ApplyLabels
-#   On NULL: log a warning and exit(1), triggering a full RDB resync.
-#   This matches the existing ValidateVersion + exit(1) pattern in
-#   Effects_Apply (effects_apply.c:654-656).
-#
-# The integration tests below drive Mechanism 2 through the public Cypher API.
-# They pass on this branch. Reverting PR #1815 causes the replica to SIGSEGV.
+# desync chain organically (no synthetic GRAPH.EFFECT payloads, no replica-
+# side mutation).  This is a PR #1815 regression test: with #1815 the
+# rollback prevents the desync, the replica stays alive and graphs match.
+# Reverting #1815 (without PR #1907) causes the replica to SIGSEGV; with
+# PR #1907 the replica exits cleanly with the desync warning.
 # ---------------------------------------------------------------------------
 class testEffectSchemaDesyncReplica():
     def __init__(self):
@@ -272,9 +108,9 @@ class testEffectSchemaDesyncReplica():
     def test01_failing_schema_query_then_effect_edge(self):
         """
         End-to-end reproduction of the v4.18.1 desync -> EFFECT crash chain.
-        The test must remain green: with PR #1815 the orphan schema is
-        rolled back on master, so the subsequent EFFECT-replicated edge
-        carries an in-range relation id and the replica stays alive.
+        With PR #1815 the orphan schema is rolled back on master, so the
+        subsequent EFFECT-replicated edge carries an in-range relation id
+        and the replica stays alive.
         """
 
         graph_id = "effect_desync_repro"
@@ -314,9 +150,7 @@ class testEffectSchemaDesyncReplica():
         self.env.assertEquals(res.relationships_created, 1)
 
         # ----------------------------------------------------------------
-        # step 3 - replica must still be alive and consistent. If the
-        # replica had segfaulted, ping() would raise / the connection
-        # would be dead.
+        # step 3 - replica must still be alive and consistent.
         # ----------------------------------------------------------------
         self.env.assertTrue(_server_alive(self.replica))
 
@@ -333,9 +167,7 @@ class testEffectSchemaDesyncReplica():
         Stress the schema-rollback path by alternating failing schema-
         introducing queries with successful EFFECT-replicated writes.
         Every cycle adds a fresh failing query (different label name) so
-        the rollback path is exercised against a non-empty schema array,
-        which is exactly the situation that produced an off-by-one
-        relation id on the customer's deployment.
+        the rollback path is exercised against a non-empty schema array.
         """
 
         graph_id = "effect_desync_repeat"
@@ -373,4 +205,91 @@ class testEffectSchemaDesyncReplica():
         r_rels = sorted(replica_g.ro_query(
             "CALL db.relationshipTypes()").result_set)
         self.env.assertEquals(m_rels, r_rels)
+        self.env.assertTrue(graph_eq(master_g, replica_g))
+
+
+# ---------------------------------------------------------------------------
+# Positive smoke test: PR #1907 added a bounds check inside the hot path
+# of every replicated edge / SET LABELS effect.  This test verifies that
+# normal master/replica operation - which now flows through that bounds
+# check on every effect application - still works correctly and does not
+# produce false positives (i.e. the replica never trips the desync warning
+# during normal operation, regardless of the EFFECTS_THRESHOLD value).
+# ---------------------------------------------------------------------------
+class testEffectReplicationStability():
+    def __init__(self):
+        self.env, self.db = Env(env='oss', useSlaves=True)
+        self.master  = self.env.getConnection()
+        self.replica = self.env.getSlaveConnection()
+
+    def __del__(self):
+        try:
+            self.replica.shutdown()
+        except Exception:
+            pass
+
+    def _wait_replica(self):
+        # wait up to 2s for at least one replica to ack
+        self.master.wait(1, 2000)
+
+    def test01_normal_writes_do_not_trip_bounds_check_effect_path(self):
+        """
+        Force every write through GRAPH.EFFECT (EFFECTS_THRESHOLD=0).  Every
+        replicated effect goes through the new GraphHub_CreateEdges /
+        ApplyLabels NULL-schema check.  Verify that normal operations do
+        NOT trigger the check (no replica exit, graphs stay equal).
+        """
+
+        self.db.config_set("EFFECTS_THRESHOLD", 0)
+        self.master.wait(1, 0)
+
+        graph_id = "stability_effect"
+        master_g  = Graph(self.master,  graph_id)
+        replica_g = Graph(self.replica, graph_id)
+
+        # mix of node creations (introduce labels), edge creations
+        # (introduce relation types), label additions and label removals -
+        # every code path that calls GraphContext_GetSchemaByID on the
+        # replica's effects-application thread.
+        master_g.query("CREATE (:A {n: 1})")
+        master_g.query("CREATE (:B {n: 2})")
+        master_g.query("CREATE (:A:B {n: 3})")
+        master_g.query(
+            "MATCH (a:A {n: 1}), (b:B {n: 2}) CREATE (a)-[:R1]->(b)"
+        )
+        master_g.query(
+            "MATCH (a:A {n: 1}), (b:B {n: 2}) CREATE (a)-[:R2 {w: 1.5}]->(b)"
+        )
+        # add and remove labels - exercises ApplyLabels and ApplyRemoveLabels
+        master_g.query("MATCH (n:A) SET n:NEWLBL")
+        master_g.query("MATCH (n:NEWLBL) REMOVE n:NEWLBL")
+        self._wait_replica()
+
+        # replica must be alive
+        self.env.assertTrue(_server_alive(self.replica))
+        # graphs must be equal
+        self.env.assertTrue(graph_eq(master_g, replica_g))
+
+    def test02_normal_writes_do_not_trip_bounds_check_query_path(self):
+        """
+        Same as test01 but with EFFECTS_THRESHOLD high enough that writes
+        replicate as GRAPH.QUERY (re-executed on replica).  Acts as a
+        control - the bounds check should not be exercised here at all,
+        but the test still validates that PR #1907 did not break the
+        normal QUERY-replicated write path.
+        """
+
+        self.db.config_set("EFFECTS_THRESHOLD", 999999)
+        self.master.wait(1, 0)
+
+        graph_id = "stability_query"
+        master_g  = Graph(self.master,  graph_id)
+        replica_g = Graph(self.replica, graph_id)
+
+        master_g.query("CREATE (:A)-[:R1]->(:B)")
+        master_g.query("CREATE (:C)-[:R2]->(:D)")
+        master_g.query("MATCH (n:A) SET n:EXTRA")
+        self._wait_replica()
+
+        self.env.assertTrue(_server_alive(self.replica))
         self.env.assertTrue(graph_eq(master_g, replica_g))

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -1,4 +1,4 @@
-import struct
+import os
 import time
 from common import *
 from graph_utils import graph_eq
@@ -15,7 +15,7 @@ from graph_utils import graph_eq
 #   SIGSEGV at (nil) (the symbolicator pointed at the nearest exported
 #   symbol, QGEdge_RelationID, in the stripped release build).
 #
-# Fix:
+# Fix (PR #1907):
 #   - GraphContext_GetSchemaByID now bounds-checks `id` and returns NULL
 #     for out-of-range IDs.
 #   - GraphHub_CreateEdges and ApplyLabels detect a NULL schema, log a
@@ -23,71 +23,9 @@ from graph_utils import graph_eq
 #     restart - matching the existing ValidateVersion pattern in
 #     Effects_Apply (effects_apply.c:654-656).
 #
-# These tests craft GRAPH.EFFECT payloads with out-of-range relation/label
-# IDs and assert the server exits cleanly instead of crashing.
+# The tests below reproduce the crash through the public Cypher API and
+# real master/replica replication - no direct GRAPH.EFFECT calls.
 # ---------------------------------------------------------------------------
-
-# Effects binary protocol constants (must match src/effects/effects.h)
-EFFECTS_VERSION    = 1
-EFFECT_CREATE_NODE = 3   # node creation
-EFFECT_CREATE_EDGE = 4   # edge creation
-EFFECT_SET_LABELS  = 7   # set labels
-EFFECT_ADD_SCHEMA  = 9   # schema addition
-
-# Schema types (must match src/schema/schema.h)
-SCHEMA_NODE = 0
-SCHEMA_EDGE = 1
-
-
-def _build_effects_payload(effects):
-    """Build a binary GRAPH.EFFECT payload from a list of effect tuples.
-
-    Supported effects (keep in sync with src/effects/effects.c writers):
-        ('add_schema',  schema_type, name_str)
-        ('create_node', [label_id, ...], attr_count)         # attr_count == 0
-        ('create_edge', relation_id, src_id, dest_id)        # 0 attributes
-        ('set_labels',  node_id, [label_id, ...])
-    """
-
-    buf = struct.pack('<B', EFFECTS_VERSION)  # version: uint8_t
-
-    for effect in effects:
-        kind = effect[0]
-        if kind == 'add_schema':
-            _, schema_type, name = effect
-            name_bytes = name.encode('utf-8') + b'\x00'
-            buf += struct.pack('<i', EFFECT_ADD_SCHEMA)      # EffectType
-            buf += struct.pack('<i', schema_type)            # SchemaType
-            buf += struct.pack('<Q', len(name_bytes))        # size_t
-            buf += name_bytes
-        elif kind == 'create_node':
-            _, label_ids, attr_count = effect
-            buf += struct.pack('<i', EFFECT_CREATE_NODE)
-            buf += struct.pack('<H', len(label_ids))         # uint16_t
-            for lid in label_ids:
-                buf += struct.pack('<i', lid)                # LabelID (int32)
-            buf += struct.pack('<H', attr_count)             # uint16_t
-        elif kind == 'create_edge':
-            _, rel_id, src_id, dest_id = effect
-            # packed struct: EffectType(int) + uint16_t rel_count + RelationID
-            # + NodeID src + NodeID dest
-            buf += struct.pack('<i', EFFECT_CREATE_EDGE)     # EffectType
-            buf += struct.pack('<H', 1)                      # rel_count
-            buf += struct.pack('<i', rel_id)                 # RelationID int32
-            buf += struct.pack('<Q', src_id)                 # NodeID uint64
-            buf += struct.pack('<Q', dest_id)                # NodeID uint64
-            buf += struct.pack('<H', 0)                      # attr_count == 0
-        elif kind == 'set_labels':
-            _, node_id, label_ids = effect
-            buf += struct.pack('<i', EFFECT_SET_LABELS)
-            buf += struct.pack('<Q', node_id)                # node ID
-            buf += struct.pack('<H', len(label_ids))         # label count
-            for lid in label_ids:
-                buf += struct.pack('<i', lid)                # LabelID
-        else:
-            raise ValueError("unknown effect kind: %s" % kind)
-
-    return buf
 
 
 def _server_alive(conn):
@@ -99,92 +37,135 @@ def _server_alive(conn):
         return False
 
 
+def _replica_log_has_desync_warning(runner):
+    """Return True if the replica log contains the PR #1907 clean-exit warning.
+
+    The warning is emitted by GraphHub_CreateEdges / ApplyLabels before
+    calling exit(1) when an OOB schema ID is detected:
+        "... schema desync detected, aborting"
+
+    When the server crashes via SIGSEGV instead, the log contains
+    "REDIS BUG REPORT START" / "Segmentation fault" instead.
+    Returns None when the log file cannot be found (non-fatal).
+    """
+    if runner.dbDirPath is None:
+        return None
+    # _getFileName(role, suffix): role='slave' matches the else branch
+    log_path = os.path.join(runner.dbDirPath,
+                            runner._getFileName('slave', '.log'))
+    try:
+        with open(log_path) as f:
+            content = f.read()
+        return "schema desync detected, aborting" in content
+    except FileNotFoundError:
+        return None
+
+
 # ---------------------------------------------------------------------------
-# EDGE: relation ID out of range -> clean exit (was SIGSEGV)
+# Crash reproduction via real replication (PR #1907 defensive hardening).
+#
+# The synthetic-payload approach (direct GRAPH.EFFECT calls) is replaced by
+# an end-to-end replication scenario that never calls GRAPH.EFFECT from
+# test code - the server sends GRAPH.EFFECT automatically when
+# EFFECTS_THRESHOLD=0, matching the customer's production configuration.
+#
+# Scenario - edge relation OOB via replication:
+#
+#   1. Both master and replica build an identical graph with N edge schemas
+#      (R0..R(N-1) at IDs 0..N-1) through normal GRAPH.EFFECT replication.
+#
+#   2. The replica's copy of the graph is deleted locally (replica-read-only
+#      disabled briefly, then re-enabled). Master still has [R0..R(N-1)].
+#
+#   3. Master creates one more edge with a brand-new relation type R_NEW.
+#      Because EFFECTS_THRESHOLD=0 the server sends:
+#
+#        EFFECT_CREATE_NODE / EFFECT_CREATE_NODE (two anonymous endpoints)
+#        EFFECT_ADD_SCHEMA(R_NEW)           <- master assigns id=N locally
+#        EFFECT_CREATE_EDGE(relation_id=N)  <- references master's id for R_NEW
+#
+#   4. The replica receives the stream.  cmd_effect.c creates a fresh empty
+#      graph (GraphContext_Retrieve with shouldCreate=true).
+#      EFFECT_ADD_SCHEMA(R_NEW) assigns id=0 (first entry in the empty
+#      schemas array).
+#      EFFECT_CREATE_EDGE(relation_id=N):
+#        GraphHub_CreateEdges calls GraphContext_GetSchemaByID(gc, N, EDGE).
+#        N >= 1 (the replica's schema array has exactly one entry) ->
+#        bounds check returns NULL -> exit(1) + warning log.
+#
+# Without PR #1907 bounds check: OOB array access -> garbage schema pointer
+#   -> Schema_HasIndices(NULL/garbage) -> SIGSEGV.
+# With PR #1907: clean exit(1), Redis triggers a full RDB resync on restart.
 # ---------------------------------------------------------------------------
-class testEffectOOBRelation():
+class testEffectSchemaDesyncViaReplication():
     def __init__(self):
-        self.env, self.db = Env()
-        self.conn = self.env.getConnection()
+        self.env, self.db = Env(env='oss', useSlaves=True)
+        self.master  = self.env.getConnection()
+        self.replica = self.env.getSlaveConnection()
+        # Force all writes through GRAPH.EFFECT - matches customer deployment
+        self.db.config_set("EFFECTS_THRESHOLD", 0)
+        self.master.wait(1, 0)
 
-    def test01_create_edge_unknown_relation_exits(self):
-        graph_id = "edge_oob_rel"
-        g = Graph(self.conn, graph_id)
+    def test01_oob_relation_triggers_clean_exit(self):
+        """
+        Trigger OOB relation-id via real GRAPH.EFFECT replication.
 
-        # create two nodes so node IDs 0 and 1 exist on this server
-        g.query("CREATE (), ()")
+        Three edge schemas are synced to both sides, the replica's graph is
+        deleted, then master creates R_NEW (local id=3).  The EFFECT stream
+        carries relation_id=3 which is out of range on the empty replica
+        (R_NEW would be id=0 there) -> bounds check -> exit(1).
 
-        # craft a GRAPH.EFFECT that creates an edge with relation_id = 100
-        # the graph has zero edge schemas - this is the customer's crash
-        payload = _build_effects_payload([
-            ('create_edge', 100, 0, 1),
-        ])
+        Without PR #1907: SIGSEGV.
+        With PR #1907: clean exit(1) + "schema desync detected" warning log.
+        """
+        GRAPH_ID = "desync_edge_crash"
+        N = 3  # number of pre-existing edge schemas to create first
+        master_g = Graph(self.master, GRAPH_ID)
 
-        try:
-            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
-        except Exception:
-            pass
+        # ------------------------------------------------------------------
+        # Step 1: create N edge schemas on BOTH master and replica via
+        # GRAPH.EFFECT replication.  After this both sides are identical.
+        # ------------------------------------------------------------------
+        for i in range(N):
+            master_g.query("CREATE ()-[:R%d]->()" % i)
+        self.master.wait(1, 2000)
 
-        # the server must NOT have segfaulted - it must have exited cleanly
-        # in either case the connection is dead, but with the fix there is
-        # no SIGSEGV in the redis log (we cannot easily assert on the log
-        # from here, but a clean exit() triggers full RDB resync on restart)
-        self.env.assertFalse(_server_alive(self.conn))
+        r_types = master_g.ro_query("CALL db.relationshipTypes()").result_set
+        self.env.assertEquals(len(r_types), N)
 
+        # ------------------------------------------------------------------
+        # Step 2: delete the graph from the REPLICA ONLY to create a schema
+        # desync: master has N schemas, replica has an empty / no graph.
+        # ------------------------------------------------------------------
+        self.replica.execute_command("CONFIG", "SET", "replica-read-only", "no")
+        self.replica.execute_command("DEL", GRAPH_ID)
+        self.replica.execute_command("CONFIG", "SET", "replica-read-only", "yes")
 
-# ---------------------------------------------------------------------------
-# EDGE: relation_id = -1 (negative) -> clean exit (was OOB read / SIGSEGV)
-# ---------------------------------------------------------------------------
-class testEffectNegativeRelation():
-    def __init__(self):
-        self.env, self.db = Env()
-        self.conn = self.env.getConnection()
+        # ------------------------------------------------------------------
+        # Step 3: create a new edge with a brand-new relation type.
+        # EFFECTS_THRESHOLD=0 makes the master send GRAPH.EFFECT:
+        #   EFFECT_ADD_SCHEMA(R_NEW)           <- id=N on master
+        #   EFFECT_CREATE_EDGE(relation_id=N)  <- OOB on empty replica
+        # ------------------------------------------------------------------
+        res = master_g.query("CREATE ()-[:R_NEW]->()")
+        self.env.assertEquals(res.relationships_created, 1)
 
-    def test01_create_edge_negative_relation_exits(self):
-        graph_id = "edge_neg_rel"
-        g = Graph(self.conn, graph_id)
+        # ------------------------------------------------------------------
+        # Step 4: replica must be dead.
+        #   _server_alive() already waits 0.5s for the EFFECT to propagate.
+        #   exit(1) with PR #1907; SIGSEGV without it.
+        # ------------------------------------------------------------------
+        self.env.assertFalse(_server_alive(self.replica))
 
-        g.query("CREATE (), ()")
-
-        payload = _build_effects_payload([
-            ('create_edge', -5, 0, 1),
-        ])
-
-        try:
-            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
-        except Exception:
-            pass
-
-        self.env.assertFalse(_server_alive(self.conn))
-
-
-# ---------------------------------------------------------------------------
-# LABEL: SET_LABELS with a label_id beyond the local schema count must
-# trigger a clean exit instead of dereferencing a NULL Schema.
-# ---------------------------------------------------------------------------
-class testEffectSetLabelsOOBLabel():
-    def __init__(self):
-        self.env, self.db = Env()
-        self.conn = self.env.getConnection()
-
-    def test01_set_labels_unknown_label_exits(self):
-        graph_id = "set_label_oob"
-        g = Graph(self.conn, graph_id)
-
-        # create one node with label A -> node id 0, label id 0
-        g.query("CREATE (:A)")
-
-        # try to add label_id = 99 to node 0
-        payload = _build_effects_payload([
-            ('set_labels', 0, [99]),
-        ])
-
-        try:
-            self.conn.execute_command('GRAPH.EFFECT', graph_id, payload)
-        except Exception:
-            pass
-
-        self.env.assertFalse(_server_alive(self.conn))
+        # ------------------------------------------------------------------
+        # Step 5: verify the replica exited cleanly (PR #1907 fix) rather
+        # than crashing with a SIGSEGV.  Check the replica log for the
+        # "schema desync detected, aborting" warning written before exit(1).
+        # (Non-fatal if the log file is not available in this environment.)
+        # ------------------------------------------------------------------
+        clean = _replica_log_has_desync_warning(self.env.envRunner)
+        if clean is not None:
+            self.env.assertTrue(clean)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/flow/test_effect_schema_desync.py
+++ b/tests/flow/test_effect_schema_desync.py
@@ -94,6 +94,7 @@ class testEffectSchemaDesyncReplica():
         try:
             self.replica.shutdown()
         except Exception:
+            # best-effort teardown; replica may already be terminated
             pass
 
     # ------------------------------------------------------------------
@@ -122,15 +123,15 @@ class testEffectSchemaDesyncReplica():
         # master only, prior to PR #1815. The "/0" raises ArithmeticError
         # AFTER the CREATE clause has registered the relation type.
         # ----------------------------------------------------------------
+        query_raised = False
         try:
             master_g.query(
                 "CREATE ()-[:R_BAD]->() WITH 1 AS x RETURN x / 0"
             )
-            # the projection must raise; if we get here the test premise
-            # is broken (the query accidentally succeeded)
-            self.env.assertTrue(False)
         except Exception:
-            pass
+            # expected: division by zero raises after CREATE registers R_BAD
+            query_raised = True
+        self.env.assertTrue(query_raised)
 
         # ----------------------------------------------------------------
         # step 2 - successful write that introduces a different brand-new
@@ -181,13 +182,15 @@ class testEffectSchemaDesyncReplica():
 
         for i in range(5):
             # failing schema-introducing query - must roll back cleanly
+            query_raised = False
             try:
                 master_g.query(
                     "CREATE ()-[:R_FAIL_%d]->() WITH 1 AS x RETURN x / 0" % i
                 )
-                self.env.assertTrue(False)
             except Exception:
-                pass
+                # expected: division by zero raises after CREATE registers type
+                query_raised = True
+            self.env.assertTrue(query_raised)
 
             # successful EFFECT-replicated write with a fresh relation
             res = self._run_and_replicate(
@@ -226,6 +229,7 @@ class testEffectReplicationStability():
         try:
             self.replica.shutdown()
         except Exception:
+            # best-effort teardown; replica may already be terminated
             pass
 
     def _wait_replica(self):

--- a/tests/unit/test_graphcontext_schema_bounds.c
+++ b/tests/unit/test_graphcontext_schema_bounds.c
@@ -55,6 +55,35 @@ void tearDown() {
 #define TEST_FINI tearDown();
 #include "acutest.h"
 
+// Free a GraphContext created by _fake_graph_context().  Mirrors the cleanup
+// in _GraphContext_Free (graphcontext.c) but avoids Config / RedisModule
+// dependencies that are absent in the unit-test harness.
+static void _free_graph_context(GraphContext *gc) {
+	uint32_t len;
+
+	if(gc->node_schemas) {
+		len = arr_len(gc->node_schemas);
+		for(uint32_t i = 0; i < len; i++) Schema_Free(gc->node_schemas[i]);
+		arr_free(gc->node_schemas);
+	}
+	if(gc->relation_schemas) {
+		len = arr_len(gc->relation_schemas);
+		for(uint32_t i = 0; i < len; i++) Schema_Free(gc->relation_schemas[i]);
+		arr_free(gc->relation_schemas);
+	}
+	QueriesLog_Free(gc->queries_log);
+	if(gc->attributes) raxFree(gc->attributes);
+	if(gc->string_mapping) {
+		len = arr_len(gc->string_mapping);
+		for(uint32_t i = 0; i < len; i++) rm_free(gc->string_mapping[i]);
+		arr_free(gc->string_mapping);
+	}
+	Graph_Free(gc->g);
+	pthread_rwlock_destroy(&gc->_schema_rwlock);
+	free(gc->graph_name);
+	free(gc);
+}
+
 // Build a minimal GraphContext suitable for exercising
 // GraphContext_GetSchemaByID without dragging in the full module-load path.
 // Mirrors the _fake_graph_context() helper used by test_algebraic_expression.c.
@@ -102,6 +131,8 @@ void test_get_schema_by_id_in_range_returns_schema(void) {
 	s = GraphContext_GetSchemaByID(gc, 1, SCHEMA_EDGE);
 	TEST_ASSERT(s != NULL);
 	TEST_ASSERT(strcmp(Schema_GetName(s), "REL1") == 0);
+
+	_free_graph_context(gc);
 }
 
 // Out-of-range positive IDs (>= arr_len(schemas)) must return NULL,
@@ -122,6 +153,8 @@ void test_get_schema_by_id_oob_positive_returns_null(void) {
 	// id far past the end.
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 999,    SCHEMA_NODE) == NULL);
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 999999, SCHEMA_EDGE) == NULL);
+
+	_free_graph_context(gc);
 }
 
 // Negative IDs other than the GRAPH_NO_LABEL sentinel must also be
@@ -143,6 +176,8 @@ void test_get_schema_by_id_negative_returns_null(void) {
 	// array.
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, -2,  SCHEMA_NODE) == NULL);
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, -42, SCHEMA_EDGE) == NULL);
+
+	_free_graph_context(gc);
 }
 
 // On an empty schema array every positive ID must come back NULL.
@@ -154,6 +189,8 @@ void test_get_schema_by_id_empty_arrays_returns_null(void) {
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 0,   SCHEMA_EDGE) == NULL);
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 1,   SCHEMA_NODE) == NULL);
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 100, SCHEMA_EDGE) == NULL);
+
+	_free_graph_context(gc);
 }
 
 // Boundary: id == arr_len - 1 is the LAST valid index; id == arr_len is
@@ -173,6 +210,8 @@ void test_get_schema_by_id_boundary(void) {
 
 	// first invalid id - must be rejected
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 3, SCHEMA_NODE) == NULL);
+
+	_free_graph_context(gc);
 }
 
 // SchemaType selection: a relation id that is in range for the EDGE array
@@ -194,6 +233,8 @@ void test_get_schema_by_id_type_dispatch(void) {
 	// edge id 1 is OUT OF RANGE against the NODE array (only 1 node
 	// schema exists) - must return NULL, not a stale Schema*.
 	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 1, SCHEMA_NODE) == NULL);
+
+	_free_graph_context(gc);
 }
 
 TEST_LIST = {

--- a/tests/unit/test_graphcontext_schema_bounds.c
+++ b/tests/unit/test_graphcontext_schema_bounds.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+// PR #1907 defensive bounds-check on GraphContext_GetSchemaByID.
+//
+// Background:
+//   On a replica, GRAPH.EFFECT may carry a relation/label schema ID that
+//   does not yet exist locally if master/replica state has diverged.
+//   Before PR #1907 the lookup performed a raw `schemas[id]` array read
+//   with no bounds check, returning garbage that callers then dereferenced
+//   as a Schema* (Schema_HasIndices(NULL/garbage) -> SIGSEGV).
+//
+//   PR #1907 hardens GraphContext_GetSchemaByID to return NULL for any
+//   out-of-range ID (negative, >= arr_len(schemas), and the documented
+//   sentinel GRAPH_NO_LABEL).  Callers (GraphHub_CreateEdges, ApplyLabels)
+//   detect the NULL and call _exit(1) instead of crashing.
+//
+// Why a unit test:
+//   With current master both historical desync mechanisms are closed
+//   (PR #1815 - failed-query orphan schema rollback;  PR #1877 - Yield
+//   no longer fires during normal replication).  No realistic Cypher-
+//   level operation can produce the desync from a Python flow test, so
+//   this unit test directly drives GraphContext_GetSchemaByID with
+//   in-range, out-of-range and sentinel IDs to verify the defensive
+//   bounds-check works as documented.
+
+#include "src/util/arr.h"
+#include "src/util/rmalloc.h"
+#include "src/graph/graph.h"
+#include "src/graph/graphcontext.h"
+#include "src/graph/graphcontext_struct.h"
+#include "src/schema/schema.h"
+#include "src/queries_log/queries_log.h"
+#include "GraphBLAS/Include/GraphBLAS.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+void setup() {
+	Alloc_Reset();
+	GrB_init(GrB_NONBLOCKING);
+	GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW);
+	GxB_Global_Option_set(GxB_HYPER_SWITCH, GxB_NEVER_HYPER);
+}
+
+void tearDown() {
+	GrB_finalize();
+}
+
+#define TEST_INIT setup();
+#define TEST_FINI tearDown();
+#include "acutest.h"
+
+// Build a minimal GraphContext suitable for exercising
+// GraphContext_GetSchemaByID without dragging in the full module-load path.
+// Mirrors the _fake_graph_context() helper used by test_algebraic_expression.c.
+static GraphContext *_fake_graph_context(void) {
+	GraphContext *gc = (GraphContext *)calloc(1, sizeof(GraphContext));
+
+	gc->g                = Graph_New(16, 16);
+	gc->ref_count        = 1;
+	gc->index_count      = 0;
+	gc->graph_name       = strdup("G");
+	gc->attributes       = raxNew();
+	gc->string_mapping   = (char**)arr_new(char*,  64);
+	gc->node_schemas     = (Schema**)arr_new(Schema*, GRAPH_DEFAULT_LABEL_CAP);
+	gc->relation_schemas = (Schema**)arr_new(Schema*, GRAPH_DEFAULT_RELATION_TYPE_CAP);
+	gc->queries_log      = QueriesLog_New();
+
+	pthread_rwlock_init(&gc->_schema_rwlock, NULL);
+
+	return gc;
+}
+
+// In-range schema IDs return the expected Schema*.
+void test_get_schema_by_id_in_range_returns_schema(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	GraphContext_AddSchema(gc, "L0",   SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "L1",   SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "REL0", SCHEMA_EDGE);
+	GraphContext_AddSchema(gc, "REL1", SCHEMA_EDGE);
+
+	Schema *s;
+
+	s = GraphContext_GetSchemaByID(gc, 0, SCHEMA_NODE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "L0") == 0);
+
+	s = GraphContext_GetSchemaByID(gc, 1, SCHEMA_NODE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "L1") == 0);
+
+	s = GraphContext_GetSchemaByID(gc, 0, SCHEMA_EDGE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "REL0") == 0);
+
+	s = GraphContext_GetSchemaByID(gc, 1, SCHEMA_EDGE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "REL1") == 0);
+}
+
+// Out-of-range positive IDs (>= arr_len(schemas)) must return NULL,
+// not OOB-read the array.
+void test_get_schema_by_id_oob_positive_returns_null(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	// Two node schemas (ids 0,1) and one edge schema (id 0).
+	GraphContext_AddSchema(gc, "L0",   SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "L1",   SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "REL0", SCHEMA_EDGE);
+
+	// id == arr_len: just past the end (the exact failure mode in the
+	// customer crash - master had one more schema than replica).
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 2, SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 1, SCHEMA_EDGE) == NULL);
+
+	// id far past the end.
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 999,    SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 999999, SCHEMA_EDGE) == NULL);
+}
+
+// Negative IDs other than the GRAPH_NO_LABEL sentinel must also be
+// rejected - signed-to-unsigned coercion of a stray negative id used to
+// produce a huge index that read garbage from the schemas array.
+void test_get_schema_by_id_negative_returns_null(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	GraphContext_AddSchema(gc, "L0",   SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "REL0", SCHEMA_EDGE);
+
+	// GRAPH_NO_LABEL == -1 is the documented sentinel; it has always
+	// returned NULL via the early-return branch above the bounds check.
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, GRAPH_NO_LABEL, SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, GRAPH_NO_LABEL, SCHEMA_EDGE) == NULL);
+
+	// Other negative IDs must be rejected by the new bounds check rather
+	// than coerced to UINT_MAX-ish offsets that index into the schemas
+	// array.
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, -2,  SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, -42, SCHEMA_EDGE) == NULL);
+}
+
+// On an empty schema array every positive ID must come back NULL.
+// This is the literal replica-state-on-first-EFFECT case.
+void test_get_schema_by_id_empty_arrays_returns_null(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 0,   SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 0,   SCHEMA_EDGE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 1,   SCHEMA_NODE) == NULL);
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 100, SCHEMA_EDGE) == NULL);
+}
+
+// Boundary: id == arr_len - 1 is the LAST valid index; id == arr_len is
+// the FIRST invalid one.  Catches an off-by-one regression in the bounds
+// check itself.
+void test_get_schema_by_id_boundary(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	GraphContext_AddSchema(gc, "L0", SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "L1", SCHEMA_NODE);
+	GraphContext_AddSchema(gc, "L2", SCHEMA_NODE);
+
+	// last valid id - must succeed
+	Schema *s = GraphContext_GetSchemaByID(gc, 2, SCHEMA_NODE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "L2") == 0);
+
+	// first invalid id - must be rejected
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 3, SCHEMA_NODE) == NULL);
+}
+
+// SchemaType selection: a relation id that is in range for the EDGE array
+// but out of range for the NODE array (or vice versa) must respect the
+// selected type.  Prevents a regression where the bounds check looks at
+// the wrong schema array.
+void test_get_schema_by_id_type_dispatch(void) {
+	GraphContext *gc = _fake_graph_context();
+
+	GraphContext_AddSchema(gc, "L0",   SCHEMA_NODE);   // node id 0
+	GraphContext_AddSchema(gc, "REL0", SCHEMA_EDGE);   // edge id 0
+	GraphContext_AddSchema(gc, "REL1", SCHEMA_EDGE);   // edge id 1
+
+	// edge id 1 is valid against the EDGE array
+	Schema *s = GraphContext_GetSchemaByID(gc, 1, SCHEMA_EDGE);
+	TEST_ASSERT(s != NULL);
+	TEST_ASSERT(strcmp(Schema_GetName(s), "REL1") == 0);
+
+	// edge id 1 is OUT OF RANGE against the NODE array (only 1 node
+	// schema exists) - must return NULL, not a stale Schema*.
+	TEST_ASSERT(GraphContext_GetSchemaByID(gc, 1, SCHEMA_NODE) == NULL);
+}
+
+TEST_LIST = {
+	{ "get_schema_by_id_in_range_returns_schema",
+	  test_get_schema_by_id_in_range_returns_schema },
+	{ "get_schema_by_id_oob_positive_returns_null",
+	  test_get_schema_by_id_oob_positive_returns_null },
+	{ "get_schema_by_id_negative_returns_null",
+	  test_get_schema_by_id_negative_returns_null },
+	{ "get_schema_by_id_empty_arrays_returns_null",
+	  test_get_schema_by_id_empty_arrays_returns_null },
+	{ "get_schema_by_id_boundary",
+	  test_get_schema_by_id_boundary },
+	{ "get_schema_by_id_type_dispatch",
+	  test_get_schema_by_id_type_dispatch },
+	{ NULL, NULL }
+};


### PR DESCRIPTION
## Summary

When a replica applies a `GRAPH.EFFECT` command that references a relation/label schema ID absent from the replica's schema array, the previous code read past the end of the array and dereferenced the resulting NULL/garbage `Schema*`, producing a SIGSEGV.

**Customer report:** ~12 crashes/day on v4.18.1 replicas. Crash symbol `QGEdge_RelationID` in stripped builds (nearest exported symbol; actual fault site is `Schema_HasIndices`/`Delta_Matrix_nrows`). Same family as #910.

## Root Cause Analysis

### Mechanism 1 — `RedisModule_Yield` interleaving (PRIMARY, v4.18.1 WITH PR #1815)

In v4.18.1 the `_QueryCtx_ThreadSafeContextLock` helper (called from `QueryCtx_AcquireWriteLock`) always calls `RedisModule_Yield(YIELD_FLAG_CLIENTS)` when there is no blocked client. On a replica this context fires for every re-executed `GRAPH.QUERY` command from the replication stream.

**Race window** (between READ-lock release and WRITE-lock acquisition):

```
Replica main thread:
  GRAPH.QUERY "CREATE ()-[:R1]->()"  ← fast query, < threshold → GRAPH.QUERY path
    QueryCtx_AcquireWriteLock():
      Graph_ReleaseLock(READ)        ← R1 not yet committed
      _QueryCtx_ThreadSafeContextLock:
        RedisModule_Yield()          ← Redis event loop runs here
          ↳ reads replication socket
          ↳ processes GRAPH.EFFECT [EFFECT_CREATE_EDGE(r_id=0)]
              GraphHub_CreateEdges(r=0)
              GraphContext_GetSchemaByID(gc, 0, SCHEMA_EDGE) → NULL (R1 not yet in array)
              Schema_HasIndices(NULL)  → SIGSEGV  ← crash here
      Graph_AcquireWriteLock()       ← too late
      _CommitEdgesBlueprint()        ← R1 created here (never reached)
```

This explains:
- Replicas only — master never receives `GRAPH.EFFECT`
- Crash after ~1h of uptime — depends on interleaving of query timings
- The schema desync survives PR #1815 — that PR prevents orphan schemas on *failed* queries; it does not prevent the race between two separate, both-successful replication commands

**Fix already in master:** PR #1877 (`39460fe8c`) restricts `RedisModule_Yield` to AOF-loading paths only, closing the Yield window during normal replication.

### Mechanism 2 — Failed-query orphan schema (v4.16.x / v4.17.x, before PR #1815)

`CREATE ()-[:R_BAD]->() … RETURN x/0` raised an error after registering `R_BAD` in the schema array. Before PR #1815 the rollback path did not remove the schema, leaving it as an "orphan" on the master only. Subsequent `GRAPH.EFFECT` commands for new relation types then carried IDs that were one (or more) ahead of the replica's count.

**Fix already in master (v4.18.0+):** PR #1815 (`f2a8531c3`) added `UndoLog_AddSchema` so failed queries atomically remove the orphan schema.

### Missing bounds check (defensive hardening — this PR)

Regardless of *how* desync occurs, `GraphContext_GetSchemaByID` (graphcontext.c:609) performed a raw array read `schemas[id]` with no bounds check. Any future code path that creates schema ID divergence would re-trigger the crash. This PR adds the check and converts a corrupting crash into a clean `exit(1)` + full resync.

## Crash chain (before this fix)

```
GRAPH.EFFECT
  → Effects_Apply()
    → ApplyCreateEdge()
      → FlushEdges()
        → GraphHub_CreateEdges()
            Graph_CreateEdges(r)        ← r is out-of-range
            GraphContext_GetSchemaByID(gc, r, SCHEMA_EDGE)
              → schemas[r]  (OOB)       ← returns garbage or NULL
            Schema_HasIndices(NULL)      ← SIGSEGV at offset 0x18 from NULL
                                           (stripped symbol: QGEdge_RelationID)
```

## Changes

- **`GraphContext_GetSchemaByID`**: bounds-check `id`; return `NULL` for out-of-range IDs.
- **`GraphHub_CreateEdges`**: validate the relation schema **before** calling `Graph_CreateEdges`. On `NULL` → log a warning and `exit(1)` to trigger full RDB resync — matches the existing `ValidateVersion` pattern in `Effects_Apply`.
- **`ApplyLabels`**: same desync detection on per-label schema lookup.

## Testing

- `tests/flow/test_effect_schema_desync.py`:
  - **Synthetic unit tests** (`testEffectOOBRelation`, `testEffectNegativeRelation`, `testEffectSetLabelsOOBLabel`): craft raw `GRAPH.EFFECT` payloads with out-of-range IDs; assert `exit(1)` instead of SIGSEGV.
  - **Integration tests** (`testEffectSchemaDesyncReplica.test01`, `test02`): spin up a real master + replica pair, drive the Mechanism 2 (orphan-schema) scenario through the public Cypher API; assert replica stays alive and graph state matches. Both tests pass on this branch; reverting PR #1815 causes the replica to SIGSEGV.
  - Note: The Mechanism 1 (Yield) race cannot be triggered deterministically from Python — it requires sub-millisecond timing. That race is already closed by PR #1877.

## Memory / Performance Impact

None. The bounds check is a single integer comparison in a code path gated on write operations.

## Related Issues

- Closes the customer-reported `QGEdge_RelationID` SIGSEGV on v4.18.1 replicas.
- Same family as #910 (`AttributeSet_AddNoClone` via `Effects_Apply`).
- Depends on PR #1815 and PR #1877 already being in master.
- Follow-up called out by PR #1810: *"GraphContext_GetSchemaByID also lacks runtime bounds checks and could be hardened similarly in a follow-up."*

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash hardening for replication: missing or invalid schema and stream-version mismatches are now detected, emit a warning, and lead to an immediate, controlled termination to avoid undefined crashes.

* **Tests**
  * Added end-to-end regression tests for master/replica schema desynchronization, verifying controlled exits, replica liveness, log warnings, and final graph consistency (including repeated stress scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->