### PR TITLE
Guard datablock iterator seek

### DIFF
--- a/src/util/datablock/datablock_iterator.c
+++ b/src/util/datablock/datablock_iterator.c
@@ -100,7 +100,10 @@ void DataBlockIterator_Seek
 	uint64_t idx            // index to seek to
 ) {
 	ASSERT (it != NULL) ;
-	ASSERT (idx <= it->_end_pos) ;
+
+    if(idx > it->_end_pos) {
+       idx = it->_end_pos ;
+     }
 
 	// reset iterator
 	it->_block_pos     = 0 ;


### PR DESCRIPTION
Resolve: #2122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of data block seeking operations—out-of-range seek requests now gracefully settle at the end position instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->