### PR TITLE
collect refered aliases within function private context

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -795,7 +795,7 @@ void AR_EXP_CollectEntities
 			AR_EXP_CollectEntities (root->op.children [i], aliases) ;
 		}
 
-		// collect refered aliases within function's private data
+		// collect referred aliases within function's private data
 		if (unlikely (root->op.private_data != NULL &&
 			root->op.f->callbacks.aliases   != NULL)) {
 			root->op.f->callbacks.aliases (root->op.private_data, aliases) ;

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -256,16 +256,18 @@ AR_ExpNode *AR_EXP_NewRecordNode() {
 
 void AR_SetPrivateData
 (
-	AR_ExpNode *node, void *pdata
+	AR_ExpNode *node,
+	void *pdata
 ) {
 	// validations
 	// node must be an operation
 	// operation private data must be NULL
-	ASSERT(node != NULL);
-	ASSERT(node->type == AR_EXP_OP);
-	ASSERT(node->op.private_data == NULL);
+	ASSERT (node                  != NULL) ;
+	ASSERT (pdata                 != NULL) ;
+	ASSERT (node->type            == AR_EXP_OP) ;
+	ASSERT (node->op.private_data == NULL) ;
 
-	node->op.private_data = pdata;
+	node->op.private_data = pdata ;
 }
 
 // compact tree by evaluating constant expressions
@@ -788,15 +790,22 @@ void AR_EXP_CollectEntities
 	ASSERT (root    != NULL) ;
 	ASSERT (aliases != NULL) ;
 
-	if(AR_EXP_IsOperation(root)) {
-		for(int i = 0; i < root->op.child_count; i++) {
-			AR_EXP_CollectEntities(root->op.children[i], aliases);
+	if (AR_EXP_IsOperation (root)) {
+		for (int i = 0 ; i < root->op.child_count ; i++) {
+			AR_EXP_CollectEntities (root->op.children [i], aliases) ;
 		}
+
+		// collect refered aliases within function's private data
+		if (unlikely (root->op.private_data != NULL &&
+			root->op.f->callbacks.aliases   != NULL)) {
+			root->op.f->callbacks.aliases (root->op.private_data, aliases) ;
+		}
+
 	} else { // type == AR_EXP_OPERAND
-		if(root->operand.type == AR_EXP_VARIADIC) {
-			const char *entity = root->operand.variadic.entity_alias;
-			raxInsert(aliases, (unsigned char *)entity, strlen(entity), NULL,
-					NULL);
+		if (root->operand.type == AR_EXP_VARIADIC) {
+			const char *entity = root->operand.variadic.entity_alias ;
+			raxInsert (aliases, (unsigned char *)entity, strlen (entity), NULL,
+					NULL) ;
 		}
 	}
 }

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -669,12 +669,18 @@ static AR_ExpNode *_AR_ExpNodeFromComprehensionFunction
 	cypher_astnode_type_t type
 ) {
 	// set the appropriate function name according to the node type
-	const char *func_name;
-	if(type == CYPHER_AST_ANY)         func_name = "ANY";
-	else if(type == CYPHER_AST_ALL)    func_name = "ALL";
-	else if(type == CYPHER_AST_SINGLE) func_name = "SINGLE";
-	else if(type == CYPHER_AST_NONE)   func_name = "NONE";
-	else                               func_name = "LIST_COMPREHENSION";
+	const char *func_name ;
+	if (type == CYPHER_AST_ANY) {
+		func_name = "ANY";
+	} else if (type == CYPHER_AST_ALL) {
+		func_name = "ALL";
+	} else if (type == CYPHER_AST_SINGLE) {
+		func_name = "SINGLE";
+	} else if (type == CYPHER_AST_NONE) {
+		func_name = "NONE";
+	} else {
+		func_name = "LIST_COMPREHENSION";
+	}
 
 	// using the sample query:
 	// WITH [1,2,3] AS arr
@@ -683,35 +689,31 @@ static AR_ExpNode *_AR_ExpNodeFromComprehensionFunction
 	// the comprehension's local variable, WHERE expression, and eval routine
 	// do not change for each invocation
 	// so are bundled together in the function's context
-	ListComprehensionCtx *ctx = rm_malloc(sizeof(ListComprehensionCtx));
-	ctx->ft           = NULL;
-	ctx->eval_exp     = NULL;
-	ctx->local_record = NULL;
-	ctx->variable_str = NULL;
-	ctx->variable_idx = INVALID_INDEX;
+	ListComprehensionCtx *ctx = rm_calloc (1, sizeof (ListComprehensionCtx)) ;
+	ctx->variable_idx = INVALID_INDEX ;
 
 	// retrieve the variable name introduced in this context to iterate over
 	// list elements in the above query, this is 'val'
 	const cypher_astnode_t *variable_node =
-		cypher_ast_list_comprehension_get_identifier(comp_exp);
-	ASSERT(cypher_astnode_type(variable_node) == CYPHER_AST_IDENTIFIER);
+		cypher_ast_list_comprehension_get_identifier (comp_exp) ;
+	ASSERT (cypher_astnode_type (variable_node) == CYPHER_AST_IDENTIFIER) ;
 
 	// retrieve the variable string for the local variable
-	ctx->variable_str = cypher_ast_identifier_get_name(variable_node);
+	ctx->variable_str = cypher_ast_identifier_get_name (variable_node) ;
 
 	// the predicate node is the set of WHERE conditions in the comprehension
 	// if any
 	const cypher_astnode_t *predicate_node =
-		cypher_ast_list_comprehension_get_predicate(comp_exp);
+		cypher_ast_list_comprehension_get_predicate (comp_exp) ;
 
 	// build a FilterTree to represent this predicate
-	if(predicate_node) {
-		AST_ConvertFilters(&ctx->ft, predicate_node);
-	} else if(type != CYPHER_AST_LIST_COMPREHENSION) {
+	if (predicate_node) {
+		AST_ConvertFilters (&ctx->ft, predicate_node) ;
+	} else if (type != CYPHER_AST_LIST_COMPREHENSION) {
 		// functions like any() and all() must have a predicate node
-		ErrorCtx_SetError(EMSG_FUNCTION_REQUIER_PREDICATE, func_name);
-		rm_free(ctx);
-		return AR_EXP_NewConstOperandNode(SI_NullVal());
+		ErrorCtx_SetError (EMSG_FUNCTION_REQUIER_PREDICATE, func_name) ;
+		rm_free (ctx) ;
+		return AR_EXP_NewConstOperandNode (SI_NullVal ()) ;
 	}
 
 	// construct the operator node that will generate updated values,
@@ -719,40 +721,42 @@ static AR_ExpNode *_AR_ExpNodeFromComprehensionFunction
 	// in the above query, this will be an operation node representing "val * 2"
 	// this will always be NULL for comprehensions like any() and all()
 	const cypher_astnode_t *eval_node =
-		cypher_ast_list_comprehension_get_eval(comp_exp);
-	if(eval_node) ctx->eval_exp = _AR_EXP_FromASTNode(eval_node);
+		cypher_ast_list_comprehension_get_eval (comp_exp) ;
+	if (eval_node) {
+		ctx->eval_exp = _AR_EXP_FromASTNode (eval_node) ;
+	}
 
 	// 'arr' is the list expression
 	// note that this value could resolve to an alias, a literal array,
 	// a function call, and so on
 	const cypher_astnode_t *list_node =
-		cypher_ast_list_comprehension_get_expression(comp_exp);
-	AR_ExpNode *list = AR_EXP_FromASTNode(list_node);
+		cypher_ast_list_comprehension_get_expression (comp_exp) ;
+	AR_ExpNode *list = AR_EXP_FromASTNode (list_node) ;
 
 	// no evaluation expression
 	// no filter
 	// e.g.
 	// RETURN [x IN [1,2,3]] -> [1,2,3]
 	// in this case we can simply use the internal array expression
-	if(eval_node == NULL && predicate_node == NULL) {
-		ASSERT(type == CYPHER_AST_LIST_COMPREHENSION);
-		rm_free(ctx);
-		return list;
+	if (eval_node == NULL && predicate_node == NULL) {
+		ASSERT (type == CYPHER_AST_LIST_COMPREHENSION) ;
+		rm_free (ctx) ;
+		return list ;
 	}
 
 	// build an operation node to represent the list comprehension
-	AR_ExpNode *op = AR_EXP_NewOpNode(func_name, true, 2);
+	AR_ExpNode *op = AR_EXP_NewOpNode (func_name, true, 2) ;
 
 	// add the context as function's private data
-	AR_SetPrivateData(op, ctx);
+	AR_SetPrivateData (op, ctx) ;
 
 	// the list expression is the function's first child
-	op->op.children[0] = list;
+	op->op.children [0] = list ;
 
 	// the second child will be a pointer to the Record being evaluated
-	op->op.children[1] = AR_EXP_NewRecordNode();
+	op->op.children [1] = AR_EXP_NewRecordNode () ;
 
-	return op;
+	return op ;
 }
 
 static AR_ExpNode *_AR_ExpNodeFromReduceFunction

--- a/src/arithmetic/comprehension_funcs/comprehension_funcs.c
+++ b/src/arithmetic/comprehension_funcs/comprehension_funcs.c
@@ -34,6 +34,42 @@ void ListComprehension_Free(void *ctx_ptr) {
 	rm_free(ctx);
 }
 
+// collect referenced aliases within a list comprehension context
+void ListComprehension_CollectAliases
+(
+	const void *ctx_ptr,  // list comprehension context
+	rax *entities         // [input/output] collected entities
+) {
+	ASSERT (ctx_ptr  != NULL) ;
+	ASSERT (entities != NULL) ;
+
+	const ListComprehensionCtx *ctx = ctx_ptr ;
+
+	if (ctx->ft != NULL) {
+		rax *inner = FilterTree_CollectModified (ctx->ft) ;
+		raxIterator it ;
+		raxStart (&it, inner) ;
+		raxSeek (&it, "^", NULL, 0) ;
+
+		while (raxNext(&it)) {
+			raxInsert(entities, it.key, it.key_len, NULL, NULL) ;
+		}
+
+		raxStop (&it) ;
+		raxFree (inner) ;
+	}
+
+	if (ctx->eval_exp != NULL) {
+		AR_EXP_CollectEntities (ctx->eval_exp, entities) ;
+	}
+
+	// remove the locally-bound variable
+	if (ctx->variable_str != NULL) {
+		raxRemove (entities, (unsigned char *)ctx->variable_str,
+				strlen (ctx->variable_str), NULL) ;
+	}
+}
+
 // Routine for cloning a comprehension function's private data.
 void *ListComprehension_Clone(void *orig) {
 	if(orig == NULL) return NULL;
@@ -60,16 +96,17 @@ static void _PopulateComprehensionCtx
 	ListComprehensionCtx *ctx,
 	Record outer_record
 ) {
-	rax *local_record_map = raxClone(outer_record->mapping);
-	intptr_t id = raxSize(local_record_map);
-	raxTryInsert(local_record_map, (unsigned char *)ctx->variable_str,
-						  strlen(ctx->variable_str), (void *)id, NULL);
-	ctx->local_record = Record_New(local_record_map);
+	rax *local_record_map = raxClone (outer_record->mapping) ;
+	intptr_t id = raxSize (local_record_map) ;
+	raxTryInsert (local_record_map, (unsigned char *)ctx->variable_str,
+						  strlen (ctx->variable_str), (void *)id, NULL) ;
+	ctx->local_record = Record_New (local_record_map) ;
 
 	// this could just be assigned to 'id'
 	// but for safety we'll use a Record lookup
-	ctx->variable_idx = Record_GetEntryIdx(ctx->local_record, ctx->variable_str, strlen(ctx->variable_str));
-	ASSERT(ctx->variable_idx != INVALID_INDEX);
+	ctx->variable_idx = Record_GetEntryIdx (ctx->local_record,
+			ctx->variable_str, strlen(ctx->variable_str)) ;
+	ASSERT (ctx->variable_idx != INVALID_INDEX) ;
 }
 
 SIValue AR_ANY(SIValue *argv, int argc, void *private_data) {
@@ -110,42 +147,58 @@ SIValue AR_ANY(SIValue *argv, int argc, void *private_data) {
 	return SI_BoolVal(false);
 }
 
-SIValue AR_ALL(SIValue *argv, int argc, void *private_data) {
-	if(SI_TYPE(argv[0]) == T_NULL) return SI_NullVal();
+SIValue AR_ALL
+(
+	SIValue *argv,
+	int argc,
+	void *private_data
+) {
+	if (SI_TYPE (argv [0]) == T_NULL) {
+		return SI_NullVal () ;
+	}
+
 	// ALL comprehensions are invoked with three children:
-	// The list to iterate over.
-	// The current Record.
-	// The function context.
-	SIValue list = argv[0];
-	Record outer_record = argv[1].ptrval;
-	ListComprehensionCtx *ctx = private_data;
+	// the list to iterate over
+	// the current Record
+	// the function context
+	SIValue list = argv [0] ;
+	Record outer_record = argv [1].ptrval ;
+	ListComprehensionCtx *ctx = private_data ;
 
-	// On the first invocation, build the local Record.
-	if(ctx->local_record == NULL) _PopulateComprehensionCtx(ctx, outer_record);
-	Record r = ctx->local_record;
-
-	// Populate the local Record with the contents of the outer Record.
-	Record_Clone(outer_record, r);
-
-	bool is_null = false;
-	uint len = SIArray_Length(list);
-	for(uint i = 0; i < len; i++) {
-		// Retrieve the current element.
-		SIValue current_elem = SIArray_Get(list, i);
-		// Add the current element to the record at its allocated position.
-		Record_AddScalar(r, ctx->variable_idx, current_elem);
-
-		// If any element in an ALL function does not pass the predicate, return false.
-		FT_Result res = FilterTree_applyFilters(ctx->ft, r);
-		if(res == FILTER_FAIL) return SI_BoolVal(false);
-		is_null |= (res == FILTER_NULL);
+	// on the first invocation, build the local Record
+	if (ctx->local_record == NULL) {
+		_PopulateComprehensionCtx (ctx, outer_record) ;
 	}
 
-	if(is_null) {
-		return SI_NullVal();
+	Record r = ctx->local_record ;
+
+	// populate the local Record with the contents of the outer Record
+	Record_Clone (outer_record, r) ;
+
+	bool is_null = false ;
+	uint len = SIArray_Length (list) ;
+	for (uint i = 0; i < len; i++) {
+		// retrieve the current element
+		SIValue current_elem = SIArray_Get (list, i) ;
+		// add the current element to the record at its allocated position
+		Record_AddScalar (r, ctx->variable_idx, current_elem) ;
+
+		// if any element in an ALL function does not pass the predicate
+		// return false
+		FT_Result res = FilterTree_applyFilters (ctx->ft, r) ;
+		if (res == FILTER_FAIL) {
+			return SI_BoolVal (false) ;
+		}
+
+		is_null |= (res == FILTER_NULL) ;
 	}
-	// All elements passed, return true.
-	return SI_BoolVal(true);
+
+	if (is_null) {
+		return SI_NullVal () ;
+	}
+
+	// all elements passed, return true
+	return SI_BoolVal (true) ;
 }
 
 SIValue AR_SINGLE(SIValue *argv, int argc, void *private_data) {
@@ -283,49 +336,75 @@ SIValue AR_LIST_COMPREHENSION
 	return retval;
 }
 
-void Register_ComprehensionFuncs() {
-	SIType *types;
-	SIType ret_type = T_BOOL | T_NULL;
-	AR_FuncDesc *func_desc;
+void Register_ComprehensionFuncs (void) {
+	SIType *types ;
+	SIType ret_type = T_BOOL | T_NULL ;
+	AR_FuncDesc *func_desc ;
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_ARRAY | T_NULL);
-	arr_append(types, T_PTR);
-	func_desc = AR_FuncDescNew("any", AR_ANY, 2, 2, types, ret_type, true, true,
-			true);
-	AR_SetPrivateDataRoutines(func_desc, ListComprehension_Free, ListComprehension_Clone);
-	AR_FuncRegister(func_desc);
+	//--------------------------------------------------------------------------
+	// ANY
+	//--------------------------------------------------------------------------
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_ARRAY | T_NULL);
-	arr_append(types, T_PTR);
-	func_desc = AR_FuncDescNew("all", AR_ALL, 2, 2, types, ret_type, true, true,
-			true);
-	AR_SetPrivateDataRoutines(func_desc, ListComprehension_Free, ListComprehension_Clone);
-	AR_FuncRegister(func_desc);
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_ARRAY | T_NULL) ;
+	arr_append (types, T_PTR) ;
+	func_desc = AR_FuncDescNew ("any", AR_ANY, 2, 2, types, ret_type, true,
+			true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListComprehension_Free,
+			ListComprehension_Clone, ListComprehension_CollectAliases) ;
+	AR_FuncRegister (func_desc) ;
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_ARRAY | T_NULL);
-	arr_append(types, T_PTR);
-	func_desc = AR_FuncDescNew("single", AR_SINGLE, 2, 2, types, ret_type, true,
-			true, true);
-	AR_SetPrivateDataRoutines(func_desc, ListComprehension_Free, ListComprehension_Clone);
-	AR_FuncRegister(func_desc);
+	//--------------------------------------------------------------------------
+	// ALL
+	//--------------------------------------------------------------------------
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_ARRAY | T_NULL);
-	arr_append(types, T_PTR);
-	func_desc = AR_FuncDescNew("none", AR_NONE, 2, 2, types, ret_type, true,
-			true, true);
-	AR_SetPrivateDataRoutines(func_desc, ListComprehension_Free, ListComprehension_Clone);
-	AR_FuncRegister(func_desc);
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_ARRAY | T_NULL) ;
+	arr_append (types, T_PTR) ;
+	func_desc = AR_FuncDescNew ("all", AR_ALL, 2, 2, types, ret_type, true,
+			true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListComprehension_Free,
+			ListComprehension_Clone, ListComprehension_CollectAliases) ;
+	AR_FuncRegister (func_desc) ;
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_ARRAY | T_NULL);
-	arr_append(types, T_PTR);
-	ret_type = T_ARRAY | T_NULL;
-	func_desc = AR_FuncDescNew("list_comprehension", AR_LIST_COMPREHENSION, 2,
-			2, types, ret_type, true, true, true);
-	AR_SetPrivateDataRoutines(func_desc, ListComprehension_Free, ListComprehension_Clone);
-	AR_FuncRegister(func_desc);
+	//--------------------------------------------------------------------------
+	// SINGLE
+	//--------------------------------------------------------------------------
+
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_ARRAY | T_NULL) ;
+	arr_append (types, T_PTR) ;
+	func_desc = AR_FuncDescNew ("single", AR_SINGLE, 2, 2, types, ret_type,
+			true, true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListComprehension_Free,
+			ListComprehension_Clone, ListComprehension_CollectAliases) ;
+	AR_FuncRegister (func_desc) ;
+
+	//--------------------------------------------------------------------------
+	// NONE
+	//--------------------------------------------------------------------------
+
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_ARRAY | T_NULL) ;
+	arr_append (types, T_PTR) ;
+	func_desc = AR_FuncDescNew ("none", AR_NONE, 2, 2, types, ret_type, true,
+			true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListComprehension_Free,
+			ListComprehension_Clone, ListComprehension_CollectAliases) ;
+	AR_FuncRegister (func_desc) ;
+
+	//--------------------------------------------------------------------------
+	// list_comprehension
+	//--------------------------------------------------------------------------
+
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_ARRAY | T_NULL) ;
+	arr_append (types, T_PTR) ;
+	ret_type = T_ARRAY | T_NULL ;
+	func_desc = AR_FuncDescNew ("list_comprehension", AR_LIST_COMPREHENSION, 2,
+			2, types, ret_type, true, true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListComprehension_Free,
+			ListComprehension_Clone, ListComprehension_CollectAliases) ;
+	AR_FuncRegister (func_desc) ;
 }
