### PR TITLE
ci: RediSearch 8.6 build infrastructure (toolchain images + workflows)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
+  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  detect-toolchain:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.choose.outputs.image }}
+    steps:
+      - name: Login to GHCR
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+      - name: Choose image
+        id: choose
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
+          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
+          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
+            echo "Using RC: $RC"
+            echo "image=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using stable: $STABLE"
+            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
+          fi
+
   haslabel:
     name: Check label or branch
     runs-on: ubuntu-latest
@@ -66,11 +97,12 @@ jobs:
   run-benchmarks:
     needs:
       - create-runners
+      - detect-toolchain
     strategy:
       matrix:
         benchmark_group: [ a, b ]
     runs-on: benchmark-${{ github.run_id }}-${{ github.run_number }}-group_${{ matrix.benchmark_group }}
-    container: falkordb/falkordb-build:ubuntu
+    container: ${{ needs.detect-toolchain.outputs.image }}
     steps:
       - name: Sanitize ref name
         run: echo "SAFE_REF=$(echo '${{ github.head_ref || github.ref_name }}' | tr '/' '-')" >> "$GITHUB_ENV"
@@ -97,12 +129,19 @@ jobs:
           path: ./bin/linux-x64-release/libcypher-parser
           key: parser-x64-${{ hashFiles('./deps/libcypher-parser/lib/src/parser.c', './build.sh') }}
 
+      # The RediSearch submodule gitlink SHA is part of the cache key so that
+      # advancing the fork pin invalidates the cache even when src/version.h is
+      # unchanged (our LLAPI-extension commits do not bump the version macros).
+      - name: Compute RediSearch SHA
+        id: rs_sha
+        run: echo "sha=$(git rev-parse HEAD:deps/RediSearch)" >> "$GITHUB_OUTPUT"
+
       - name: Cache search
         id: cache_search
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./bin/linux-x64-release/search-static
-          key: search-x64-${{ hashFiles('./deps/RediSearch/src/version.h') }}
+          key: search-x64-${{ hashFiles('./deps/RediSearch/src/version.h') }}-${{ steps.rs_sha.outputs.sha }}
 
       - name: Cache libcurl
         id: cache_libcurl

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,32 +19,9 @@ permissions:
   packages: read
 
 jobs:
-  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  # Prefer the PR's RC toolchain image, fall back to stable (shared workflow).
   detect-toolchain:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.choose.outputs.image }}
-    steps:
-      - name: Login to GHCR
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Choose image
-        id: choose
-        env:
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
-          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
-          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
-            echo "Using RC: $RC"
-            echo "image=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "Using stable: $STABLE"
-            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-toolchain.yml
 
   haslabel:
     name: Check label or branch

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,6 +26,9 @@ jobs:
   haslabel:
     name: Check label or branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # github-script pulls.get
     outputs:
       has-benchmark-label: ${{ steps.haslabel.outputs.result }}
     steps:
