### PR TITLE
Fix same-alias variable-length traversal label filters

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -81,6 +81,17 @@ static bool _AlgebraicExpression_ContainsVariableLengthEdge
 	return false;
 }
 
+static inline bool _QGNodes_ShareAlias
+(
+	const QGNode *a,
+	const QGNode *b
+) {
+	ASSERT(a != NULL);
+	ASSERT(b != NULL);
+
+	return strcmp(a->alias, b->alias) == 0;
+}
+
 static void _RemovePathFromGraph
 (
 	QueryGraph *g,
@@ -189,6 +200,7 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps
 
 		QGNode *dest = QueryGraph_GetNodeByAlias(qg,
 				AlgebraicExpression_Dest(exp));
+		bool same_alias = _QGNodes_ShareAlias(src, dest);
 
 		if(QGNode_Labeled(dest)) {
 			// remove dest node matrix from expression
@@ -196,11 +208,11 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps
 		}
 
 		if(op != NULL) {
-			// remove destination if following expression isn't a
-			// variable length edge (src/dest sharing) otherwise introduce a new
-			// label expression
-			if(expIdx < expCount - 1 &&
-			   !_AlgebraicExpression_ContainsVariableLengthEdge(qg, expressions[expIdx + 1])) {
+			// A variable-length self traversal should not re-resolve its
+			// endpoint through a second label filter after the edge operand.
+			if(same_alias ||
+			   (expIdx < expCount - 1 &&
+			    !_AlgebraicExpression_ContainsVariableLengthEdge(qg, expressions[expIdx + 1]))) {
 				AlgebraicExpression_Free(op);
 			} else {
 				arr_append(res, op);
@@ -698,4 +710,3 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph
 	QueryGraph_Free(g);
 	return exps;
 }
-

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -31,6 +31,18 @@ static inline bool _isInSubExecutionPlan(OpBase *op) {
 	return ExecutionPlan_LocateOp(op, OPType_ARGUMENT) != NULL;
 }
 
+static inline bool _traversalSelfReferencesAlias
+(
+	const AlgebraicExpression *ae
+) {
+	ASSERT(ae != NULL);
+
+	const char *src = AlgebraicExpression_Src(ae);
+	const char *dest = AlgebraicExpression_Dest(ae);
+
+	return strcmp(src, dest) == 0;
+}
+
 static void _removeRedundantTraversal(ExecutionPlan *plan, OpCondTraverse *traverse) {
 	AlgebraicExpression *ae =  traverse->ae;
 	if(AlgebraicExpression_OperandCount(ae) == 1 &&
@@ -113,8 +125,9 @@ void reduceTraversal(ExecutionPlan *plan) {
 			 * to perform label filtering, but in case a node is already
 			 * resolved this filtering is redundent and should be removed. */
 			OpBase *t;
+			bool self_ref = _traversalSelfReferencesAlias(ae);
 			QGNode *src = QueryGraph_GetNodeByAlias(traverse_plan->query_graph, AlgebraicExpression_Src(ae));
-			if(QGNode_Labeled(src)) {
+			if(QGNode_Labeled(src) && !self_ref) {
 				t = op->children[0];
 				if(t->type == OPType_CONDITIONAL_TRAVERSE && !_isInSubExecutionPlan(op)) {
 					// Queue traversal for removal.
@@ -123,7 +136,7 @@ void reduceTraversal(ExecutionPlan *plan) {
 			}
 			QGNode *dest = QueryGraph_GetNodeByAlias(traverse_plan->query_graph,
 													 AlgebraicExpression_Dest(ae));
-			if(QGNode_Labeled(dest)) {
+			if(QGNode_Labeled(dest) && !self_ref) {
 				t = op->parent;
 				if(t->type == OPType_CONDITIONAL_TRAVERSE && !_isInSubExecutionPlan(op)) {
 					// Queue traversal for removal.
@@ -141,4 +154,3 @@ void reduceTraversal(ExecutionPlan *plan) {
 	// Clean up.
 	arr_free(traversals);
 }
-

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -456,3 +456,30 @@ class testVariableLengthTraversals(FlowTestsBase):
                 Node(2, labels=["C"], properties={"v": 5})],
             [Edge(0, "R", 1, 0, properties={"v": 2}), Edge(1, "R", 2, 1, properties={"v": 4})]
         ))
+
+    def test16_var_len_same_alias_label_filters(self):
+        self.graph.delete()
+
+        q = "CREATE (:A), (:B)"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 2)
+
+        queries = [
+            "MATCH (n:A)<-[*]-(n:Z) RETURN 1",
+            # Preserve the original regression shape with an additional predicate.
+            "MATCH (n:A)<-[*]-(n:Z) WHERE n.prop7 = [false] RETURN 1",
+        ]
+        for q in queries:
+            res = self.graph.query(q)
+            self.env.assertEquals(res.result_set, [])
+
+        self.graph.delete()
+
+        q = "CREATE (n:A:Z {v: 1})-[:R]->(n)"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 1)
+        self.env.assertEquals(res.relationships_created, 1)
+
+        q = "MATCH p = (n:A)<-[*]-(n:Z) RETURN n.v, length(p)"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [[1, 1]])


### PR DESCRIPTION
## Summary
- avoid emitting a second destination label filter after a variable-length traversal whose endpoints are the same alias
- keep same-alias variable-length label-filter traversals from being removed as redundant during reduceTraversal
- add a flow regression for the #636 fuzzer shape and a matching self-loop case

/claim #636

## Testing
- `git diff --check origin/master...HEAD`
- `python3 -m py_compile tests/flow/test_variable_length_traversals.py`
- `make flow-tests TEST=test_variable_length_traversals.py`

The focused native flow test now builds FalkorDB successfully, starts Redis 8.0.0, loads the module, and runs `test_variable_length_traversals.py`: 16 tests run, 0 failed, 16 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of variable-length traversals when the same alias is used at both ends with different label constraints.

* **Performance Improvements**
  * Optimized redundant traversal detection to reduce unnecessary operations in self-referential query patterns.

* **Tests**
  * Extended test coverage for variable-length traversals with identical aliases and label filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->