+

--- a/src/arithmetic/conditional_funcs/conditional_funcs.c
+++ b/src/arithmetic/conditional_funcs/conditional_funcs.c
@@ -125,7 +125,7 @@ void Register_ConditionalFuncs() {
 	arr_append(types, SI_ALL);
 	func_desc = AR_FuncDescNew("distinct", AR_DISTINCT, 1, 1, types, ret_type,
 			true, false, true);
-	AR_SetPrivateDataRoutines(func_desc, Distinct_Free, Distinct_Clone);
+	AR_SetPrivateDataRoutines(func_desc, Distinct_Free, Distinct_Clone, NULL);
 	AR_FuncRegister(func_desc);
 }
 

--- a/src/arithmetic/func_desc.c
+++ b/src/arithmetic/func_desc.c
@@ -218,10 +218,16 @@ inline void AR_SetPrivateDataRoutines
 (
 	AR_FuncDesc *func_desc,
 	AR_Func_Free free,
-	AR_Func_Clone clone
+	AR_Func_Clone clone,
+	AR_Func_PrivateDataAliases aliases
 ) {
-	func_desc->callbacks.free = free;
-	func_desc->callbacks.clone = clone;
+	ASSERT (func_desc->callbacks.free    == NULL) ;
+	ASSERT (func_desc->callbacks.clone   == NULL) ;
+	ASSERT (func_desc->callbacks.aliases == NULL) ;
+
+	func_desc->callbacks.free    = free ;
+	func_desc->callbacks.clone   = clone ;
+	func_desc->callbacks.aliases = aliases ;
 }
 
 // get arithmetic function

