### PR TITLE
Fix: Null pointer dereference in AlgebraicExpression_Dest for variable length edges

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
@@ -22,8 +22,11 @@ static const AlgebraicExpression *_AlgebraicExpression_SrcOperand
 	while(exp->type == AL_OPERATION) {
 		switch(exp->operation.op) {
 			case AL_EXP_ADD:
+			case AL_EXP_POW:
 				// Src (A+B) = Src(A)
+				// Src (A^n) = Src(A)
 				// Src (Transpose(A+B)) = Src (Transpose(A)+Transpose(B)) = Src (Transpose(A))
+				// Src (Transpose(A^n)) = Src(Transpose(A)^n) = Src(Transpose(A))
 				exp = FIRST_CHILD(exp);
 				break;
 			case AL_EXP_MUL:

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -286,7 +286,9 @@ static void _Pushdown_TransposeOperation
 ) {
 	switch(exp->operation.op) {
 	case AL_EXP_ADD:
+	case AL_EXP_POW:
 		// T(A + B) = T(A) + T(B)
+		// T(A^n) = T(A)^n
 		_Pushdown_TransposeAddition(exp);
 		break;
 	case AL_EXP_MUL:


### PR DESCRIPTION
Closes #636. 

Variable-length traversals (e.g., `[*..]`) generate an `AL_EXP_POW` operation. However, the recursive AST functions `_AlgebraicExpression_SrcOperand` and `_Pushdown_TransposeOperation` were missing coverage for this algebraic operation type, falling through to a default case that asserted false and returned a `NULL` pointer, crashing the Redis server.

This PR adds `AL_EXP_POW` support directly adjacent to `AL_EXP_ADD` in both switch cases since they have structurally equivalent data-flow properties for source resolution and transpose pushdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of power expressions in algebraic expression optimization.
  * Enhanced support for transpose operations with exponentiation to ensure consistent mathematical expression processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->