### PR TITLE
stop bulk deletion from silently failing

### DIFF
--- a/src/graph/graph_delete_nodes.c
+++ b/src/graph/graph_delete_nodes.c
@@ -40,9 +40,9 @@ void Graph_DeleteNodes
 	ASSERT (nodes      != NULL) ;
 	ASSERT (node_count > 0) ;
 
-	// set matrix sync policy to NOP
+	// set matrix sync policy to RESIZE
 	MATRIX_POLICY policy = Graph_GetMatrixPolicy (g) ;
-	Graph_SetMatrixPolicy (g, SYNC_POLICY_NOP) ;
+	Graph_SetMatrixPolicy (g, SYNC_POLICY_RESIZE) ;
 
 #if RG_DEBUG
 	Edge *es = arr_new (Edge, 0) ;
@@ -136,7 +136,7 @@ void Graph_DeleteNodes
 	// phase two
 	//--------------------------------------------------------------------------
 
-	Delta_Matrix_removeElements (lbls, elems, NULL) ;
+	GrB_OK (Delta_Matrix_removeElements (lbls, elems, NULL)) ;
 
 	// restore matrix sync policy
 	Graph_SetMatrixPolicy (g, policy) ;

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -535,6 +535,26 @@ class testGraphDeletionFlow(FlowTestsBase):
         self.env.assertEquals(result[1][0], b)
         self.env.assertEquals(result[2][0], a1)
 
+    def test25_delete_does_not_leave_phantom_label_entries(self):
+        # clean the db
+        self.graph.delete()
+
+        # create a single labeled node and then grow the graph dimensions
+        self.graph.query("CREATE (ghost:BOO)")
+        self.graph.query("UNWIND range(0, 100000) AS x CREATE ()")
+
+        # delete a subset that includes the BOO node (id 0)
+        res = self.graph.query("MATCH (x) WITH x LIMIT 10000 DELETE x")
+        self.env.assertEquals(res.nodes_deleted, 10000)
+
+        # regression: deleted node must not remain discoverable via label scan
+        res = self.graph.query("MATCH (x:BOO) RETURN count(x)")
+        self.env.assertEquals(res.result_set[0][0], 0)
+
+        # regression: property access on labeled result must not hit undefined attribute
+        res = self.graph.query("MATCH (x:BOO) WHERE x.id = 0 RETURN x")
+        self.env.assertEquals(res.result_set, [])
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()
@@ -796,4 +816,3 @@ class testGraphBulkDeletion(FlowTestsBase):
         self.env.assertEquals(relTypes,  relTypes_expected)
         self.env.assertEquals(relCount,  relCount_expected)
         self.env.assertEquals(nodeCount, nodeCount_expected)
-


### PR DESCRIPTION
solves #2103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting nodes could leave stray label entries, ensuring deleted nodes are no longer discoverable by label queries.

* **Tests**
  * Added a regression test that verifies label cleanup after node deletion to prevent phantom label lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->