### PR TITLE
Fix crash and support DUMP/RESTORE of a graph to a different key (#2048)

### DIFF
--- a/src/serializers/decoders/current/v19/decode_graph.c
+++ b/src/serializers/decoders/current/v19/decode_graph.c
@@ -69,16 +69,41 @@ static void _ComputeTransposeMatrices
 
 static GraphContext *_GetOrCreateGraphContext
 (
-	char *graph_name
+	const char *key_name,  // destination key name (from Redis)
+	char *graph_name,      // embedded graph name (from the serialized payload)
+	uint64_t key_number    // total number of virtual keys for this graph
 ) {
 	GraphContext *gc = GraphContext_UnsafeGetGraphContext (graph_name) ;
-	if (!gc) {
-		// new graph is being decoded
-		// inform the module and create new graph context
-		gc = GraphContext_New (graph_name) ;
+
+	// detect a single-key RESTORE to a different key name
+	// e.g. DUMP a | RESTORE c — the payload embeds "a" but the destination is "c"
+	bool renamed_single_key =
+		(key_number == 1 && strcmp(key_name, graph_name) != 0) ;
+
+	if (gc != NULL) {
+		GraphDecodeContext *decoding_context = GraphContext_GetDecodingCtx (gc) ;
+		uint64_t processed =
+			GraphDecodeContext_GetProcessedKeyCount (decoding_context) ;
+
+		// a fully-loaded graph already exists under the embedded name, but this
+		// is a single-key restore to a different key: reusing it would re-load
+		// the schema onto the live graph, corrupting it and crashing the server
+		// (issue #2048). fall through and create an independent new graph instead
+		if (processed == 0 && renamed_single_key) {
+			gc = NULL ;
+		}
+		// else: multi-key continuation (processed > 0) - reuse the existing gc
 	}
 
-	// free the name string, as it either not in used or copied
+	if (gc == NULL) {
+		// new graph is being decoded
+		// use the destination key name for a renamed single-key restore so the
+		// restored graph is independent; otherwise use the embedded graph name
+		// (normal load and multi-key meta-key decodes)
+		gc = GraphContext_New (renamed_single_key ? key_name : graph_name) ;
+	}
+
+	// free the name string, as it is either unused or was copied
 	RedisModule_Free (graph_name) ;
 
 	return gc ;
@@ -101,7 +126,8 @@ static void _InitGraphDataStructure
 
 static GraphContext *_DecodeHeader
 (
-	SerializerIO rdb
+	SerializerIO rdb,
+	const char *key_name  // destination key name (from Redis)
 ) {
 	// Header format:
 	// Graph name
@@ -135,7 +161,7 @@ static GraphContext *_DecodeHeader
 	// total keys representing the graph
 	uint64_t key_number = SerializerIO_ReadUnsigned(rdb);
 
-	GraphContext *gc = _GetOrCreateGraphContext(graph_name);
+	GraphContext *gc = _GetOrCreateGraphContext(key_name, graph_name, key_number);
 	Graph *g = GraphContext_GetGraph (gc) ;
 	GraphDecodeContext *decoding_context = GraphContext_GetDecodingCtx (gc) ;
 
@@ -212,7 +238,11 @@ GraphContext *RdbLoadGraphContext_latest
 	//      Entities in payload
 	//  Payload(s) X N
 
-	GraphContext *gc = _DecodeHeader(rdb);
+	// destination key name (from Redis); used both to detect a renamed
+	// single-key restore during header decode and to record meta-keys below
+	const char *key_name = RedisModule_StringPtrLen(rm_key_name, NULL);
+
+	GraphContext *gc = _DecodeHeader(rdb, key_name);
 	Graph        *g  = GraphContext_GetGraph (gc) ;
 	GraphDecodeContext *decoding_context = GraphContext_GetDecodingCtx (gc) ;
 
@@ -326,8 +356,6 @@ GraphContext *RdbLoadGraphContext_latest
 	GraphDecodeContext_IncreaseProcessedKeyCount(decoding_context);
 
 	// before finalizing keep encountered meta keys names, for future deletion
-	const char *key_name = RedisModule_StringPtrLen(rm_key_name, NULL);
-
 	// the virtual key name is not equal the graph name
 	if(strcmp(key_name, GraphContext_GetName (gc)) != 0) {
 		GraphDecodeContext_AddMetaKey(decoding_context, key_name);

--- a/tests/flow/test_dump_restore_rename.py
+++ b/tests/flow/test_dump_restore_rename.py
@@ -1,0 +1,64 @@
+from common import Env
+
+# Regression test for issue #2048.
+#
+# DUMP-ing a graph and RESTORE-ing the payload under a *different* key while the
+# original graph still exists used to crash the server with a NULL dereference:
+# the dumped payload embeds the original graph name, so on RESTORE the decoder
+# found the still-live graph, treated the payload as that graph's first virtual
+# key, and re-loaded the schema on top of the populated graph - doubling the
+# relation-matrix count and driving the matrix decode loop past the end of the
+# matrices array.
+#
+# The decoder now threads the destination key name through and, for a single-key
+# restore to a different name, creates an independent new graph under the
+# destination key instead of corrupting the live one. So the restore succeeds and
+# produces an independent copy. (Aligned with the approach in PR #1737.)
+class testDumpRestoreRename():
+    def __init__(self):
+        self.env, self.db = Env()
+        self.conn = self.env.getConnection()
+
+    def test01_restore_to_different_key_while_original_exists(self):
+        # the exact #2048 crash scenario: original key is NOT deleted
+        src = self.db.select_graph("g")
+        src.query("CREATE (:A)-[:R]->(:B)")
+
+        payload = self.conn.dump("g")
+        self.env.assertIsNotNone(payload)
+
+        # RESTORE under a different key while 'g' still exists -> must not crash
+        self.conn.restore("g2", 0, payload)
+
+        # server is alive
+        self.env.assertTrue(self.conn.ping())
+
+        # the restored graph is an independent copy with the same content
+        dst = self.db.select_graph("g2")
+        self.env.assertEqual(
+            dst.query("MATCH (:A)-[r:R]->(:B) RETURN count(r)").result_set[0][0], 1)
+
+        # the original graph is untouched
+        self.env.assertEqual(
+            src.query("MATCH (:A)-[r:R]->(:B) RETURN count(r)").result_set[0][0], 1)
+
+        # both graphs are listed
+        graphs = self.conn.execute_command("GRAPH.LIST")
+        self.env.assertContains("g", graphs)
+        self.env.assertContains("g2", graphs)
+
+    def test02_restored_copy_is_independent(self):
+        src = self.db.select_graph("src")
+        src.query("CREATE (:Person {name: 'Alice'})")
+
+        payload = self.conn.dump("src")
+        self.conn.restore("dst", 0, payload)
+        dst = self.db.select_graph("dst")
+
+        # mutate the copy only
+        dst.query("CREATE (:Person {name: 'Bob'})")
+
+        self.env.assertEqual(
+            src.query("MATCH (n) RETURN count(n)").result_set[0][0], 1)
+        self.env.assertEqual(
+            dst.query("MATCH (n) RETURN count(n)").result_set[0][0], 2)


### PR DESCRIPTION
## Summary

`DUMP`-ing a graph and `RESTORE`-ing the payload under a **different key while the original graph still exists** crashes the server with a NULL-pointer dereference. Any client able to run `RESTORE` can take the whole server down.

This makes restoring to a different key produce an **independent copy** of the graph (and removes the crash), following the approach in #1737 — ported here to the current `v19` decoder, which #1737 predates.

Closes #2048. Related: #1737.

## Reproduction

```
GRAPH.QUERY g "CREATE (:A)-[:R]->(:B)"
EVAL "return redis.call('RESTORE', KEYS[2], 0, redis.call('DUMP', KEYS[1]))" 2 g g2
```

The server dies with SIGSEGV in `Delta_Matrix_nvals` ← `RdbLoadRelationMatrices` ← `RdbLoadGraphContext_latest`. Deleting `g` before restoring does not crash — the crash requires the embedded graph name to collide with a live graph.

## Root cause

A graph dump embeds the **graph name**, and `_GetOrCreateGraphContext` looks the graph up by that embedded name. Restoring under a different key while the original is still present returns the **existing, populated** graph. Its decode context has `processed == 0`, so the payload is treated as that graph's first virtual key and `RdbLoadGraphSchema_v19` re-adds every schema on top of the live graph, **doubling** `Graph_RelationTypeCount`. `RdbLoadRelationMatrices_v19` then iterates more times than there are matrix blocks in the payload; the stream desyncs, the relation id read from it goes out of range, and `Graph_GetRelationMatrix` indexes `g->relations[r]` out of bounds (the only guards in the decode path are `ASSERT`, a no-op in release builds). The result is a NULL `Delta_Matrix` dereferenced in `Delta_Matrix_nvals`.

## Fix

Thread the **destination key name** (from `RedisModule_GetKeyNameFromIO`) into the header decode. For a single-key restore to a different name (`key_number == 1 && key_name != graph_name`) where a fully-loaded graph already exists under the embedded name (`processed == 0`), create an **independent new graph under the destination key name** instead of reusing the live one.

Normal load and multi-key meta-key decodes (`processed > 0`, or `key_number > 1`) keep resolving by the embedded name exactly as before.

## Test

Adds `tests/flow/test_dump_restore_rename.py`: restoring to a different key while the original exists no longer crashes, produces an independent copy, leaves the original intact, and lists both graphs in `GRAPH.LIST`.

## Verification

Built the patched module and ran the reproduction above: the restore now succeeds, `g2` is an independent copy, `g` is unchanged, both appear in `GRAPH.LIST`, and the server stays up. Normal load and the delete-then-restore path are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where restoring a dumped graph to a different key name while the original graph still exists could cause crashes or schema conflicts.
  * Restored graphs are now properly independent from the original graph.

* **Tests**
  * Added regression test coverage for graph dump/restore operations with different destination keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->