@@ -210,6 +213,10 @@ jobs:
       - merge-results
     if: ${{ github.event_name == 'pull_request' }} # No need to run this job for branches and tags
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read          # download artifacts via the Actions API
+      pull-requests: write   # update the PR body with the comparison
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Sanitize ref name

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,0 +1,120 @@
+# Builds one OS-flavoured toolchain image
+# (build/docker/builder/Dockerfile.<os>) for linux/amd64 and linux/arm64 and
+# publishes it as a multi-arch manifest at:
+#
+#   ghcr.io/falkordb/falkordb-build:<tag>
+#
+# Triggers:
+#   - workflow_call from build.yml's per-OS RC job (caller-supplied tag,
+#     typically "<os>-pr-<N>").
+#   - workflow_dispatch (UI / API) — manual escape hatch for refreshing the
+#     stable :<os> tag when only the apt/dnf/apk pin drifts but the Dockerfile
+#     didn't change. Only allowed from master.
+#
+# Master-branch :<os> is normally produced via PROMOTION, not rebuild:
+# build.yml's master-push job retags the merging PR's :<os>-pr-<N> to :<os>
+# via `docker buildx imagetools create`, giving a byte-identical guarantee
+# (what PR CI validated == what master publishes).
+
+name: Build toolchain image
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Builder OS (ubuntu / debian / alpine / amazonlinux2023 / rhel / rhel8 / rhel9)"
+        required: true
+        type: string
+      tag:
+        description: "Image tag to push (e.g. ubuntu-pr-42). Defaults to the OS name."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      os:
+        description: "Builder OS"
+        required: true
+        type: string
+      tag:
+        description: "Image tag (e.g. ubuntu-pr-42)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-toolchain-${{ inputs.os }}-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    # workflow_call passes through unchanged; gating done in caller.
+    # workflow_dispatch is only allowed from master so a feature-branch
+    # dispatch can't clobber the stable :<os> tag.
+    if: ${{ github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/master' }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,     platform: linux/amd64, runner: ubuntu-latest }
+          - { arch: arm64v8, platform: linux/arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (${{ inputs.os }} / ${{ matrix.arch }})
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        env:
+          TAG: ${{ inputs.tag || inputs.os }}
+        with:
+          context: .
+          file: build/docker/builder/Dockerfile.${{ inputs.os }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          tags: ghcr.io/falkordb/falkordb-build:${{ env.TAG }}-${{ matrix.arch }}
+          cache-from: type=registry,ref=ghcr.io/falkordb/falkordb-build:buildcache-${{ inputs.os }}-${{ matrix.arch }}
+          cache-to:   type=registry,ref=ghcr.io/falkordb/falkordb-build:buildcache-${{ inputs.os }}-${{ matrix.arch }},mode=max
+
+  manifest:
+    needs: build
+    if: ${{ github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assemble multi-arch manifest
+        env:
+          TAG: ${{ inputs.tag || inputs.os }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t ghcr.io/falkordb/falkordb-build:${TAG} \
+            ghcr.io/falkordb/falkordb-build:${TAG}-x64 \
+            ghcr.io/falkordb/falkordb-build:${TAG}-arm64v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,110 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  BASE_IMAGE_VERSION: 1.2.0
+permissions:
+  contents: read
+  packages: read
+
 jobs:
+  # Detect which builder Dockerfiles (build/docker/builder/Dockerfile.<os>)
+  # the PR or push changed, and emit a JSON array of changed OS names.
+  # Downstream jobs use this to (a) build RC toolchain images per changed OS,
+  # and (b) consume the RC tag instead of the stable tag for those OSes.
+  check-builder-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_oses: ${{ steps.detect.outputs.changed_oses }}
+      any_changed: ${{ steps.detect.outputs.any_changed }}
+      merged_pr: ${{ steps.find-pr.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed builder Dockerfiles
+        id: detect
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            pull_request)
+              BASE='${{ github.event.pull_request.base.sha }}'
+              HEAD='${{ github.event.pull_request.head.sha }}'
+              ;;
+            push)
+              BASE='${{ github.event.before }}'
+              HEAD='${{ github.sha }}'
+              # First-push or shallow histories give 000...000 as before.
+              if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+                BASE="${HEAD}~1"
+              fi
+              ;;
+            *)
+              BASE="HEAD~1"
+              HEAD="HEAD"
+              ;;
+          esac
+
+          changed=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null \
+            | grep '^build/docker/builder/Dockerfile\.' \
+            | sed 's|^build/docker/builder/Dockerfile\.||' \
+            | sort -u || true)
+
+          if [ -z "$changed" ]; then
+            echo "changed_oses=[]" >> "$GITHUB_OUTPUT"
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No builder Dockerfile changes detected."
+          else
+            json=$(echo "$changed" | jq -R . | jq -s -c .)
+            echo "changed_oses=$json" >> "$GITHUB_OUTPUT"
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changed OSes: $json"
+          fi
+
+      - name: Find merged PR (master push only)
+        id: find-pr
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.detect.outputs.any_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The merge commit was authored by the PR; find that PR number.
+          PR=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[] | select(.state == "closed" and .merged_at != null) | .number' \
+            | head -1)
+          if [ -z "$PR" ]; then
+            echo "Error: no merged PR found for commit ${GITHUB_SHA}, but a builder Dockerfile changed." >&2
+            echo "Refusing to proceed: without an RC toolchain tag the build would silently fall back to the stale :<os> image and promote-toolchain would be skipped, shipping the Dockerfile change without rebuilding/publishing its toolchain." >&2
+            exit 1
+          fi
+          echo "Merged PR: #$PR"
+          echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+
+  # Build RC toolchain images for each OS whose Dockerfile.<os> changed in the
+  # PR. Tag: ghcr.io/falkordb/falkordb-build:<os>-pr-<N>. Downstream PR build
+  # jobs use this tag instead of the stable :<os>.
+  build-rc-toolchain:
+    needs: check-builder-changes
+    if: github.event_name == 'pull_request' && needs.check-builder-changes.outputs.any_changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.check-builder-changes.outputs.changed_oses) }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-toolchain.yml
+    with:
+      os: ${{ matrix.os }}
+      tag: ${{ matrix.os }}-pr-${{ github.event.pull_request.number }}
+
   build:
+    needs: [check-builder-changes, build-rc-toolchain]
+    # build-rc-toolchain is skipped when no builder Dockerfile changed; allow that.
+    if: |
+      always() &&
+      needs.check-builder-changes.result == 'success' &&
+      (needs.build-rc-toolchain.result == 'success' || needs.build-rc-toolchain.result == 'skipped')
     runs-on: ${{ matrix.platform.machine_label }}
     services:
       registry:
@@ -147,14 +247,21 @@ jobs:
         run: |
           # Generate a single combined hash of all dependencies to avoid 512 char key limit
           # build.sh is included so that changes to dep build flags (e.g. libcurl SSL) invalidate the cache
-          DEPS_HASH=$(cat ./deps/GraphBLAS/Include/GraphBLAS.h ./deps/GraphBLAS/Config/GB_prejit.c ./deps/libcypher-parser/lib/src/parser.c ./deps/RediSearch/src/version.h ./deps/libcurl/RELEASE-NOTES ./deps/libcsv/ChangeLog ./deps/LAGraph/include/LAGraph.h ./deps/LAGraph/include/LAGraphX.h ./deps/rax/rax.h ./deps/xxHash/xxhash.h ./deps/utf8proc/utf8proc.h ./deps/oniguruma/src/oniguruma.h ./deps/FalkorDB-core-rs/Cargo.toml ./build.sh 2>/dev/null | sha256sum | cut -d' ' -f1 || echo "no-hash")
+          # The RediSearch submodule gitlink SHA is included so that advancing the
+          # fork pin invalidates the cache even when src/version.h is unchanged
+          # (our LLAPI-extension commits do not bump the version macros).
+          RS_SHA=$(git rev-parse HEAD:deps/RediSearch 2>/dev/null || echo "no-rs-sha")
+          DEPS_HASH=$( { cat ./deps/GraphBLAS/Include/GraphBLAS.h ./deps/GraphBLAS/Config/GB_prejit.c ./deps/libcypher-parser/lib/src/parser.c ./deps/RediSearch/src/version.h ./deps/libcurl/RELEASE-NOTES ./deps/libcsv/ChangeLog ./deps/LAGraph/include/LAGraph.h ./deps/LAGraph/include/LAGraphX.h ./deps/rax/rax.h ./deps/xxHash/xxhash.h ./deps/utf8proc/utf8proc.h ./deps/oniguruma/src/oniguruma.h ./deps/FalkorDB-core-rs/Cargo.toml ./build.sh; echo "$RS_SHA"; } 2>/dev/null | sha256sum | cut -d' ' -f1 || echo "no-hash")
           echo "combined=${DEPS_HASH}" >> $GITHUB_OUTPUT
 
       - name: Generate cache key (macOS)
         if: matrix.platform.os == 'macos'
         id: cache-key-macos
         run: |
-          DEPS_HASH=$(cat deps/GraphBLAS/Include/GraphBLAS.h deps/libcypher-parser/lib/src/parser.c deps/RediSearch/src/version.h deps/libcurl/RELEASE-NOTES deps/libcsv/ChangeLog deps/LAGraph/include/LAGraph.h deps/LAGraph/include/LAGraphX.h deps/rax/rax.h deps/xxHash/xxhash.h deps/utf8proc/utf8proc.h deps/oniguruma/src/oniguruma.h deps/FalkorDB-core-rs/Cargo.toml build.sh | shasum -a 256 | cut -d' ' -f1)
+          # Include the RediSearch submodule gitlink SHA so advancing the fork
+          # pin invalidates the cache even when src/version.h is unchanged.
+          RS_SHA=$(git rev-parse HEAD:deps/RediSearch 2>/dev/null || echo "no-rs-sha")
+          DEPS_HASH=$( { cat deps/GraphBLAS/Include/GraphBLAS.h deps/libcypher-parser/lib/src/parser.c deps/RediSearch/src/version.h deps/libcurl/RELEASE-NOTES deps/libcsv/ChangeLog deps/LAGraph/include/LAGraph.h deps/LAGraph/include/LAGraphX.h deps/rax/rax.h deps/xxHash/xxhash.h deps/utf8proc/utf8proc.h deps/oniguruma/src/oniguruma.h deps/FalkorDB-core-rs/Cargo.toml build.sh; echo "$RS_SHA"; } | shasum -a 256 | cut -d' ' -f1)
           echo "key=macos-deps-${{ matrix.build_type }}-${DEPS_HASH}" >> $GITHUB_OUTPUT
 
       - name: Restore dependency caches (Docker)
@@ -263,6 +370,37 @@ jobs:
             echo "build_server=false" >> $GITHUB_OUTPUT
           fi
 
+      # Decide which toolchain image to pull. On a PR that touched this OS's
+      # Dockerfile.<os>, use the RC tag :<os>-pr-<N>. On master-push that
+      # introduced such a change, use :<os>-pr-<N> from the merged PR (the
+      # promote-toolchain job retags it to :<os> after this job completes).
+      # Otherwise use the stable :<os>.
+      - name: Compute toolchain image tag
+        if: matrix.platform.use_docker
+        id: toolchain_tag
+        env:
+          OS: ${{ matrix.platform.os }}
+          CHANGED_OSES: ${{ needs.check-builder-changes.outputs.changed_oses }}
+          PR_NUMBER: ${{ github.event.pull_request.number || needs.check-builder-changes.outputs.merged_pr }}
+        run: |
+          set -euo pipefail
+          changed=$(echo "$CHANGED_OSES" | jq -r '.[]' | grep -Fx "$OS" || true)
+          if [ -n "$changed" ] && [ -n "$PR_NUMBER" ]; then
+            echo "image=ghcr.io/falkordb/falkordb-build:${OS}-pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image=ghcr.io/falkordb/falkordb-build:${OS}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Toolchain image:"
+          cat "$GITHUB_OUTPUT" | grep '^image='
+
+      - name: Login to GHCR
+        if: matrix.platform.use_docker
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build compiler image
         if: matrix.platform.use_docker
         id: build_compiler
@@ -275,8 +413,7 @@ jobs:
           push: true
           build-args: |
             TARGETPLATFORM=linux/${{ matrix.platform.arch }}
-            OS=${{ matrix.platform.os }}
-            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
+            BUILD_IMAGE=${{ steps.toolchain_tag.outputs.image }}
             DEBUG=${{ matrix.build_type == 'debug' && '1' || '0' }}
 
       - name: Copy artifacts from compiler image
@@ -405,7 +542,14 @@ jobs:
 
   test:
     needs: build
-    if: ${{ !inputs.skip_tests && (needs.build.result == 'success') }}
+    # Run tests as long as the run wasn't cancelled and the user didn't
+    # opt out. The previous `needs.build.result == 'success'` skipped the
+    # entire test matrix whenever ANY single platform's build failed —
+    # masking tests on every platform that DID build correctly. Each
+    # matrix entry downloads its own platform-specific test image, so
+    # entries whose image is missing will fail individually instead of
+    # silently hiding the rest.
+    if: ${{ !inputs.skip_tests && !cancelled() && needs.build.result != 'skipped' }}
     runs-on: ${{ matrix.platform.machine_label }}
     strategy:
       fail-fast: false
@@ -462,7 +606,9 @@ jobs:
 
   security-scan:
     needs: build
-    if: needs.build.result == 'success'
+    # Same per-platform reasoning as `test:` above — scan whichever
+    # images built; entries whose artifact is missing fail individually.
+    if: ${{ !cancelled() && needs.build.result != 'skipped' }}
     runs-on: ${{ matrix.platform.machine_label }}
     strategy:
       fail-fast: false
@@ -650,3 +796,43 @@ jobs:
           name: ${{ steps.create_ramp.outputs.file_name }}
           path: /tmp/ramp/${{ steps.create_ramp.outputs.file_name }}
           retention-days: 7
+
+  # On master-push that introduced a Dockerfile.<os> change, retag the merged
+  # PR's RC toolchain image (:<os>-pr-<N>) to the stable :<os>. Byte-identical
+  # promotion via `docker buildx imagetools create` — no rebuild. The
+  # cleanup-rc-images workflow eventually sweeps the orphan :<os>-pr-<N> tag.
+  promote-toolchain:
+    needs: [check-builder-changes, build]
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      needs.check-builder-changes.outputs.any_changed == 'true' &&
+      needs.check-builder-changes.outputs.merged_pr != '' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.check-builder-changes.outputs.changed_oses) }}
+    steps:
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote ${{ matrix.os }}-pr-${{ needs.check-builder-changes.outputs.merged_pr }} to ${{ matrix.os }}
+        env:
+          OS: ${{ matrix.os }}
+          PR_N: ${{ needs.check-builder-changes.outputs.merged_pr }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "ghcr.io/falkordb/falkordb-build:${OS}" \
+            "ghcr.io/falkordb/falkordb-build:${OS}-pr-${PR_N}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
   # and (b) consume the RC tag instead of the stable tag for those OSes.
   check-builder-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # find-pr: gh api .../commits/<sha>/pulls on master push
     outputs:
       changed_oses: ${{ steps.detect.outputs.changed_oses }}
       any_changed: ${{ steps.detect.outputs.any_changed }}
@@ -814,7 +817,7 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.check-builder-changes.outputs.changed_oses) }}
     steps:
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -542,13 +542,9 @@ jobs:
 
   test:
     needs: build
-    # Run tests as long as the run wasn't cancelled and the user didn't
-    # opt out. The previous `needs.build.result == 'success'` skipped the
-    # entire test matrix whenever ANY single platform's build failed —
-    # masking tests on every platform that DID build correctly. Each
-    # matrix entry downloads its own platform-specific test image, so
-    # entries whose image is missing will fail individually instead of
-    # silently hiding the rest.
+    # Run the test matrix unless the run was cancelled or the user opted out.
+    # Each entry uses its own platform image and fails individually, so one
+    # platform's build failure doesn't skip the rest.
     if: ${{ !inputs.skip_tests && !cancelled() && needs.build.result != 'skipped' }}
     runs-on: ${{ matrix.platform.machine_label }}
     strategy:

