### PR TITLE
fix(execution_plan): rebind EdgeTraverseCtx->e after BindOpsToPlan to prevent UAF (private#101)

### DIFF
--- a/src/execution_plan/execution_plan_build/execution_plan_construct.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.c
@@ -212,6 +212,41 @@ static void _buildForeachOp
 	ExecutionPlan_AddOp(foreach, embedded_plan->root);
 }
 
+// After ExecutionPlan_BindOpsToPlan merges the temporary sub-QueryGraph into the
+// parent plan's QueryGraph (cloning edges), ops that were built against sub_qg
+// still hold EdgeTraverseCtx->e pointers into sub_qg.  Those pointers become
+// dangling the moment sub_qg is freed.  Walk the op tree and rebind each
+// EdgeTraverseCtx->e to the corresponding (already-cloned) edge in `qg` so
+// that freeing the temporary plan is safe.
+static void _RebindEdgeCtxToMergedQG
+(
+	OpBase    *op,
+	QueryGraph *qg
+) {
+	if(op == NULL) return;
+
+	if(op->type == OPType_CONDITIONAL_TRAVERSE ||
+	   op->type == OPType_OPTIONAL_CONDITIONAL_TRAVERSE) {
+		OpCondTraverse *ct = (OpCondTraverse *)op;
+		if(ct->edge_ctx != NULL) {
+			QGEdge *e = QueryGraph_GetEdgeByAlias(qg, ct->edge_ctx->e->alias);
+			ASSERT(e != NULL);
+			if(e != NULL) ct->edge_ctx->e = e;
+		}
+	} else if(op->type == OPType_EXPAND_INTO) {
+		OpExpandInto *ei = (OpExpandInto *)op;
+		if(ei->edge_ctx != NULL) {
+			QGEdge *e = QueryGraph_GetEdgeByAlias(qg, ei->edge_ctx->e->alias);
+			ASSERT(e != NULL);
+			if(e != NULL) ei->edge_ctx->e = e;
+		}
+	}
+
+	for(int i = 0; i < op->childCount; i++) {
+		_RebindEdgeCtxToMergedQG(op->children[i], qg);
+	}
+}
+
 OpBase *ExecutionPlan_BuildOpsFromPath
 (
 	ExecutionPlan *plan,
@@ -257,8 +292,13 @@ OpBase *ExecutionPlan_BuildOpsFromPath
 	QueryCtx_SetAST(ast); // reset the AST
 
 	// associate all new ops with the correct ExecutionPlan and QueryGraph
+	// NOTE: BindOpsToPlan calls QueryGraph_MergeGraphs which clones edges from
+	// match_stream_plan->query_graph (sub_qg) into plan->query_graph.  Any op
+	// holding an EdgeTraverseCtx->e pointer still references the originals in
+	// sub_qg; rebind them now, before sub_qg is freed below.
 	OpBase *match_stream_root = match_stream_plan->root;
 	ExecutionPlan_BindOpsToPlan(plan, match_stream_root);
+	_RebindEdgeCtxToMergedQG(match_stream_root, plan->query_graph);
 
 	// NULL-set map shared between the match_stream_plan and the overall plan
 	match_stream_plan->record_map = NULL;

--- a/src/execution_plan/execution_plan_build/execution_plan_modify.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_modify.c
@@ -298,6 +298,14 @@ static void _ExecutionPlan_BindOpsToPlan
 
 // for all ops in the given tree, associate the provided ExecutionPlan
 // merge the query graphs of the temporary and main plans
+//
+// IMPORTANT LIFETIME INVARIANT: QueryGraph_MergeGraphs clones QGEdge/QGNode
+// objects from root->plan->query_graph into plan->query_graph.  Any op that
+// stores a raw QGEdge* pointer (e.g. EdgeTraverseCtx->e) still references the
+// originals in the temporary QueryGraph after this call.  The caller must
+// rebind those pointers to the cloned equivalents in plan->query_graph before
+// freeing the temporary plan; see _RebindEdgeCtxToMergedQG in
+// execution_plan_construct.c for the canonical example.
 void ExecutionPlan_BindOpsToPlan
 (
 	ExecutionPlan *plan,  // plan to bind the operations to

--- a/tests/flow/test_call_subquery.py
+++ b/tests/flow/test_call_subquery.py
@@ -2884,3 +2884,56 @@ updating clause.")
         res = self.graph.query(q).result_set
         self.env.assertEquals(res[0][0], 2) # avgX
 
+    def test_54_optional_match_edge_traversal_in_call_subquery(self):
+        """Regression test for use-after-free in ExecutionPlan_BuildOpsFromPath.
+        
+        When an OPTIONAL MATCH with an edge traversal is planned inside a CALL
+        subquery, EdgeTraverseCtx->e previously held a dangling pointer to a
+        QGEdge that was freed when the temporary sub-QueryGraph was destroyed.
+        This caused SIGSEGV in QGEdge_RelationID (reltypeIDs == NULL) under
+        production heap pressure (FalkorDB/private#101).
+        """
+        g = self.db.select_graph("test_54_uaf")
+        g.query("CREATE (:City {id: 1})-[:HAS_MEMBER]->(:Member {id: 10})")
+        g.query("CREATE (:City {id: 2})")  # city with no members
+
+        # The OPTIONAL MATCH inside CALL {} with an explicit edge variable is
+        # the pattern that triggered the UAF: ops were built against a temporary
+        # QueryGraph that was subsequently freed while EdgeTraverseCtx->e still
+        # pointed into it.
+        q = """MATCH (c:City)
+               CALL {
+                   WITH c
+                   OPTIONAL MATCH (c)-[r:HAS_MEMBER]->(m:Member)
+                   RETURN r, m
+               }
+               RETURN c.id AS cid, m.id AS mid
+               ORDER BY cid"""
+
+        res = g.query(q).result_set
+        self.env.assertEquals(len(res), 2)
+        self.env.assertEquals(res[0][0], 1)  # city 1 has a member
+        self.env.assertEquals(res[0][1], 10)
+        self.env.assertEquals(res[1][0], 2)  # city 2 has no member
+        self.env.assertIsNone(res[1][1])
+
+        # Nested CALL with OPTIONAL MATCH edge traversal – exercises the deeper
+        # nesting that appeared in the customer's OGM-generated query.
+        q = """MATCH (c:City)
+               CALL {
+                   WITH c
+                   CALL {
+                       WITH c
+                       OPTIONAL MATCH (c)-[r:HAS_MEMBER]->(m:Member)
+                       RETURN r, m
+                   }
+                   RETURN r, m
+               }
+               RETURN c.id AS cid, m.id AS mid
+               ORDER BY cid"""
+
+        res = g.query(q).result_set
+        self.env.assertEquals(len(res), 2)
+        self.env.assertEquals(res[0][1], 10)
+        self.env.assertIsNone(res[1][1])
+


### PR DESCRIPTION
## Summary
Fix a use-after-free crash in `ExecutionPlan_BuildOpsFromPath` that caused SIGSEGV in `QGEdge_RelationID` under production heap pressure (reported in FalkorDB/private#101, customer Angelo Alessio, v4.18.0, crashed twice within 1.5 hours).

## Root Cause

When `ExecutionPlan_BuildOpsFromPath` builds ops for an **OPTIONAL MATCH with an edge variable inside a CALL {} subquery**:

1. A temporary plan `match_stream_plan` is created with its own `query_graph` (`sub_qg`) via `QueryGraph_ExtractPatterns`
2. `ExecutionPlan_PopulateExecutionPlan` creates ops (e.g. `OpCondTraverse`, `OpExpandInto`) which store `EdgeTraverseCtx->e` = pointer into `sub_qg`'s QGEdge objects
3. `ExecutionPlan_BindOpsToPlan` calls `QueryGraph_MergeGraphs` which **clones** those edges into the parent plan's QueryGraph — but `EdgeTraverseCtx->e` still points at the originals
4. `ExecutionPlan_Free(match_stream_plan)` → `QueryGraph_Free(sub_qg)` → `QGEdge_Free` destroys the originals
5. `EdgeTraverseCtx->e` is now a **dangling pointer** — under heap reuse, `reltypeIDs` becomes NULL → SIGSEGV in `QGEdge_RelationID`

The bug has existed since CALL {} subquery support was introduced (commit `a4e99e6`, June 2023).

## Changes

- **`src/execution_plan/execution_plan_build/execution_plan_construct.c`** — Add `_RebindEdgeCtxToMergedQG()` that walks the op tree after `BindOpsToPlan` and updates `EdgeTraverseCtx->e` for `OPType_CONDITIONAL_TRAVERSE`, `OPType_OPTIONAL_CONDITIONAL_TRAVERSE`, and `OPType_EXPAND_INTO` to reference the cloned edges in `plan->query_graph`. Call it between `BindOpsToPlan` and `ExecutionPlan_Free`.
- **`src/execution_plan/execution_plan_build/execution_plan_modify.c`** — Document the lifetime invariant on `ExecutionPlan_BindOpsToPlan` so future callers are aware of the raw-pointer hazard.
- **`tests/flow/test_call_subquery.py`** — Add `test_54_optional_match_edge_traversal_in_call_subquery`: exercises single and doubly-nested CALL {} with OPTIONAL MATCH + typed edge variable, verifying correct results for both nodes that have matching edges and nodes that don't.

## Testing

- New regression test passes (both single and nested CALL variants)
- MERGE path through `ExecutionPlan_BuildOpsFromPath` verified
- Direct OPTIONAL MATCH (not in CALL) verified

## Memory / Performance Impact

`_RebindEdgeCtxToMergedQG` runs once per `ExecutionPlan_BuildOpsFromPath` call (query plan construction time only, not hot path). It does a linear walk of the op tree and an O(n) alias lookup per edge op. Negligible compared to plan construction cost.

## Related Issues

Closes #1915
Refs FalkorDB/private#101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge variable references in CALL subqueries with OPTIONAL MATCH clauses to ensure correct result sets.
  * Improved memory safety for query execution plans when handling merged subgraph contexts.

* **Tests**
  * Added regression test for optional match edge traversal within CALL subqueries, including nested cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
