### PR TITLE
do not mark anonymous aliases of a search path

### DIFF
--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -654,7 +654,7 @@ static AR_ExpNode *_AR_ExpFromShortestPath
 }
 
 static AR_ExpNode *_AR_ExpNodeFromGraphEntity(const cypher_astnode_t *entity) {
-	const char *alias = AST_ToString(entity);
+	const char *alias = AST_ToString(entity, NULL);
 	return AR_EXP_NewVariableOperandNode(alias);
 }
 
@@ -913,7 +913,7 @@ static AR_ExpNode *_AR_EXP_FromASTNode(const cypher_astnode_t *expr) {
 		return _AR_ExpNodeFromReduceFunction(expr);
 	} else if(t == CYPHER_AST_PATTERN_PATH || t == CYPHER_AST_PATTERN_COMPREHENSION) {
 		// this variable is assign by operitions that created in build_pattern_comprehension_ops.c
-		const char *alias = AST_ToString(expr);
+		const char *alias = AST_ToString(expr, NULL);
 		return AR_EXP_NewVariableOperandNode(alias);
 	} else {
 		/*

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -615,38 +615,66 @@ static inline char *_create_anon_alias
 	return alias;
 }
 
+// get a string representation of an AST node
+// usually used by to get either a node or an edge alias
+// the function will auto generate an `anon_x` alias for anonymous entities
+// e.g. MATCH (a)-[]->()
+// both the edge [] and the destination node are anonymous
 const char *AST_ToString
 (
-	const cypher_astnode_t *node
+	const cypher_astnode_t *node,  // AST node
+	bool *anonymous                // [optional] rather or not node is anonymous
 ) {
-	QueryCtx *ctx = QueryCtx_GetQueryCtx();
-	AST *ast = QueryCtx_GetAST();
-	AnnotationCtx *to_string_ctx = AST_AnnotationCtxCollection_GetToStringCtx(ast->anot_ctx_collection);
+	AST *ast = QueryCtx_GetAST () ;
+	QueryCtx *ctx = QueryCtx_GetQueryCtx () ;
 
-	char *str = (char *)cypher_astnode_get_annotation(to_string_ctx, node);
-	if(str == NULL) {
-		cypher_astnode_type_t t = cypher_astnode_type(node);
-		const cypher_astnode_t *ast_identifier = NULL;
-		if(t == CYPHER_AST_NODE_PATTERN) {
-			ast_identifier = cypher_ast_node_pattern_get_identifier(node);
-		} else if(t == CYPHER_AST_REL_PATTERN) {
-			ast_identifier = cypher_ast_rel_pattern_get_identifier(node);
-		} else {
-			struct cypher_input_range range = cypher_astnode_range(node);
-			uint length = range.end.offset - range.start.offset + 1;
-			str = malloc(sizeof(char) * length);
-			strncpy(str, ctx->query_data.query_no_params + range.start.offset, length - 1);
-			str[length - 1] = '\0';
+	AnnotationCtx *to_string_ctx =
+		AST_AnnotationCtxCollection_GetToStringCtx (ast->anot_ctx_collection) ;
+
+	char *str = (char *)cypher_astnode_get_annotation (to_string_ctx, node) ;
+
+	// string annotation exists
+	if (str != NULL) {
+		if (anonymous != NULL) {
+			*anonymous = true ;
 		}
-		if(ast_identifier) {
-			// Graph entity has a user-defined alias return it.
-			return cypher_ast_identifier_get_name(ast_identifier);
-		} else if(str == NULL) {
-			str = _create_anon_alias(ast->anot_ctx_collection->anon_count++);
-		}
-		cypher_astnode_attach_annotation(to_string_ctx, node, (void *)str, NULL);
+		return str ;
 	}
-	return str;
+
+	const cypher_astnode_t *ast_identifier = NULL ;
+	cypher_astnode_type_t t = cypher_astnode_type (node) ;
+
+	if (t == CYPHER_AST_NODE_PATTERN) {
+		ast_identifier = cypher_ast_node_pattern_get_identifier (node) ;
+	} else if (t == CYPHER_AST_REL_PATTERN) {
+		ast_identifier = cypher_ast_rel_pattern_get_identifier (node) ;
+	} else {
+		struct cypher_input_range range = cypher_astnode_range (node) ;
+		uint length = range.end.offset - range.start.offset + 1;
+		str = malloc(sizeof(char) * length);
+		strncpy(str, ctx->query_data.query_no_params + range.start.offset, length - 1);
+		str[length - 1] = '\0';
+	}
+
+	if (ast_identifier) {
+		if (anonymous != NULL) {
+			*anonymous = false ;
+		}
+		// graph entity has a user-defined alias return it
+		return cypher_ast_identifier_get_name (ast_identifier) ;
+	}
+
+	if (str == NULL) {
+		str = _create_anon_alias (ast->anot_ctx_collection->anon_count++) ;
+	}
+
+	if (anonymous != NULL) {
+		*anonymous = true ;
+	}
+
+	cypher_astnode_attach_annotation (to_string_ctx, node, (void *)str, NULL) ;
+
+	return str ;
 }
 
 cypher_parse_result_t *parse_query

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -623,7 +623,7 @@ static inline char *_create_anon_alias
 const char *AST_ToString
 (
 	const cypher_astnode_t *node,  // AST node
-	bool *anonymous                // [optional] rather or not node is anonymous
+	bool *anonymous                // [optional] whether or not node is anonymous
 ) {
 	AST *ast = QueryCtx_GetAST () ;
 	QueryCtx *ctx = QueryCtx_GetQueryCtx () ;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -244,7 +244,7 @@ AST_AnnotationCtxCollection *AST_GetAnnotationCtxCollection
 const char *AST_ToString
 (
 	const cypher_astnode_t *node,  // AST node
-	bool *anonymous                // [optional] rather or not node is anonymous
+	bool *anonymous                // [optional] whether or not node is anonymous
 ) ;
 
 void AST_Free

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -236,10 +236,16 @@ AST_AnnotationCtxCollection *AST_GetAnnotationCtxCollection
 	AST *ast
 );
 
+// get a string representation of an AST node
+// usually used by to get either a node or an edge alias
+// the function will auto generate an `anon_x` alias for anonymous entities
+// e.g. MATCH (a)-[]->()
+// both the edge [] and the destination node are anonymous
 const char *AST_ToString
 (
-	const cypher_astnode_t *node
-);
+	const cypher_astnode_t *node,  // AST node
+	bool *anonymous                // [optional] rather or not node is anonymous
+) ;
 
 void AST_Free
 (

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -179,8 +179,8 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 
 	if(!props) return NULL;
 
-	// Retrieve the entity's alias.
-	const char *alias = AST_ToString(entity);
+	// retrieve the entity's alias
+	const char *alias = AST_ToString (entity, NULL) ;
 
 	FT_FilterNode *root = NULL;
 	uint nelems = cypher_ast_map_nentries(props);

--- a/src/ast/ast_build_op_contexts.c
+++ b/src/ast/ast_build_op_contexts.c
@@ -152,7 +152,7 @@ static void _ConvertUpdateItem
 	if(ctx == raxNotFound) {
 		ctx = UpdateCtx_New(alias);
 		raxInsert(updates, (unsigned char *)alias, len, ctx, NULL);
-	} 
+	}
 
 	//--------------------------------------------------------------------------
 	// collect update information
@@ -275,7 +275,7 @@ void AST_PreparePathCreation
 		 * 1. Current entity is NOT bound in a previous clause.
 		 * 2. We have yet to account for this entity. */
 		const cypher_astnode_t *elem = cypher_ast_pattern_path_get_element(path, i);
-		const char *alias = AST_ToString(elem);
+		const char *alias = AST_ToString (elem, NULL) ;
 
 		// Skip entities defined in previous clauses or already represented in our nodes/edges arrays.
 		int rc = raxTryInsert(bound_vars, (unsigned char *)alias, strlen(alias), NULL, NULL);

--- a/src/ast/ast_build_reference_map.c
+++ b/src/ast/ast_build_reference_map.c
@@ -8,46 +8,78 @@
 #include "RG.h"
 #include "../util/arr.h"
 
-// Forward declerations:
-static void _AST_MapReferencedEntitiesInPath(AST *ast, const cypher_astnode_t *path,
-											 bool force_mapping);
-static void _ASTClause_BuildReferenceMap(AST *ast,
-										const cypher_astnode_t *clause);
+// define the which entities get mapped
+typedef enum {
+	MAP_ALL        = 0,  // map all entities
+	MAP_IDENTIFIED = 1,  // map only non anonymous entities
+	MAP_SKIP       = 2,  // don't map entity
+} MappingLevel;
 
-/* Check if a path is a named path or shortest path.
- * If so, all the entities it contains should be mapped,
- * otherwise only referenced entities should be mapped. */
-static inline bool _shouldForceMapping(const cypher_astnode_t *path) {
-	const cypher_astnode_type_t type = cypher_astnode_type(path);
-	return (type == CYPHER_AST_NAMED_PATH || type == CYPHER_AST_SHORTEST_PATH);
+// forward declerations
+static void _AST_MapReferencedEntitiesInPath
+(
+	AST *ast,
+	const cypher_astnode_t *path,
+	MappingLevel mapping_level
+) ;
+
+static void _ASTClause_BuildReferenceMap
+(
+	AST *ast,
+	const cypher_astnode_t *clause
+) ;
+
+// check if a path is a named path or shortest path
+// if so, all the entities it contains should be mapped,
+// otherwise only referenced entities should be mapped
+static inline MappingLevel _shouldForceMapping
+(
+	const cypher_astnode_t *path
+) {
+	const cypher_astnode_type_t type = cypher_astnode_type (path) ;
+	if (type == CYPHER_AST_NAMED_PATH || type == CYPHER_AST_SHORTEST_PATH) {
+		return MAP_ALL ;
+	}
+
+	return MAP_SKIP ;
 }
 
-// Adds an identifier or an alias to the reference map.
-static inline void _AST_UpdateRefMap(AST *ast, const char *name) {
-	raxInsert(ast->referenced_entities, (unsigned char *)name, strlen(name), NULL, NULL);
+// adds an identifier or an alias to the reference map
+static inline void _AST_UpdateRefMap
+(
+	AST *ast,
+	const char *name
+) {
+	raxInsert (ast->referenced_entities, (unsigned char *)name, strlen (name),
+			NULL, NULL) ;
 }
 
-// Map identifiers within an expression.
-static void _AST_MapExpression(AST *ast, const cypher_astnode_t *exp) {
-	cypher_astnode_type_t type = cypher_astnode_type(exp);
+// map identifiers within an expression
+static void _AST_MapExpression
+(
+	AST *ast,
+	const cypher_astnode_t *exp,
+	MappingLevel mapping_level
+) {
+	cypher_astnode_type_t type = cypher_astnode_type (exp) ;
 
-	// In case of identifier.
-	if(type == CYPHER_AST_IDENTIFIER) {
-		const char *identifier_name = cypher_ast_identifier_get_name(exp);
-		_AST_UpdateRefMap(ast, identifier_name);
-	} else if(type == CYPHER_AST_PATTERN_PATH) {
-		// In case of pattern filter or path projection.
-		_AST_MapReferencedEntitiesInPath(ast, exp, true);
-	} else if(type == CYPHER_AST_SHORTEST_PATH) {
-		// Reference all entity names in a shortest path.
-		_AST_MapReferencedEntitiesInPath(ast, exp, true);
+	// in case of identifier
+	if (type == CYPHER_AST_IDENTIFIER) {
+		const char *identifier_name = cypher_ast_identifier_get_name (exp) ;
+		_AST_UpdateRefMap (ast, identifier_name) ;
+	} else if (type == CYPHER_AST_PATTERN_PATH) {
+		// in case of pattern filter or path projection
+		_AST_MapReferencedEntitiesInPath (ast, exp, mapping_level) ;
+	} else if (type == CYPHER_AST_SHORTEST_PATH) {
+		// reference all entity names in a shortest path
+		_AST_MapReferencedEntitiesInPath (ast, exp, mapping_level) ;
 	} else {
-		// Recurse over children.
-		uint child_count = cypher_astnode_nchildren(exp);
-		for(uint i = 0; i < child_count; i++) {
-			const cypher_astnode_t *child = cypher_astnode_get_child(exp, i);
-			// Recursively continue mapping.
-			_AST_MapExpression(ast, child);
+		// recurse over children
+		uint child_count = cypher_astnode_nchildren (exp) ;
+		for (uint i = 0 ; i < child_count ; i++) {
+			const cypher_astnode_t *child = cypher_astnode_get_child (exp, i) ;
+			// recursively continue mapping
+			_AST_MapExpression (ast, child, mapping_level) ;
 		}
 	}
 }
@@ -72,98 +104,165 @@ static void _AST_MapOrderByReferences(AST *ast, const cypher_astnode_t *order_by
 	for(uint i = 0; i < count; i++) {
 		const cypher_astnode_t *item = cypher_ast_order_by_get_item(order_by, i);
 		const cypher_astnode_t *expression = cypher_ast_sort_item_get_expression(item);
-		_AST_MapExpression(ast, expression);
+		_AST_MapExpression (ast, expression, MAP_ALL) ;
 	}
 }
 
-// Adds a node to the referenced entities rax, in case it has labels or properties (inline filter).
-static void _AST_MapReferencedNode(AST *ast, const cypher_astnode_t *node, bool force_mapping) {
+// adds a node to the referenced entities rax, in case it has labels or
+// properties (inline filter)
+static void _AST_MapReferencedNode
+(
+	AST *ast,
+	const cypher_astnode_t *node,
+	MappingLevel mapping_level
+) {
+	const cypher_astnode_t *properties =
+		cypher_ast_node_pattern_get_properties (node) ;
 
-	const cypher_astnode_t *properties = cypher_ast_node_pattern_get_properties(node);
-	// Disregard empty property maps.
-	if(properties && cypher_astnode_nchildren(properties) == 0) properties = NULL;
-	// A node with inlined filters is always referenced for the FilterTree.
-	// (In the case of a CREATE path, these are properties being set)
-	if(properties || force_mapping) {
-		const char *alias = AST_ToString(node);
-		_AST_UpdateRefMap(ast, alias);
+	// disregard empty property maps
+	if (properties && cypher_astnode_nchildren (properties) == 0) {
+		properties = NULL ;
+	}
 
-		// Map any references within the properties map, such as 'b' in:
+	// a node with inlined filters is always referenced for the FilterTree
+	// (in the case of a CREATE path, these are properties being set)
+	bool anonymous = false ;
+	const char *alias = AST_ToString (node, &anonymous) ;
+
+	if (properties                ||
+		mapping_level  == MAP_ALL ||
+		(mapping_level == MAP_IDENTIFIED && !anonymous)) {
+		_AST_UpdateRefMap (ast, alias) ;
+
+		// map any references within the properties map, such as 'b' in:
 		// ({val: ID(b)})
-		if(properties) _AST_MapExpression(ast, properties);
+		if (properties) {
+			_AST_MapExpression (ast, properties, MAP_ALL) ;
+		}
 	}
 }
 
-// Adds an edge to the referenced entities rax if it has multiple types or any properties (inline filter).
-static void _AST_MapReferencedEdge(AST *ast, const cypher_astnode_t *edge, bool force_mapping) {
+// adds an edge to the referenced entities rax if it has multiple types or any
+// properties (inline filter)
+static void _AST_MapReferencedEdge
+(
+	AST *ast,
+	const cypher_astnode_t *edge,
+	MappingLevel mapping_level
+) {
+	const cypher_astnode_t *properties =
+		cypher_ast_rel_pattern_get_properties (edge) ;
 
-	const cypher_astnode_t *properties = cypher_ast_rel_pattern_get_properties(edge);
-	// Disregard empty property maps.
-	if(properties && cypher_astnode_nchildren(properties) == 0) properties = NULL;
-	// An edge with inlined filters is always referenced for the FilterTree.
-	// (In the case of a CREATE path, these are properties being set)
-	if(properties || force_mapping) {
-		const char *alias = AST_ToString(edge);
-		_AST_UpdateRefMap(ast, alias);
+	// disregard empty property maps
+	if (properties && cypher_astnode_nchildren (properties) == 0) {
+		properties = NULL ;
+	}
 
-		// Map any references within the properties map, such as 'b' in:
+	// an edge with inlined filters is always referenced for the FilterTree
+	// (in the case of a CREATE path, these are properties being set)
+	bool anonymous = false ;
+	const char *alias = AST_ToString (edge, &anonymous) ;
+
+	if (properties                ||
+		mapping_level  == MAP_ALL ||
+		(mapping_level == MAP_IDENTIFIED && !anonymous)) {
+		_AST_UpdateRefMap (ast, alias) ;
+
+		// map any references within the properties map, such as 'b' in:
 		// ({val: ID(b)})
-		if(properties) _AST_MapExpression(ast, properties);
+		if (properties) {
+			_AST_MapExpression (ast, properties, MAP_ALL) ;
+		}
 	}
 }
 
 // Maps entities in a given path.
-static void _AST_MapReferencedEntitiesInPath(AST *ast, const cypher_astnode_t *path,
-											 bool force_mapping) {
-	uint path_len = cypher_ast_pattern_path_nelements(path);
-	// Node are in even positions.
-	for(uint i = 0; i < path_len; i += 2)
-		_AST_MapReferencedNode(ast, cypher_ast_pattern_path_get_element(path, i), force_mapping);
-	// Edges are in odd positions.
-	for(uint i = 1; i < path_len; i += 2)
-		_AST_MapReferencedEdge(ast, cypher_ast_pattern_path_get_element(path, i), force_mapping);
-}
+static void _AST_MapReferencedEntitiesInPath
+(
+	AST *ast,
+	const cypher_astnode_t *path,
+	MappingLevel mapping_level
+) {
+	uint path_len = cypher_ast_pattern_path_nelements (path) ;
 
-// Add referenced aliases from MATCH clause - inline filtered and explicit WHERE filter.
-static void _AST_MapMatchClauseReferences(AST *ast, const cypher_astnode_t *match_clause) {
-	// Inline filters.
-	const cypher_astnode_t *pattern = cypher_ast_match_get_pattern(match_clause);
-	uint path_count = cypher_ast_pattern_npaths(pattern);
-	for(uint i = 0; i < path_count; i++) {
-		const cypher_astnode_t *path = cypher_ast_pattern_get_path(pattern, i);
-		bool force_mapping = _shouldForceMapping(path);
-		_AST_MapReferencedEntitiesInPath(ast, path, force_mapping);
+	// node are in even positions
+	for (uint i = 0; i < path_len ; i += 2) {
+		_AST_MapReferencedNode (ast,
+				cypher_ast_pattern_path_get_element (path, i), mapping_level) ;
 	}
 
-	// Where clause.
-	const cypher_astnode_t *predicate = cypher_ast_match_get_predicate(match_clause);
-	if(predicate) _AST_MapExpression(ast, predicate);
-}
-
-// Add referenced aliases from CREATE clause.
-static void _AST_MapCreateClauseReferences(AST *ast, const cypher_astnode_t *create_clause) {
-	const cypher_astnode_t *pattern = cypher_ast_create_get_pattern(create_clause);
-	uint path_count = cypher_ast_pattern_npaths(pattern);
-	for(uint i = 0; i < path_count; i++) {
-		const cypher_astnode_t *path = cypher_ast_pattern_get_path(pattern, i);
-		bool force_mapping = _shouldForceMapping(path);
-		_AST_MapReferencedEntitiesInPath(ast, path, force_mapping);
+	// edges are in odd positions
+	for (uint i = 1 ; i < path_len ; i += 2) {
+		_AST_MapReferencedEdge (ast,
+				cypher_ast_pattern_path_get_element (path, i), mapping_level) ;
 	}
 }
 
-// Maps entities in SET clauses that update an individual property.
-static void _AST_MapSetPropertyReferences(AST *ast, const cypher_astnode_t *set_item) {
-	// Retrieve the alias being modified from the property descriptor.
-	const cypher_astnode_t *ast_prop = cypher_ast_set_property_get_property(set_item);
-	const cypher_astnode_t *ast_entity = cypher_ast_property_operator_get_expression(ast_prop);
-	ASSERT(cypher_astnode_type(ast_entity) == CYPHER_AST_IDENTIFIER);
+// add referenced aliases from MATCH clause
+// inline filtered and explicit WHERE filter
+static void _AST_MapMatchClauseReferences
+(
+	AST *ast,
+	const cypher_astnode_t *match_clause
+) {
+	// inline filters
+	const cypher_astnode_t *pattern =
+		cypher_ast_match_get_pattern (match_clause) ;
+	uint path_count = cypher_ast_pattern_npaths (pattern) ;
 
-	const char *alias = cypher_ast_identifier_get_name(ast_entity);
-	_AST_UpdateRefMap(ast, alias);
+	for (uint i = 0 ; i < path_count ; i++) {
+		const cypher_astnode_t *path =
+			cypher_ast_pattern_get_path (pattern, i) ;
+		MappingLevel mapping_level = _shouldForceMapping (path) ;
+		_AST_MapReferencedEntitiesInPath (ast, path, mapping_level) ;
+	}
+
+	// where clause
+	const cypher_astnode_t *predicate =
+		cypher_ast_match_get_predicate (match_clause) ;
+	if (predicate) {
+		_AST_MapExpression (ast, predicate, MAP_IDENTIFIED) ;
+	}
+}
+
+// add referenced aliases from CREATE clause
+static void _AST_MapCreateClauseReferences
+(
+	AST *ast,
+	const cypher_astnode_t *create_clause
+) {
+	const cypher_astnode_t *pattern =
+		cypher_ast_create_get_pattern (create_clause) ;
+	uint path_count = cypher_ast_pattern_npaths (pattern) ;
+
+	for (uint i = 0 ; i < path_count ; i++) {
+		const cypher_astnode_t *path = cypher_ast_pattern_get_path (pattern, i) ;
+		MappingLevel mapping_level = _shouldForceMapping (path) ;
+		_AST_MapReferencedEntitiesInPath (ast, path, mapping_level) ;
+	}
+}
+
+// maps entities in SET clauses that update an individual property
+static void _AST_MapSetPropertyReferences
+(
+	AST *ast,
+	const cypher_astnode_t *set_item
+) {
+	// retrieve the alias being modified from the property descriptor
+	const cypher_astnode_t *ast_prop =
+		cypher_ast_set_property_get_property (set_item) ;
+	const cypher_astnode_t *ast_entity =
+		cypher_ast_property_operator_get_expression (ast_prop) ;
+
+	ASSERT (cypher_astnode_type(ast_entity) == CYPHER_AST_IDENTIFIER) ;
+
+	const char *alias = cypher_ast_identifier_get_name (ast_entity) ;
+	_AST_UpdateRefMap (ast, alias) ;
 
 	// Map expression right hand side, e.g. a.v = 1, a.x = b.x
-	const cypher_astnode_t *set_exp = cypher_ast_set_property_get_expression(set_item);
-	_AST_MapExpression(ast, set_exp);
+	const cypher_astnode_t *set_exp =
+		cypher_ast_set_property_get_expression (set_item) ;
+	_AST_MapExpression (ast, set_exp, MAP_ALL) ;
 }
 
 // maps entities in SET clauses that update labels
@@ -172,42 +271,54 @@ static void _AST_MapSetLabelsReferences
 	AST *ast,
 	const cypher_astnode_t *set_item
 ) {
-	ASSERT(cypher_astnode_type(set_item) == CYPHER_AST_SET_LABELS);
+	ASSERT (cypher_astnode_type (set_item) == CYPHER_AST_SET_LABELS) ;
 
 	const cypher_astnode_t *identifier =
-		cypher_ast_set_labels_get_identifier(set_item);
-	ASSERT(cypher_astnode_type(identifier) == CYPHER_AST_IDENTIFIER);
+		cypher_ast_set_labels_get_identifier (set_item) ;
+	ASSERT (cypher_astnode_type (identifier) == CYPHER_AST_IDENTIFIER) ;
 
-	const char *alias = cypher_ast_identifier_get_name(identifier);
-	_AST_UpdateRefMap(ast, alias);
+	const char *alias = cypher_ast_identifier_get_name (identifier) ;
+	_AST_UpdateRefMap (ast, alias) ;
 }
 
-// Maps entities in SET clauses that replace all properties.
-static void _AST_MapSetAllPropertiesReferences(AST *ast, const cypher_astnode_t *set_item) {
-	// Retrieve the alias being modified.
-	const cypher_astnode_t *ast_alias = cypher_ast_set_all_properties_get_identifier(set_item);
-	ASSERT(cypher_astnode_type(ast_alias) == CYPHER_AST_IDENTIFIER);
+// maps entities in SET clauses that replace all properties
+static void _AST_MapSetAllPropertiesReferences
+(
+	AST *ast,
+	const cypher_astnode_t *set_item
+) {
+	// retrieve the alias being modified
+	const cypher_astnode_t *ast_alias =
+		cypher_ast_set_all_properties_get_identifier (set_item) ;
+	ASSERT (cypher_astnode_type(ast_alias) == CYPHER_AST_IDENTIFIER) ;
 
-	const char *alias = cypher_ast_identifier_get_name(ast_alias);
-	_AST_UpdateRefMap(ast, alias);
+	const char *alias = cypher_ast_identifier_get_name (ast_alias) ;
+	_AST_UpdateRefMap (ast, alias) ;
 
-	// Map expression right hand side, e.g. a = {v: b.v}
-	const cypher_astnode_t *set_exp = cypher_ast_set_all_properties_get_expression(set_item);
-	_AST_MapExpression(ast, set_exp);
+	// map expression right hand side, e.g. a = {v: b.v}
+	const cypher_astnode_t *set_exp =
+		cypher_ast_set_all_properties_get_expression (set_item) ;
+	_AST_MapExpression (ast, set_exp, MAP_ALL) ;
 }
 
-// Maps entities in SET clauses that merge multiple properties.
-static void _AST_MapMergePropertiesReferences(AST *ast, const cypher_astnode_t *set_item) {
-	// Retrieve the alias being modified.
-	const cypher_astnode_t *ast_alias = cypher_ast_merge_properties_get_identifier(set_item);
-	ASSERT(cypher_astnode_type(ast_alias) == CYPHER_AST_IDENTIFIER);
+// maps entities in SET clauses that merge multiple properties
+static void _AST_MapMergePropertiesReferences
+(
+	AST *ast,
+	const cypher_astnode_t *set_item
+) {
+	// retrieve the alias being modified
+	const cypher_astnode_t *ast_alias =
+		cypher_ast_merge_properties_get_identifier (set_item) ;
+	ASSERT (cypher_astnode_type (ast_alias) == CYPHER_AST_IDENTIFIER) ;
 
-	const char *alias = cypher_ast_identifier_get_name(ast_alias);
-	_AST_UpdateRefMap(ast, alias);
+	const char *alias = cypher_ast_identifier_get_name (ast_alias) ;
+	_AST_UpdateRefMap (ast, alias) ;
 
-	// Map expression right hand side, e.g. a += {v: b.v}
-	const cypher_astnode_t *set_exp = cypher_ast_merge_properties_get_expression(set_item);
-	_AST_MapExpression(ast, set_exp);
+	// map expression right hand side, e.g. a += {v: b.v}
+	const cypher_astnode_t *set_exp =
+		cypher_ast_merge_properties_get_expression (set_item) ;
+	_AST_MapExpression (ast, set_exp, MAP_ALL) ;
 }
 
 static void _AST_MapSetItemReferences
@@ -215,18 +326,18 @@ static void _AST_MapSetItemReferences
 	AST *ast,
 	const cypher_astnode_t *set_item
 ) {
-	const cypher_astnode_type_t type = cypher_astnode_type(set_item);
+	const cypher_astnode_type_t type = cypher_astnode_type (set_item) ;
 
-	if(type == CYPHER_AST_SET_PROPERTY) {
-		_AST_MapSetPropertyReferences(ast, set_item);
-	} else if(type == CYPHER_AST_SET_ALL_PROPERTIES) {
-		_AST_MapSetAllPropertiesReferences(ast, set_item);
-	} else if(type == CYPHER_AST_MERGE_PROPERTIES) {
-		_AST_MapMergePropertiesReferences(ast, set_item);
-	} else if(type == CYPHER_AST_SET_LABELS) {
-		_AST_MapSetLabelsReferences(ast, set_item);
+	if (type == CYPHER_AST_SET_PROPERTY) {
+		_AST_MapSetPropertyReferences (ast, set_item) ;
+	} else if (type == CYPHER_AST_SET_ALL_PROPERTIES) {
+		_AST_MapSetAllPropertiesReferences (ast, set_item) ;
+	} else if (type == CYPHER_AST_MERGE_PROPERTIES) {
+		_AST_MapMergePropertiesReferences (ast, set_item) ;
+	} else if (type == CYPHER_AST_SET_LABELS) {
+		_AST_MapSetLabelsReferences (ast, set_item) ;
 	} else {
-		ASSERT(false);
+		ASSERT (false) ;
 	}
 }
 
@@ -245,16 +356,16 @@ static void _AST_MapRemovePropertyReferences
 	AST *ast,
 	const cypher_astnode_t *remove_item
 ) {
-	ASSERT(cypher_astnode_type(remove_item) == CYPHER_AST_REMOVE_PROPERTY);
+	ASSERT (cypher_astnode_type (remove_item) == CYPHER_AST_REMOVE_PROPERTY) ;
 
 	const cypher_astnode_t *ast_prop =
-		cypher_ast_remove_property_get_property(remove_item);
+		cypher_ast_remove_property_get_property (remove_item) ;
 	const cypher_astnode_t *ast_entity =
-		cypher_ast_property_operator_get_expression(ast_prop);
-	ASSERT(cypher_astnode_type(ast_entity) == CYPHER_AST_IDENTIFIER);
+		cypher_ast_property_operator_get_expression (ast_prop) ;
+	ASSERT (cypher_astnode_type (ast_entity) == CYPHER_AST_IDENTIFIER) ;
 
-	const char *alias = cypher_ast_identifier_get_name(ast_entity);
-	_AST_UpdateRefMap(ast, alias);
+	const char *alias = cypher_ast_identifier_get_name (ast_entity) ;
+	_AST_UpdateRefMap (ast, alias) ;
 }
 
 // maps entities in REMOVE clauses that update labels
@@ -263,16 +374,16 @@ static void _AST_MapRemoveLabelsReferences
 	AST *ast,
 	const cypher_astnode_t *remove_item
 ) {
-	ASSERT(ast != NULL);
-	ASSERT(remove_item != NULL);
-	ASSERT(cypher_astnode_type(remove_item) == CYPHER_AST_REMOVE_LABELS);
+	ASSERT (ast != NULL) ;
+	ASSERT (remove_item != NULL) ;
+	ASSERT (cypher_astnode_type (remove_item) == CYPHER_AST_REMOVE_LABELS) ;
 
 	const cypher_astnode_t *identifier =
-		cypher_ast_remove_labels_get_identifier(remove_item);
-	ASSERT(cypher_astnode_type(identifier) == CYPHER_AST_IDENTIFIER);
+		cypher_ast_remove_labels_get_identifier (remove_item) ;
+	ASSERT (cypher_astnode_type (identifier) == CYPHER_AST_IDENTIFIER) ;
 
-	const char *alias = cypher_ast_identifier_get_name(identifier);
-	_AST_UpdateRefMap(ast, alias);
+	const char *alias = cypher_ast_identifier_get_name (identifier) ;
+	_AST_UpdateRefMap (ast, alias) ;
 }
 
 static void _AST_MapRemoveItemReferences
@@ -317,11 +428,12 @@ static void _AST_MapUnwindClauseReferences
 	AST *ast,
 	const cypher_astnode_t *unwind_clause
 ) {
-	ASSERT(ast != NULL);
-	ASSERT(unwind_clause != NULL);
+	ASSERT (ast != NULL) ;
+	ASSERT (unwind_clause != NULL) ;
 
-	const cypher_astnode_t * expr = cypher_ast_unwind_get_expression(unwind_clause);
-	_AST_MapExpression(ast, expr);
+	const cypher_astnode_t * expr =
+		cypher_ast_unwind_get_expression (unwind_clause) ;
+	_AST_MapExpression (ast, expr, MAP_ALL) ;
 }
 
 // maps entities in a FOREACH clause
@@ -331,19 +443,20 @@ static void _AST_MapForeachClauseReferences
 	AST *ast,
 	const cypher_astnode_t *foreach_clause
 ) {
-	ASSERT(ast != NULL);
-	ASSERT(foreach_clause != NULL);
+	ASSERT (ast != NULL) ;
+	ASSERT (foreach_clause != NULL) ;
 
 	// extract list expression from FOREACH
-	const cypher_astnode_t *exp = cypher_ast_foreach_get_expression(foreach_clause);
-	_AST_MapExpression(ast, exp);
+	const cypher_astnode_t *exp =
+		cypher_ast_foreach_get_expression (foreach_clause) ;
+	_AST_MapExpression (ast, exp, MAP_ALL) ;
 
 	// process each clause within FOREACH body
-	uint nclauses = cypher_ast_foreach_nclauses(foreach_clause);
-	for(uint i = 0; i < nclauses; i++) {
-		const cypher_astnode_t *clause = cypher_ast_foreach_get_clause(
-				foreach_clause, i);
-		_ASTClause_BuildReferenceMap(ast, clause);
+	uint nclauses = cypher_ast_foreach_nclauses (foreach_clause) ;
+	for (uint i = 0; i < nclauses; i++) {
+		const cypher_astnode_t *clause = cypher_ast_foreach_get_clause (
+				foreach_clause, i) ;
+		_ASTClause_BuildReferenceMap (ast, clause) ;
 	}
 }
 
@@ -369,154 +482,214 @@ static void _AST_MapDeleteClauseReferences
 	AST *ast,
 	const cypher_astnode_t *delete_clause
 ) {
-	ASSERT(ast != NULL);
-	ASSERT(delete_clause != NULL);
+	ASSERT (ast != NULL) ;
+	ASSERT (delete_clause != NULL) ;
 
-	uint nitems = cypher_ast_delete_nexpressions(delete_clause);
-	for(uint i = 0; i < nitems; i++) {
+	uint nitems = cypher_ast_delete_nexpressions (delete_clause) ;
+	for (uint i = 0 ; i < nitems ; i++) {
 		const cypher_astnode_t *delete_exp =
-			cypher_ast_delete_get_expression(delete_clause, i);
-		_AST_MapExpression(ast, delete_exp);
+			cypher_ast_delete_get_expression (delete_clause, i) ;
+		_AST_MapExpression (ast, delete_exp, MAP_ALL) ;
 	}
 }
 
 // Maps entities in MERGE clause. Either by implicit filters, or modified entities by SET clause.
-static void _AST_MapMergeClauseReference(AST *ast, const cypher_astnode_t *merge_clause) {
-	// Collect implicitly filtered entities.
-	const cypher_astnode_t *merge_path = cypher_ast_merge_get_pattern_path(merge_clause);
-	bool force_mapping = _shouldForceMapping(merge_path);
-	_AST_MapReferencedEntitiesInPath(ast, merge_path, force_mapping);
+static void _AST_MapMergeClauseReference
+(
+	AST *ast,
+	const cypher_astnode_t *merge_clause
+) {
+	// collect implicitly filtered entities
+	const cypher_astnode_t *merge_path =
+		cypher_ast_merge_get_pattern_path (merge_clause) ;
+	MappingLevel mapping_level = _shouldForceMapping (merge_path) ;
+	_AST_MapReferencedEntitiesInPath (ast, merge_path, mapping_level) ;
 
-	// Map modified entities, either by ON MATCH or ON CREATE clause.
-	uint merge_actions = cypher_ast_merge_nactions(merge_clause);
-	for(uint i = 0; i < merge_actions; i++) {
-		const cypher_astnode_t *action = cypher_ast_merge_get_action(merge_clause, i);
-		cypher_astnode_type_t type = cypher_astnode_type(action);
-		// ON CREATE.
-		if(type == CYPHER_AST_ON_CREATE) {
-			uint on_create_items = cypher_ast_on_create_nitems(action);
-			for(uint j = 0; j < on_create_items; j ++) {
-				const cypher_astnode_t *set_item = cypher_ast_on_create_get_item(action, j);
-				_AST_MapSetItemReferences(ast, set_item);
+	// map modified entities, either by ON MATCH or ON CREATE clause
+	uint merge_actions = cypher_ast_merge_nactions (merge_clause) ;
+	for (uint i = 0 ; i < merge_actions ; i++) {
+		const cypher_astnode_t *action =
+			cypher_ast_merge_get_action (merge_clause, i) ;
+		cypher_astnode_type_t type = cypher_astnode_type (action) ;
+
+		// ON CREATE
+		if (type == CYPHER_AST_ON_CREATE) {
+			uint on_create_items = cypher_ast_on_create_nitems (action) ;
+			for (uint j = 0 ; j < on_create_items ; j++) {
+				const cypher_astnode_t *set_item =
+					cypher_ast_on_create_get_item (action, j) ;
+				_AST_MapSetItemReferences (ast, set_item) ;
 			}
-		} else if(type == CYPHER_AST_ON_MATCH) {
-			// ON MATCH.
-			uint on_match_items = cypher_ast_on_match_nitems(action);
-			for(uint j = 0; j < on_match_items; j ++) {
-				const cypher_astnode_t *set_item = cypher_ast_on_match_get_item(action, j);
-				_AST_MapSetItemReferences(ast, set_item);
+		} else if (type == CYPHER_AST_ON_MATCH) {
+			// ON MATCH
+			uint on_match_items = cypher_ast_on_match_nitems (action) ;
+			for (uint j = 0 ; j < on_match_items ; j++) {
+				const cypher_astnode_t *set_item =
+					cypher_ast_on_match_get_item (action, j) ;
+				_AST_MapSetItemReferences (ast, set_item) ;
 			}
 		}
 	}
 }
 
-// Map the LHS of "AS" projected entities. "WITH a as x order by x" will just collect a to the map.
-static void _AST_MapWithReferredEntities(AST *ast_segment, const cypher_astnode_t *with_clause) {
-	int projectionCount = cypher_ast_with_nprojections(with_clause);
-	for(uint i = 0 ; i < projectionCount; i ++) {
-		const cypher_astnode_t *projection = cypher_ast_with_get_projection(with_clause, i);
-		// The expression forms the LHS of the projection.
-		const cypher_astnode_t *exp = cypher_ast_projection_get_expression(projection);
-		_AST_MapExpression(ast_segment, exp);
+// map the LHS of "AS" projected entities
+// "WITH a as x order by x" will just collect a to the map
+static void _AST_MapWithReferredEntities
+(
+	AST *ast_segment,
+	const cypher_astnode_t *with_clause
+) {
+	int projectionCount = cypher_ast_with_nprojections (with_clause) ;
+	for (uint i = 0 ; i < projectionCount ; i++) {
+		const cypher_astnode_t *projection =
+			cypher_ast_with_get_projection (with_clause, i) ;
+		// the expression forms the LHS of the projection
+		const cypher_astnode_t *exp =
+			cypher_ast_projection_get_expression (projection) ;
+		_AST_MapExpression (ast_segment, exp, MAP_ALL) ;
 	}
-	// Add referenced aliases for WITH's ORDER BY entities.
-	const cypher_astnode_t *order_by = cypher_ast_with_get_order_by(with_clause);
-	if(order_by) _AST_MapOrderByReferences(ast_segment, order_by);
+
+	// add referenced aliases for WITH's ORDER BY entities
+	const cypher_astnode_t *order_by =
+		cypher_ast_with_get_order_by (with_clause) ;
+	if (order_by) {
+		_AST_MapOrderByReferences (ast_segment, order_by) ;
+	}
 }
 
-// Map the LHS of "AS" projected entities. "RETURN a as x order by x" will just collect a to the map.
-static void _AST_MapReturnReferredEntities(AST *ast_segment,
-										   const cypher_astnode_t *return_clause) {
-	// Add referenced aliases for RETURN projections.
-	uint projectionCount = cypher_ast_return_nprojections(return_clause);
-	for(uint i = 0 ; i < projectionCount; i ++) {
-		const cypher_astnode_t *projection = cypher_ast_return_get_projection(return_clause, i);
-		// The expression forms the LHS of the projection.
-		const cypher_astnode_t *exp = cypher_ast_projection_get_expression(projection);
-		_AST_MapExpression(ast_segment, exp);
+// map the LHS of "AS" projected entities
+// "RETURN a as x order by x" will just collect a to the map
+static void _AST_MapReturnReferredEntities
+(
+	AST *ast_segment,
+	const cypher_astnode_t *return_clause
+) {
+	// add referenced aliases for RETURN projections.
+	uint projectionCount = cypher_ast_return_nprojections (return_clause) ;
+	for (uint i = 0 ; i < projectionCount ; i++) {
+		const cypher_astnode_t *projection
+			= cypher_ast_return_get_projection (return_clause, i) ;
+		// the expression forms the LHS of the projection
+		const cypher_astnode_t *exp =
+			cypher_ast_projection_get_expression (projection) ;
+		_AST_MapExpression (ast_segment, exp, MAP_ALL) ;
 	}
-	// Add referenced aliases for RETURN's ORDER BY entities.
-	const cypher_astnode_t *order_by = cypher_ast_return_get_order_by(return_clause);
-	if(order_by) _AST_MapOrderByReferences(ast_segment, order_by);
+
+	// add referenced aliases for RETURN's ORDER BY entities
+	const cypher_astnode_t *order_by =
+		cypher_ast_return_get_order_by (return_clause) ;
+	if (order_by) {
+		_AST_MapOrderByReferences (ast_segment, order_by) ;
+	}
 }
 
-static void _ASTClause_BuildReferenceMap(AST *ast, const cypher_astnode_t *clause) {
-	if(!clause) return;
+static void _ASTClause_BuildReferenceMap
+(
+	AST *ast,
+	const cypher_astnode_t *clause
+) {
+	if (!clause) {
+		return ;
+	}
 
-	cypher_astnode_type_t type = cypher_astnode_type(clause);
-	if(type == CYPHER_AST_RETURN) {
+	cypher_astnode_type_t type = cypher_astnode_type (clause) ;
+	if (type == CYPHER_AST_RETURN) {
 		// add referenced aliases for RETURN projections
-		uint projectionCount = cypher_ast_return_nprojections(clause);
-		for(uint i = 0 ; i < projectionCount; i ++) {
-			_AST_MapProjectionAlias(ast, cypher_ast_return_get_projection(clause, i));
+		uint projectionCount = cypher_ast_return_nprojections (clause) ;
+		for (uint i = 0 ; i < projectionCount ; i++) {
+			_AST_MapProjectionAlias (ast,
+					cypher_ast_return_get_projection (clause, i)) ;
 		}
+
 		// add referenced aliases for RETURN's ORDER BY entities
-		const cypher_astnode_t *order_by = cypher_ast_return_get_order_by(clause);
-		if(order_by) _AST_MapOrderByReferences(ast, order_by);
-	} else if(type == CYPHER_AST_WITH) {
-		// add referenced aliases for WITH projections
-		uint projectionCount = cypher_ast_with_nprojections(clause);
-		for(uint i = 0 ; i < projectionCount; i ++) {
-			_AST_MapProjectionAlias(ast, cypher_ast_with_get_projection(clause, i));
+		const cypher_astnode_t *order_by =
+			cypher_ast_return_get_order_by (clause) ;
+		if (order_by) {
+			_AST_MapOrderByReferences (ast, order_by) ;
 		}
+	} else if (type == CYPHER_AST_WITH) {
+		// add referenced aliases for WITH projections
+		uint projectionCount = cypher_ast_with_nprojections (clause) ;
+		for (uint i = 0 ; i < projectionCount ; i++) {
+			_AST_MapProjectionAlias (ast,
+					cypher_ast_with_get_projection (clause, i)) ;
+		}
+
 		// add referenced aliases for WITH's ORDER BY entities
-		const cypher_astnode_t *order_by = cypher_ast_with_get_order_by(clause);
-		if(order_by) _AST_MapOrderByReferences(ast, order_by);
-	} else if(type == CYPHER_AST_MATCH) {
+		const cypher_astnode_t *order_by =
+			cypher_ast_with_get_order_by (clause) ;
+		if (order_by) {
+			_AST_MapOrderByReferences (ast, order_by) ;
+		}
+	} else if (type == CYPHER_AST_MATCH) {
 		// add referenced aliases from MATCH clause
 		// inline filtered and explicit WHERE filter
-		_AST_MapMatchClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_CREATE) {
+		_AST_MapMatchClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_CREATE) {
 		// add referenced aliases for CREATE clause
-		_AST_MapCreateClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_MERGE) {
+		_AST_MapCreateClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_MERGE) {
 		// add referenced aliases for MERGE clause
 		// inline filtered and modified entities
-		_AST_MapMergeClauseReference(ast, clause);
-	} else if(type == CYPHER_AST_SET) {
+		_AST_MapMergeClauseReference (ast, clause) ;
+	} else if (type == CYPHER_AST_SET) {
 		// add referenced aliases for SET clause
-		_AST_MapSetClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_DELETE) {
+		_AST_MapSetClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_DELETE) {
 		// add referenced aliases for DELETE clause
-		_AST_MapDeleteClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_REMOVE) {
+		_AST_MapDeleteClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_REMOVE) {
 		// add referenced aliases for REMOVE clause
-		_AST_MapRemoveClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_UNWIND) {
+		_AST_MapRemoveClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_UNWIND) {
 		// add referenced aliases for UNWIND clause
-		_AST_MapUnwindClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_FOREACH) {
+		_AST_MapUnwindClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_FOREACH) {
 		// add referenced aliases for a FOREACH clause
-		_AST_MapForeachClauseReferences(ast, clause);
-	} else if(type == CYPHER_AST_CALL_SUBQUERY) {
+		_AST_MapForeachClauseReferences (ast, clause) ;
+	} else if (type == CYPHER_AST_CALL_SUBQUERY) {
 		// add referenced aliases for a CALL {} clause
-		_AST_MapCallSubqueryReferences(ast, clause);
+		_AST_MapCallSubqueryReferences (ast, clause) ;
 	}
 }
 
-// Map the referred aliases (LHS) in entities projected by a WITH or RETURN clause.
-static void _AST_MapProjectionClause(AST *ast_segment, const cypher_astnode_t *projection) {
-	cypher_astnode_type_t type = cypher_astnode_type(projection);
-	ASSERT(type == CYPHER_AST_WITH || type == CYPHER_AST_RETURN);
+// map the referred aliases (LHS) in entities projected by a WITH
+// or RETURN clause
+static void _AST_MapProjectionClause
+(
+	AST *ast_segment,
+	const cypher_astnode_t *projection
+) {
+	cypher_astnode_type_t type = cypher_astnode_type (projection) ;
+	ASSERT (type == CYPHER_AST_WITH || type == CYPHER_AST_RETURN) ;
 
-	if(type == CYPHER_AST_WITH) {
-		_AST_MapWithReferredEntities(ast_segment, projection);
+	if (type == CYPHER_AST_WITH) {
+		_AST_MapWithReferredEntities (ast_segment, projection) ;
 	} else {
-		_AST_MapReturnReferredEntities(ast_segment, projection);
+		_AST_MapReturnReferredEntities (ast_segment, projection) ;
 	}
 }
 
-// Populate the AST's map of all referenced aliases.
-void AST_BuildReferenceMap(AST *ast, const cypher_astnode_t *project_clause) {
-	ast->referenced_entities = raxNew();
+// populate the AST's map of all referenced aliases
+void AST_BuildReferenceMap
+(
+	AST *ast,
+	const cypher_astnode_t *project_clause
+) {
+	ast->referenced_entities = raxNew () ;
 
-	// If this segment is followed by a projection clause, map that clause's references.
-	if(project_clause) _AST_MapProjectionClause(ast, project_clause);
+	// if this segment is followed by a projection clause
+	// map that clause's references
+	if (project_clause) {
+		_AST_MapProjectionClause (ast, project_clause) ;
+	}
 
-	// Check every clause in this AST.
-	uint clause_count = cypher_ast_query_nclauses(ast->root);
-	for(uint i = 0; i < clause_count; i++) {
-		const cypher_astnode_t *clause = cypher_ast_query_get_clause(ast->root, i);
-		_ASTClause_BuildReferenceMap(ast, clause);
+	// check every clause in this AST
+	uint clause_count = cypher_ast_query_nclauses (ast->root) ;
+	for (uint i = 0 ; i < clause_count ; i++) {
+		const cypher_astnode_t *clause =
+			cypher_ast_query_get_clause (ast->root, i) ;
+		_ASTClause_BuildReferenceMap (ast, clause) ;
 	}
 }
+

--- a/src/ast/ast_build_reference_map.c
+++ b/src/ast/ast_build_reference_map.c
@@ -8,14 +8,14 @@
 #include "RG.h"
 #include "../util/arr.h"
 
-// define the which entities get mapped
+// define which entities get mapped
 typedef enum {
 	MAP_ALL        = 0,  // map all entities
-	MAP_IDENTIFIED = 1,  // map only non anonymous entities
+	MAP_IDENTIFIED = 1,  // map only non-anonymous entities
 	MAP_SKIP       = 2,  // don't map entity
 } MappingLevel;
 
-// forward declerations
+// forward declarations
 static void _AST_MapReferencedEntitiesInPath
 (
 	AST *ast,

--- a/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
+++ b/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
@@ -154,7 +154,7 @@ void buildPatternComprehensionOps
 		// collect evaluation results into an array using `collect`
 		AR_ExpNode *collect_exp = AR_EXP_NewOpNode ("collect", false, 1) ;
 		collect_exp->op.children [0] = eval_exp ;
-		collect_exp->resolved_name = AST_ToString (pc) ;
+		collect_exp->resolved_name = AST_ToString (pc, NULL) ;
 
 		// add collect expression to an AGGREGATION Operation
 		AR_ExpNode **exps = arr_new (AR_ExpNode*, 1) ;
@@ -316,7 +316,7 @@ void buildPatternPathOps
 		// we're require to return an ARRAY of paths, use `collect` to aggregate paths
 		AR_ExpNode *collect_exp = AR_EXP_NewOpNode("collect", false, 1);
 		collect_exp->op.children[0] = path_exp;
-		collect_exp->resolved_name = AST_ToString(path);
+		collect_exp->resolved_name = AST_ToString (path, NULL) ;
 
 		// constuct aggregation operation
 		AR_ExpNode **exps = arr_new(AR_ExpNode *, 1);

--- a/src/execution_plan/execution_plan_build/build_projection_ops.c
+++ b/src/execution_plan/execution_plan_build/build_projection_ops.c
@@ -29,7 +29,7 @@ static AR_ExpNode **_BuildOrderExpressions
 			cypher_ast_sort_item_get_expression (item) ;
 
 		AR_ExpNode *exp = AR_EXP_FromASTNode (ast_exp) ;
-		exp->resolved_name = AST_ToString (ast_exp) ;
+		exp->resolved_name = AST_ToString (ast_exp, NULL) ;
 		arr_append (order_exps, exp) ;
 	}
 
@@ -49,7 +49,7 @@ AR_ExpNode **_BuildProjectionExpressions
 	ASSERT (t == CYPHER_AST_RETURN || t == CYPHER_AST_WITH) ;
 
 	if (t == CYPHER_AST_RETURN) {
-		// if we have a "RETURN *" at this point, it is because we raised 
+		// if we have a "RETURN *" at this point, it is because we raised
 		// an error in AST rewriting
 		if (cypher_ast_return_has_include_existing(clause)) {
 			return NULL ;

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -39,7 +39,7 @@ static void _QueryGraphAddNode
 	QueryGraph *qg,
 	const cypher_astnode_t *ast_entity
 ) {
-	const char *alias = AST_ToString(ast_entity);
+	const char *alias = AST_ToString (ast_entity, NULL) ;
 
 	// look up this alias in the QueryGraph
 	// this node may already exist
@@ -64,7 +64,7 @@ static void _QueryGraphAddEdge
 	bool only_shortest                   // edge is part of a shortest path
 ) {
 	GraphContext *gc = QueryCtx_GetGraphCtx();
-	const char *alias = AST_ToString(ast_entity);
+	const char *alias = AST_ToString (ast_entity, NULL) ;
 	enum cypher_rel_direction dir =
 		cypher_ast_rel_pattern_get_direction(ast_entity);
 
@@ -145,7 +145,7 @@ static void _QueryGraph_ExtractNode
 	ASSERT(ast_node  !=  NULL);
 
 	// see if node is already in 'graph'
-	const char *alias = AST_ToString(ast_node);
+	const char *alias = AST_ToString (ast_node, NULL) ;
 	QGNode *n = QueryGraph_GetNodeByAlias(graph, alias);
 
 	if(n == NULL) {
@@ -188,7 +188,7 @@ static void _QueryGraph_ExtractEdge
 	QGNode *right,
 	const cypher_astnode_t *ast_edge
 ) {
-	const char *alias = AST_ToString(ast_edge);
+	const char *alias = AST_ToString (ast_edge, NULL) ;
 
 	// validate input, edge shouldn't be in graph
 	ASSERT(left != NULL);
@@ -227,12 +227,12 @@ static void _QueryGraph_ExtractPath
 	for(uint i = 1; i < nelems; i += 2) {
 		// retrieve the QGNode corresponding to the node left of this edge
 		const cypher_astnode_t *l_node = cypher_ast_pattern_path_get_element(path, i - 1);
-		const char *l_alias = AST_ToString(l_node);
+		const char *l_alias = AST_ToString (l_node, NULL) ;
 		QGNode *left = QueryGraph_GetNodeByAlias(graph, l_alias);
 
 		// retrieve the QGNode corresponding to the node right of this edge
 		const cypher_astnode_t *r_node = cypher_ast_pattern_path_get_element(path, i + 1);
-		const char *r_alias = AST_ToString(r_node);
+		const char *r_alias = AST_ToString (r_node, NULL) ;
 		QGNode *right = QueryGraph_GetNodeByAlias(graph, r_alias);
 
 		ast_node = cypher_ast_pattern_path_get_element(path, i);
@@ -297,13 +297,13 @@ void QueryGraph_AddPath
 		// retrieve the QGNode corresponding to the node left of this edge
 		const cypher_astnode_t *l_node =
 			cypher_ast_pattern_path_get_element(path, i - 1);
-		const char *l_alias = AST_ToString(l_node);
+		const char *l_alias = AST_ToString (l_node, NULL) ;
 		QGNode *left = QueryGraph_GetNodeByAlias(qg, l_alias);
 
 		// retrieve the QGNode corresponding to the node right of this edge
 		const cypher_astnode_t *r_node =
 			cypher_ast_pattern_path_get_element(path, i + 1);
-		const char *r_alias = AST_ToString(r_node);
+		const char *r_alias = AST_ToString (r_node, NULL) ;
 		QGNode *right = QueryGraph_GetNodeByAlias(qg, r_alias);
 
 		// retrieve the AST reference to this edge

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -278,3 +278,74 @@ class testPathFilter(FlowTestsBase):
 
         res = self.graph.query(q).result_set
         self.env.assertEqual(res[0][0], 1)
+
+    def test_16_bidirectional_filter_path(self):
+        # check bidirectional filter
+        # create a graph where
+        # s0->s1
+        # s2 isn't connected
+
+        res = self.graph.query("""CREATE (s0:Service {name:'s0'}),
+                         (s1:Service {name:'s1'}),
+                         (s2:Service {name:'s2'}),
+                         (s0)-[:R]->(s1)
+                         RETURN s0, s1, s2""").result_set
+        s0 = res[0][0]
+        s1 = res[0][1]
+        s2 = res[0][2]
+
+        # find all services which aren't connected
+        q = "MATCH (s:Service) WHERE NOT (s)--(:Service) RETURN s"
+        res = self.graph.query(q).result_set
+
+        self.env.assertEqual(len(res), 1)
+        self.env.assertEqual(res[0][0], s2)
+
+        # find all connected services
+        q = "MATCH (s:Service) WHERE (s)--(:Service) RETURN s ORDER BY ID(s)"
+        res = self.graph.query(q).result_set
+
+        self.env.assertEqual(len(res), 2)
+        self.env.assertEqual(res[0][0], s0)
+        self.env.assertEqual(res[1][0], s1)
+
+        # clean up
+        self.graph.query ("MATCH (s:Service) DELETE s")
+
+    def test_17_filter_count(self):
+        # filter paths should hit multiple times for tensors
+        # create a graph where
+        # s0->s1, s0->s1, s0->s2
+
+        self.graph.query("""CREATE (s0:Service {name:'s0'}),
+        (s1:Service {name:'s1'}),
+        (s2:Service {name:'s2'}),
+        (s0)-[:R]->(s1),
+        (s0)-[:R]->(s1),
+        (s0)-[:R]->(s2)""")
+
+        # count all services which aren't connected
+        queries = ["MATCH (s:Service) WHERE NOT (s)-[]->(:Service) RETURN count(1)",
+                   "MATCH (s:Service) WHERE NOT (s)-[*1..]->(:Service) RETURN count(1)",
+                   "MATCH (s:Service) WHERE NOT (:Service)<-[]-(s) RETURN count(1)",
+                   "MATCH (s:Service) WHERE NOT (:Service)<-[*1..]-(s) RETURN count(1)"
+                   ]
+
+        for q in queries:
+            res = self.graph.query(q).result_set
+            self.env.assertEqual(res[0][0], 2)
+
+        # count all connected services
+        queries = ["MATCH (s:Service) WHERE (s)-[]->(:Service) RETURN count(1)",
+                   "MATCH (s:Service) WHERE (s)-[*1..]->(:Service) RETURN count(1)",
+                   "MATCH (s:Service) WHERE (:Service)<-[]-(s) RETURN count(1)",
+                   "MATCH (s:Service) WHERE (:Service)<-[*1..]-(s) RETURN count(1)"
+                   ]
+
+        for q in queries:
+            res = self.graph.query(q).result_set
+            self.env.assertEqual(res[0][0], 1)
+
+        # clean up
+        self.graph.query ("MATCH (s:Service) DELETE s")
+

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -279,7 +279,7 @@ class testPathFilter(FlowTestsBase):
         res = self.graph.query(q).result_set
         self.env.assertEqual(res[0][0], 1)
 
-    def test_16_bidirectional_filter_path(self):
+    def test16_bidirectional_filter_path(self):
         # check bidirectional filter
         # create a graph where
         # s0->s1
@@ -312,7 +312,7 @@ class testPathFilter(FlowTestsBase):
         # clean up
         self.graph.query ("MATCH (s:Service) DELETE s")
 
-    def test_17_filter_count(self):
+    def test17_filter_count(self):
         # filter paths should hit multiple times for tensors
         # create a graph where
         # s0->s1, s0->s1, s0->s2


### PR DESCRIPTION
Resolve: #1934


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path filter behavior for bidirectional connectivity and multi-path/count scenarios.

* **Refactor**
  * Improved handling of anonymous entity aliases for more consistent query naming and mapping across clauses.
  * Streamlined reference-mapping logic for more predictable query processing.

* **Tests**
  * Added tests covering bidirectional path filters and count semantics for path expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->