--- a/.github/workflows/cleanup-rc-images.yml
+++ b/.github/workflows/cleanup-rc-images.yml
@@ -1,0 +1,103 @@
+name: Cleanup PR toolchain images
+
+# Sweeps GHCR PR-scoped toolchain image tags older than the TTL window.
+#
+# Tag families covered (matched per-OS via `<os>-pr-`):
+#   ghcr.io/falkordb/falkordb-build:<os>-pr-<N>
+#   ghcr.io/falkordb/falkordb-build:<os>-pr-<N>-x64
+#   ghcr.io/falkordb/falkordb-build:<os>-pr-<N>-arm64v8
+#
+# After a PR merges, build.yml's promote-toolchain job retags <os>-pr-<N> to
+# <os>, so the pr- tag is dead weight; if the PR closed un-merged it never
+# mattered. Folding both cases into a single TTL sweep keeps the cleanup
+# surface tiny — only PRs that touch build/docker/builder/Dockerfile.<os>
+# produce an RC.
+#
+# The 7-OS variant means the matcher pattern is `^[a-z0-9]+-pr-` (any of
+# ubuntu / alpine / debian / amazonlinux2023 / rhel / rhel8 / rhel9 prefixes).
+#
+# Triggers: daily cron + workflow_dispatch (manual sweep, e.g. to verify the
+# filter after editing). The dry-run input lists candidates without deleting.
+
+on:
+  schedule:
+    - cron: '17 4 * * *'   # 04:17 UTC daily — offset from the hour to avoid GHA cron lock contention
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List candidates without deleting"
+        type: boolean
+        default: false
+      ttl_days:
+        description: "Override TTL window in days"
+        type: string
+        default: "30"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cleanup-rc-images
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Sweep falkordb-build pr- tags older than TTL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: falkordb-build
+          # Matches any of "<os>-pr-..." across all builder OSes.
+          # The trailing `.*` lets it match the bare manifest tag and the
+          # per-arch variants (-x64 / -arm64v8).
+          TAG_PATTERN: '^(ubuntu|debian|alpine|amazonlinux2023|rhel|rhel8|rhel9)-pr-'
+          TTL_DAYS: ${{ inputs.ttl_days || '30' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          # Exported so jq's env.cutoff can read it — safer than
+          # string-interpolating the shell var into the jq filter.
+          export cutoff=$(date -u -d "${TTL_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Sweeping ghcr.io/falkordb/${REPO} versions created before ${cutoff} matching /${TAG_PATTERN}/ (TTL=${TTL_DAYS}d)"
+          echo "DRY_RUN=${DRY_RUN}"
+
+          # Pull every version's id, tags, and created_at. Then in jq:
+          #   - filter by created_at < cutoff
+          #   - keep only versions whose tags ALL match the pattern. The
+          #     `all()` check is a safety net: after promotion, a version
+          #     may carry both an <os>-pr-<N> tag AND a stable <os> /
+          #     :<os>-edge / semver tag. Such versions must NOT be swept —
+          #     a non-matching tag fails `all()` and the version is preserved.
+          #   - drop untagged versions (layer remnants — separate concern).
+          candidates=$(gh api \
+            -X GET "/orgs/falkordb/packages/container/${REPO}/versions?per_page=100" \
+            --paginate \
+            --jq '
+              .[]
+              | select(.created_at < env.cutoff)
+              | select(.metadata.container.tags | length > 0)
+              | select(.metadata.container.tags | all(test(env.TAG_PATTERN)))
+              | {id: .id, tags: .metadata.container.tags, created: .created_at}
+            ')
+
+          if [ -z "$candidates" ]; then
+            echo "Nothing to sweep."
+            exit 0
+          fi
+
+          echo "$candidates" | jq -c '.' | while read -r row; do
+            vid=$(echo "$row" | jq -r '.id')
+            tags=$(echo "$row" | jq -r '.tags | join(",")')
+            created=$(echo "$row" | jq -r '.created')
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] would delete ${REPO} version ${vid} created=${created} tags=[${tags}]"
+            else
+              echo "deleting ${REPO} version ${vid} created=${created} tags=[${tags}]"
+              gh api -X DELETE "/orgs/falkordb/packages/container/${REPO}/versions/${vid}" || true
+            fi
+          done

--- a/.github/workflows/cleanup-rc-images.yml
+++ b/.github/workflows/cleanup-rc-images.yml
@@ -60,6 +60,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Validate the TTL window before feeding it to `date -d`
+          # (ttl_days is a free-form workflow_dispatch input).
+          if ! printf '%s' "${TTL_DAYS}" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::ttl_days must be a positive integer (got: '${TTL_DAYS}')"
+            exit 1
+          fi
+
           # Exported so jq's env.cutoff can read it — safer than
           # string-interpolating the shell var into the jq filter.
           export cutoff=$(date -u -d "${TTL_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
@@ -90,7 +97,8 @@ jobs:
             exit 0
           fi
 
-          echo "$candidates" | jq -c '.' | while read -r row; do
+          fail=0
+          while read -r row; do
             vid=$(echo "$row" | jq -r '.id')
             tags=$(echo "$row" | jq -r '.tags | join(",")')
             created=$(echo "$row" | jq -r '.created')
@@ -98,6 +106,14 @@ jobs:
               echo "[dry-run] would delete ${REPO} version ${vid} created=${created} tags=[${tags}]"
             else
               echo "deleting ${REPO} version ${vid} created=${created} tags=[${tags}]"
-              gh api -X DELETE "/orgs/falkordb/packages/container/${REPO}/versions/${vid}" || true
+              if ! gh api -X DELETE "/orgs/falkordb/packages/container/${REPO}/versions/${vid}"; then
+                echo "::warning::failed to delete ${REPO} version ${vid}"
+                fail=1
+              fi
             fi
-          done
+          done < <(echo "$candidates" | jq -c '.')
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::one or more RC image deletions failed"
+            exit 1
+          fi

--- a/.github/workflows/cleanup-rc-images.yml
+++ b/.github/workflows/cleanup-rc-images.yml
@@ -51,9 +51,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: falkordb-build
-          # Matches any of "<os>-pr-..." across all builder OSes.
-          # The trailing `.*` lets it match the bare manifest tag and the
-          # per-arch variants (-x64 / -arm64v8).
+          # Matches any "<os>-pr-..." tag across all builder OSes. Anchored
+          # at the start only (no end anchor), so it also matches the bare
+          # manifest tag and the per-arch variants (-x64 / -arm64v8).
           TAG_PATTERN: '^(ubuntu|debian|alpine|amazonlinux2023|rhel|rhel8|rhel9)-pr-'
           TTL_DAYS: ${{ inputs.ttl_days || '30' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
+  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  detect-toolchain:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.choose.outputs.image }}
+    steps:
+      - name: Login to GHCR
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+      - name: Choose image
+        id: choose
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
+          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
+          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
+            echo "Using RC: $RC"
+            echo "image=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using stable: $STABLE"
+            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
+          fi
+
   create-runner:
     runs-on: ubuntu-latest
     steps:
@@ -46,10 +77,10 @@ jobs:
           runner_label: codeql-${{ github.run_id }}-${{ github.run_number }}
 
   analyze:
-    needs: create-runner
+    needs: [create-runner, detect-toolchain]
     name: Analyze
     runs-on: codeql-${{ github.run_id }}-${{ github.run_number }}
-    container: falkordb/falkordb-build:ubuntu
+    container: ${{ needs.detect-toolchain.outputs.image }}
     permissions:
       actions: read
       contents: read
@@ -88,12 +119,19 @@ jobs:
           path: $GITHUB_WORKSPACE/bin/linux-x64-release/libcypher-parser
           key: parser-${{ hashFiles('./deps/libcypher-parser/lib/src/parser.c') }}
 
+      # The RediSearch submodule gitlink SHA is part of the cache key so that
+      # advancing the fork pin invalidates the cache even when src/version.h is
+      # unchanged (our LLAPI-extension commits do not bump the version macros).
+      - name: Compute RediSearch SHA
+        id: rs_sha
+        run: echo "sha=$(git rev-parse HEAD:deps/RediSearch)" >> "$GITHUB_OUTPUT"
+
       - name: Cache search
         id: cache_search
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: $GITHUB_WORKSPACE/bin/linux-x64-release/search-static
-          key: search-${{ hashFiles('./deps/RediSearch/src/version.h') }}
+          key: search-${{ hashFiles('./deps/RediSearch/src/version.h') }}-${{ steps.rs_sha.outputs.sha }}
 
       - name: Cache libcurl
         id: cache_libcurl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,32 +33,9 @@ permissions:
   packages: read
 
 jobs:
-  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  # Prefer the PR's RC toolchain image, fall back to stable (shared workflow).
   detect-toolchain:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.choose.outputs.image }}
-    steps:
-      - name: Login to GHCR
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Choose image
-        id: choose
-        env:
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
-          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
-          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
-            echo "Using RC: $RC"
-            echo "image=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "Using stable: $STABLE"
-            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-toolchain.yml
 
   create-runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,10 +13,42 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
-  code-coverage:
+  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  detect-toolchain:
     runs-on: ubuntu-latest
-    container: falkordb/falkordb-build:ubuntu
+    outputs:
+      image: ${{ steps.choose.outputs.image }}
+    steps:
+      - name: Login to GHCR
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+      - name: Choose image
+        id: choose
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
+          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
+          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
+            echo "Using RC: $RC"
+            echo "image=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using stable: $STABLE"
+            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
+          fi
+
+  code-coverage:
+    needs: detect-toolchain
+    runs-on: ubuntu-latest
+    container: ${{ needs.detect-toolchain.outputs.image }}
     steps:
 
     - name: Safe dir
@@ -41,12 +73,19 @@ jobs:
         path: ./bin/linux-x64-release-cov/libcypher-parser
         key: parser-coverage-llvm-${{ hashFiles('./deps/libcypher-parser/lib/src/parser.c') }}
 
+    # The RediSearch submodule gitlink SHA is part of the cache key so that
+    # advancing the fork pin invalidates the cache even when src/version.h is
+    # unchanged (our LLAPI-extension commits do not bump the version macros).
+    - name: Compute RediSearch SHA
+      id: rs_sha
+      run: echo "sha=$(git rev-parse HEAD:deps/RediSearch)" >> "$GITHUB_OUTPUT"
+
     - name: Cache search
       id: cache_search
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ./bin/linux-x64-debug-cov/search-static
-        key: search-coverage-llvm-${{ hashFiles('./deps/RediSearch/src/version.h') }}
+        key: search-coverage-llvm-${{ hashFiles('./deps/RediSearch/src/version.h') }}-${{ steps.rs_sha.outputs.sha }}
 
     - name: Cache libcurl
       id: cache_libcurl

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,32 +18,9 @@ permissions:
   packages: read
 
 jobs:
-  # See sanitize.yml: prefer the PR's RC toolchain image, fall back to stable.
+  # Prefer the PR's RC toolchain image, fall back to stable (shared workflow).
   detect-toolchain:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.choose.outputs.image }}
-    steps:
-      - name: Login to GHCR
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Choose image
-        id: choose
-        env:
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
-          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
-          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
-            echo "Using RC: $RC"
-            echo "image=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "Using stable: $STABLE"
-            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-toolchain.yml
 
   code-coverage:
     needs: detect-toolchain