--- a/src/arithmetic/func_desc.h
+++ b/src/arithmetic/func_desc.h
@@ -33,15 +33,27 @@ typedef void (*AR_Func_Free)(void *ctx);
 // AR_Func_Clone - function pointer to a routine for cloning a function's private data
 typedef void *(*AR_Func_Clone)(void *orig);
 
+// AR_Func_PrivateDataAliases - function pointers to a routine which
+// collects aliases referenced within function's private data
+//
+// e.g.
+//
+// for the 'ALL' predicate there's a private data context: 'ListComprehensionCtx'
+// MATCH (a)
+// WHERE ALL (item IN ['x', 'z'] WHERE item IN a.tags)
+// RETURN count(1)
+typedef void (*AR_Func_PrivateDataAliases)(const void*, rax*) ;
+
 // AR_Func_PrivateData - function pointer to a routine which produce function's private data
 typedef AggregateCtx *(*AR_Func_PrivateData)(void);
 
 // aggregation function callbacks
 typedef struct {
-	AR_Func_Free free;                  // [optional] function pointer to cleanup routine
-	AR_Func_Clone clone;                // [optional] function pointer to clone routine
-	AR_Func_Finalize finalize;          // [optional] function pointer to finalizing aggregate value routine
-	AR_Func_PrivateData private_data;   // function pointer to private data generator
+	AR_Func_Free free;                   // [optional] function pointer to cleanup routine
+	AR_Func_Clone clone;                 // [optional] function pointer to clone routine
+	AR_Func_Finalize finalize;           // [optional] function pointer to finalizing aggregate value routine
+	AR_Func_PrivateDataAliases aliases;  // [optional] function pointer to collect private data referenced entities
+	AR_Func_PrivateData private_data;    // function pointer to private data generator
 } AR_FuncCBs;
 
 typedef struct {
@@ -56,7 +68,7 @@ typedef struct {
 	bool udf;              // user define function
 	bool deterministic;    // true if return value is predictable
 	char *name;            // function name
-	AR_FuncCBs callbacks;  // aggregation callbacks
+	AR_FuncCBs callbacks;  // function's callbacks
 } AR_FuncDesc;
 
 // initialize functions repository
@@ -99,7 +111,8 @@ void AR_SetPrivateDataRoutines
 (
 	AR_FuncDesc *func_desc,
 	AR_Func_Free free,
-	AR_Func_Clone clone
+	AR_Func_Clone clone,
+	AR_Func_PrivateDataAliases aliases
 );
 
 // get arithmetic function

--- a/src/arithmetic/general_funcs/general_funcs.c
+++ b/src/arithmetic/general_funcs/general_funcs.c
@@ -61,17 +61,18 @@ SIValue AR_PREV
 	return value;
 }
 
