### PR TITLE
ci(build): decouple promote-toolchain from the app build (fix unpublished stable images)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -801,23 +801,10 @@ jobs:
   # promotion via `docker buildx imagetools create` — no rebuild. The
   # cleanup-rc-images workflow eventually sweeps the orphan :<os>-pr-<N> tag.
   promote-toolchain:
-    # Promote the merging PR's RC toolchain image (:<os>-pr-<N>) to the stable
-    # :<os> tag by retagging the existing multi-arch manifest — no rebuild, so
-    # what PR CI validated is byte-identically what becomes :<os>.
-    #
-    # Depends ONLY on check-builder-changes, an entry job that always runs on a
-    # push and is never skipped, so there is no skipped dependency to propagate
-    # and no always()/status function is needed.
-    #
-    # We deliberately do NOT gate on the `build` job: a toolchain image's
-    # validity is independent of whether the FalkorDB app compiles, and the RC
-    # was already exercised end-to-end in the PR's CI. Gating on `build` is also
-    # exactly what broke promotion before — `build` transitively depends on the
-    # PR-only `build-rc-toolchain` (skipped on push), and GitHub propagated that
-    # skip down to promote, which (lacking a status function) was skipped before
-    # its conditions ran, leaving the stable :<os> images unpublished after the
-    # toolchain PR merged. Mirrors the promote step in
-    # FalkorDB/falkordb-rs-next-gen.
+    # Retag the PR's RC image (:<os>-pr-<N>) to stable :<os> — no rebuild.
+    # Depends only on check-builder-changes (never skipped on push), not on
+    # `build`: toolchain validity is independent of the app build, and gating on
+    # `build` propagated build-rc-toolchain's push-time skip to promote.
     needs: check-builder-changes
     if: |
       github.event_name == 'push' &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -802,7 +802,15 @@ jobs:
   # cleanup-rc-images workflow eventually sweeps the orphan :<os>-pr-<N> tag.
   promote-toolchain:
     needs: [check-builder-changes, build]
+    # always() is required: build-rc-toolchain is PR-only, so it is SKIPPED on
+    # the master push. GitHub propagates that skip down the needs chain
+    # (build-rc-toolchain -> build -> promote-toolchain); without a status
+    # function here, promote is skipped before its conditions are even
+    # evaluated — which is what left the stable :<os> images unpublished after
+    # the toolchain PR merged. (The `build` job carries always() for the same
+    # reason.)
     if: |
+      always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
       needs.check-builder-changes.outputs.any_changed == 'true' &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -801,21 +801,29 @@ jobs:
   # promotion via `docker buildx imagetools create` — no rebuild. The
   # cleanup-rc-images workflow eventually sweeps the orphan :<os>-pr-<N> tag.
   promote-toolchain:
-    needs: [check-builder-changes, build]
-    # always() is required: build-rc-toolchain is PR-only, so it is SKIPPED on
-    # the master push. GitHub propagates that skip down the needs chain
-    # (build-rc-toolchain -> build -> promote-toolchain); without a status
-    # function here, promote is skipped before its conditions are even
-    # evaluated — which is what left the stable :<os> images unpublished after
-    # the toolchain PR merged. (The `build` job carries always() for the same
-    # reason.)
+    # Promote the merging PR's RC toolchain image (:<os>-pr-<N>) to the stable
+    # :<os> tag by retagging the existing multi-arch manifest — no rebuild, so
+    # what PR CI validated is byte-identically what becomes :<os>.
+    #
+    # Depends ONLY on check-builder-changes, an entry job that always runs on a
+    # push and is never skipped, so there is no skipped dependency to propagate
+    # and no always()/status function is needed.
+    #
+    # We deliberately do NOT gate on the `build` job: a toolchain image's
+    # validity is independent of whether the FalkorDB app compiles, and the RC
+    # was already exercised end-to-end in the PR's CI. Gating on `build` is also
+    # exactly what broke promotion before — `build` transitively depends on the
+    # PR-only `build-rc-toolchain` (skipped on push), and GitHub propagated that
+    # skip down to promote, which (lacking a status function) was skipped before
+    # its conditions ran, leaving the stable :<os> images unpublished after the
+    # toolchain PR merged. Mirrors the promote step in
+    # FalkorDB/falkordb-rs-next-gen.
+    needs: check-builder-changes
     if: |
-      always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
       needs.check-builder-changes.outputs.any_changed == 'true' &&
-      needs.check-builder-changes.outputs.merged_pr != '' &&
-      needs.build.result == 'success'
+      needs.check-builder-changes.outputs.merged_pr != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

After #2101 merged, every master build / PR that doesn't touch a builder Dockerfile fails with `ghcr.io/falkordb/falkordb-build:<os>: not found` — the **stable** toolchain images were never published.

## Root cause

`promote-toolchain` depended on the `build` job and gated on `needs.build.result == 'success'`. `build` transitively depends on the **PR-only** `build-rc-toolchain`, which is **skipped** on the master push. GitHub propagates a skipped state down the `needs` chain, and a downstream job whose `if` lacks a status function is skipped **before its conditions are evaluated**. So promote was skipped on the #2101 merge despite every condition being satisfied, and the stable `:<os>` images were never published.

## Fix

Converge `promote-toolchain` onto the proven pattern in [FalkorDB/falkordb-rs-next-gen](https://github.com/FalkorDB/falkordb-rs-next-gen)'s `rust-push.yml`:

- **Depend only on `check-builder-changes`** — an entry job that always runs on push and is never skipped. No skipped dependency to propagate ⇒ no `always()`/status function needed.
- **Drop the `build` gate.** A toolchain image's validity is independent of whether the FalkorDB app compiles, and the RC was already exercised end-to-end in the PR's CI. Promotion is a pure byte-identical retag (`imagetools create`) of `:<os>-pr-<N>` → `:<os>`.

This **structurally** cannot hit the skip-propagation footgun, rather than papering over it with `always()`.

The current breakage was recovered by republishing the 7 stable images via `build-toolchain.yml` `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Decoupled toolchain promotion from the app build process so promotion runs independently; promotion now triggers only when relevant changes are detected and a merged PR exists, preventing skipped promotions and helping ensure stable manifests are published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->