### PR TITLE
fix(execution_plan): rebind EdgeTraverseCtx->e after BindOpsToPlan to prevent UAF (SIGSEGV in QGEdge_RelationID)

### DIFF
--- a/src/execution_plan/execution_plan_build/execution_plan_construct.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.c
@@ -212,6 +212,41 @@ static void _buildForeachOp
 	ExecutionPlan_AddOp(foreach, embedded_plan->root);
 }
 
+// After ExecutionPlan_BindOpsToPlan merges the temporary sub-QueryGraph into the
+// parent plan's QueryGraph (cloning edges), ops that were built against sub_qg
+// still hold EdgeTraverseCtx->e pointers into sub_qg.  Those pointers become
+// dangling the moment sub_qg is freed.  Walk the op tree and rebind each
+// EdgeTraverseCtx->e to the corresponding (already-cloned) edge in `qg` so
+// that freeing the temporary plan is safe.
+static void _RebindEdgeCtxToMergedQG
+(
+	OpBase    *op,
+	QueryGraph *qg
+) {
+	if(op == NULL) return;
+
+	if(op->type == OPType_CONDITIONAL_TRAVERSE ||
+	   op->type == OPType_OPTIONAL_CONDITIONAL_TRAVERSE) {
+		OpCondTraverse *ct = (OpCondTraverse *)op;
+		if(ct->edge_ctx != NULL) {
+			QGEdge *e = QueryGraph_GetEdgeByAlias(qg, ct->edge_ctx->e->alias);
+			ASSERT(e != NULL);
+			if(e != NULL) ct->edge_ctx->e = e;
+		}
+	} else if(op->type == OPType_EXPAND_INTO) {
+		OpExpandInto *ei = (OpExpandInto *)op;
+		if(ei->edge_ctx != NULL) {
+			QGEdge *e = QueryGraph_GetEdgeByAlias(qg, ei->edge_ctx->e->alias);
+			ASSERT(e != NULL);
+			if(e != NULL) ei->edge_ctx->e = e;
+		}
+	}
+
+	for(int i = 0; i < op->childCount; i++) {
+		_RebindEdgeCtxToMergedQG(op->children[i], qg);
+	}
+}
+
 OpBase *ExecutionPlan_BuildOpsFromPath
 (
 	ExecutionPlan *plan,
@@ -257,8 +292,13 @@ OpBase *ExecutionPlan_BuildOpsFromPath
 	QueryCtx_SetAST(ast); // reset the AST
 
 	// associate all new ops with the correct ExecutionPlan and QueryGraph
+	// NOTE: BindOpsToPlan calls QueryGraph_MergeGraphs which clones edges from
+	// match_stream_plan->query_graph (sub_qg) into plan->query_graph.  Any op
+	// holding an EdgeTraverseCtx->e pointer still references the originals in
+	// sub_qg; rebind them now, before sub_qg is freed below.
 	OpBase *match_stream_root = match_stream_plan->root;
 	ExecutionPlan_BindOpsToPlan(plan, match_stream_root);
+	_RebindEdgeCtxToMergedQG(match_stream_root, plan->query_graph);
 
 	// NULL-set map shared between the match_stream_plan and the overall plan
 	match_stream_plan->record_map = NULL;

--- a/src/execution_plan/execution_plan_build/execution_plan_modify.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_modify.c
@@ -298,6 +298,14 @@ static void _ExecutionPlan_BindOpsToPlan
 
 // for all ops in the given tree, associate the provided ExecutionPlan
 // merge the query graphs of the temporary and main plans
+//
+// IMPORTANT LIFETIME INVARIANT: QueryGraph_MergeGraphs clones QGEdge/QGNode
+// objects from root->plan->query_graph into plan->query_graph.  Any op that
+// stores a raw QGEdge* pointer (e.g. EdgeTraverseCtx->e) still references the
+// originals in the temporary QueryGraph after this call.  The caller must
+// rebind those pointers to the cloned equivalents in plan->query_graph before
+// freeing the temporary plan; see _RebindEdgeCtxToMergedQG in
+// execution_plan_construct.c for the canonical example.
 void ExecutionPlan_BindOpsToPlan
 (
 	ExecutionPlan *plan,  // plan to bind the operations to

--- a/tests/flow/test_call_subquery.py
+++ b/tests/flow/test_call_subquery.py
@@ -2884,3 +2884,56 @@ updating clause.")
         res = self.graph.query(q).result_set
         self.env.assertEquals(res[0][0], 2) # avgX
 
+    def test_54_optional_match_edge_traversal_in_call_subquery(self):
+        """Regression test for use-after-free in ExecutionPlan_BuildOpsFromPath.
+        
+        When an OPTIONAL MATCH with an edge traversal is planned inside a CALL
+        subquery, EdgeTraverseCtx->e previously held a dangling pointer to a
+        QGEdge that was freed when the temporary sub-QueryGraph was destroyed.
+        This caused SIGSEGV in QGEdge_RelationID (reltypeIDs == NULL) under
+        production heap pressure (FalkorDB/private#101).
+        """
+        g = self.db.select_graph("test_54_uaf")
+        g.query("CREATE (:City {id: 1})-[:HAS_MEMBER]->(:Member {id: 10})")
+        g.query("CREATE (:City {id: 2})")  # city with no members
+
+        # The OPTIONAL MATCH inside CALL {} with an explicit edge variable is
+        # the pattern that triggered the UAF: ops were built against a temporary
+        # QueryGraph that was subsequently freed while EdgeTraverseCtx->e still
+        # pointed into it.
+        q = """MATCH (c:City)
+               CALL {
+                   WITH c
+                   OPTIONAL MATCH (c)-[r:HAS_MEMBER]->(m:Member)
+                   RETURN r, m
+               }
+               RETURN c.id AS cid, m.id AS mid
+               ORDER BY cid"""
+
+        res = g.query(q).result_set
+        self.env.assertEquals(len(res), 2)
+        self.env.assertEquals(res[0][0], 1)  # city 1 has a member
+        self.env.assertEquals(res[0][1], 10)
+        self.env.assertEquals(res[1][0], 2)  # city 2 has no member
+        self.env.assertIsNone(res[1][1])
+
+        # Nested CALL with OPTIONAL MATCH edge traversal – exercises the deeper
+        # nesting that appeared in the customer's OGM-generated query.
+        q = """MATCH (c:City)
+               CALL {
+                   WITH c
+                   CALL {
+                       WITH c
+                       OPTIONAL MATCH (c)-[r:HAS_MEMBER]->(m:Member)
+                       RETURN r, m
+                   }
+                   RETURN r, m
+               }
+               RETURN c.id AS cid, m.id AS mid
+               ORDER BY cid"""
+
+        res = g.query(q).result_set
+        self.env.assertEquals(len(res), 2)
+        self.env.assertEquals(res[0][1], 10)
+        self.env.assertIsNone(res[1][1])
+


### PR DESCRIPTION
## Summary

Replica replicas crashed with SIGSEGV at `QGEdge_RelationID+0x4` (accessing address nil).  
Root cause: `EdgeTraverseCtx->e` is a dangling pointer after `ExecutionPlan_Free(match_stream_plan)` in `ExecutionPlan_BuildOpsFromPath`.

### The bug

`ExecutionPlan_BuildOpsFromPath` builds a temporary plan (`match_stream_plan`) with its own sub-QueryGraph (`sub_qg`).  Ops like `OpCondTraverse` and `OpExpandInto` store a raw `QGEdge *` in `EdgeTraverseCtx->e` that points into `sub_qg`.

`ExecutionPlan_BindOpsToPlan` then calls `QueryGraph_MergeGraphs`, which **clones** edges from `sub_qg` into the parent plan's `query_graph`.  However, the `EdgeTraverseCtx->e` pointers in those ops are **not updated** — they still reference the originals in `sub_qg`.

When `ExecutionPlan_Free(match_stream_plan)` frees `sub_qg`, those pointers dangle.  Under production heap pressure the freed memory is overwritten with zeros, so the next call to `_Traverse_CollectEdges` → `QGEdge_RelationID(edge_ctx->e, i)` reads `e->reltypeIDs == NULL` and segfaults.

Trigger: any query with a `CALL { … UNION … }` or `CALL { WITH … OPTIONAL MATCH (n)-[r:TYPE]->() … }` pattern, especially on replicas handling concurrent writes that invalidate the plan cache.

## Changes

- Add `_RebindEdgeCtxToMergedQG()` in `execution_plan_construct.c`: walks the op tree after `BindOpsToPlan` and rebinds `EdgeTraverseCtx->e` for `OPType_CONDITIONAL_TRAVERSE`, `OPType_OPTIONAL_CONDITIONAL_TRAVERSE`, and `OPType_EXPAND_INTO` to the already-cloned edges in `plan->query_graph`.
- Document the lifetime invariant on `ExecutionPlan_BindOpsToPlan` in `execution_plan_modify.c`.
- Add regression test `test_54_optional_match_edge_traversal_in_call_subquery` (single and doubly-nested `CALL {}`).

## Testing

- New regression test added in `tests/flow/test_call_subquery.py`.
- Existing `test_call_subquery` suite passes.
- Crash reproduced with the provided repro scripts before fix; no crash after.

## Memory / Performance Impact

Pointer rebind only — no allocations, no copies, O(ops-in-subtree) time. Negligible.

## Related Issues

Closes FalkorDB/private#101  
Reproducer: `debug-edge-20260426T185708Z` crash bundle (two replicas, SIGSEGV at `QGEdge_RelationID+0x4`, address nil)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge reference handling in optional conditional traversal operations within call subqueries.

* **Tests**
  * Added regression test for optional match edge traversal in nested call subqueries to ensure stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->