-void Register_GeneralFuncs() {
-	SIType *types;
-	SIType ret_type;
-	AR_FuncDesc *func_desc;
+void Register_GeneralFuncs(void) {
+	SIType *types ;
+	SIType ret_type ;
+	AR_FuncDesc *func_desc ;
 
-	types = arr_new(SIType, 1);
-	arr_append(types, T_NULL | SI_ALL);
-	ret_type = SI_ALL;
-	func_desc = AR_FuncDescNew("prev", AR_PREV, 1, 1, types, ret_type, false,
-			false, true);
-	AR_SetPrivateDataRoutines(func_desc, AR_PrevPrivateData_Free, AR_PrevPrivateData_Clone);
-	AR_FuncRegister(func_desc);
+	types = arr_new (SIType, 1) ;
+	arr_append (types, T_NULL | SI_ALL) ;
+	ret_type = SI_ALL ;
+	func_desc = AR_FuncDescNew ("prev", AR_PREV, 1, 1, types, ret_type, false,
+			false, true) ;
+	AR_SetPrivateDataRoutines (func_desc, AR_PrevPrivateData_Free,
+			AR_PrevPrivateData_Clone, NULL) ;
+	AR_FuncRegister (func_desc) ;
 }
 

--- a/src/arithmetic/list_funcs/list_funcs.c
+++ b/src/arithmetic/list_funcs/list_funcs.c
@@ -42,6 +42,33 @@ void ListReduceCtx_Free
 	rm_free(ctx);
 }
 
