### PR TITLE
refactor(temporal): move is_leap_year to temporal_value.h, fix dayOfQuarter

### DIFF
--- a/src/datatypes/date.c
+++ b/src/datatypes/date.c
@@ -6,6 +6,7 @@
 #include "RG.h"
 #include "../value.h"
 #include "../util/rmalloc.h"
+#include "temporal_value.h"
 
 #define _XOPEN_SOURCE  700 // needed for gmtime_r
 
@@ -225,16 +226,12 @@ bool Date_getComponent
         *value = (month - 1) / 3 + 1;
     } else if(strcasecmp(component, "dayOfQuarter") == 0 ||
 			  strcasecmp(component, "quarterDay")   == 0) {
-        int doy = yday;
         int q = (month - 1) / 3 + 1;
-        int dayOfQuarter = doy;
-
-        if(q > 1) {
-            // subtract days of prior months in current year
-            static const int daysUntilQuarter[] = {0, 0, 90, 181, 273};
-            dayOfQuarter = doy - daysUntilQuarter[q];
-        }
-        *value = dayOfQuarter + 1;
+        static const int quarter_offsets[]      = {0, 0, 90, 181, 273};
+        static const int quarter_offsets_leap[] = {0, 0, 91, 182, 274};
+        const int *offsets = is_leap_year(year) ? quarter_offsets_leap
+                                                : quarter_offsets;
+        *value = yday - offsets[q];
     }
 
     return (*value != -1);

--- a/src/datatypes/datetime.c
+++ b/src/datatypes/datetime.c
@@ -6,6 +6,7 @@
 #include "RG.h"
 #include "../value.h"
 #include "../util/rmalloc.h"
+#include "temporal_value.h"
 
 #define _XOPEN_SOURCE  700 // needed for gmtime_r
 
@@ -252,14 +253,6 @@ SIValue DateTime_fromComponents
     time_t sec_since_epoch = timegm(&timeinfo);
 
 	return SI_DateTime(sec_since_epoch);
-}
-
-// Helper function to check if a year is a leap year
-static bool is_leap_year
-(
-	int year
-) {
-    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
 }
 
 // Helper function to get ISO week number and week year

--- a/src/datatypes/temporal_value.h
+++ b/src/datatypes/temporal_value.h
@@ -6,6 +6,15 @@
 
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
+
+// returns true if year is a leap year (ISO 8601 / Gregorian calendar)
+static inline bool is_leap_year
+(
+	int year
+) {
+	return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
 
 // new temporal values
 /* Create a new timestamp - millis from epoch */

--- a/tests/flow/test_temporal.py
+++ b/tests/flow/test_temporal.py
@@ -155,7 +155,7 @@ class testTemporalDate(FlowTestsBase):
         self.env.assertEquals(week, 42)
         self.env.assertEquals(day, 21)
         self.env.assertEquals(dayOfWeek, 0)
-        self.env.assertEquals(dayOfQuarter, 23)
+        self.env.assertEquals(dayOfQuarter, 21)
         self.env.assertEquals(ordinalDay, 295)
 
     def test_date_to_from_string(self):


### PR DESCRIPTION
## Summary
Move the `is_leap_year` helper out of `datetime.c` (where it was `static` and unreachable from other translation units) into `temporal_value.h` as a `static inline` function, making it available to the entire temporal layer.

## Changes
- **`src/datatypes/temporal_value.h`** – add `static inline bool is_leap_year(int year)`
- **`src/datatypes/datetime.c`** – remove the duplicate `static` definition; include `temporal_value.h`
- **`src/datatypes/date.c`** – include `temporal_value.h`; fix `dayOfQuarter` computation (see below)
- **`tests/flow/test_temporal.py`** – correct expected value from `23` → `21`

## Testing
Logic verified with an isolated C test covering all four quarters in both leap and non-leap years (8/8 pass).

## Memory / Performance Impact
N/A — `static inline` function, zero runtime overhead.

## Related Issues
Closes #1731

---

### dayOfQuarter root-cause (two bugs fixed together)

**Bug 1 – wrong offset table for leap years**
The old `daysUntilQuarter[]` was hardcoded for non-leap years. In a leap year Q2/Q3/Q4 each start one day later, so a separate leap-year table is now selected via `is_leap_year(year)`.

**Bug 2 – spurious `+1`**
`yday` is already 1-based (`tm_yday + 1`, line 194). The subtraction `yday - offset` already yields the correct 1-based day-within-quarter. The extra `+1` in `*value = dayOfQuarter + 1` was wrong for every quarter including Q1.

Combined effect for `date({year:1984, month:10, day:21})`:
| | value |
|---|---|
| Before fix | `23` |
| After fix | `21` ✓ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quarter-day component calculation to correctly account for leap years, ensuring accurate date component retrieval.

* **Tests**
  * Updated test assertion to reflect corrected quarter-day calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->