### PR TITLE
fix: prevent double-free in AttributeSet_Update on duplicate attribute IDs

### DIFF
--- a/src/graph/entities/attribute_set.c
+++ b/src/graph/entities/attribute_set.c
@@ -628,7 +628,7 @@ void AttributeSet_Update
 		SIValue     _vals[n] ;  // attribute values
 		AttributeID _ids [n] ;  // attribute ids
 
-		// discard NULLs
+		// discard NULLs and duplicate attribute IDs
 		for (uint16_t i = 0; i < n; i++) {
 			SIValue     v       = vals[i] ;
 			AttributeID attr_id = ids [i] ;
@@ -640,14 +640,28 @@ void AttributeSet_Update
 				if (change) {
 					change[i] = CT_NONE ;
 				}
-			} else {
-				_ids [m] = ids [i] ;
-				_vals[m] = vals[i] ;
-				m++ ;
+				continue ;
+			}
 
-				if (change) {
-					change[i] = CT_ADD ;
+			// skip if same attr_id appears again later (last occurrence wins)
+			bool dup = false ;
+			for (uint16_t j = i + 1; j < n; j++) {
+				if (ids[j] == attr_id) {
+					dup = true ;
+					break ;
 				}
+			}
+			if (dup) {
+				if (change) change[i] = CT_NONE ;
+				continue ;
+			}
+
+			_ids [m] = ids [i] ;
+			_vals[m] = vals[i] ;
+			m++ ;
+
+			if (change) {
+				change[i] = CT_ADD ;
 			}
 		}
 
@@ -674,6 +688,20 @@ void AttributeSet_Update
 		AttributeID attr_id = ids [i] ;
 
 		ASSERT (SI_TYPE (v) & t) ;
+
+		// if this attr_id appears again later, skip this occurrence
+		// to prevent duplicate entries in remove_idx/add_idx
+		bool skip = false;
+		for(uint16_t j = i + 1; j < n; j++) {
+			if(ids[j] == attr_id) {
+				skip = true;
+				break;
+			}
+		}
+		if(skip) {
+			if(change) change[i] = CT_NONE;
+			continue;
+		}
 
 		bool remove   = SIValue_IsNull (v) ;
 		bool contains = AttributeSet_Contains (_set, attr_id, &idx) ;

--- a/tests/flow/test_null_handling.py
+++ b/tests/flow/test_null_handling.py
@@ -106,8 +106,22 @@ class testNullHandlingFlow(FlowTestsBase):
         expected_result = []
         self.env.assertEquals(actual_result.result_set, expected_result)
 
+    # Duplicate attribute IDs in SET should not cause double-free
+    def test08_duplicate_set_attribute_double_free(self):
+        # Create a node with a property
+        self.graph.query("CREATE (:L {v: 'test'})")
+        # SET the same property to NULL twice should not crash
+        result = self.graph.query("MATCH (n:L) SET n.v = NULL, n.v = NULL")
+        self.env.assertEquals(result.nodes_created, 0)
+        # Verify the property was removed
+        result = self.graph.query("MATCH (n:L) RETURN n.v")
+        self.env.assertEquals(result.result_set, [[None]])
+
+        # Cleanup
+        self.graph.query("MATCH (n:L) DELETE n")
+
     # ValueHashJoin ops should not treat null values as equal.
-    def test08_null_value_hash_join(self):
+    def test09_null_value_hash_join(self):
         query = """MATCH (a), (b) WHERE a.fakeval = b.fakeval RETURN a, b"""
         plan = str(self.graph.explain(query))
         # Verify that we are performing a ValueHashJoin


### PR DESCRIPTION
Fixes #1885

When a Cypher SET clause references the same property more than once (e.g. `SET n.x = NULL, n.x = NULL`), the categorization loop in `AttributeSet_Update` would add the same attribute index to `remove_idx` multiple times, causing `AttributeSet_RemoveIdx` to free the same slot twice.

**Root cause:** The categorization loop calls `AttributeSet_Contains` to locate the existing slot for each attr_id. When the same attr_id appears twice, both iterations find the same index and add it to `remove_idx` (or `add_idx`), leading to a double-free / heap-use-after-free.

**Fix:** Skip duplicate attr_id occurrences, keeping only the last occurrence. Applied to both the `only_additions` path (where duplicates would create duplicate entries in the set) and the main categorized path (where duplicates corrupt remove_idx/add_idx).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate attribute handling to ensure only the latest value is applied when the same attribute is updated multiple times in a single operation, preventing potential memory issues.

* **Tests**
  * Added regression test for duplicate attribute update scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2019)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->