### PR TITLE
fix floating point vector compare

### DIFF
--- a/src/datatypes/vector.c
+++ b/src/datatypes/vector.c
@@ -129,17 +129,18 @@ int SIVector_Compare
 	uint32_t dim_a = va->dim;
 	uint32_t dim_b = vb->dim;
 
-	if(dim_a > dim_b) return 1;
-	if(dim_a < dim_b) return -1;
+	if (dim_a > dim_b) return 1;
+	if (dim_a < dim_b) return -1;
 
 	// compare vectors' elements
 	float *elements_a = (float*)va->elements;
 	float *elements_b = (float*)vb->elements;
 
 	for(uint32_t i = 0; i < dim_a; i++) {
-		if (elements_a[i] > elements_b[i]){
-			return 1;
-		} else if(elements_a[i] < elements_b[i]) {
+		if (elements_a[i] != elements_b[i]) {
+			if (elements_a[i] > elements_b[i]) {
+				return 1;
+			}
 			return -1;
 		}
 	}

--- a/src/datatypes/vector.c
+++ b/src/datatypes/vector.c
@@ -129,15 +129,18 @@ int SIVector_Compare
 	uint32_t dim_a = va->dim;
 	uint32_t dim_b = vb->dim;
 
-	if(dim_a != dim_b) return dim_a - dim_b;
+	if(dim_a > dim_b) return 1;
+	if(dim_a < dim_b) return -1;
 
 	// compare vectors' elements
 	float *elements_a = (float*)va->elements;
 	float *elements_b = (float*)vb->elements;
 
 	for(uint32_t i = 0; i < dim_a; i++) {
-		if(elements_a[i] != elements_b[i]) {
-			return elements_a[i] - elements_b[i];
+		if (elements_a[i] > elements_b[i]){
+			return 1;
+		} else if(elements_a[i] < elements_b[i]) {
+			return -1;
 		}
 	}
 

--- a/tests/unit/test_vector.c
+++ b/tests/unit/test_vector.c
@@ -112,6 +112,20 @@ void test_vector_compare(void) {
 	b_f_elements[0] = 1;
 	TEST_ASSERT(SIVector_Compare(a, b) < 0);
 
+	for(int i = 0; i < 3; i++) {
+		a_f_elements[i] = i / 10.0;
+		b_f_elements[i] = i / 10.0;
+	}
+
+	TEST_ASSERT(SIVector_Compare(a, b) == 0);
+
+	a_f_elements[0] = .21;
+	TEST_ASSERT(SIVector_Compare(a, b) > 0);
+
+	a_f_elements[0] = 0;
+	b_f_elements[0] = .1;
+	TEST_ASSERT(SIVector_Compare(a, b) < 0);
+
 	SIVector_Free(a);
 	SIVector_Free(b);
 }


### PR DESCRIPTION
solves #2099
solves #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized vector comparisons to consistently return only -1, 0, or 1 for dimension mismatches and element differences, ensuring predictable ordering behavior.

* **Tests**
  * Updated unit tests for vector comparison to use fractional values and validate the revised ordering semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->