### PR TITLE
Fix label scan costing for varlen traversals

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -9,6 +9,7 @@
 #include "../ops/op_expand_into.h"
 #include "../ops/op_node_by_label_scan.h"
 #include "../ops/op_conditional_traverse.h"
+#include "../ops/op_cond_var_len_traverse.h"
 #include "../execution_plan_build/execution_plan_util.h"
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
@@ -273,6 +274,28 @@ static bool _transposeExpression
 	return true;
 }
 
+static AlgebraicExpression *_traversalExpression
+(
+	OpBase *op
+) {
+	if(op == NULL) {
+		return NULL;
+	}
+
+	switch(OpBase_Type(op)) {
+		case OPType_CONDITIONAL_TRAVERSE:
+		case OPType_OPTIONAL_CONDITIONAL_TRAVERSE:
+			return ((OpCondTraverse*)op)->ae;
+		case OPType_EXPAND_INTO:
+			return ((OpExpandInto*)op)->ae;
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE:
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO:
+			return ((CondVarLenTraverse*)op)->ae;
+		default:
+			return NULL;
+	}
+}
+
 static void _costBaseLabelScan
 (
 	NodeByLabelScan *scan
@@ -296,15 +319,11 @@ static void _costBaseLabelScan
 		parent = parent->parent ;
 	}
 
-	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+	AlgebraicExpression *ae = _traversalExpression(parent) ;
+	if (ae == NULL) {
 		// no AE to swap operands on; nothing to do here
 		return ;
 	}
-
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;
@@ -416,4 +435,3 @@ void costBaseLabelScan
 
 	arr_free(label_scan_ops);
 }
-

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -91,6 +91,9 @@ class testMultiLabel():
             "MATCH (n:{ls})-[e:R]->(m) RETURN n",
             "MATCH (n:{ls})<-[e:R]-(m) RETURN n",
             "MATCH (n:{ls})-[e:R]-(m) RETURN n",
+            "MATCH (n:{ls})-[*]->(m) RETURN n",
+            "MATCH (n:{ls})<-[*]-(m) RETURN n",
+            "MATCH (n:{ls})-[*]-(m) RETURN n",
             "MATCH (n:{ls}) WHERE n.v = 1 RETURN n",
             "MATCH (n:{ls})-[e:R]->(m) WHERE n.v = 1 RETURN n",
             "MATCH (n:{ls})<-[e:R]-(m) WHERE n.v = 1 RETURN n",
@@ -202,6 +205,16 @@ class testMultiLabel():
         query = """MATCH (a:L0:L1)-[*]->(b {v: 3}) RETURN labels(a), labels(b)"""
         query_result = self.graph.query(query)
         self.env.assertEquals(query_result.result_set, expected_result)
+
+    def test09_variable_length_expand_into_multilabel_no_crash(self):
+        graph = self.db.select_graph('multi_label_issue_636')
+
+        query = """CREATE (:label8), (:label2)<-[:reltype5]-()<-[:reltype7]-()"""
+        graph.query(query)
+
+        query = """MATCH (node_0:label8)<-[*..]-(node_0:label9) RETURN *"""
+        query_result = graph.query(query)
+        self.env.assertEquals(query_result.result_set, [])
 
     def test10_test_delete_label(self):
         self.graph = self.db.select_graph('delete_multi_label')


### PR DESCRIPTION
Summary:
- Handle optional and variable-length traversal operators in cost-based multi-label scan operand swapping.
- Add optimizer coverage for variable-length traversal plans.
- Add a regression for the issue #636 self-alias variable-length traversal repro.

Tests:
- `PATH=.venv/bin:tools/peg/usr/bin:$PATH CMAKE_POLICY_VERSION_MINIMUM=3.5 REDIS_SERVER=/path/to/redis-server make flow-tests TEST=test_multi_label.py RANDPORTS=1`

Fixes #636
/claim #636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crash when executing variable-length expansion queries involving multi-label patterns.

* **Performance Improvements**
  * Improved query optimization for wildcard relationship matching in traversal operations.
  * Extended support for additional relationship traversal operation types in query planning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->