--- a/.github/workflows/detect-toolchain.yml
+++ b/.github/workflows/detect-toolchain.yml
@@ -1,0 +1,54 @@
+name: Detect toolchain image
+
+# Reusable workflow: pick the builder/toolchain image a job should run in.
+# If this PR built a release-candidate image for the given OS (its
+# build/docker/builder/Dockerfile.<os> changed -> build-rc-toolchain published
+# ghcr.io/falkordb/falkordb-build:<os>-pr-<N>), use that RC so the toolchain
+# change is exercised end-to-end; otherwise fall back to the stable :<os>.
+#
+# Centralizes what used to be a copy-pasted `detect-toolchain` job in
+# sanitize.yml / coverage.yml / codeql-analysis.yml / benchmark.yml.
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: "Builder OS (default: ubuntu)"
+        required: false
+        type: string
+        default: ubuntu
+    outputs:
+      image:
+        description: "Toolchain image ref to use as the job container"
+        value: ${{ jobs.detect.outputs.image }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.choose.outputs.image }}
+    steps:
+      - name: Login to GHCR
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+      - name: Choose image
+        id: choose
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          OS: ${{ inputs.os }}
+        run: |
+          set -euo pipefail
+          RC="ghcr.io/falkordb/falkordb-build:${OS}-pr-${PR}"
+          STABLE="ghcr.io/falkordb/falkordb-build:${OS}"
+          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
+            echo "Using RC: $RC"
+            echo "image=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using stable: $STABLE"
+            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/detect-toolchain.yml
+++ b/.github/workflows/detect-toolchain.yml
@@ -6,8 +6,7 @@ name: Detect toolchain image
 # ghcr.io/falkordb/falkordb-build:<os>-pr-<N>), use that RC so the toolchain
 # change is exercised end-to-end; otherwise fall back to the stable :<os>.
 #
-# Centralizes what used to be a copy-pasted `detect-toolchain` job in
-# sanitize.yml / coverage.yml / codeql-analysis.yml / benchmark.yml.
+# Shared by sanitize.yml / coverage.yml / codeql-analysis.yml / benchmark.yml.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -13,10 +13,46 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
-  sanitize-test:
+  # Pick the toolchain image: PR's RC if it built one (Dockerfile.ubuntu
+  # touched in this PR), otherwise the stable tag. Falling back to stable
+  # when no RC exists means non-Dockerfile PRs and master pushes use the
+  # already-promoted stable image; Dockerfile PRs validate against their
+  # own RC so the toolchain change is exercised end-to-end.
+  detect-toolchain:
     runs-on: ubuntu-latest
-    container: falkordb/falkordb-build:ubuntu
+    outputs:
+      image: ${{ steps.choose.outputs.image }}
+    steps:
+      - name: Login to GHCR
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+      - name: Choose image
+        id: choose
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
+          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
+          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
+            echo "Using RC: $RC"
+            echo "image=$RC" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using stable: $STABLE"
+            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
+          fi
+
+  sanitize-test:
+    needs: detect-toolchain
+    runs-on: ubuntu-latest
+    container: ${{ needs.detect-toolchain.outputs.image }}
     steps:
 
     - name: Safe dir
@@ -41,12 +77,19 @@ jobs:
         path: ./bin/linux-x64-debug-asan/libcypher-parser
         key: parser-sanitizer-llvm-${{ hashFiles('./deps/libcypher-parser/lib/src/parser.c') }}
 
+    # The RediSearch submodule gitlink SHA is part of the cache key so that
+    # advancing the fork pin invalidates the cache even when src/version.h is
+    # unchanged (our LLAPI-extension commits do not bump the version macros).
+    - name: Compute RediSearch SHA
+      id: rs_sha
+      run: echo "sha=$(git rev-parse HEAD:deps/RediSearch)" >> "$GITHUB_OUTPUT"
+
     - name: Cache search
       id: cache_search
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ./bin/linux-x64-debug-asan/search-static
-        key: search-sanitizer-llvm-${{ hashFiles('./deps/RediSearch/src/version.h') }}
+        key: search-sanitizer-llvm-${{ hashFiles('./deps/RediSearch/src/version.h') }}-${{ steps.rs_sha.outputs.sha }}
 
     - name: Cache libcurl
       id: cache_libcurl
@@ -65,6 +108,10 @@ jobs:
     - name: Build
       run: |
         rustup default nightly
+        # -Zbuild-std (enabled by RediSearch's redisearch_rs CMakeLists.txt
+        # when SAN=address) needs the standard library *source* installed
+        # alongside the nightly toolchain.
+        rustup component add rust-src --toolchain nightly
         apt-get update
         apt-get install -y lsb-release wget software-properties-common gnupg
         wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -18,36 +18,10 @@ permissions:
   packages: read
 
 jobs:
-  # Pick the toolchain image: PR's RC if it built one (Dockerfile.ubuntu
-  # touched in this PR), otherwise the stable tag. Falling back to stable
-  # when no RC exists means non-Dockerfile PRs and master pushes use the
-  # already-promoted stable image; Dockerfile PRs validate against their
-  # own RC so the toolchain change is exercised end-to-end.
+  # Pick the toolchain image (PR's RC if it built one, else stable) via the
+  # shared reusable workflow.
   detect-toolchain:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.choose.outputs.image }}
-    steps:
-      - name: Login to GHCR
-        env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: echo "$TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-      - name: Choose image
-        id: choose
-        env:
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          RC="ghcr.io/falkordb/falkordb-build:ubuntu-pr-${PR}"
-          STABLE="ghcr.io/falkordb/falkordb-build:ubuntu"
-          if [[ -n "$PR" ]] && docker manifest inspect "$RC" >/dev/null 2>&1; then
-            echo "Using RC: $RC"
-            echo "image=$RC" >> "$GITHUB_OUTPUT"
-          else
-            echo "Using stable: $STABLE"
-            echo "image=$STABLE" >> "$GITHUB_OUTPUT"
-          fi
+    uses: ./.github/workflows/detect-toolchain.yml
 
   sanitize-test:
     needs: detect-toolchain

