### PR TITLE
fix(delete): skip stale graph entities

### DIFF
--- a/deps/FalkorDB-core-rs/src/undo_log/ffi.rs
+++ b/deps/FalkorDB-core-rs/src/undo_log/ffi.rs
@@ -40,6 +40,9 @@ unsafe extern "C" fn UndoLog_DeleteNode(
     labels_count: usize,
 ) {
     let n = node.read();
+    if n.attributes.is_null() {
+        return;
+    }
     let set = n.attributes.read_unaligned();
     n.attributes
         .write((set as u64 | (1u64 << (u64::BITS as usize - 1))) as *mut _);
@@ -52,6 +55,9 @@ unsafe extern "C" fn UndoLog_DeleteEdge(
     edge: *const Edge,
 ) {
     let e = edge.read();
+    if e.attributes.is_null() {
+        return;
+    }
     let set = e.attributes.read_unaligned();
     e.attributes
         .write((set as u64 | (1u64 << (u64::BITS as usize - 1))) as *mut _);

--- a/deps/FalkorDB-core-rs/src/undo_log/ffi.rs
+++ b/deps/FalkorDB-core-rs/src/undo_log/ffi.rs
@@ -40,9 +40,6 @@ unsafe extern "C" fn UndoLog_DeleteNode(
     labels_count: usize,
 ) {
     let n = node.read();
-    if n.attributes.is_null() {
-        return;
-    }
     let set = n.attributes.read_unaligned();
     n.attributes
         .write((set as u64 | (1u64 << (u64::BITS as usize - 1))) as *mut _);
@@ -55,9 +52,6 @@ unsafe extern "C" fn UndoLog_DeleteEdge(
     edge: *const Edge,
 ) {
     let e = edge.read();
-    if e.attributes.is_null() {
-        return;
-    }
     let set = e.attributes.read_unaligned();
     e.attributes
         .write((set as u64 | (1u64 << (u64::BITS as usize - 1))) as *mut _);

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -21,6 +21,13 @@ static Record DeleteConsume(OpBase *opBase);
 static OpBase *DeleteClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void DeleteFree(OpBase *opBase);
 
+static inline bool _EntityCannotBeDeleted
+(
+	const GraphEntity *e
+) {
+	return e->attributes == NULL || Graph_EntityIsDeleted (e) ;
+}
+
 static void _BulkDeleteEntities
 (
 	OpDelete *op
@@ -250,7 +257,7 @@ static inline void _CollectDeletedEntities
 			Node *n = (Node *)value.ptrval ;
 
 			// skip duplicated & deleted nodes
-			if (!Graph_EntityIsDeleted ((GraphEntity *)n) &&
+			if (!_EntityCannotBeDeleted ((GraphEntity *)n) &&
 				roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 				arr_append (op->deleted_nodes, *n) ;
 			}
@@ -260,7 +267,7 @@ static inline void _CollectDeletedEntities
 			Edge *e = (Edge *)value.ptrval ;
 
 			// skip already deleted edges
-			if (!Graph_EntityIsDeleted ((GraphEntity *)e)                &&
+			if (!_EntityCannotBeDeleted ((GraphEntity *)e)               &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->src_id)  &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->dest_id) &&
 				roaring64_bitmap_add_checked (op->edge_bitmap, ENTITY_GET_ID (e))) {
@@ -277,7 +284,7 @@ static inline void _CollectDeletedEntities
 				Node *n = Path_GetNode (p, j) ;
 
 				// skip duplicated & deleted nodes
-				if (!Graph_EntityIsDeleted ((GraphEntity *)n) &&
+				if (!_EntityCannotBeDeleted ((GraphEntity *)n) &&
 					roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 					arr_append (op->deleted_nodes, *n) ;
 				}
@@ -415,4 +422,3 @@ static void DeleteFree
 		op->edge_bitmap = NULL ;
 	}
 }
-

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -21,13 +21,6 @@ static Record DeleteConsume(OpBase *opBase);
 static OpBase *DeleteClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void DeleteFree(OpBase *opBase);
 
-static inline bool _EntityCannotBeDeleted
-(
-	const GraphEntity *e
-) {
-	return e->attributes == NULL || Graph_EntityIsDeleted (e) ;
-}
-
 static void _BulkDeleteEntities
 (
 	OpDelete *op
@@ -256,8 +249,8 @@ static inline void _CollectDeletedEntities
 		if (type & T_NODE) {
 			Node *n = (Node *)value.ptrval ;
 
-			// skip duplicated & deleted nodes
-			if (!_EntityCannotBeDeleted ((GraphEntity *)n) &&
+			// skip duplicated and non-modifiable nodes
+			if (GraphEntity_CanModify ((GraphEntity *)n) &&
 				roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 				arr_append (op->deleted_nodes, *n) ;
 			}
@@ -266,8 +259,8 @@ static inline void _CollectDeletedEntities
 		else if (type & T_EDGE) {
 			Edge *e = (Edge *)value.ptrval ;
 
-			// skip already deleted edges
-			if (!_EntityCannotBeDeleted ((GraphEntity *)e)               &&
+			// skip non-modifiable edges
+			if (GraphEntity_CanModify ((GraphEntity *)e)                 &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->src_id)  &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->dest_id) &&
 				roaring64_bitmap_add_checked (op->edge_bitmap, ENTITY_GET_ID (e))) {
@@ -283,8 +276,8 @@ static inline void _CollectDeletedEntities
 			for (size_t j = 0; j < nodeCount; j++) {
 				Node *n = Path_GetNode (p, j) ;
 
-				// skip duplicated & deleted nodes
-				if (!_EntityCannotBeDeleted ((GraphEntity *)n) &&
+				// skip duplicated and non-modifiable nodes
+				if (GraphEntity_CanModify ((GraphEntity *)n) &&
 					roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 					arr_append (op->deleted_nodes, *n) ;
 				}

--- a/src/execution_plan/ops/shared/update_functions.c
+++ b/src/execution_plan/ops/shared/update_functions.c
@@ -69,7 +69,7 @@ void CommitUpdates
 		PendingUpdateCtx *update = HashTableGetVal (entry) ;
 
 		// if entity has been deleted, perform no updates
-		if (GraphEntity_IsDeleted (update->ge)) {
+		if (!GraphEntity_CanModify (update->ge)) {
 			continue ;
 		}
 
@@ -470,9 +470,8 @@ void EvalEntityUpdates
 	// get the updated entity
 	GraphEntity *entity = Record_GetGraphEntity (r, ctx->record_idx) ;
 
-	// if the entity wasn't materialized or was marked as deleted, make no
-	// updates but do not error
-	if (unlikely (entity->attributes == NULL || Graph_EntityIsDeleted (entity))) {
+	// if the entity can't be modified, make no updates but do not error
+	if (unlikely (!GraphEntity_CanModify (entity))) {
 		return ;
 	}
 

--- a/src/execution_plan/ops/shared/update_functions.c
+++ b/src/execution_plan/ops/shared/update_functions.c
@@ -470,8 +470,9 @@ void EvalEntityUpdates
 	// get the updated entity
 	GraphEntity *entity = Record_GetGraphEntity (r, ctx->record_idx) ;
 
-	// if the entity is marked as deleted, make no updates but do not error
-	if (unlikely (Graph_EntityIsDeleted (entity))) {
+	// if the entity wasn't materialized or was marked as deleted, make no
+	// updates but do not error
+	if (unlikely (entity->attributes == NULL || Graph_EntityIsDeleted (entity))) {
 		return ;
 	}
 
@@ -674,4 +675,3 @@ void PendingUpdateCtx_Free
 	arr_free(ctx->remove_labels);
 	rm_free(ctx);
 }
-

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -243,6 +243,13 @@ inline bool GraphEntity_IsDeleted
 	return Graph_EntityIsDeleted(e);
 }
 
+inline bool GraphEntity_CanModify
+(
+	const GraphEntity *e
+) {
+	return e != NULL && e->attributes != NULL && !Graph_EntityIsDeleted (e) ;
+}
+
 inline AttributeSet GraphEntity_GetAttributes
 (
 	const GraphEntity *e

--- a/src/graph/entities/graph_entity.h
+++ b/src/graph/entities/graph_entity.h
@@ -100,6 +100,12 @@ bool GraphEntity_IsDeleted
 	const GraphEntity *e
 );
 
+// returns true if the given graph entity can be mutated
+bool GraphEntity_CanModify
+(
+	const GraphEntity *e
+);
+
 // returns attribute-set of entity
 AttributeSet GraphEntity_GetAttributes
 (

--- a/tests/flow/test_access_del_entity.py
+++ b/tests/flow/test_access_del_entity.py
@@ -213,6 +213,57 @@ class testAccessDelNode():
         self.env.assertEquals(nodes[2].properties['v'], 'c')
         self.env.assertIn('C', nodes[2].labels)
 
+    def test10_delete_deleted_endpoint(self):
+        # startNode/endNode can materialize a deleted endpoint as a node with
+        # NULL attributes. Deleting that stale value should be a no-op.
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a)
+               WITH r, a
+               DETACH DELETE a
+               WITH startNode(r) AS ec
+               DETACH DELETE ec"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 1)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+        q = """CREATE (a:Start)-[r:R]->(b:End)
+               WITH r, b
+               DETACH DELETE b
+               WITH endNode(r) AS ec
+               DETACH DELETE ec"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 2)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a), (b:Valid)
+               WITH r, a, b
+               DETACH DELETE a
+               WITH startNode(r) AS ec, b
+               DETACH DELETE ec, b"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 2)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 2)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+    def test11_update_deleted_endpoint(self):
+        # Updating a deleted endpoint materialized by startNode/endNode should
+        # be a no-op rather than dereferencing its NULL attributes.
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a)
+               WITH r, a
+               DETACH DELETE a
+               WITH startNode(r) AS ec
+               SET ec.v = 1"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 1)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+        self.env.assertEquals(res.properties_set, 0)
+
 class testAccessDelEdge():
     def __init__(self):
         GRAPH_ID = "access_del_edge"
@@ -377,4 +428,3 @@ class testAccessDelEdge():
 
         self.env.assertEquals(edges[1].properties['v'], 2)
         self.env.assertEquals(edges[1].relation, 'R2')
-


### PR DESCRIPTION
## Summary

Fixes a crash in `UndoLog_DeleteNode` when a stale node value with `attributes == NULL` is produced from a deleted relationship endpoint and later passed to `DELETE`.

## Changes

- Add `GraphEntity_CanModify` as the shared predicate for graph entities that are materialized and not already deleted.
- Use the shared predicate in `OpDelete` so stale/deleted entities are not collected as deletion candidates before `GraphHub_DeleteNodes`/`GraphHub_DeleteEdges`.
- Use the shared predicate in SET/REMOVE update paths so stale/deleted entities are treated as no-op updates.
- Add flow regression tests covering stale `startNode()`/`endNode()` DELETE and stale endpoint SET no-op behavior.

## Testing

- `./build.sh RUN_FLOW_TESTS=1 TEST=test_access_del_entity` ✅
- `git diff --check` ✅
- `make unit-tests` ⚠️ local run reached unit execution but failed existing `test_comparators` overflow assertions under the local GCC 15 / Redis 8.2.2 environment; unrelated to this change.

## Memory / Performance Impact

No expected memory impact. Runtime impact is limited to a shared materialized/not-deleted predicate while collecting DELETE/SET candidates.

## Related Issues

Fixes #2049
References FalkorDB/private#126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed handling of endpoints produced by `startNode()` and `endNode()` functions when endpoints reference already-deleted nodes—`DETACH DELETE` and property update operations now behave correctly in these edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->