+// collect referenced entities within a reduce context
+// MATCH (n) RETURN reduce (sum = 0, n IN n.v | sum + n)
+void ListReduceCtx_CollectEntities
+(
+	const void *ctx_ptr,  // reduce context
+	rax *entities         // [input/output] collected entities
+) {
+	const ListReduceCtx *ctx = ctx_ptr ;
+
+	if (ctx->exp != NULL) {
+		AR_EXP_CollectEntities (ctx->exp, entities) ;
+	}
+
+	// remove the locally-bound variable and accumulator
+	if (ctx->variable != NULL) {
+		raxRemove (entities,
+				(unsigned char *)ctx->variable,
+				strlen (ctx->variable), NULL) ;
+	}
+
+	if (ctx->accumulator != NULL) {
+		raxRemove (entities,
+				(unsigned char *)ctx->accumulator,
+				strlen (ctx->accumulator), NULL) ;
+	}
+}
+
 // Routine for cloning a comprehension function's private data.
 void *ListReduceCtx_Clone
 (
@@ -893,14 +920,16 @@ void Register_ListFuncs() {
 			false, true, true);
 	AR_FuncRegister(func_desc);
 
-	types = arr_new(SIType, 4);
-	arr_append(types, SI_ALL);            // accumulator initial value
-	arr_append(types, T_ARRAY | T_NULL);  // array to iterate over
-	arr_append(types, T_PTR);             // input record
-	ret_type = SI_ALL;
-	func_desc = AR_FuncDescNew("reduce", AR_REDUCE, 3, 3, types, ret_type, true,
-			true, true);
-	AR_SetPrivateDataRoutines(func_desc, ListReduceCtx_Free,
-							  ListReduceCtx_Clone);
-	AR_FuncRegister(func_desc);
+	types = arr_new (SIType, 4) ;
+	arr_append (types, SI_ALL) ;            // accumulator initial value
+	arr_append (types, T_ARRAY | T_NULL) ;  // array to iterate over
+	arr_append (types, T_PTR) ;             // input record
+	ret_type = SI_ALL ;
+	func_desc = AR_FuncDescNew ("reduce", AR_REDUCE, 3, 3, types, ret_type,
+			true, true, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ListReduceCtx_Free,
+							  ListReduceCtx_Clone,
+							  ListReduceCtx_CollectEntities) ;
+	AR_FuncRegister (func_desc) ;
 }