--- a/build.sh
+++ b/build.sh
@@ -1194,6 +1194,9 @@ prepare_cmake_arguments() {
     # Sanitizer
     if [[ -n "$SAN" ]]; then
         CMAKE_ARGS+=(-DSAN="$SAN")
+        # ASan + Rust requires nightly's -Zbuild-std; RediSearch's
+        # redisearch_rs CMakeLists.txt accepts +<toolchain> via this var.
+        CMAKE_ARGS+=(-DRUST_TOOLCHAIN_MODIFIER=+nightly)
     fi
 
     # Memory checking

--- a/build.sh
+++ b/build.sh
@@ -1194,8 +1194,9 @@ prepare_cmake_arguments() {
     # Sanitizer
     if [[ -n "$SAN" ]]; then
         CMAKE_ARGS+=(-DSAN="$SAN")
-        # ASan + Rust requires nightly's -Zbuild-std; RediSearch's
-        # redisearch_rs CMakeLists.txt accepts +<toolchain> via this var.
+        # A Rust sanitizer build needs nightly's -Zbuild-std (to rebuild
+        # std with the sanitizer), so request nightly whenever SAN is set;
+        # redisearch_rs's CMakeLists.txt accepts +<toolchain> via this var.
         CMAKE_ARGS+=(-DRUST_TOOLCHAIN_MODIFIER=+nightly)
     fi
 

--- a/build/docker/Dockerfile.compiler
+++ b/build/docker/Dockerfile.compiler
@@ -1,11 +1,16 @@
+# Compiler stage — uses a per-OS toolchain image as base.
+#
+# BUILD_IMAGE is the fully-qualified toolchain image reference, decided by the
+# caller workflow (.github/workflows/build.yml). On a PR that touches
+# build/docker/builder/Dockerfile.<os>, the caller passes the RC tag
+# (ghcr.io/falkordb/falkordb-build:<os>-pr-<N>). Otherwise it passes the stable
+# tag (ghcr.io/falkordb/falkordb-build:<os>).
+
+ARG BUILD_IMAGE=ghcr.io/falkordb/falkordb-build:ubuntu
+
+FROM ${BUILD_IMAGE} AS builder
+
 ARG TARGETPLATFORM=linux/amd64
-
-ARG OS=ubuntu
-
-ARG BASE_IMAGE_VERSION=1.0.0
-
-FROM falkordb/falkordb-build:$OS-${BASE_IMAGE_VERSION} AS builder
-
 ARG DEBUG=0
 
 WORKDIR /FalkorDB

--- a/build/docker/builder/Dockerfile.alpine
+++ b/build/docker/builder/Dockerfile.alpine
@@ -1,0 +1,124 @@
+# Builder toolchain image — Alpine
+#
+# Alpine cmake from apk is too old; pip-install the same pinned version as
+# the other builder OSes for byte-identical cmake across the matrix.
+#
+# clang-sys / bindgen need libclang AT BUILD TIME. On musl, clang-sys's
+# build script defaults to *static* linking (libclang.a, not libclang.so),
+# so the per-major *-static packages must be installed alongside the
+# normal -dev / -libs. Alpine ships these as separate `clangNN-static` /
+# `llvmNN-static` packages.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Must be built on
+# alpine itself — a glibc binary from debian:trixie-slim won't run against
+# musl. Same pinned tag (8.6.3) as the other toolchains and sanitize so
+# every test sees identical Redis behaviour.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli on alpine itself (musl-linked).
+#--------------------------------------------------------------------------
+FROM alpine:3.22 AS redis-builder
+
+ARG REDIS_VERSION
+RUN apk add --no-cache --no-scripts \
+    git ca-certificates gcc g++ libc-dev linux-headers \
+    openssl-dev make bsd-compat-headers && \
+    update-ca-certificates || true
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+# Flip protected-mode default so test runs without --protected-mode no
+# accept connections — same one-line sed used in the upstream redis image
+# and falkordb-rs-next-gen.
+# (Skip the jemalloc page-size tweak — alpine's musl + jemalloc combo is
+#  simpler than the debian/dpkg path, default jemalloc is fine.)
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+# Pinned to alpine:3.22 (rather than alpine:latest) so the toolchain version
+# is reproducible across image rebuilds. Bump deliberately when alpine 3.23+
+# becomes the production target.
+FROM alpine:3.22 AS builder
+
+# --no-scripts avoids trigger issues in QEMU emulation during multi-arch builds.
+RUN apk add --no-cache --no-scripts \
+    git \
+    bash \
+    python3 \
+    py3-pip \
+    ca-certificates \
+    curl \
+    curl-dev \
+    wget \
+    unzip \
+    automake \
+    libtool \
+    autoconf \
+    openssl-dev \
+    zlib-dev \
+    zstd-dev \
+    clang20-dev \
+    clang20-libs \
+    clang20-static \
+    llvm20-dev \
+    llvm20-static \
+    gperf \
+    gcc \
+    g++ \
+    musl-dev \
+    libffi-dev \
+    ncurses-dev \
+    bsd-compat-headers \
+    linux-headers \
+    build-base && \
+    update-ca-certificates || true
+
+# Python venv (the apk python is PEP-668 marked)
+RUN python3 -m venv /venv && chmod +x /venv/bin/*
+ENV PATH="/venv/bin:$PATH"
+
+RUN pip install --disable-pip-version-check --no-cache-dir setuptools --upgrade
+# Pin cmake to the same exact version across every builder OS.
+RUN pip install --no-cache-dir --break-system-packages 'cmake==3.31.6'
+
+# minipeg ships as `peg` on alpine but build.sh expects `leg`
+RUN apk add --no-cache --no-scripts minipeg && \
+    (ln -s "$(which minipeg)" /usr/local/bin/leg || ln -s "$(which minipeg)" /usr/bin/leg)
+
+# Install rust via rustup (matches the other builder OSes). Alpine's apk
+# `rust` package on 3.22 ships 1.87.0, which is one minor too old for
+# RediSearch's redisearch_rs build_utils crate that uses `let` chains
+# (stabilized in 1.88). rustup gets us the current stable.
+# The default-host x86_64-unknown-linux-musl / aarch64-unknown-linux-musl
+# triple is auto-selected.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Rust's musl target defaults to `-C target-feature=+crt-static`, which makes
+# every build artifact (including build-scripts and the final .so) a static
+# PIE. Alpine ships libclang.a / per-component LLVM static archives but NOT
+# a combined `libLLVM-20.a` — clang-sys's build script then fails with
+# `ld: cannot find -lLLVM-20`. We're building a Redis module (.so) loaded
+# at runtime, so static linking gives us nothing. Opt out → dynamic link
+# against the libLLVM-20.so / libclang.so that llvm20-libs / clang20-libs
+# provide.
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.amazonlinux2023
+++ b/build/docker/builder/Dockerfile.amazonlinux2023
@@ -1,0 +1,110 @@
+# Builder toolchain image — Amazon Linux 2023
+#
+# AL2023 dnf cmake is 3.22.2 (too old for RediSearch's boost.cmake). Override
+# with pip 3.28.x. Adds clang-devel for bindgen/clang-sys.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
+# (8.6.3) as the other toolchains and sanitize. Built on AL2023 itself so
+# the resulting glibc 2.34 binary runs in the same base.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM amazonlinux:2023 AS redis-builder
+
+ARG REDIS_VERSION
+RUN set -eux; \
+    dnf install -y --setopt=install_weak_deps=False \
+      git ca-certificates gcc gcc-c++ glibc-devel openssl-devel make tar gzip; \
+    dnf clean all
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+# Flip protected-mode default — same one-line sed as the other toolchains.
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM amazonlinux:2023 AS builder
+
+RUN set -eux; \
+    dnf update -y; \
+    dnf install -y \
+      git \
+      wget \
+      ca-certificates \
+      unzip \
+      rsync \
+      m4 \
+      automake \
+      gperf \
+      libtool \
+      autoconf \
+      make \
+      diffutils \
+      which \
+      gcc \
+      gcc-c++ \
+      libstdc++-static \
+      openssl \
+      openssl-devel \
+      python3.11 \
+      python3.11-pip \
+      python3.11-devel \
+      clang \
+      clang-devel \
+      llvm-devel \
+      cmake; \
+    dnf clean all
+
+# Pin cmake to the same exact version across every builder OS. Overrides
+# dnf's 3.22.x; pip installs into /usr/local/bin which precedes /usr/bin.
+#
+# Install under python3.11 explicitly: AL2023 ships `yum`/`dnf` as Python
+# wrappers that import the `dnf` module from the system python (3.9), and
+# the test image (tests/Dockerfile.amazonlinux2023) later repoints
+# /usr/bin/python3 → python3.11. We do NOT change /usr/bin/python3 here —
+# doing so during toolchain build would break the next `yum install …` in
+# the test image with `ModuleNotFoundError: No module named 'dnf'` because
+# python3.11 wouldn't have the dnf module installed.
+#
+# Instead, pip-install under python3.11 directly. The cmake wrapper at
+# /usr/local/bin/cmake has `#!/usr/bin/env python` — when the test image
+# later flips /usr/bin/python3 to 3.11 it resolves cleanly because cmake
+# is on 3.11's site-packages.
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build & install peg (alpine's minipeg equivalent — for libcypher-parser)
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+    url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+    wget -O peg.tar.gz "$url"; \
+    echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+    tar -xzf peg.tar.gz; \
+    cd "peg-${PEG_VERSION}"; \
+    make && make install; \
+    cd ..; \
+    rm -rf "peg-${PEG_VERSION}" peg.tar.gz
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.amazonlinux2023
+++ b/build/docker/builder/Dockerfile.amazonlinux2023
@@ -1,7 +1,7 @@
 # Builder toolchain image — Amazon Linux 2023
 #
 # AL2023 dnf cmake is 3.22.2 (too old for RediSearch's boost.cmake). Override
-# with pip 3.28.x. Adds clang-devel for bindgen/clang-sys.
+# with pip 3.31.6. Adds clang-devel for bindgen/clang-sys.
 #
 # Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
 # (8.6.3) as the other toolchains and sanitize. Built on AL2023 itself so

--- a/build/docker/builder/Dockerfile.debian
+++ b/build/docker/builder/Dockerfile.debian
@@ -1,0 +1,80 @@
+# Builder toolchain image — Debian trixie-slim
+#
+# Pip-installs cmake 3.31.6 to align with the other builder OSes (apt's
+# distro cmake works but drifts per Debian version). Adds libclang-dev +
+# clang headers required by `bindgen`/`clang-sys` in redisearch_rs.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). See the equivalent
+# comment in Dockerfile.ubuntu — same pattern, mirrors falkordb-rs-next-gen,
+# pins everything to the sanitize-test redis tag so test_temporal et al
+# don't drift between Build and Sanitizer runs.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM debian:trixie-slim AS redis-builder
+
+ARG REDIS_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git dpkg-dev gcc g++ libc6-dev libssl-dev make && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    extraJemallocConfigureFlags="--build=$gnuArch"; \
+    case "${arch##*-}" in \
+        amd64 | i386 | x32) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=12" ;; \
+        *) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=16" ;; \
+    esac; \
+    extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-hugepage=21"; \
+    sed -ri 's!cd jemalloc && ./configure !&'"$extraJemallocConfigureFlags"' !' deps/Makefile; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM debian:trixie-slim
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      git wget build-essential lcov \
+      openssl libssl-dev \
+      python3 python3-venv python3-pip \
+      rsync unzip curl m4 automake gperf peg libtool autoconf \
+      clang libclang-dev \
+      gcc-13 g++-13 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set gcc-13 and g++-13 as the default gcc/g++
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+
+# Pin cmake to the same exact version across every builder OS.
+RUN pip3 install --no-cache-dir --break-system-packages 'cmake==3.31.6'
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.debian
+++ b/build/docker/builder/Dockerfile.debian
@@ -4,10 +4,8 @@
 # distro cmake works but drifts per Debian version). Adds libclang-dev +
 # clang headers required by `bindgen`/`clang-sys` in redisearch_rs.
 #
-# Redis: built from git at REDIS_VERSION (multi-stage). See the equivalent
-# comment in Dockerfile.ubuntu — same pattern, mirrors falkordb-rs-next-gen,
-# pins everything to the sanitize-test redis tag so test_temporal et al
-# don't drift between Build and Sanitizer runs.
+# Redis: built from git at REDIS_VERSION (multi-stage). See Dockerfile.ubuntu
+# for the rationale (same pattern, pinned to REDIS_VERSION).
 
 ARG REDIS_VERSION=8.6.3
 

--- a/build/docker/builder/Dockerfile.rhel
+++ b/build/docker/builder/Dockerfile.rhel
@@ -52,7 +52,7 @@ RUN yum update -y && \
 
 # Enable gcc-toolset-14 on PATH
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64"
 
 # Pin cmake to the same exact version across every builder OS.
 RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'

--- a/build/docker/builder/Dockerfile.rhel
+++ b/build/docker/builder/Dockerfile.rhel
@@ -1,0 +1,96 @@
+# Builder toolchain image — RHEL UBI9
+#
+# UBI9 cmake 3.26.5 is fine for RediSearch's boost.cmake.
+# Adds clang + clang-devel for bindgen/clang-sys.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
+# (8.6.3) as the other toolchains and sanitize. Built on UBI9 itself so
+# the glibc 2.34 binary runs against the same base. Removes the per-test
+# image redis-stable.tar.gz build, eliminating drift between Build and
+# Sanitizer runs.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM redhat/ubi9 AS redis-builder
+
+ARG REDIS_VERSION
+RUN yum install -y \
+      git ca-certificates gcc gcc-c++ glibc-devel openssl-devel make tar gzip && \
+    yum clean all
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM redhat/ubi9 AS builder
+
+RUN yum update -y && \
+    yum install -y \
+      wget autoconf automake \
+      python3.11 python3.11-pip \
+      libtool git make \
+      openssl-devel \
+      gcc-toolset-14 \
+      libstdc++-static \
+      diffutils \
+      clang clang-devel && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3 && \
+    yum clean all
+
+# Enable gcc-toolset-14 on PATH
+ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+
+# Pin cmake to the same exact version across every builder OS.
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build & install peg
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+    url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+    wget -O peg.tar.gz "$url"; \
+    echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+    tar -xzf peg.tar.gz; \
+    cd "peg-${PEG_VERSION}"; \
+    make && make install; \
+    cd ..; \
+    rm -rf "peg-${PEG_VERSION}" peg.tar.gz
+
+# Build & install gperf
+ARG GPERF_VERSION=3.1
+ARG GPERF_SHA256=588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+RUN set -eux; \
+    wget -O gperf.tar.gz "https://ftp.gnu.org/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz"; \
+    echo "${GPERF_SHA256}  gperf.tar.gz" | sha256sum -c -; \
+    tar -xzf gperf.tar.gz; \
+    cd "gperf-${GPERF_VERSION}"; \
+    ./configure; make; make install; \
+    cd ..; \
+    rm -rf "gperf-${GPERF_VERSION}" gperf.tar.gz
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.rhel
+++ b/build/docker/builder/Dockerfile.rhel
@@ -3,11 +3,8 @@
 # UBI9 cmake 3.26.5 is fine for RediSearch's boost.cmake.
 # Adds clang + clang-devel for bindgen/clang-sys.
 #
-# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
-# (8.6.3) as the other toolchains and sanitize. Built on UBI9 itself so
-# the glibc 2.34 binary runs against the same base. Removes the per-test
-# image redis-stable.tar.gz build, eliminating drift between Build and
-# Sanitizer runs.
+# Redis: built from git at REDIS_VERSION (multi-stage). Built on UBI9 so the
+# glibc 2.34 binary runs against the same base.
 
 ARG REDIS_VERSION=8.6.3
 

--- a/build/docker/builder/Dockerfile.rhel8
+++ b/build/docker/builder/Dockerfile.rhel8
@@ -1,0 +1,136 @@
+# Builder toolchain image — RHEL UBI8
+#
+# UBI8 cmake 3.26.5 is fine; needs clang for bindgen/clang-sys. UBI8 has no
+# OpenSSL 3 package — build from source as before.
+#
+# Additional fix on top of build-image's Dockerfile.rhel8: the locally-built
+# OpenSSL 3 lives under /usr/local/openssl3/include. Setting OPENSSL_ROOT_DIR
+# (for cmake's find_package) isn't enough — RediSearch's coord/rmr/conn.c
+# `#include <openssl/ssl.h>` is resolved by the bare compiler driver. Export
+# C_INCLUDE_PATH / CPLUS_INCLUDE_PATH so gcc/clang find the headers without
+# explicit -I.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
+# (8.6.3) as the other toolchains and sanitize. Built on UBI8 with the
+# default openssl-devel (1.1) since Redis's BUILD_TLS doesn't require
+# OpenSSL 3.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM redhat/ubi8 AS redis-builder
+
+ARG REDIS_VERSION
+RUN yum install -y \
+      git ca-certificates gcc gcc-c++ glibc-devel openssl-devel make tar gzip && \
+    yum clean all
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM redhat/ubi8 AS builder
+
+# UBI8 needs codeready-builder repo for clang-devel
+RUN yum update -y && \
+    yum install -y dnf-plugins-core && \
+    dnf config-manager --set-enabled ubi-8-codeready-builder-rpms || true && \
+    yum install -y \
+      wget autoconf automake \
+      python3.11 python3.11-pip \
+      libtool git make perl-core \
+      zlib-devel libstdc++-static \
+      gcc-toolset-14 \
+      diffutils \
+      clang clang-devel && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3 && \
+    yum clean all
+
+ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+
+# Pin cmake to the same exact version across every builder OS.
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Build & install OpenSSL 3 from source (no OpenSSL 3 package in UBI8)
+ARG OPENSSL_VERSION=3.0.15
+ARG OPENSSL_SHA256=23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
+RUN set -eux; \
+    wget -O openssl.tar.gz "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz"; \
+    echo "${OPENSSL_SHA256}  openssl.tar.gz" | sha256sum -c -; \
+    tar -xzf openssl.tar.gz; \
+    cd "openssl-${OPENSSL_VERSION}"; \
+    ./Configure --prefix=/usr/local/openssl3 --openssldir=/usr/local/openssl3/ssl --libdir=lib64 shared zlib; \
+    make -j"$(nproc)"; \
+    make install_sw install_ssldirs; \
+    echo "/usr/local/openssl3/lib64" > /etc/ld.so.conf.d/openssl3.conf; \
+    ldconfig; \
+    cd ..; \
+    rm -rf "openssl-${OPENSSL_VERSION}" openssl.tar.gz
+
+# cmake find_package(OpenSSL)
+ENV OPENSSL_ROOT_DIR="/usr/local/openssl3"
+ENV OPENSSL_INCLUDE_DIR="/usr/local/openssl3/include"
+ENV OPENSSL_CRYPTO_LIBRARY="/usr/local/openssl3/lib64/libcrypto.so"
+ENV OPENSSL_SSL_LIBRARY="/usr/local/openssl3/lib64/libssl.so"
+ENV PKG_CONFIG_PATH="/usr/local/openssl3/lib64/pkgconfig:${PKG_CONFIG_PATH}"
+ENV PATH="/usr/local/openssl3/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:${LD_LIBRARY_PATH}"
+
+# Bare compiler driver needs the headers too — RediSearch's coord
+# sources do `#include <openssl/ssl.h>` without going through cmake/pkg-config.
+ENV C_INCLUDE_PATH="/usr/local/openssl3/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="/usr/local/openssl3/include:${CPLUS_INCLUDE_PATH}"
+ENV LIBRARY_PATH="/usr/local/openssl3/lib64:${LIBRARY_PATH}"
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build & install peg
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+    url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+    wget -O peg.tar.gz "$url"; \
+    echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+    tar -xzf peg.tar.gz; \
+    cd "peg-${PEG_VERSION}"; \
+    make && make install; \
+    cd ..; \
+    rm -rf "peg-${PEG_VERSION}" peg.tar.gz
+
+# Build & install gperf
+ARG GPERF_VERSION=3.1
+ARG GPERF_SHA256=588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+RUN set -eux; \
+    wget -O gperf.tar.gz "https://ftp.gnu.org/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz"; \
+    echo "${GPERF_SHA256}  gperf.tar.gz" | sha256sum -c -; \
+    tar -xzf gperf.tar.gz; \
+    cd "gperf-${GPERF_VERSION}"; \
+    ./configure; make; make install; \
+    cd ..; \
+    rm -rf "gperf-${GPERF_VERSION}" gperf.tar.gz
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli
+
+CMD ["/bin/bash"]

--- a/build/docker/builder/Dockerfile.rhel8
+++ b/build/docker/builder/Dockerfile.rhel8
@@ -62,7 +62,7 @@ RUN yum update -y && \
     yum clean all
 
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64"
 
 # Pin cmake to the same exact version across every builder OS.
 RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
@@ -94,9 +94,9 @@ ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:${LD_LIBRARY_PATH}"
 
 # Bare compiler driver needs the headers too — RediSearch's coord
 # sources do `#include <openssl/ssl.h>` without going through cmake/pkg-config.
-ENV C_INCLUDE_PATH="/usr/local/openssl3/include:${C_INCLUDE_PATH}"
-ENV CPLUS_INCLUDE_PATH="/usr/local/openssl3/include:${CPLUS_INCLUDE_PATH}"
-ENV LIBRARY_PATH="/usr/local/openssl3/lib64:${LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="/usr/local/openssl3/include"
+ENV CPLUS_INCLUDE_PATH="/usr/local/openssl3/include"
+ENV LIBRARY_PATH="/usr/local/openssl3/lib64"
 
 # Rust toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/build/docker/builder/Dockerfile.rhel9
+++ b/build/docker/builder/Dockerfile.rhel9
@@ -52,7 +52,7 @@ RUN yum update -y && \
 
 # Enable gcc-toolset-14 on PATH
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64"
 
 # Pin cmake to the same exact version across every builder OS.
 RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'

--- a/build/docker/builder/Dockerfile.rhel9
+++ b/build/docker/builder/Dockerfile.rhel9
@@ -1,0 +1,96 @@
+# Builder toolchain image — RHEL UBI9
+#
+# UBI9 cmake 3.26.5 is fine for RediSearch's boost.cmake.
+# Adds clang + clang-devel for bindgen/clang-sys.
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
+# (8.6.3) as the other toolchains and sanitize. Built on UBI9 itself so
+# the glibc 2.34 binary runs against the same base. Removes the per-test
+# image redis-stable.tar.gz build, eliminating drift between Build and
+# Sanitizer runs.
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM redhat/ubi9 AS redis-builder
+
+ARG REDIS_VERSION
+RUN yum install -y \
+      git ca-certificates gcc gcc-c++ glibc-devel openssl-devel make tar gzip && \
+    yum clean all
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM redhat/ubi9 AS builder
+
+RUN yum update -y && \
+    yum install -y \
+      wget autoconf automake \
+      python3.11 python3.11-pip \
+      libtool git make \
+      openssl-devel \
+      gcc-toolset-14 \
+      libstdc++-static \
+      diffutils \
+      clang clang-devel && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3 && \
+    yum clean all
+
+# Enable gcc-toolset-14 on PATH
+ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
+
+# Pin cmake to the same exact version across every builder OS.
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build & install peg
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+    url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+    wget -O peg.tar.gz "$url"; \
+    echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+    tar -xzf peg.tar.gz; \
+    cd "peg-${PEG_VERSION}"; \
+    make && make install; \
+    cd ..; \
+    rm -rf "peg-${PEG_VERSION}" peg.tar.gz
+
+# Build & install gperf
+ARG GPERF_VERSION=3.1
+ARG GPERF_SHA256=588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+RUN set -eux; \
+    wget -O gperf.tar.gz "https://ftp.gnu.org/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz"; \
+    echo "${GPERF_SHA256}  gperf.tar.gz" | sha256sum -c -; \
+    tar -xzf gperf.tar.gz; \
+    cd "gperf-${GPERF_VERSION}"; \
+    ./configure; make; make install; \
+    cd ..; \
+    rm -rf "gperf-${GPERF_VERSION}" gperf.tar.gz
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.rhel9
+++ b/build/docker/builder/Dockerfile.rhel9
@@ -3,11 +3,8 @@
 # UBI9 cmake 3.26.5 is fine for RediSearch's boost.cmake.
 # Adds clang + clang-devel for bindgen/clang-sys.
 #
-# Redis: built from git at REDIS_VERSION (multi-stage). Same pinned tag
-# (8.6.3) as the other toolchains and sanitize. Built on UBI9 itself so
-# the glibc 2.34 binary runs against the same base. Removes the per-test
-# image redis-stable.tar.gz build, eliminating drift between Build and
-# Sanitizer runs.
+# Redis: built from git at REDIS_VERSION (multi-stage). Built on UBI9 so the
+# glibc 2.34 binary runs against the same base.
 
 ARG REDIS_VERSION=8.6.3
 

--- a/build/docker/builder/Dockerfile.ubuntu
+++ b/build/docker/builder/Dockerfile.ubuntu
@@ -1,0 +1,89 @@
+# Builder toolchain image — Ubuntu 22.04
+#
+# Absorbed from FalkorDB/build-image (Dockerfile.ubuntu) with two RediSearch 8.6
+# prerequisites added:
+#
+#   1. cmake >= 3.24 (required by RediSearch's boost.cmake — `DOWNLOAD_EXTRACT_TIMESTAMP`).
+#      Ubuntu 22.04 ships cmake 3.22.1; pip-install 3.28.x to /usr/local/bin/cmake
+#      which precedes /usr/bin/cmake on PATH.
+#   2. libclang + clang headers (required by `bindgen`/`clang-sys` in redisearch_rs).
+#
+# Redis: built from git at REDIS_VERSION (multi-stage). Mirrors the pattern in
+# falkordb-rs-next-gen (build/Dockerfile) — we keep the same redis-server binary
+# across every image so behaviour doesn't drift between the toolchain, the
+# release runtime, and the sanitizer runtime. Avoids the apt-priority trap on
+# jammy (Ubuntu ships `redis 5:6.0.16-1ubuntu1` at epoch 5, which outranks
+# packages.redis.io's `redis 8.x`; plain `apt-get install redis` lands on
+# 6.0.16 and FalkorDB hard-requires >= 8.0).
+
+ARG REDIS_VERSION=8.6.3
+
+#--------------------------------------------------------------------------
+# Stage 1: build redis-server / redis-cli from source at a pinned tag.
+#--------------------------------------------------------------------------
+FROM ubuntu:22.04 AS redis-builder
+
+ARG REDIS_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates git dpkg-dev gcc g++ libc6-dev libssl-dev make && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN git clone --depth 1 --branch "${REDIS_VERSION}" https://github.com/redis/redis.git redis-src
+WORKDIR /tmp/redis-src
+
+# Mirror upstream redis image's protected-mode default flip (1 → 0) and
+# jemalloc page-size tuning so behaviour is identical to the upstream
+# redis:${REDIS_VERSION} image. Matches falkordb-rs-next-gen.
+RUN set -eux; \
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' src/config.c; \
+    grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' src/config.c; \
+    gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+    arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    extraJemallocConfigureFlags="--build=$gnuArch"; \
+    case "${arch##*-}" in \
+        amd64 | i386 | x32) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=12" ;; \
+        *) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=16" ;; \
+    esac; \
+    extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-hugepage=21"; \
+    sed -ri 's!cd jemalloc && ./configure !&'"$extraJemallocConfigureFlags"' !' deps/Makefile; \
+    export BUILD_TLS=yes BUILD_WITH_MODULES=no; \
+    make -j "$(nproc)" all; \
+    make PREFIX=/redis-install install; \
+    strip /redis-install/bin/redis-server /redis-install/bin/redis-cli; \
+    /redis-install/bin/redis-server --version
+
+#--------------------------------------------------------------------------
+# Stage 2: actual toolchain image.
+#--------------------------------------------------------------------------
+FROM ubuntu:22.04 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      git wget build-essential lcov \
+      openssl libssl-dev ca-certificates \
+      python3 python3-venv python3-dev python3-pip \
+      unzip rsync curl m4 automake gperf peg libtool autoconf \
+      clang-15 libclang-15-dev libclang-common-15-dev \
+      cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pin cmake to the same exact version across every builder OS so the matrix
+# uses one CMake build. Overrides apt's 3.22.1; pip installs into
+# /usr/local/bin which precedes /usr/bin in PATH. No --break-system-packages
+# flag because jammy's system Python isn't PEP-668-marked, and the flag
+# wasn't introduced until pip 23 (jammy ships pip 22).
+RUN pip install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain (used to build redisearch_rs)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# redis-server / redis-cli — copied LAST so a REDIS_VERSION bump only rebuilds
+# this cheap layer and leaves the toolchain download layers (rust/cmake/apt)
+# cached. /usr/local/bin precedes /usr/bin on PATH (where RLTest looks).
+COPY --from=redis-builder /redis-install/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis-builder /redis-install/bin/redis-cli    /usr/local/bin/redis-cli

--- a/build/docker/builder/Dockerfile.ubuntu
+++ b/build/docker/builder/Dockerfile.ubuntu
@@ -4,7 +4,7 @@
 # prerequisites added:
 #
 #   1. cmake >= 3.24 (required by RediSearch's boost.cmake — `DOWNLOAD_EXTRACT_TIMESTAMP`).
-#      Ubuntu 22.04 ships cmake 3.22.1; pip-install 3.28.x to /usr/local/bin/cmake
+#      Ubuntu 22.04 ships cmake 3.22.1; pip-install 3.31.6 to /usr/local/bin/cmake
 #      which precedes /usr/bin/cmake on PATH.
 #   2. libclang + clang headers (required by `bindgen`/`clang-sys` in redisearch_rs).
 #

--- a/build/docker/builder/Dockerfile.ubuntu
+++ b/build/docker/builder/Dockerfile.ubuntu
@@ -76,7 +76,7 @@ RUN apt-get update -y && \
 # /usr/local/bin which precedes /usr/bin in PATH. No --break-system-packages
 # flag because jammy's system Python isn't PEP-668-marked, and the flag
 # wasn't introduced until pip 23 (jammy ships pip 22).
-RUN pip install --no-cache-dir 'cmake==3.31.6'
+RUN pip3 install --no-cache-dir 'cmake==3.31.6'
 
 # Rust toolchain (used to build redisearch_rs)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/build/docker/builder/README.md
+++ b/build/docker/builder/README.md
@@ -1,0 +1,72 @@
+# Builder toolchain Dockerfiles
+
+Per-OS toolchain images used as `FROM` bases by the FalkorDB compiler image
+(`build/docker/Dockerfile.compiler`). Absorbed from
+[FalkorDB/build-image](https://github.com/FalkorDB/build-image) and extended with
+the dependencies RediSearch 8.6 added on top of the previous (`1.2.0`)
+generation:
+
+| Prerequisite | Why | Affected OS bases |
+|---|---|---|
+| CMake `3.31.6` | RediSearch's `boost.cmake` uses `FetchContent`'s `DOWNLOAD_EXTRACT_TIMESTAMP` (added in 3.24). Pinned identically across all OSes via pip so `cmake --version` is byte-identical across the matrix. | all bases |
+| libclang / clang dev headers (LLVM **≥ 15**) | `redisearch_rs`'s `bindgen` / `clang-sys` crates need to load `libclang.so` to generate FFI bindings at build time. bindgen accepts any libclang ≥ 9, but we enforce ≥ 15 to keep C++23-era parsing consistent across the matrix. | all bases |
+| OpenSSL 3 headers on default compiler include path | RediSearch's `coord/rmr/conn.c` does `#include <openssl/ssl.h>` without going through cmake's `find_package` | `rhel8` only (no OpenSSL 3 package in UBI8 — built from source under `/usr/local/openssl3`) |
+
+## libclang version per OS (first-party, floor ≥ 15)
+
+We pick each OS's newest first-party LLVM major rather than chasing a single
+integer across all 7 (the cost of forcing a specific major on UBI8 / AL2023
+outweighs the symmetry gain — see commit history for the research). The
+contract is: **libclang ≥ 15, from the distro's official repo**. No
+`apt.llvm.org`, no EPEL, no COPR, no source builds.
+
+| Image | Base | clang/libclang | Source |
+|---|---|---|---|
+| `ubuntu` | `ubuntu:22.04` | LLVM 15 | jammy universe (explicit `clang-15 libclang-15-dev`) |
+| `debian` | `debian:trixie-slim` | LLVM 19 | trixie main (default) |
+| `alpine` | `alpine:3.22` | LLVM 20 | alpine community (explicit `clang20-dev/-libs/-static` + `llvm20-dev/-static`; *-static needed for clang-sys's musl-only static link) |
+| `amazonlinux2023` | `amazonlinux:2023` | LLVM 15 | AL2023 default (`clang clang-devel`) |
+| `rhel` / `rhel9` | `redhat/ubi9` | LLVM 21 | UBI9 default (`clang clang-devel`) |
+| `rhel8` | `redhat/ubi8` | LLVM 21 | UBI8 default + `ubi-8-codeready-builder-rpms` for `clang-devel` |
+
+If you bump a base image (e.g. `alpine:3.22` → `alpine:3.23`, or `ubuntu:22.04` → `ubuntu:24.04`), check that the new default clang still meets the floor and update this table.
+
+## Release workflow
+
+These images are released to **GHCR only** as `ghcr.io/falkordb/falkordb-build:<os>`.
+
+| Event | Tag(s) produced |
+|---|---|
+| PR opened/updated, touching `build/docker/builder/Dockerfile.<os>` | `:<os>-pr-<N>` (per-arch `:<os>-pr-<N>-x64`, `:<os>-pr-<N>-arm64v8`, plus multi-arch manifest) |
+| PR merged to `master` | `imagetools create` retags `:<os>-pr-<N>` → `:<os>` — no rebuild |
+| 30 days after last access | swept by `.github/workflows/cleanup-rc-images.yml` daily cron |
+
+## Consumer pattern (`.github/workflows/build.yml`)
+
+Downstream build jobs select between the PR's RC image and the stable image
+via a `Compute toolchain image tag` step that consults the `changed_oses`
+JSON list emitted by `check-builder-changes`:
+
+```yaml
+- name: Compute toolchain image tag
+  id: toolchain_tag
+  env:
+    OS: ${{ matrix.platform.os }}
+    CHANGED_OSES: ${{ needs.check-builder-changes.outputs.changed_oses }}
+    PR_NUMBER: ${{ github.event.pull_request.number || needs.check-builder-changes.outputs.merged_pr }}
+  run: |
+    set -euo pipefail
+    changed=$(echo "$CHANGED_OSES" | jq -r '.[]' | grep -Fx "$OS" || true)
+    if [ -n "$changed" ] && [ -n "$PR_NUMBER" ]; then
+      echo "image=ghcr.io/falkordb/falkordb-build:${OS}-pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+    else
+      echo "image=ghcr.io/falkordb/falkordb-build:${OS}" >> "$GITHUB_OUTPUT"
+    fi
+```
+
+The resolved tag is then passed into the compiler image build as
+`BUILD_IMAGE=${{ steps.toolchain_tag.outputs.image }}`.
+
+This means a PR that modifies `Dockerfile.ubuntu` validates the runtime build
+against the new image before merge, and the same image becomes the stable
+`falkordb-build:ubuntu` automatically on merge.

--- a/tests/Dockerfile.alpine
+++ b/tests/Dockerfile.alpine
@@ -4,7 +4,12 @@ ARG TARGETPLATFORM=linux/x86_64
 
 FROM $BASE_IMAGE AS compiler
 
-ENV DEPS "curl automake libtool autoconf py3-pip wget cmake m4 git valgrind python3-dev build-base redis gcc musl-dev linux-headers"
+# `redis` removed — provided by the toolchain image
+# (build/docker/builder/Dockerfile.alpine) at /usr/local/bin/redis-server,
+# pinned to 8.6.3 like the other platforms and sanitize. apk's redis on
+# alpine 3.22 floats with the distro update cadence; pinning at the
+# toolchain layer keeps every test run on the same binary.
+ENV DEPS "curl automake libtool autoconf py3-pip wget cmake m4 git valgrind python3-dev build-base gcc musl-dev linux-headers"
 
 # Set up a build environment by installing necessary dependencies.
 # 'set -ex' ensures that the script exits immediately if any command fails.

--- a/tests/Dockerfile.amazonlinux2023
+++ b/tests/Dockerfile.amazonlinux2023
@@ -18,16 +18,13 @@ RUN set -ex ;\
     python3 --version ;\
     pip3 --version
 
-# Build and install redis from source
-RUN set -ex ;\
-    cd /tmp ;\
-    curl -LO https://download.redis.io/redis-stable.tar.gz ;\
-    tar -xzf redis-stable.tar.gz ;\
-    cd redis-stable ;\
-    make -j$(nproc) ;\
-    make install ;\
-    cd / ;\
-    rm -rf /tmp/redis-stable /tmp/redis-stable.tar.gz
+# Redis: provided by the toolchain image
+# (build/docker/builder/Dockerfile.amazonlinux2023) at
+# /usr/local/bin/redis-server, pinned to the same 8.6.3 tag the sanitizer
+# uses. The previous `redis-stable.tar.gz` build at test-image time has
+# been removed — it overwrote the toolchain's pinned binary with whatever
+# upstream stable currently is, causing drift between Build and Sanitizer
+# test runs.
 
 # Create virtual environment
 RUN set -ex ;\

--- a/tests/Dockerfile.amazonlinux2023
+++ b/tests/Dockerfile.amazonlinux2023
@@ -20,11 +20,7 @@ RUN set -ex ;\
 
 # Redis: provided by the toolchain image
 # (build/docker/builder/Dockerfile.amazonlinux2023) at
-# /usr/local/bin/redis-server, pinned to the same 8.6.3 tag the sanitizer
-# uses. The previous `redis-stable.tar.gz` build at test-image time has
-# been removed — it overwrote the toolchain's pinned binary with whatever
-# upstream stable currently is, causing drift between Build and Sanitizer
-# test runs.
+# /usr/local/bin/redis-server, pinned to 8.6.3.
 
 # Create virtual environment
 RUN set -ex ;\

--- a/tests/Dockerfile.debian
+++ b/tests/Dockerfile.debian
@@ -13,11 +13,15 @@ RUN set -ex ;\
     apt-get upgrade -y ;\
     apt-get install -y --no-install-recommends $deps ;
 
-# Set up redis
-RUN curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg ;\
-    echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list ;\
-    apt-get update -qq ;\
-    apt-get install -y redis
+# Redis: provided by the toolchain image
+# (build/docker/builder/Dockerfile.{ubuntu,debian}) at
+# /usr/local/bin/redis-server, pinned to 8.6.3 like the sanitizer. The
+# previous `apt-get install -y redis` step was a no-op on PATH (the
+# /usr/local/bin binary wins over apt's /usr/bin one) AND it failed in
+# practice on jammy bases — Ubuntu ships `redis 5:6.0.16-1ubuntu1` at apt
+# epoch 5, which outranks packages.redis.io's `redis 8.x`, so plain `apt
+# install redis` resolved to 6.0.16 and crashed module load with
+# 'FalkorDB requires redis-server version 8.0.0 and up'.
 
 # Create venv
 RUN set -ex ;\

--- a/tests/Dockerfile.rhel
+++ b/tests/Dockerfile.rhel
@@ -20,8 +20,8 @@ RUN set -ex ;\
     python3 --version ;\
     pip3 --version
 
-# Redis: provided by the toolchain image (build/docker/builder/Dockerfile.rhel)
-# at /usr/local/bin/redis-server, pinned to 8.6.3.
+# Redis: provided by the toolchain image (build/docker/builder/Dockerfile.rhel8
+# or .rhel9, depending on the build) at /usr/local/bin/redis-server, pinned to 8.6.3.
 
 # Create virtual environment
 RUN set -ex ;\

--- a/tests/Dockerfile.rhel
+++ b/tests/Dockerfile.rhel
@@ -21,11 +21,7 @@ RUN set -ex ;\
     pip3 --version
 
 # Redis: provided by the toolchain image (build/docker/builder/Dockerfile.rhel)
-# at /usr/local/bin/redis-server, pinned to the same 8.6.3 tag the sanitizer
-# uses. The previous `redis-stable.tar.gz` build at test-image time has been
-# removed — it overwrote the toolchain's pinned binary with whatever
-# `download.redis.io/redis-stable.tar.gz` happened to be, causing drift
-# between Build and Sanitizer test runs.
+# at /usr/local/bin/redis-server, pinned to 8.6.3.
 
 # Create virtual environment
 RUN set -ex ;\

--- a/tests/Dockerfile.rhel
+++ b/tests/Dockerfile.rhel
@@ -20,16 +20,12 @@ RUN set -ex ;\
     python3 --version ;\
     pip3 --version
 
-# Build and install redis from source
-RUN set -ex ;\
-    cd /tmp ;\
-    curl -LO http://download.redis.io/redis-stable.tar.gz ;\
-    tar -xzf redis-stable.tar.gz ;\
-    cd redis-stable ;\
-    make -j$(nproc) ;\
-    make install ;\
-    cd / ;\
-    rm -rf /tmp/redis-stable /tmp/redis-stable.tar.gz
+# Redis: provided by the toolchain image (build/docker/builder/Dockerfile.rhel)
+# at /usr/local/bin/redis-server, pinned to the same 8.6.3 tag the sanitizer
+# uses. The previous `redis-stable.tar.gz` build at test-image time has been
+# removed — it overwrote the toolchain's pinned binary with whatever
+# `download.redis.io/redis-stable.tar.gz` happened to be, causing drift
+# between Build and Sanitizer test runs.
 
 # Create virtual environment
 RUN set -ex ;\


### PR DESCRIPTION
## Summary

**All build/CI infrastructure** for the RediSearch 8.6 migration — the toolchain images *and* the CI that builds/consumes them, together in one PR. The code change ([#2102](https://github.com/FalkorDB/FalkorDB/pull/2102)) stacks on this.

Contains only `.github/`, `build/docker/`, `tests/Dockerfile.*`, and `build.sh` — no `src/`/`deps/`.

- **`build/docker/builder/Dockerfile.*`** — per-OS toolchain images building **redis 8.6.3** from source (redis `COPY` last for layer-cache reuse). `Dockerfile.compiler` + runtime/test images updated for the 8.6.3 base.
- **`build-toolchain.yml` / `cleanup-rc-images.yml`** — build/publish per-PR RC toolchain images (`ghcr…/falkordb-build:<os>-pr-N`) and GC them.
- **`build.yml`** — `check-builder-changes` + `build-rc-toolchain` + `promote-toolchain` (+ `find-pr`); least-privilege permissions; test/security-scan gating (`!cancelled() && != skipped`).
- **`sanitize`/`coverage`/`codeql`/`benchmark`** — detect + consume the PR's RC toolchain image; RediSearch-submodule-SHA cache key.
- **`build.sh`** — `-DRUST_TOOLCHAIN_MODIFIER=+nightly` under SAN.

### ⚠️ First-run note
Standing up a brand-new toolchain-image system means the **first** CI run can need a **rerun**: the per-PR RC image must publish before the parallel `sanitize`/`coverage`/`codeql` jobs pull it, and there's no promoted stable `:<os>` to fall back to yet. After the RC publishes, a rerun is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable toolchain detector plus automated multi-architecture toolchain/image build and cleanup workflows.
* **Chores**
  * CI now uses caller-selected toolchain images, tightens workflow permissions, and updates gating logic.
  * Caching improved to invalidate when the pinned RediSearch reference changes.
  * Test images now rely on toolchain-provided Redis binaries.
* **Documentation**
  * Expanded builder toolchain README with usage, tagging and image-resolution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->