### PR TITLE
Fix variable-length traversal planning for same endpoint alias

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -190,17 +190,22 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps
 		QGNode *dest = QueryGraph_GetNodeByAlias(qg,
 				AlgebraicExpression_Dest(exp));
 
+		bool same_endpoint_alias = (src == dest);
+
 		if(QGNode_Labeled(dest)) {
 			// remove dest node matrix from expression
 			op = AlgebraicExpression_RemoveDest(&exp);
 		}
 
 		if(op != NULL) {
-			// remove destination if following expression isn't a
-			// variable length edge (src/dest sharing) otherwise introduce a new
-			// label expression
-			if(expIdx < expCount - 1 &&
+			if(same_endpoint_alias) {
+				// already represented by the source label expression
+				AlgebraicExpression_Free(op);
+			} else if(expIdx < expCount - 1 &&
 			   !_AlgebraicExpression_ContainsVariableLengthEdge(qg, expressions[expIdx + 1])) {
+				// remove destination if following expression isn't a
+				// variable length edge (src/dest sharing) otherwise introduce a new
+				// label expression
 				AlgebraicExpression_Free(op);
 			} else {
 				arr_append(res, op);
@@ -698,4 +703,3 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph
 	QueryGraph_Free(g);
 	return exps;
 }
-

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -113,8 +113,10 @@ void reduceTraversal(ExecutionPlan *plan) {
 			 * to perform label filtering, but in case a node is already
 			 * resolved this filtering is redundent and should be removed. */
 			OpBase *t;
+			bool same_endpoint_alias =
+				!strcmp(AlgebraicExpression_Src(ae), AlgebraicExpression_Dest(ae));
 			QGNode *src = QueryGraph_GetNodeByAlias(traverse_plan->query_graph, AlgebraicExpression_Src(ae));
-			if(QGNode_Labeled(src)) {
+			if(QGNode_Labeled(src) && !same_endpoint_alias) {
 				t = op->children[0];
 				if(t->type == OPType_CONDITIONAL_TRAVERSE && !_isInSubExecutionPlan(op)) {
 					// Queue traversal for removal.
@@ -123,7 +125,7 @@ void reduceTraversal(ExecutionPlan *plan) {
 			}
 			QGNode *dest = QueryGraph_GetNodeByAlias(traverse_plan->query_graph,
 													 AlgebraicExpression_Dest(ae));
-			if(QGNode_Labeled(dest)) {
+			if(QGNode_Labeled(dest) && !same_endpoint_alias) {
 				t = op->parent;
 				if(t->type == OPType_CONDITIONAL_TRAVERSE && !_isInSubExecutionPlan(op)) {
 					// Queue traversal for removal.
@@ -141,4 +143,3 @@ void reduceTraversal(ExecutionPlan *plan) {
 	// Clean up.
 	arr_free(traversals);
 }
-

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -458,6 +458,7 @@ class testVariableLengthTraversals(FlowTestsBase):
         ))
 
     def test16_var_len_same_alias_with_labels(self):
+        """Label filters must survive variable-length traversals to the same alias."""
         self.graph.delete()
 
         q = "CREATE (:A), (:B)<-[:R0]-()<-[:R1]-(), (:A)-[:R]->(:A)"

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -456,3 +456,19 @@ class testVariableLengthTraversals(FlowTestsBase):
                 Node(2, labels=["C"], properties={"v": 5})],
             [Edge(0, "R", 1, 0, properties={"v": 2}), Edge(1, "R", 2, 1, properties={"v": 4})]
         ))
+
+    def test16_var_len_same_alias_with_labels(self):
+        self.graph.delete()
+
+        q = "CREATE (:A), (:B)<-[:R0]-()<-[:R1]-(), (:A)-[:R]->(:A)"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 6)
+        self.env.assertEquals(res.relationships_created, 3)
+
+        q = "MATCH (n:A)<-[*]-(n:Z) RETURN 1"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [])
+
+        q = "MATCH (n:A)<-[*]-(n:Z) WHERE n.v = [false] RETURN 1"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [])


### PR DESCRIPTION
Fixes #636
/claim #636

## Summary
- avoid emitting a duplicate destination-label expression when isolating a variable-length traversal whose source and destination are the same query alias
- keep the alias labels represented by the source label expression, preventing the planner from constructing a variable-length traversal that must resolve that same node alias again after the traversal
- add a regression for the simplified crash shape from the issue, including the filtered variant

## Testing
- `python3 -m py_compile tests/flow/test_variable_length_traversals.py`
- `make flow-tests TESTFILE=tests/flow/test_variable_length_traversals.py` currently cannot complete locally because the macOS build host is missing `autoreconf` while building libcurl dependencies (`./build.sh: line 764: autoreconf: command not found`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate label representation and redundant traversal steps when a variable-length traversal reuses the same node alias with conflicting labels.

* **Tests**
  * Added a test covering reverse variable-length traversals that reuse the same alias with different label constraints.
  * Fixed a syntax/assertion issue in an existing variable-length traversal test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2039)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->