### PR TITLE
abort cron timeout when failing to queue write query

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -519,6 +519,11 @@ void _query
 	return ;
 
 cleanup:
+	// avoid timeout callbacks touching a plan that is about to be freed
+	if(timeout_task != 0) {
+		Cron_AbortTask(timeout_task);
+	}
+
 	// if there were any query compile time errors, report them
 	if (ErrorCtx_EncounteredError ()) {
 		ErrorCtx_EmitException () ;
@@ -547,3 +552,4 @@ void Graph_Query
 ) {
 	_query (false, args) ;
 }
+

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -21,7 +21,7 @@
 
 // allocate a new ExecutionPlan segment
 inline ExecutionPlan *ExecutionPlan_NewEmptyExecutionPlan(void) {
-	return rm_calloc(1, sizeof(ExecutionPlan));
+	return rm_calloc (1, sizeof (ExecutionPlan)) ;
 }
 
 void ExecutionPlan_PopulateExecutionPlan
@@ -548,18 +548,47 @@ ResultSet *ExecutionPlan_Execute(ExecutionPlan *plan) {
 // Execution plan draining
 //------------------------------------------------------------------------------
 
-// return true if execution plan been drained
-// false otherwise
-bool ExecutionPlan_Drained(ExecutionPlan *plan) {
-	ASSERT(plan != NULL);
-	return atomic_load(&plan->drained);
+// NOP operation consume routine for immediately terminating execution.
+static Record deplete_consume
+(
+	struct OpBase *op
+) {
+	return NULL ;
 }
 
-// Mark execution-plan as drained.
-// Consumers check this flag and stop execution.
-void ExecutionPlan_Drain(ExecutionPlan *plan) {
-	ASSERT(plan != NULL);
-	atomic_store(&plan->drained, true);
+// return true if execution plan been drained
+// false otherwise
+bool ExecutionPlan_Drained
+(
+	ExecutionPlan *plan
+) {
+	ASSERT (plan != NULL) ;
+	return atomic_load (&plan->drained) ;
+}
+
+static void _ExecutionPlan_Drain
+(
+	OpBase *root
+) {
+	root->consume = deplete_consume ;
+	for (int i = 0; i < root->childCount; i++) {
+		_ExecutionPlan_Drain (root->children [i]) ;
+	}
+}
+
+// mark execution-plan as drained
+// consumers check this flag and stop execution
+void ExecutionPlan_Drain
+(
+	ExecutionPlan *plan
+) {
+	ASSERT (plan != NULL) ;
+
+	if (plan->root != NULL) {
+		_ExecutionPlan_Drain (plan->root) ;
+	}
+
+	atomic_store (&plan->drained, true) ;
 }
 
 //------------------------------------------------------------------------------

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -548,31 +548,18 @@ ResultSet *ExecutionPlan_Execute(ExecutionPlan *plan) {
 // Execution plan draining
 //------------------------------------------------------------------------------
 
-// NOP operation consume routine for immediately terminating execution.
-static Record deplete_consume(struct OpBase *op) {
-	return NULL;
-}
-
 // return true if execution plan been drained
 // false otherwise
 bool ExecutionPlan_Drained(ExecutionPlan *plan) {
 	ASSERT(plan != NULL);
-	ASSERT(plan->root != NULL);
-	return (plan->root->consume == deplete_consume);
+	return atomic_load(&plan->drained);
 }
 
-static void _ExecutionPlan_Drain(OpBase *root) {
-	root->consume = deplete_consume;
-	for(int i = 0; i < root->childCount; i++) {
-		_ExecutionPlan_Drain(root->children[i]);
-	}
-}
-
-// Resets each operation consume function to simply return NULL
-// this will cause the execution-plan to quickly deplete
+// Mark execution-plan as drained.
+// Consumers check this flag and stop execution.
 void ExecutionPlan_Drain(ExecutionPlan *plan) {
-	ASSERT(plan && plan->root);
-	_ExecutionPlan_Drain(plan->root);
+	ASSERT(plan != NULL);
+	atomic_store(&plan->drained, true);
 }
 
 //------------------------------------------------------------------------------
@@ -701,6 +688,7 @@ void ExecutionPlan_Free
 	OpBase **to_visit = arr_new (OpBase *, 1) ;
 
 	OpBase *op = plan->root ;
+	plan->root = NULL ;
 	arr_append (to_visit, op) ;
 
 	while (arr_len(to_visit) > 0) {

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -21,7 +21,9 @@
 
 // allocate a new ExecutionPlan segment
 inline ExecutionPlan *ExecutionPlan_NewEmptyExecutionPlan(void) {
-	return rm_calloc (1, sizeof (ExecutionPlan)) ;
+	ExecutionPlan *plan = rm_calloc (1, sizeof (ExecutionPlan)) ;
+	atomic_init (&plan->drained, false) ;
+	return plan ;
 }
 
 void ExecutionPlan_PopulateExecutionPlan
@@ -584,11 +586,11 @@ void ExecutionPlan_Drain
 ) {
 	ASSERT (plan != NULL) ;
 
+	atomic_store (&plan->drained, true) ;
+
 	if (plan->root != NULL) {
 		_ExecutionPlan_Drain (plan->root) ;
 	}
-
-	atomic_store (&plan->drained, true) ;
 }
 
 //------------------------------------------------------------------------------

--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -11,6 +11,7 @@
 #include "../resultset/resultset.h"
 #include "../filter_tree/filter_tree.h"
 #include "../util/object_pool/object_pool.h"
+
 #include <stdatomic.h>
 
 typedef struct ExecutionPlan ExecutionPlan;
@@ -22,7 +23,7 @@ struct ExecutionPlan {
 	QueryGraph *query_graph;  // queryGraph representing all graph entities in this segment
 	ObjectPool *record_pool;
 	bool prepared;            // indicates if the execution plan is ready for execute
-	atomic_bool drained; // timeout/abort requested for this execution
+	atomic_bool drained;      // timeout/abort requested for this execution
 };
 
 // creates a new execution plan from AST

--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -11,6 +11,7 @@
 #include "../resultset/resultset.h"
 #include "../filter_tree/filter_tree.h"
 #include "../util/object_pool/object_pool.h"
+#include <stdatomic.h>
 
 typedef struct ExecutionPlan ExecutionPlan;
 
@@ -21,6 +22,7 @@ struct ExecutionPlan {
 	QueryGraph *query_graph;  // queryGraph representing all graph entities in this segment
 	ObjectPool *record_pool;
 	bool prepared;            // indicates if the execution plan is ready for execute
+	atomic_bool drained; // timeout/abort requested for this execution
 };
 
 // creates a new execution plan from AST

--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -9,7 +9,6 @@
 #include "op_sort.h"
 #include "op_project.h"
 #include "op_aggregate.h"
-#include "../execution_plan.h"
 #include "../../util/rmalloc.h"
 #include "../../util/simple_timer.h"
 
@@ -103,12 +102,8 @@ inline Record OpBase_Consume
 (
 	OpBase *op
 ) {
-	ASSERT(op != NULL);
-	if(ExecutionPlan_Drained((ExecutionPlan *)op->plan)) {
-		return NULL;
-	}
-
-	return op->consume(op);
+	ASSERT (op != NULL) ;
+	return op->consume (op) ;
 }
 
 // returns true if operation is aware of all aliases

--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -9,6 +9,7 @@
 #include "op_sort.h"
 #include "op_project.h"
 #include "op_aggregate.h"
+#include "../execution_plan.h"
 #include "../../util/rmalloc.h"
 #include "../../util/simple_timer.h"
 
@@ -103,6 +104,9 @@ inline Record OpBase_Consume
 	OpBase *op
 ) {
 	ASSERT(op != NULL);
+	if(ExecutionPlan_Drained((ExecutionPlan *)op->plan)) {
+		return NULL;
+	}
 
 	return op->consume(op);
 }


### PR DESCRIPTION
Solves #2120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent scheduled query timeout callbacks from running against plans being cleaned up, avoiding use-after-free errors.

* **Refactor**
  * Strengthened execution-plan drained/abort handling with an atomic drained flag and safer traversal/clear-before-free semantics for more robust, thread-safe query shutdown.

* **Style**
  * Minor formatting adjustments in execution flow checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->