### PR TITLE
fix(graph): early-return on tombstoned id in Update{Node,Edge}Property (AOF-replay SIGSEGV)

### DIFF
--- a/src/graph/graph_hub.c
+++ b/src/graph/graph_hub.c
@@ -332,6 +332,7 @@ void GraphHub_UpdateNodeProperty
 	Node n;  // node to update
 	int res = Graph_GetNode (g, id, &n) ;
 	ASSERT(res == true);  // make sure entity was found
+	if (res != true) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
 
 	if(attr_id == ATTRIBUTE_ID_ALL) {
 		AttributeSet_Free(n.attributes);
@@ -382,6 +383,7 @@ void GraphHub_UpdateEdgeProperty
 	// get src node, dest node and edge from the graph
 	int res = Graph_GetEdge (GraphContext_GetGraph (gc), id, &e);
 	ASSERT(res != 0);
+	if (res == 0) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
 
 	// set edge relation, src and destination node
 	Edge_SetRelationID(&e, r_id);

--- a/src/graph/graph_hub.c
+++ b/src/graph/graph_hub.c
@@ -332,7 +332,13 @@ void GraphHub_UpdateNodeProperty
 	Node n;  // node to update
 	int res = Graph_GetNode (g, id, &n) ;
 	ASSERT(res == true);  // make sure entity was found
-	if (res != true) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
+	if (res != true) {
+		// tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
+		// v is otherwise moved into the attribute set below (clone=false);
+		// on this early-return path that transfer never happens, so free it here
+		SIValue_Free(v);
+		return;
+	}
 
 	if(attr_id == ATTRIBUTE_ID_ALL) {
 		AttributeSet_Free(n.attributes);
@@ -383,7 +389,13 @@ void GraphHub_UpdateEdgeProperty
 	// get src node, dest node and edge from the graph
 	int res = Graph_GetEdge (GraphContext_GetGraph (gc), id, &e);
 	ASSERT(res != 0);
-	if (res == 0) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
+	if (res == 0) {
+		// tombstoned id → no-op write (prevents AOF-replay SIGSEGV)
+		// v is otherwise moved into the attribute set below (clone=false);
+		// on this early-return path that transfer never happens, so free it here
+		SIValue_Free(v);
+		return;
+	}
 
 	// set edge relation, src and destination node
 	Edge_SetRelationID(&e, r_id);


### PR DESCRIPTION
## Summary

In release builds, `ASSERT()` compiles to a no-op. When AOF replay calls `GraphHub_UpdateNodeProperty` / `GraphHub_UpdateEdgeProperty` against an attribute-write whose target id was deleted later in the same AOF, the return value of `Graph_GetNode` / `Graph_GetEdge` is silently ignored. The stack-allocated `Node` / `Edge` struct (declared just above the call) is left uninitialized, and the next statements call `AttributeSet_Update` or `AttributeSet_Free` against `n.attributes` / `e.attributes` — which is junk. Result: SIGSEGV during AOF replay, server fails to start.

This patch turns the existing assertion into an explicit early-return for the failure path. Tombstoned-id writes become a no-op (which appears to be the intended semantics — the entity is gone) instead of crashing the process.

## Reproducer

Any graph that has had entities deleted via `DETACH DELETE` followed by an attribute SET on the same path, replayed from AOF on a release build (the kind shipped in `falkordb/falkordb-server:*`).

Concretely: we hit this in production on `v4.16.9` against a 1.4 GB AOF carrying ~17 hours of mixed write+delete traffic. The server `SIGSEGV`'d at AOF replay and could not start. After applying the same two-line fix below to a custom-built `falkordb.so`, replay completed cleanly and the server has been running healthily for 24h+ in production.

## Patch sites

- `src/graph/graph_hub.c:GraphHub_UpdateNodeProperty` — line 334 ASSERT, add early-return after
- `src/graph/graph_hub.c:GraphHub_UpdateEdgeProperty` — line 384 ASSERT, add early-return after

\`\`\`diff
@@ -332,6 +332,7 @@ void GraphHub_UpdateNodeProperty
 	Node n;  // node to update
 	int res = Graph_GetNode (g, id, &n) ;
 	ASSERT(res == true);  // make sure entity was found
+	if (res != true) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)

 	if(attr_id == ATTRIBUTE_ID_ALL) {
 		AttributeSet_Free(n.attributes);
@@ -382,6 +383,7 @@ void GraphHub_UpdateEdgeProperty
 	// get src node, dest node and edge from the graph
 	int res = Graph_GetEdge (GraphContext_GetGraph (gc), id, &e);
 	ASSERT(res != 0);
+	if (res == 0) return;  // tombstoned id → no-op write (prevents AOF-replay SIGSEGV)

 	// set edge relation, src and destination node
 	Edge_SetRelationID(&e, r_id);
\`\`\`

## Stack trace (representative)

The crash signature on the production server, from a debug rebuild:

\`\`\`
SIGSEGV in AttributeSet_Update at AttributeSet_Update (attribute_set.c)
called from GraphHub_UpdateNodeProperty (graph_hub.c:339)
called from Effects_Apply (effects/effects.c during AOF replay)
\`\`\`

\`n.attributes\` is the dereference target. \`n\` was declared on the stack at \`graph_hub.c:332\` and never written because \`Graph_GetNode\` returned false (the entity was tombstoned earlier in the AOF stream).

## Production impact

This bug took our knowledge-graph service offline for several hours because the FalkorDB instance could not complete AOF replay after a routine restart. Recovering required building a patched \`.so\` against the v4.16.9 source tree and bind-mounting it into the upstream container image. We've been running the patched binary in production for 24h+ with no regressions.

We're happy to upstream the patch so other operators don't have to do the same. The change is two lines, defensive, and matches what \`ASSERT()\` already implies in the original code's intent.

## Notes for reviewers

- We considered fixing this in \`Effects_Apply\` (skipping the property write entirely if the entity is gone) but it felt cleaner to fix at the lowest level — both \`Update*Property\` functions have the same shape and the same assumption, so a localized early-return there covers both call paths and any future caller.
- The patch is conservative: it only changes behavior in the path where the existing \`ASSERT()\` would already have aborted in a debug build. In a debug build, the \`ASSERT\` still aborts (we're not touching it). In a release build, instead of UB, we early-return — which we believe matches the original intent.
- We have **not** added a test case here, since FalkorDB's existing test suite seems to be largely Cypher-level (this is a release-build-only AOF-replay edge case that requires reproducing a specific tombstone-then-replay sequence). Happy to write one if you point us at a useful pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced property update operations to properly detect missing or deleted entities. Updates on node and edge properties now short-circuit immediately when targets cannot be found, preventing invalid state modifications and ensuring consistent behavior during system recovery and replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->