+

--- a/src/arithmetic/list_funcs/list_funcs.c
+++ b/src/arithmetic/list_funcs/list_funcs.c
@@ -44,7 +44,7 @@ void ListReduceCtx_Free
 
 // collect referenced entities within a reduce context
 // MATCH (n) RETURN reduce (sum = 0, n IN n.v | sum + n)
-void ListReduceCtx_CollectEntities
+void ListReduceCtx_CollectAliases
 (
 	const void *ctx_ptr,  // reduce context
 	rax *entities         // [input/output] collected entities
@@ -929,7 +929,7 @@ void Register_ListFuncs() {
 			true, true, true) ;
 	AR_SetPrivateDataRoutines (func_desc, ListReduceCtx_Free,
 							  ListReduceCtx_Clone,
-							  ListReduceCtx_CollectEntities) ;
+							  ListReduceCtx_CollectAliases) ;
 	AR_FuncRegister (func_desc) ;
 }
 

--- a/src/arithmetic/path_funcs/path_funcs.c
+++ b/src/arithmetic/path_funcs/path_funcs.c
@@ -321,14 +321,15 @@ void Register_PathFuncs() {
 			ret_type, true, false, true);
 	AR_FuncRegister(func_desc);
 
-	types = arr_new(SIType, 3);
-	arr_append(types, T_NULL | T_NODE);
-	arr_append(types, T_NULL | T_NODE);
-	ret_type = T_PATH | T_NULL;
-	func_desc = AR_FuncDescNew("shortestpath", AR_SHORTEST_PATH, 2, 2, types,
-			ret_type, true, false, true);
-	AR_SetPrivateDataRoutines(func_desc, ShortestPath_Free, ShortestPath_Clone);
-	AR_FuncRegister(func_desc);
+	types = arr_new (SIType, 3) ;
+	arr_append (types, T_NULL | T_NODE) ;
+	arr_append (types, T_NULL | T_NODE) ;
+	ret_type = T_PATH | T_NULL ;
+	func_desc = AR_FuncDescNew ("shortestpath", AR_SHORTEST_PATH, 2, 2, types,
+			ret_type, true, false, true) ;
+	AR_SetPrivateDataRoutines (func_desc, ShortestPath_Free, ShortestPath_Clone,
+			NULL) ;
+	AR_FuncRegister (func_desc) ;
 
 	types = arr_new(SIType, 1);
 	arr_append(types, T_NULL | T_PATH);

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -77,14 +77,20 @@ void Record_Clone
 		// locate coresponding entry in clone
 		// if such exists shallow clone it
 		raxIterator it;
