### PR TITLE
Add regression test for optional fixed-length variable traversal

### DIFF
--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -361,3 +361,29 @@ class testOptionalFlow(FlowTestsBase):
 
         self.env.assertEquals(len(res), 10)
 
+    def test28_optional_fixed_length_variable_relationship(self):
+        # Reproduce issue #1404: OPTIONAL MATCH with a fixed-length,
+        # bidirectional variable-length relationship and labeled destination.
+        self.graph.delete()
+
+        q = """CREATE (n8:l1:l5:l10 {id:8}),
+                      (n13:l0 {id:13}),
+                      (n66:l9:l3:l1:l7:l6:l10 {id:66}),
+                      (n13)-[:rt11 {id:4}]->(n8),
+                      (n8)-[:rt6 {id:3}]->(n66)"""
+        self.graph.query(q)
+
+        q = """OPTIONAL MATCH ()-[alias0*2..2]-(n1:l1:l5:l10)
+               RETURN *"""
+        self.graph.query(q)
+
+        q = """OPTIONAL MATCH ()-[alias0*2..2]-(n1:l1:l5:l10)
+               RETURN DISTINCT n1.id
+               ORDER BY n1.id"""
+        res = self.graph.query(q).result_set
+
+        self.env.assertGreater(len(res), 0)
+        for row in res:
+            self.env.assertIn(row[0], [8, 66])
+        self.env.assertNotIn([13], res)
+

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -382,8 +382,5 @@ class testOptionalFlow(FlowTestsBase):
                ORDER BY n1.id"""
         res = self.graph.query(q).result_set
 
-        self.env.assertGreater(len(res), 0)
-        for row in res:
-            self.env.assertIn(row[0], [8, 66])
-        self.env.assertNotIn([13], res)
+        self.env.assertEquals(res, [[8]])
 


### PR DESCRIPTION
## Summary
- add a flow regression test for issue #1404
- cover OPTIONAL MATCH with a fixed-length bidirectional variable-length relationship and a labeled destination
- assert the query completes with labeled destination results and does not return the unlabeled node

## Validation
- make flow-tests TEST=test_optional_match:testOptionalFlow.test28_optional_fixed_length_variable_relationship REDIS_SERVER=/home/hermes/redis-8.0.0/src/redis-server RANDPORTS=1

Refs #1404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering OPTIONAL MATCH behavior with a fixed-length, bidirectional variable-length relationship to ensure correct result filtering and ordering.

**Note:** Test-only update; no user-facing functionality or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->