### PR TITLE
fix: handle variable-length traversal types in _costBaseLabelScan

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -9,6 +9,7 @@
 #include "../ops/op_expand_into.h"
 #include "../ops/op_node_by_label_scan.h"
 #include "../ops/op_conditional_traverse.h"
+#include "../ops/op_cond_var_len_traverse.h"
 #include "../execution_plan_build/execution_plan_util.h"
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
@@ -297,14 +298,29 @@ static void _costBaseLabelScan
 	}
 
 	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO &&
+		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE &&
+		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO) {
 		// no AE to swap operands on; nothing to do here
 		return ;
 	}
 
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
+	AlgebraicExpression *ae;
+	switch(t) {
+		case OPType_CONDITIONAL_TRAVERSE:
+			ae = ((OpCondTraverse*) parent)->ae;
+			break;
+		case OPType_EXPAND_INTO:
+			ae = ((OpExpandInto*) parent)->ae;
+			break;
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE:
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO:
+			ae = ((CondVarLenTraverse*) parent)->ae;
+			break;
+		default:
+			ASSERT(false && "unknown operation type");
+			return;
+	}
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;

--- a/tests/flow/test_bfs.py
+++ b/tests/flow/test_bfs.py
@@ -233,3 +233,13 @@ class testBFS(FlowTestsBase):
         expected_result = [[['b'], ['e']]]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
+    # variable-length traversal with labels of different cardinalities
+    # should not crash in _costBaseLabelScan
+    def test08_variable_length_traversal_label_scan(self):
+        # create nodes with labels of different cardinalities
+        self.graph.query("CREATE (:X), (:Y), (:Y)")
+        self.graph.query("MATCH (a:X), (b:Y) CREATE (a)-[:R]->(b)")
+        # variable-length traversal with different labels
+        result = self.graph.query("MATCH (a:X)-[*]-(b:Y) RETURN count(a)")
+        self.env.assertEquals(result.result_set[0][0], 2)
+


### PR DESCRIPTION
Fixes #636

## Root cause

`_costBaseLabelScan` only recognized `OPType_CONDITIONAL_TRAVERSE` and `OPType_EXPAND_INTO` as valid parent operation types when determining which label to scan. Queries using variable-length traversals (e.g. `MATCH (n:A)<-[*]-(n:Z)`) produce `OPType_CONDITIONAL_VAR_LEN_TRAVERSE` or `OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO` as the parent, causing the optimizer to skip label switching and later crash in `AlgebraicExpression_Dest` due to a NULL dereference.

## Fix

- Added `#include` for `op_cond_var_len_traverse.h`
- Extended the type check to also accept `OPType_CONDITIONAL_VAR_LEN_TRAVERSE` and `OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO`
- Retrieves the `AlgebraicExpression` from `CondVarLenTraverse` struct (which has the same `ae` field as `OpCondTraverse` and `OpExpandInto`)
- Used a `switch` statement for clarity and type safety

This was already identified by @swilly22 in the issue comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved optimizer to better handle conditional variable-length traversals across additional traversal types.

* **Tests**
  * Added a regression test to validate variable-length traversal with label scans, ensuring correct results and preventing crashes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2018)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->