-		raxStart(&it, clone->mapping);
-		raxSeek(&it, "^", NULL, 0);
+		raxStart (&it, clone->mapping) ;
+		raxSeek (&it, "^", NULL, 0) ;
 
-		while(raxNext(&it)) {
-			uint src_idx = Record_GetEntryIdx(r, (const char*)it.key, it.key_len);
+		while (raxNext (&it)) {
+			uint src_idx =
+				Record_GetEntryIdx (r, (const char*)it.key, it.key_len) ;
 
-			if(src_idx == INVALID_INDEX) continue;
-			if(Record_GetType(r, src_idx) == REC_TYPE_UNKNOWN) continue;
+			if (src_idx == INVALID_INDEX) {
+				continue ;
+			}
+
+			if (Record_GetType (r, src_idx) == REC_TYPE_UNKNOWN) {
+				continue ;
+			}
 
 			intptr_t target_idx = (intptr_t)it.data;
 			Record_Add(clone, target_idx, Record_Get(r, src_idx));

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -470,31 +470,34 @@ void _FilterTree_CollectModified
 	const FT_FilterNode *root,
 	rax *modified
 ) {
-	if(root == NULL) return;
+	if (root == NULL) {
+		return ;
+	}
 
-	switch(root->t) {
+	switch (root->t) {
 		case FT_N_COND: {
-			_FilterTree_CollectModified(root->cond.left, modified);
-			_FilterTree_CollectModified(root->cond.right, modified);
-			break;
+			_FilterTree_CollectModified (root->cond.left, modified) ;
+			_FilterTree_CollectModified (root->cond.right, modified) ;
+			break ;
 		}
 		case FT_N_PRED: {
 			// traverse left and right-hand expressions,
 			// adding all encountered modified to the triemap
 			// we'll typically encounter 0 or 1 modified in each expression,
 			// but there are multi-argument exceptions
-			AR_EXP_CollectEntities(root->pred.lhs, modified);
-			AR_EXP_CollectEntities(root->pred.rhs, modified);
-			break;
+			AR_EXP_CollectEntities (root->pred.lhs, modified) ;
+			AR_EXP_CollectEntities (root->pred.rhs, modified) ;
+			break ;
 		}
 		case FT_N_EXP: {
-			// traverse expression, adding all encountered modified to the triemap
-			AR_EXP_CollectEntities(root->exp.exp, modified);
-			break;
+			// traverse expression
+			// adding all encountered modified to the triemap
+			AR_EXP_CollectEntities (root->exp.exp, modified) ;
+			break ;
 		}
 		default: {
-			ASSERT(0);
-			break;
+			ASSERT (0) ;
+			break ;
 		}
 	}
 }
@@ -503,10 +506,10 @@ rax *FilterTree_CollectModified
 (
 	const FT_FilterNode *root
 ) {
-	rax *modified = raxNew();
-	_FilterTree_CollectModified(root, modified);
+	rax *modified = raxNew () ;
+	_FilterTree_CollectModified (root, modified) ;
 
-	return modified;
+	return modified ;
 }
 
 // collect filtered attribute for a given entity
@@ -577,7 +580,7 @@ bool FilterTree_FiltersAlias
 	const cypher_astnode_t *ast  // AST
 ) {
 	// collect all filtered variables
-	rax *filtered_variables = FilterTree_CollectModified(root);
+	rax *filtered_variables = FilterTree_CollectModified (root) ;
 
 	raxIterator it;
 	raxStart(&it, filtered_variables);

--- a/tests/flow/test_comprehension_functions.py
+++ b/tests/flow/test_comprehension_functions.py
@@ -521,3 +521,67 @@ class testComprehensionFunctions(FlowTestsBase):
         except redis.exceptions.ResponseError as e:
             self.env.assertIn("Invalid use of aggregating function", str(e))
 
+    def test22_comprehension_predicate_after_with(self):
+        # Validate that aliases referenced within comprehension predicate
+        # (any/all/single/none) private-data are visible to the planner
+        g = self.db.select_graph("comprehension_after_with")
+        g.query("CREATE (n:Person {name: 'Alice', tags: ['friend', 'colleague']})")
+
+        # all() over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE all(item IN ['friend', 'colleague'] WHERE item IN a.tags)
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # all() over a renamed carried variable
+        query = """MATCH (a:Person)
+                   WITH a AS p
+                   WHERE all(item IN ['friend', 'colleague'] WHERE item IN p.tags)
+                   RETURN p.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # any() over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE any(item IN ['friend', 'missing'] WHERE item IN a.tags)
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # none() over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE none(item IN ['x', 'y'] WHERE item IN a.tags)
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # single() over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE single(item IN ['friend', 'x'] WHERE item IN a.tags)
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # list comprehension with predicate over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE size([item IN ['friend', 'colleague'] WHERE item IN a.tags]) = 2
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # reduce over a carried variable
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE reduce(s = 0, x IN a.tags | s + 1) = 2
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+
+        # negative case - predicate that should filter the row out
+        query = """MATCH (a:Person)
+                   WITH a
+                   WHERE all(item IN ['x', 'y'] WHERE item IN a.tags)
+                   RETURN a.name AS name"""
+        self.env.assertEquals(g.query(query).result_set, [])
+
+        g.delete()
+

--- a/tests/flow/test_comprehension_functions.py
+++ b/tests/flow/test_comprehension_functions.py
@@ -525,63 +525,72 @@ class testComprehensionFunctions(FlowTestsBase):
         # Validate that aliases referenced within comprehension predicate
         # (any/all/single/none) private-data are visible to the planner
         g = self.db.select_graph("comprehension_after_with")
+
+        # delete graph in case it exists
+        try:
+            g.delete()
+        except:
+            pass
+
         g.query("CREATE (n:Person {name: 'Alice', tags: ['friend', 'colleague']})")
 
-        # all() over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE all(item IN ['friend', 'colleague'] WHERE item IN a.tags)
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+        try:
+            # all() over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE all(item IN ['friend', 'colleague'] WHERE item IN a.tags)
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # all() over a renamed carried variable
-        query = """MATCH (a:Person)
-                   WITH a AS p
-                   WHERE all(item IN ['friend', 'colleague'] WHERE item IN p.tags)
-                   RETURN p.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # all() over a renamed carried variable
+            query = """MATCH (a:Person)
+                       WITH a AS p
+                       WHERE all(item IN ['friend', 'colleague'] WHERE item IN p.tags)
+                       RETURN p.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # any() over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE any(item IN ['friend', 'missing'] WHERE item IN a.tags)
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # any() over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE any(item IN ['friend', 'missing'] WHERE item IN a.tags)
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # none() over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE none(item IN ['x', 'y'] WHERE item IN a.tags)
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # none() over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE none(item IN ['x', 'y'] WHERE item IN a.tags)
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # single() over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE single(item IN ['friend', 'x'] WHERE item IN a.tags)
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # single() over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE single(item IN ['friend', 'x'] WHERE item IN a.tags)
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # list comprehension with predicate over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE size([item IN ['friend', 'colleague'] WHERE item IN a.tags]) = 2
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # list comprehension with predicate over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE size([item IN ['friend', 'colleague'] WHERE item IN a.tags]) = 2
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # reduce over a carried variable
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE reduce(s = 0, x IN a.tags | s + 1) = 2
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [['Alice']])
+            # reduce over a carried variable
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE reduce(s = 0, x IN a.tags | s + 1) = 2
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [['Alice']])
 
-        # negative case - predicate that should filter the row out
-        query = """MATCH (a:Person)
-                   WITH a
-                   WHERE all(item IN ['x', 'y'] WHERE item IN a.tags)
-                   RETURN a.name AS name"""
-        self.env.assertEquals(g.query(query).result_set, [])
+            # negative case - predicate that should filter the row out
+            query = """MATCH (a:Person)
+                       WITH a
+                       WHERE all(item IN ['x', 'y'] WHERE item IN a.tags)
+                       RETURN a.name AS name"""
+            self.env.assertEquals(g.query(query).result_set, [])
 
-        g.delete()
+        finally:
+            g.delete()
 


### PR DESCRIPTION
Resolve: #1987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehension and reduce functions now correctly collect and respect aliases/variables carried across WITH clauses, improving queries that use any/all/single/none/list/reduce patterns.

* **Tests**
  * Added an end-to-end test validating comprehension predicates and reduce/list behaviors when referencing aliases across WITH clauses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2013)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->