### PR TITLE
Handle AL_EXP_POW in variable-length traversal expressions

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
@@ -26,6 +26,11 @@ static const AlgebraicExpression *_AlgebraicExpression_SrcOperand
 				// Src (Transpose(A+B)) = Src (Transpose(A)+Transpose(B)) = Src (Transpose(A))
 				exp = FIRST_CHILD(exp);
 				break;
+			case AL_EXP_POW:
+				// Src (A^n) = Src(A)
+				// Src (Transpose(A^n)) = Src (Transpose(A)^n) = Src (Transpose(A))
+				exp = FIRST_CHILD(exp);
+				break;
 			case AL_EXP_MUL:
 				// Src (A*B) = Src(A)
 				// Src (Transpose(A*B)) = Src (Transpose(B)*Transpose(A)) = Src (Transpose(B))
@@ -150,4 +155,3 @@ const char *AlgebraicExpression_Dest
 	exp = _AlgebraicExpression_SrcOperand(root, &transposed);
 	return (transposed) ? exp->operand.dest : exp->operand.src;
 }
-

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -265,6 +265,16 @@ static void _Pushdown_TransposeMultiplication
 	for(uint i = 0; i < child_count; i++) _Pushdown_TransposeExp(exp->operation.children[i]);
 }
 
+// Transpose power.
+static void _Pushdown_TransposePower
+(
+	AlgebraicExpression *exp
+) {
+	// T(A^n) = T(A)^n
+	ASSERT(AlgebraicExpression_ChildCount(exp) == 1);
+	_Pushdown_TransposeExp(exp->operation.children[0]);
+}
+
 // Transpose transpose.
 static void _Pushdown_TransposeTranspose
 (
@@ -291,6 +301,9 @@ static void _Pushdown_TransposeOperation
 		break;
 	case AL_EXP_MUL:
 		_Pushdown_TransposeMultiplication(exp);
+		break;
+	case AL_EXP_POW:
+		_Pushdown_TransposePower(exp);
 		break;
 	case AL_EXP_TRANSPOSE:
 		_Pushdown_TransposeTranspose(exp);
@@ -427,4 +440,3 @@ void AlgebraicExpression_Optimize
 	// retrieve all operands now that they are guaranteed to be leaves.
 	_AlgebraicExpression_PopulateOperands(*exp, QueryCtx_GetGraphCtx());
 }
-

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -456,3 +456,20 @@ class testVariableLengthTraversals(FlowTestsBase):
                 Node(2, labels=["C"], properties={"v": 5})],
             [Edge(0, "R", 1, 0, properties={"v": 2}), Edge(1, "R", 2, 1, properties={"v": 4})]
         ))
+
+    def test16_repeated_alias_with_incoming_var_len(self):
+        self.graph.delete()
+
+        q = """MERGE (:label8)
+               MERGE (:label2{})<-[:reltype5]-(node_0{})<-[:reltype7]-({})"""
+        self.graph.query(q)
+
+        q = """MATCH (node_0:label8{})<-[*..]-(node_0:label9)
+               WHERE node_0.prop7 = [FALSE]
+               RETURN *"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [])
+
+        q = "MATCH (node_0:label8{})<-[*..]-(node_0:label9) RETURN *"
+        res = self.graph.query(q)
+        self.env.assertEquals(res.result_set, [])

--- a/tests/unit/test_algebraic_expression.c
+++ b/tests/unit/test_algebraic_expression.c
@@ -559,6 +559,31 @@ void test_algebraicExpression_domains() {
 	GrB_Matrix_free(&B);
 }
 
+void test_powerExpressionDomains() {
+	AlgebraicExpression *operand =
+		AlgebraicExpression_NewOperand(NULL, false, "src", "dest", "edge", NULL);
+
+	AlgebraicExpression *power = AlgebraicExpression_NewOperation(AL_EXP_POW);
+	AlgebraicExpression_AddChild(power, operand);
+
+	TEST_ASSERT(strcmp(AlgebraicExpression_Src(power), "src") == 0);
+	TEST_ASSERT(strcmp(AlgebraicExpression_Dest(power), "dest") == 0);
+
+	AlgebraicExpression_Transpose(&power);
+	TEST_ASSERT(strcmp(AlgebraicExpression_Src(power), "dest") == 0);
+	TEST_ASSERT(strcmp(AlgebraicExpression_Dest(power), "src") == 0);
+
+	AlgebraicExpression_PushDownTranspose(power);
+	TEST_ASSERT(power->type == AL_OPERATION);
+	TEST_ASSERT(power->operation.op == AL_EXP_POW);
+	TEST_ASSERT(AlgebraicExpression_ChildCount(power) == 1);
+	TEST_ASSERT(AlgebraicExpression_Transposed(FIRST_CHILD(power)));
+	TEST_ASSERT(strcmp(AlgebraicExpression_Src(power), "dest") == 0);
+	TEST_ASSERT(strcmp(AlgebraicExpression_Dest(power), "src") == 0);
+
+	AlgebraicExpression_Free(power);
+}
+
 void test_algebraicExpression_Clone() {
 	AlgebraicExpression *exp = NULL;
 	AlgebraicExpression *clone = NULL;
@@ -1810,6 +1835,7 @@ TEST_LIST = {
 	{"MultipleIntermidiateReturnNodes", test_MultipleIntermidiateReturnNodes},
 	{"OneIntermidiateReturnNode", test_OneIntermidiateReturnNode},
 	{"NoIntermidiateReturnNodes", test_NoIntermidiateReturnNodes},
+	{"PowerExpressionDomains", test_powerExpressionDomains},
 	{"ONeIntermidiateReturnEdge", test_ONeIntermidiateReturnEdge},
 	{"BothDirections", test_BothDirections},
 	{"SingleNode", test_SingleNode},
@@ -1820,4 +1846,3 @@ TEST_LIST = {
 	{"LocateOperand", test_LocateOperand},
 	{NULL, NULL}
 };
-


### PR DESCRIPTION
# Handle AL_EXP_POW in variable-length traversal expressions

## Summary

- Handle `AL_EXP_POW` when resolving algebraic expression source/destination operands.
- Push transpose operations through `AL_EXP_POW` expressions as `T(A^n) = T(A)^n`.
- Add unit coverage for power expression domains and transpose pushdown.
- Add a flow regression for the fuzzer query from #636.

## Tests

- `make unit-tests TEST=test_algebraic_expression`
- `make flow-tests TEST=test_variable_length_traversals`

Fixes #636.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of power expressions in algebraic operations with proper operand extraction and transpose pushdown optimization.
  * Fixed variable-length traversals to correctly handle repeated aliases with incoming directions.

* **Tests**
  * Added regression tests for variable-length traversals and power expression domain verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/FalkorDB/pull/2071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->