### PR TITLE
Support variable-length traversals in label scan optimization

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -9,6 +9,7 @@
 #include "../ops/op_expand_into.h"
 #include "../ops/op_node_by_label_scan.h"
 #include "../ops/op_conditional_traverse.h"
+#include "../ops/op_cond_var_len_traverse.h"
 #include "../execution_plan_build/execution_plan_util.h"
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
@@ -287,7 +288,7 @@ static void _costBaseLabelScan
 	const char *node_alias = n_ctx->alias ;
 
 	// determine the parent traversal op (if any) below filters
-	// (CondTraverse or ExpandInto) - its algebraic expression is the
+	// (CondTraverse, ExpandInto or variable-length traverse) - its algebraic expression is the
 	// authoritative source of truth for which labels are in scope on
 	// this scan's alias
 
@@ -297,14 +298,22 @@ static void _costBaseLabelScan
 	}
 
 	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+	if (t != OPType_CONDITIONAL_TRAVERSE &&
+		t != OPType_EXPAND_INTO &&
+		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE &&
+		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO) {
 		// no AE to swap operands on; nothing to do here
 		return ;
 	}
 
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
+	AlgebraicExpression *ae = NULL ;
+	if (t == OPType_CONDITIONAL_TRAVERSE) {
+		ae = ((OpCondTraverse*) parent)->ae ;
+	} else if (t == OPType_EXPAND_INTO) {
+		ae = ((OpExpandInto*) parent)->ae ;
+	} else {
+		ae = ((CondVarLenTraverse*) parent)->ae ;
+	}
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;
@@ -416,4 +425,3 @@ void costBaseLabelScan
 
 	arr_free(label_scan_ops);
 }
-

--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -299,6 +299,7 @@ static void _costBaseLabelScan
 
 	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
 	if (t != OPType_CONDITIONAL_TRAVERSE &&
+		t != OPType_OPTIONAL_CONDITIONAL_TRAVERSE &&
 		t != OPType_EXPAND_INTO &&
 		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE &&
 		t != OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO) {
@@ -307,7 +308,8 @@ static void _costBaseLabelScan
 	}
 
 	AlgebraicExpression *ae = NULL ;
-	if (t == OPType_CONDITIONAL_TRAVERSE) {
+	if (t == OPType_CONDITIONAL_TRAVERSE ||
+		t == OPType_OPTIONAL_CONDITIONAL_TRAVERSE) {
 		ae = ((OpCondTraverse*) parent)->ae ;
 	} else if (t == OPType_EXPAND_INTO) {
 		ae = ((OpExpandInto*) parent)->ae ;

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -284,7 +284,31 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(result[0][0], 'a')
         self.env.assertEquals(result[1][0], 'c')
 
-    def test13_fanout(self):
+    def test13_issue_636_reused_alias_var_len_traversal(self):
+        # Regression test for a fuzzer crash where a reused node alias on a
+        # variable-length incoming traversal caused AlgebraicExpression_Dest()
+        # to dereference a NULL source operand during label-scan optimization.
+        self.graph.delete()
+
+        create_query = """CREATE (:label8),
+                          (:label2)<-[:reltype5]-({})<-[:reltype7]-({})"""
+        result = self.graph.query(create_query)
+        self.env.assertEquals(result.nodes_created, 4)
+        self.env.assertEquals(result.relationships_created, 2)
+
+        queries = [
+            """MATCH (node_0:label8)<-[*..]-(node_0:label9)
+               WHERE node_0.prop7 = [false]
+               RETURN *""",
+            """MATCH (node_0:label8)<-[*..]-(node_0:label9)
+               RETURN *"""
+        ]
+
+        for query in queries:
+            result = self.graph.query(query)
+            self.env.assertEquals(result.result_set, [])
+
+    def test14_fanout(self):
         # create a tree structure graph with a fanout of 3
         # root->a1
         # root->a2
@@ -335,7 +359,7 @@ class testVariableLengthTraversals(FlowTestsBase):
             self.env.assertEquals(l, 2)
             self.env.assertEquals(identity, i)
 
-    def test14_no_hops(self):
+    def test15_no_hops(self):
         self.graph.delete()
 
         # create graph
@@ -547,4 +571,3 @@ class testVariableLengthTraversals(FlowTestsBase):
 
         count = self.graph.query(q).result_set[0][0]
         self.env.assertEquals(count, 16)
-


### PR DESCRIPTION
## Summary

This fixes the crash described in #636 by allowing `costBaseLabelScan` to inspect variable-length traversal algebraic expressions, in addition to regular `Conditional Traverse` and `Expand Into` operations.

It adds a flow-test regression using the simplified fuzzer shape discussed in the issue, including the variant with a property filter:

```cypher
MERGE (:label8) MERGE (:label2{})<-[:reltype5]-(node_0{})<-[:reltype7]-({})
MATCH (node_0:label8{})<-[*..]-(node_0:label9) WHERE node_0.prop7 = [FALSE] RETURN *
MATCH (node_0:label8{})<-[*..]-(node_0:label9) RETURN *
```

The implementation follows the maintainer guidance to support label switching around variable-length traversal operations rather than adding a defensive `NULL` check in `AlgebraicExpression_Dest`.

## Validation

- FalkorDB module build completed successfully on macOS x64.
- `test_variable_length_traversals.py`: 17 passed, 0 failed.
- The new `test13_issue_636_reused_alias_var_len_traversal` regression passed.
- `git diff --check` passed.
- The format patch applies with `git am --3way` against a fresh `master` clone.

/claim #636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash when variable-length traversal queries reused the same alias for source and destination nodes.

* **Refactor**
  * Improved query planning to handle additional conditional and variable-length traversal variants more robustly.

* **Tests**
  * Added a regression test covering the alias reuse case and adjusted subsequent test numbering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #636