### PR TITLE
handle empty relationship types and use atomic bool better

### DIFF
--- a/src/procedures/proc_maxflow.c
+++ b/src/procedures/proc_maxflow.c
@@ -102,8 +102,8 @@ static void _get_edge_capacity
 	// set invalid flag if value is still negative
 	// meaning we have encountered an invalid value and the default was not set
 	bool valid = *z >= 0.0 ;
-	if (!valid && !(*(ctx->invalid))) {
-		atomic_store(ctx->invalid, true) ;
+	if (!valid && !atomic_load_explicit(ctx->invalid, memory_order_relaxed)) {
+		atomic_store_explicit(ctx->invalid, true, memory_order_relaxed) ;
 	}
 }
 
@@ -512,6 +512,27 @@ ProcedureResult Proc_MaxFlowInvoke
 	GrB_OK (Build_Matrix (&A, NULL, g, lbls, arr_len (lbls), rels,
 			arr_len(rels), false, false)) ;
 
+	GrB_Index nvals_A = 0;
+	GrB_OK (GrB_Matrix_nvals(&nvals_A, A));
+	if (nvals_A == 0) {
+		GrB_OK (GrB_free (&A)) ;
+
+		// No edges match the label/relationship filter: max flow is 0.
+		// Build an empty flow matrix so Step yields one row with maxFlow=0
+		// and empty nodes/edges/edgeFlows arrays.
+		GrB_Index nrows, ncols ;
+		GrB_OK (GrB_Matrix_nrows (&nrows, U)) ;
+		GrB_OK (GrB_Matrix_ncols (&ncols, U)) ;
+		GrB_Matrix empty_flow ;
+		GrB_OK (GrB_Matrix_new (&empty_flow, GrB_FP64, nrows, ncols)) ;
+
+		pdata->R         = U ;
+		pdata->max_flow  = 0.0 ;
+		pdata->flow_mtx  = empty_flow ;
+		ctx->privateData = pdata ;
+		goto cleanup ;
+	}
+
 	//--------------------------------------------------------------------------
 	// cast A to uint64 matrix
 	//--------------------------------------------------------------------------
@@ -560,6 +581,7 @@ ProcedureResult Proc_MaxFlowInvoke
 	GrB_OK (GrB_free (&cap_ctx_s)) ;
 	GrB_OK (GrB_free (&cap_ctx_type)) ;
 	GrB_OK (GrB_free (&get_capacity)) ;
+
 
 	if (invalid_attributes) {
 		ErrorCtx_SetError ("algo.maxFlow: invalid or missing attribute and no"

--- a/tests/flow/test_maxflow.py
+++ b/tests/flow/test_maxflow.py
@@ -1313,3 +1313,32 @@ class testMaxFlow(FlowTestsBase):
             YIELD maxFlow
         """)
         self.env.assertAlmostEqual(result.result_set[0][0], 4.5, 5)
+
+    def test_37_no_edges_of_relationship_type(self):
+        """When the relationship type exists but no edges survive the label
+        filter, maxFlow should return one row with maxFlow=0 and empty arrays."""
+        # Create a PIPE edge (registers the rel-type in the schema) between
+        # nodes labelled 'X', then query between nodes labelled 'Y' where no
+        # PIPE edges exist – Build_Matrix produces an empty matrix.
+        self.graph.query("""
+            CREATE (:X {name:'P'})-[:PIPE {cap:5}]->(:X {name:'Q'}),
+                   (:Y {name:'A'}),
+                   (:Y {name:'B'})
+        """)
+        result = self.graph.query("""
+            MATCH (s:Y {name:'A'}), (t:Y {name:'B'})
+            CALL algo.maxFlow({
+                sourceNodes:       [s],
+                targetNodes:       [t],
+                capacityProperty:  'cap',
+                nodeLabels:        ['Y'],
+                relationshipTypes: ['PIPE']
+            })
+            YIELD nodes, edges, edgeFlows, maxFlow
+        """)
+        self.env.assertEqual(len(result.result_set), 1)
+        row = result.result_set[0]
+        self.env.assertEqual(row[0], [])       # nodes
+        self.env.assertEqual(row[1], [])       # edges
+        self.env.assertEqual(row[2], [])       # edgeFlows
+        self.env.assertEqual(row[3], 0.0)      # maxFlow


### PR DESCRIPTION
Fix #2037 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The maxFlow procedure now correctly handles cases where no edges match the specified relationship type filter, returning zero flow with empty arrays for nodes, edges, and edge flows.

* **Tests**
  * Added comprehensive test coverage for the edge case where a relationship type exists in the graph but no edges survive the label and relationship type filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2036)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->