### PR TITLE
Fix variable-length traversal label scan crash

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_operand.c
@@ -22,8 +22,11 @@ static const AlgebraicExpression *_AlgebraicExpression_SrcOperand
 	while(exp->type == AL_OPERATION) {
 		switch(exp->operation.op) {
 			case AL_EXP_ADD:
+			case AL_EXP_POW:
 				// Src (A+B) = Src(A)
+				// Src (A^n) = Src(A)
 				// Src (Transpose(A+B)) = Src (Transpose(A)+Transpose(B)) = Src (Transpose(A))
+				// Src (Transpose(A^n)) = Src(Transpose(A)^n) = Src(Transpose(A))
 				exp = FIRST_CHILD(exp);
 				break;
 			case AL_EXP_MUL:
@@ -150,4 +153,3 @@ const char *AlgebraicExpression_Dest
 	exp = _AlgebraicExpression_SrcOperand(root, &transposed);
 	return (transposed) ? exp->operand.dest : exp->operand.src;
 }
-

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -286,7 +286,9 @@ static void _Pushdown_TransposeOperation
 ) {
 	switch(exp->operation.op) {
 	case AL_EXP_ADD:
+	case AL_EXP_POW:
 		// T(A + B) = T(A) + T(B)
+		// T(A^n) = T(A)^n
 		_Pushdown_TransposeAddition(exp);
 		break;
 	case AL_EXP_MUL:
@@ -427,4 +429,3 @@ void AlgebraicExpression_Optimize
 	// retrieve all operands now that they are guaranteed to be leaves.
 	_AlgebraicExpression_PopulateOperands(*exp, QueryCtx_GetGraphCtx());
 }
-

--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -9,6 +9,7 @@
 #include "../ops/op_expand_into.h"
 #include "../ops/op_node_by_label_scan.h"
 #include "../ops/op_conditional_traverse.h"
+#include "../ops/op_cond_var_len_traverse.h"
 #include "../execution_plan_build/execution_plan_util.h"
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
@@ -273,6 +274,28 @@ static bool _transposeExpression
 	return true;
 }
 
+static AlgebraicExpression *_traversalExpression
+(
+	OpBase *op
+) {
+	if(op == NULL) {
+		return NULL;
+	}
+
+	switch(OpBase_Type(op)) {
+		case OPType_CONDITIONAL_TRAVERSE:
+		case OPType_OPTIONAL_CONDITIONAL_TRAVERSE:
+			return ((OpCondTraverse*)op)->ae;
+		case OPType_EXPAND_INTO:
+			return ((OpExpandInto*)op)->ae;
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE:
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO:
+			return ((CondVarLenTraverse*)op)->ae;
+		default:
+			return NULL;
+	}
+}
+
 static void _costBaseLabelScan
 (
 	NodeByLabelScan *scan
@@ -296,15 +319,11 @@ static void _costBaseLabelScan
 		parent = parent->parent ;
 	}
 
-	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+	AlgebraicExpression *ae = _traversalExpression(parent) ;
+	if (ae == NULL) {
 		// no AE to swap operands on; nothing to do here
 		return ;
 	}
-
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;
@@ -416,4 +435,3 @@ void costBaseLabelScan
 
 	arr_free(label_scan_ops);
 }
-

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -91,6 +91,9 @@ class testMultiLabel():
             "MATCH (n:{ls})-[e:R]->(m) RETURN n",
             "MATCH (n:{ls})<-[e:R]-(m) RETURN n",
             "MATCH (n:{ls})-[e:R]-(m) RETURN n",
+            "MATCH (n:{ls})-[*]->(m) RETURN n",
+            "MATCH (n:{ls})<-[*]-(m) RETURN n",
+            "MATCH (n:{ls})-[*]-(m) RETURN n",
             "MATCH (n:{ls}) WHERE n.v = 1 RETURN n",
             "MATCH (n:{ls})-[e:R]->(m) WHERE n.v = 1 RETURN n",
             "MATCH (n:{ls})<-[e:R]-(m) WHERE n.v = 1 RETURN n",
@@ -202,6 +205,21 @@ class testMultiLabel():
         query = """MATCH (a:L0:L1)-[*]->(b {v: 3}) RETURN labels(a), labels(b)"""
         query_result = self.graph.query(query)
         self.env.assertEquals(query_result.result_set, expected_result)
+
+    def test09_variable_length_expand_into_multilabel_no_crash(self):
+        graph = self.db.select_graph('multi_label_issue_636')
+
+        query = """CREATE (:label8), (:label2)<-[:reltype5]-()<-[:reltype7]-()"""
+        graph.query(query)
+
+        queries = [
+            "MATCH (node_0:label8)<-[*..]-(node_0:label9) RETURN *",
+            "MATCH (node_0:label8)<-[*..]-(node_0:label9) WHERE node_0.prop7 = [false] RETURN *",
+        ]
+
+        for query in queries:
+            query_result = graph.query(query)
+            self.env.assertEquals(query_result.result_set, [])
 
     def test10_test_delete_label(self):
         self.graph = self.db.select_graph('delete_multi_label')


### PR DESCRIPTION
Fixes the crash from #636 when a variable-length traversal reuses the same node alias with different labels, such as:

```cypher
MATCH (node_0:label8)<-[*..]-(node_0:label9) RETURN *
```

The patch teaches algebraic expression source/destination lookup and transpose pushdown how to walk power expressions used by variable-length traversals, preventing the NULL operand path that led to `AlgebraicExpression_Dest()` crashes. It also extends cost-based label-scan operand lookup to the traversal op variants called out in the issue discussion, including conditional variable-length expand-into.

Regression coverage was added for the original fuzzer shape, the predicate variant, and multi-label label-scan optimization through variable-length traversal patterns.

Validation:
- `make build DEBUG=1`
- Redis 8 smoke test loading the built module and running the original fuzzer queries plus the simplified maintainer repro
- `python3 -m py_compile tests/flow/test_multi_label.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced optimizer to properly handle exponentiation operations in expressions.
  * Improved label-scan optimization to support additional traversal operation types.
  * Fixed potential crashes when executing variable-length traversal queries on multi-labeled graphs.

* **Tests**
  * Added regression test for variable-length expansion queries on multi-labeled nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->