### PR TITLE
Fix NULL pointer dereference in costBaseLabelScan optimization

### DIFF
--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -297,14 +297,24 @@ static void _costBaseLabelScan
 	}
 
 	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
-		// no AE to swap operands on; nothing to do here
-		return ;
-	}
+	AlgebraicExpression *ae = NULL;
 
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
+	switch (t) {
+		case OPType_CONDITIONAL_TRAVERSE:
+		case OPType_OPTIONAL_CONDITIONAL_TRAVERSE:
+			ae = ((OpCondTraverse*) parent)->ae;
+			break;
+		case OPType_EXPAND_INTO:
+			ae = ((OpExpandInto*) parent)->ae;
+			break;
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE:
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO:
+			ae = ((CondVarLenTraverse*) parent)->ae;
+			break;
+		default:
+			// no AE to swap operands on; nothing to do here
+			return;
+	}
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;


### PR DESCRIPTION
This PR fixes a crash in the `costBaseLabelScan` optimization where it failed to handle variable length traversals and optional traversals, leading to a NULL pointer dereference when attempting to access the `AlgebraicExpression` field.

The fix expands the supported `OPType` in `_costBaseLabelScan` to include:
- `OPType_OPTIONAL_CONDITIONAL_TRAVERSE`
- `OPType_CONDITIONAL_VAR_LEN_TRAVERSE`
- `OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO`

Fixes #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced query optimizer to support additional traversal operation variants, enabling improved execution plan cost estimation for a broader range of graph queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->