### PR TITLE
fix(delta_matrix): NULL-guard lock/synchronize to prevent SIGSEGV on RESTORE

### DIFF
--- a/src/graph/delta_matrix/delta_matrix.c
+++ b/src/graph/delta_matrix/delta_matrix.c
@@ -40,6 +40,20 @@ void Delta_Matrix_lock
 ) {
 	ASSERT (C) ;
 
+	// Defensive: ASSERT() is no-op in release builds. Without this NULL
+	// guard, callers passing a NULL Delta_Matrix (observed during
+	// RESTORE of a v18-encoded graph where a relation matrix slot was
+	// unpopulated) would segfault via pthread_mutex_lock(&NULL->mutex).
+	// Log + early-return so the host process stays up; the upstream
+	// caller still receives undefined behavior for whatever they were
+	// trying to do, but Redis itself does not crash.
+	if (C == NULL) {
+		RedisModule_Log(NULL, "warning",
+			"Delta_Matrix_lock: NULL matrix — skipping lock "
+			"(upstream caller bug)");
+		return ;
+	}
+
 	int res = pthread_mutex_lock (&C->mutex) ;
 
 	ASSERT (res       == 0) ;
@@ -54,6 +68,11 @@ void Delta_Matrix_unlock
 	Delta_Matrix C
 ) {
 	ASSERT (C) ;
+	if (C == NULL) {
+		RedisModule_Log(NULL, "warning",
+			"Delta_Matrix_unlock: NULL matrix — skipping unlock");
+		return ;
+	}
 	ASSERT (C->locked == true) ;
 
 	C->locked = false ;

--- a/src/graph/delta_matrix/delta_wait.c
+++ b/src/graph/delta_matrix/delta_wait.c
@@ -145,6 +145,18 @@ GrB_Info Delta_Matrix_synchronize
 ) {
 	ASSERT (C != NULL) ;
 
+	// Defensive: ASSERT() compiles to no-op in release. A NULL C here
+	// means the caller (e.g. Graph_GetRelationMatrix invoked during v18
+	// RDB-load of a graph snapshot with an unallocated relation matrix
+	// slot) handed us nothing. Returning GrB_NULL_POINTER lets the
+	// caller treat this as a recoverable error instead of crashing
+	// Redis in pthread_mutex_lock.
+	if (C == NULL) {
+		RedisModule_Log(NULL, "warning",
+			"Delta_Matrix_synchronize: NULL matrix — returning GrB_NULL_POINTER");
+		return GrB_NULL_POINTER ;
+	}
+
 	GrB_Info info = GrB_SUCCESS ;
 	uint64_t C_nrows = 0 ;
 	uint64_t C_ncols = 0 ;


### PR DESCRIPTION
## What this fixes

Redis segfaults when FalkorDB receives certain `RESTORE` commands.
The trigger: the v18 graph decoder encounters a relation-matrix slot that
was never allocated, and the resulting null pointer is fed through
`Graph_GetRelationMatrix` → `Delta_Matrix_synchronize` →
`Delta_Matrix_lock`, where `pthread_mutex_lock(&NULL->mutex)` brings
the whole host process down.

---

Delta_Matrix_lock, Delta_Matrix_unlock and Delta_Matrix_synchronize all begin with `ASSERT(C != NULL)`. In release builds ASSERT() compiles to a no-op, so when a caller passes a NULL Delta_Matrix the next line attempts pthread_mutex_lock(&NULL->mutex) and Redis segfaults with SIGSEGV (signal 11) accessing address ~0x28 (offsetof mutex in Delta_Matrix struct).

## Reproducer

Observed against FalkorDB v4.18.4 and v4.18.7 in production, then reproduced locally against current master built with `make` (release).

1. Build the module: `make` (release, no DEBUG=1).
2. Start redis: `redis-server --loadmodule .../falkordb.so --appendonly yes`.
3. Populate any graph (script content not bug-specific — we used a 923-node `:Pattern -[:HAS_LAYER]-> :SignalLayer` KG plus 36 other sibling graphs imported from cypher dumps).
4. From a separate client, issue `RESTORE <existing_key> 0 <serialized blob> REPLACE` against an already-populated graph key, using a blob produced by an earlier DUMP of a similar graph that exercised the v18 encoder. (In our environment, an application-layer "kg-restore-on-login" warmup was re-RESTORE-ing graphs whose KV state was already in memory; the meta tracking went out of sync after a manual cypher reimport.)
5. Redis crashes:

   ``` pthread_mutex_lock+0x4
   ↑ Delta_Matrix_lock+0x11               (delta_matrix.c)
   ↑ Delta_Matrix_synchronize+0x41        (delta_wait.c)
   ↑ _MatrixSynchronize+0x16              (graph.c)
   ↑ Graph_GetRelationMatrix+0x37         (graph.c:1568)
   ↑ RdbLoadRelationMatrices_v18+0x9b     (prev/v18/decode_matrix.c:269)
   ↑ RdbLoadGraphContext_v18+0x45d
   ↑ Decode_Previous+0xc3
   ↑ rdbLoadObject+0x8bb
   ↑ restoreCommand+0x426
   ```

The faulting deref is on the relation matrix at `g->relations[r]` returned by `Graph_GetRelationMatrix` — for some relation IDs in `[0, Graph_RelationTypeCount(g))` the slot is NULL when entered via the v18 decoder.

## Fix

Convert the silent NULL deref into a logged warning + safe early return at all three Delta_Matrix entry points. Behavior in correctly- formed call paths is unchanged (NULL was already an ASSERT-violation contract violation). The change keeps Redis alive when an upstream caller bug would otherwise crash the process.

## Note for maintainers

The defensive guard prevents the crash but does not fix the root cause: somewhere in the RESTORE → v18-decoder path, one or more relation matrices in `g->relations[]` remain NULL when `RdbLoadRelationMatrices_v18` iterates `Graph_RelationTypeCount(g)`. Candidate root-cause sites: `_DecodeHeader` may not be allocating matrices for all schema-declared relations, OR there's a payload ordering assumption that doesn't hold for RESTORE-on-existing-key (REPLACE) flows where the prior graph state mutates the relations array mid-decode. We have a reliable reproducer environment if a maintainer wants help reducing further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of matrix operations by implementing defensive null pointer validation. These improvements prevent potential crashes in release builds where assertions may be disabled, with appropriate error logging and graceful error handling for null pointer conditions encountered during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->