### PR TITLE
 fix(optional-traverse): initialize reduction vectors in Init using   LIMIT-adjusted record_cap

### DIFF
--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -173,23 +173,18 @@ void CondTraverse_MakeOptional
 (
 	OpCondTraverse *op
 ) {
-	ASSERT (op != NULL) ;
-	ASSERT (op->optional == false) ;
-	ASSERT (op->optional_records == NULL) ;
+	ASSERT (op                   != NULL)  ;
+	ASSERT (op->optional         == false) ;
+	ASSERT (op->optional_records == NULL)  ;
 
-	op->optional = true ;
-	op->op.name  = "Optional Conditional Traverse" ;
-	op->op.type  = OPType_OPTIONAL_CONDITIONAL_TRAVERSE ;
+	op->optional         = true ;
+	op->op.name          = "Optional Conditional Traverse" ;
+	op->op.type          = OPType_OPTIONAL_CONDITIONAL_TRAVERSE ;
 	op->optional_records = arr_new (Record, op->record_cap) ;
 
 	// s = true
 	GrB_OK (GxB_Scalar_new (&op->s, GrB_BOOL)) ;
 	GrB_OK (GxB_Scalar_setElement_BOOL (op->s, true)) ;
-
-	// allocate reduction & neighborless vectors
-	GrB_Index nrows = op->record_cap ;
-	GrB_OK (GrB_Vector_new (&op->w, GrB_BOOL, nrows)) ;
-	GrB_OK (GrB_Vector_new (&op->e, GrB_BOOL, nrows)) ;
 }
 
 static OpResult CondTraverseInit
@@ -200,14 +195,23 @@ static OpResult CondTraverseInit
 
 	// in case this operation is restricted by a limit
 	// set record_cap to the specified limit
-	ExecutionPlan_ContainsLimit(opBase, &op->record_cap);
+	ExecutionPlan_ContainsLimit (opBase, &op->record_cap) ;
 
 	// record_cap should not be greater than BATCH_SIZE
-	if(op->record_cap > BATCH_SIZE) op->record_cap = BATCH_SIZE;
+	if (op->record_cap > BATCH_SIZE) {
+		op->record_cap = BATCH_SIZE ;
+	}
 
-	op->records = rm_calloc(op->record_cap, sizeof(Record));
+	op->records = rm_calloc (op->record_cap, sizeof (Record)) ;
 
-	return OP_OK;
+	if (op->optional) {
+		// allocate reduction & neighborless vectors
+		GrB_Index nrows = op->record_cap ;
+		GrB_OK (GrB_Vector_new (&op->w, GrB_BOOL, nrows)) ;
+		GrB_OK (GrB_Vector_new (&op->e, GrB_BOOL, nrows)) ;
+	}
+
+	return OP_OK ;
 }
 
 // each call to CondTraverseConsume emits a Record containing the

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -349,7 +349,7 @@ class testOptionalFlow(FlowTestsBase):
 
     def test28_limited_optional_match(self):
         """
-        make sure limit is handeled and enforced by the
+        make sure limit is handled and enforced by the
         optional conditional traverse operation
         """
 

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -347,3 +347,33 @@ class testOptionalFlow(FlowTestsBase):
 
         g.delete()
 
+    def test28_limited_optional_match(self):
+        """
+        make sure limit is handeled and enforced by the
+        optional conditional traverse operation
+        """
+
+        # start fresh
+        self.graph.delete()
+
+        # create the graph
+        q = "UNWIND range(0, 2) AS x CREATE (:Label)-[:REL]->()"
+        self.graph.query(q)
+
+        q = "CREATE (:Label)"
+        self.graph.query(q)
+
+        q = "MATCH (a:Label) OPTIONAL MATCH (a)-[:REL]->(b) RETURN a, b LIMIT 10"
+        res = self.graph.query(q).result_set
+
+        self.env.assertEquals(len(res), 4)
+
+        # enlarge the graph
+        q = "UNWIND range(0, 9) AS x CREATE (:Label)-[:REL]->()"
+        self.graph.query(q)
+
+        q = "MATCH (a:Label) OPTIONAL MATCH (a)-[:REL]->(b) RETURN a, b LIMIT 10"
+        res = self.graph.query(q).result_set
+
+        self.env.assertEquals(len(res), 10)
+


### PR DESCRIPTION
Resolve: #1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row count accuracy when using LIMIT with OPTIONAL MATCH queries so limits are correctly enforced.
* **Tests**
  * Added a new integration test that validates LIMIT behavior for queries combining MATCH with OPTIONAL MATCH as the graph grows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->