### PR TITLE
fix: prevent SIGSEGV in self-referential variable-length algebraic expressions

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -11,8 +11,18 @@
 #include "../../query_ctx.h"
 #include "../../algorithms/algorithms.h"
 
-// node with (income + outcome degree) > 2
-// is considered a highly connected node
+//------------------------------------------------------------------------------
+// Algebraic expression construction.
+//------------------------------------------------------------------------------
+
+/**
+ * @brief Checks if a node is highly connected (degree > 2).
+ *
+ * @param qg    Pointer to the query graph.
+ * @param alias Node alias to look up.
+ *
+ * @return true if the node has income + outcome degree > 2, false otherwise.
+ */
 static bool _highly_connected_node
 (
 	const QueryGraph *qg,
@@ -124,11 +134,22 @@ static inline bool _should_divide_expression
 			_referred_entity(e->dest->alias));              // destination node is referenced
 }
 
-// variable length expression must contain only a single operand: the edge being
-// traversed, in cases such as (:labelA)-[e*]->(:labelB) both label A and B
-// are applied via a label matrix operand, this function migrates A and B from a
-// variable length expression to new expressions
-// or completely discards them when possible
+/**
+ * @brief Isolates variable-length edges into individual algebraic expressions.
+ *
+ * Variable length expression must contain only a single operand: the edge being
+ * traversed. In cases such as (:labelA)-[e*]->(:labelB) both label A and B
+ * are applied via a label matrix operand, this function migrates A and B from a
+ * variable length expression to new expressions or completely discards them when
+ * possible.
+ *
+ * @param qg          Pointer to the query graph containing node and edge metadata.
+ * @param expressions Array of algebraic expression pointers to be processed.
+ *
+ * @return A newly allocated array of algebraic expressions where each variable-length
+ *         expression is guaranteed to have a single operand. The caller is responsible
+ *         for freeing the returned array.
+ */
 static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps
 (
 	const QueryGraph *qg,

--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -158,52 +158,63 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps
 		// expression contains a variable length edge
 		QGNode *src = QueryGraph_GetNodeByAlias(qg,
 				AlgebraicExpression_Src(exp));
-
-		// a variable length expression with a labeled source node
-		// we only care about the source label matrix, when it comes to
-		// the first expression, as in the following expressions
-		// src is the destination of the previous expression
-		AlgebraicExpression *op = NULL;
-		if(QGNode_Labeled(src)) {
-			// remove src node matrix from expression
-			op = AlgebraicExpression_RemoveSource(&exp);
-		}
-
-		if(op != NULL) {
-			if(expIdx == 0) {
-				arr_append(res, op);
-			} else {
-				AlgebraicExpression_Free(op);
-			}
-		}
-
-		arr_append(res, exp);
-
-		// if the expression has a labeled destination,
-		// separate it into its own expression
-		op = NULL;
-
-		//----------------------------------------------------------------------
-		// handle destination
-		//----------------------------------------------------------------------
-
 		QGNode *dest = QueryGraph_GetNodeByAlias(qg,
 				AlgebraicExpression_Dest(exp));
 
+		// Self-referential var-len: same alias with different labels
+		const bool self_ref = (src == dest);
+
+		// Extract source and destination label operands BEFORE any mutations
+		AlgebraicExpression *src_op = NULL;
+		AlgebraicExpression *dest_op = NULL;
+
+		if(QGNode_Labeled(src)) {
+			src_op = AlgebraicExpression_RemoveSource(&exp);
+		}
 		if(QGNode_Labeled(dest)) {
-			// remove dest node matrix from expression
-			op = AlgebraicExpression_RemoveDest(&exp);
+			dest_op = AlgebraicExpression_RemoveDest(&exp);
 		}
 
-		if(op != NULL) {
-			// remove destination if following expression isn't a
-			// variable length edge (src/dest sharing) otherwise introduce a new
-			// label expression
-			if(expIdx < expCount - 1 &&
-			   !_AlgebraicExpression_ContainsVariableLengthEdge(qg, expressions[expIdx + 1])) {
-				AlgebraicExpression_Free(op);
+		//----------------------------------------------------------------------
+		// Emit source label operand (unless combined into dest for self-ref)
+		//----------------------------------------------------------------------
+
+		if(self_ref && dest_op != NULL) {
+			// Self-referential: destination labels constrain the same node.
+			// Merge into source label to be applied before traversal.
+			if(src_op != NULL) {
+				src_op = _AlgebraicExpression_MultiplyToTheRight(src_op, dest_op);
 			} else {
-				arr_append(res, op);
+				src_op = dest_op;
+			}
+			dest_op = NULL;
+		}
+
+		if(src_op != NULL) {
+			if(expIdx == 0) {
+				arr_append(res, src_op);
+			} else {
+				AlgebraicExpression_Free(src_op);
+			}
+		}
+
+		//----------------------------------------------------------------------
+		// Emit the base variable-length expression
+		//----------------------------------------------------------------------
+
+		arr_append(res, exp);
+
+		//----------------------------------------------------------------------
+		// Emit remaining destination label operand if needed
+		//----------------------------------------------------------------------
+
+		if(dest_op != NULL) {
+			const bool follow_varlen = (expIdx < expCount - 1) &&
+				_AlgebraicExpression_ContainsVariableLengthEdge(qg, expressions[expIdx + 1]);
+			if(!follow_varlen) {
+				AlgebraicExpression_Free(dest_op);
+			} else {
+				arr_append(res, dest_op);
 			}
 		}
 	}

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -9,7 +9,19 @@
 #include "../../util/rmalloc.h"
 #include "../../configuration/config.h"
 
-// performs inplace re-purposing of an operand into an operation
+//------------------------------------------------------------------------------
+// Utilities for algebraic expressions.
+//------------------------------------------------------------------------------
+
+/**
+ * @brief Performs inplace re-purposing of an operand into an operation.
+ *
+ * Converts an operand node into an operation node in-place, reusing the
+ * existing memory structure.
+ *
+ * @param operand Pointer to the algebraic expression operand to convert.
+ * @param op      The operation type to convert the operand into.
+ */
 void _InplaceRepurposeOperandToOperation
 (
 	AlgebraicExpression *operand,
@@ -24,7 +36,15 @@ void _InplaceRepurposeOperandToOperation
 	rm_free(operation);
 }
 
-// performs inplace re-purposing of an operation into an operand
+/**
+ * @brief Performs inplace re-purposing of an operation into an operand.
+ *
+ * Replaces an operation expression with an operand expression in-place,
+ * appropriately freeing the operation's internal resources.
+ *
+ * @param exp         Pointer to the algebraic expression to replace.
+ * @param replacement Pointer to the replacement operand expression.
+ */
 void _AlgebraicExpression_InplaceRepurpose
 (
 	AlgebraicExpression *exp,
@@ -47,6 +67,15 @@ void _AlgebraicExpression_InplaceRepurpose
 	rm_free(replacement);
 }
 
+/**
+ * @brief Removes a child node from an operation's children array.
+ *
+ * Searches for and removes the specified child from the parent operation,
+ * shifting remaining children and updating the array.
+ *
+ * @param parent Pointer to the parent algebraic expression operation.
+ * @param child  Pointer to the child expression to remove.
+ */
 void _AlgebraicExpression_OperationRemoveChild
 (
 	AlgebraicExpression *parent,
@@ -76,7 +105,13 @@ void _AlgebraicExpression_OperationRemoveChild
 	}
 }
 
-// removes the rightmost direct child node of root
+/**
+ * @brief Removes the rightmost direct child node from an operation.
+ *
+ * @param root Pointer to the root algebraic expression operation.
+ *
+ * @return Pointer to the removed child, or NULL if no child exists.
+ */
 AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 (
 	AlgebraicExpression *root  // Root from which to remove a child.
@@ -92,7 +127,13 @@ AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 	return child;
 }
 
-// removes the leftmost direct child node of root
+/**
+ * @brief Removes the leftmost direct child node from an operation.
+ *
+ * @param root Pointer to the root algebraic expression operation.
+ *
+ * @return Pointer to the removed child, or NULL if no child exists.
+ */
 AlgebraicExpression *_AlgebraicExpression_OperationRemoveSource
 (
 	AlgebraicExpression *root   // Root from which to remove a child.

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -409,6 +409,7 @@ void _AlgebraicExpression_RemoveRedundentOperands
 		for(int j = i-1; j >= 0; j--) {
 			AlgebraicExpression *prev_exp = exps[j];
 			const char *dest_alias = AlgebraicExpression_Dest(prev_exp);
+			if(dest_alias == NULL) continue;
 			if(strcmp(src_alias, dest_alias)) continue;
 
 			resolved = (AlgebraicExpression_DiagonalOperand(

--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -9,6 +9,7 @@
 #include "../ops/op_expand_into.h"
 #include "../ops/op_node_by_label_scan.h"
 #include "../ops/op_conditional_traverse.h"
+#include "../ops/op_cond_var_len_traverse.h"
 #include "../execution_plan_build/execution_plan_util.h"
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
@@ -273,6 +274,28 @@ static bool _transposeExpression
 	return true;
 }
 
+static AlgebraicExpression *_TraversalAlgebraicExpression
+(
+	OpBase *op
+) {
+	if(op == NULL) {
+		return NULL;
+	}
+
+	switch(OpBase_Type(op)) {
+		case OPType_CONDITIONAL_TRAVERSE:
+		case OPType_OPTIONAL_CONDITIONAL_TRAVERSE:
+			return ((OpCondTraverse*)op)->ae;
+		case OPType_EXPAND_INTO:
+			return ((OpExpandInto*)op)->ae;
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE:
+		case OPType_CONDITIONAL_VAR_LEN_TRAVERSE_EXPAND_INTO:
+			return ((CondVarLenTraverse*)op)->ae;
+		default:
+			return NULL;
+	}
+}
+
 static void _costBaseLabelScan
 (
 	NodeByLabelScan *scan
@@ -287,24 +310,19 @@ static void _costBaseLabelScan
 	const char *node_alias = n_ctx->alias ;
 
 	// determine the parent traversal op (if any) below filters
-	// (CondTraverse or ExpandInto) - its algebraic expression is the
-	// authoritative source of truth for which labels are in scope on
-	// this scan's alias
+	// its algebraic expression is the authoritative source of truth
+	// for which labels are in scope on this scan's alias
 
 	OpBase *parent = op->parent ;
 	while (parent != NULL && OpBase_Type (parent) == OPType_FILTER) {
 		parent = parent->parent ;
 	}
 
-	OPType t = (parent != NULL) ? OpBase_Type (parent) : OPType_AGGREGATE ;
-	if (t != OPType_CONDITIONAL_TRAVERSE && t != OPType_EXPAND_INTO) {
+	AlgebraicExpression *ae = _TraversalAlgebraicExpression(parent);
+	if (ae == NULL) {
 		// no AE to swap operands on; nothing to do here
 		return ;
 	}
-
-	AlgebraicExpression *ae = (t == OPType_CONDITIONAL_TRAVERSE)
-		? ((OpCondTraverse*) parent)->ae
-		: ((OpExpandInto*)   parent)->ae ;
 
 	// collect operands from the parent AE
 	uint operand_n = 0 ;

--- a/src/execution_plan/optimizations/cost_base_label_scan.c
+++ b/src/execution_plan/optimizations/cost_base_label_scan.c
@@ -14,6 +14,10 @@
 #include "../execution_plan_build/execution_plan_modify.h"
 #include "../../arithmetic/algebraic_expression/utils.h"
 
+//------------------------------------------------------------------------------
+// Cost-based label scan optimization for execution plans.
+//------------------------------------------------------------------------------
+
 // this optimization scans through each label-scan operation
 // in case the node being scaned is associated with multiple labels
 // e.g. MATCH (n:A:B) RETURN n
@@ -274,6 +278,16 @@ static bool _transposeExpression
 	return true;
 }
 
+/**
+ * @brief Extracts algebraic expression from a traversal operation.
+ *
+ * Retrieves the algebraic expression from various traversal operation types
+ * including conditional traverse, expand_into, and variable-length traverse.
+ *
+ * @param op Pointer to the operation base.
+ *
+ * @return Pointer to the algebraic expression, or NULL if not found.
+ */
 static AlgebraicExpression *_TraversalAlgebraicExpression
 (
 	OpBase *op
@@ -296,6 +310,14 @@ static AlgebraicExpression *_TraversalAlgebraicExpression
 	}
 }
 
+/**
+ * @brief Performs cost-based label scan optimization.
+ *
+ * Scans through each label-scan operation and optimizes by preferring
+ * the label with the least number of nodes when multiple labels are present.
+ *
+ * @param scan Pointer to the node by label scan operation.
+ */
 static void _costBaseLabelScan
 (
 	NodeByLabelScan *scan


### PR DESCRIPTION
## fix: prevent SIGSEGV in self-referential variable-length algebraic expressions

### Abstract

Self-referential variable-length path patterns `(n:A)<-[*..]->(n:B)` with differing labels on the same alias trigger a NULL pointer dereference in `AlgebraicExpression_Dest()`. The fix implements atomic operand extraction to ensure source and destination label operands are captured before any AST mutations, preventing intermediate NULL states that caused the crash.

### Root Cause

In `_AlgebraicExpression_IsolateVariableLenExps()`, label extraction was performed sequentially: first `AlgebraicExpression_RemoveSource()` modified the expression tree, then `AlgebraicExpression_Dest(exp)` was called on the partially-stripped expression. For self-referential traversals with different labels, this second call returned NULL because the expression's operand source/destination pointers had been cleared. The subsequent `exp->operand.dest` access in `AlgebraicExpression_Dest()` at `algebraic_expression_operand.c:151` then dereferenced this NULL, producing SIGSEGV.

### Architectural Correction

**Atomic Operand Extraction:** Both source and destination label operands are now extracted BEFORE any AST mutations. For self-referential paths, destination labels are merged into source via `_AlgebraicExpression_MultiplyToTheRight()` applied pre-traversal.

**Defensive NULL Guard:** Added NULL check in `_AlgebraicExpression_RemoveRedundentOperands()` to survive edge cases.

### Verification

All three fuzzer queries from Issue #636 now execute cleanly:

- `MERGE (:label8) MERGE (:label2{})<-[:reltype5]-(node_0{})<-[:reltype7]-({})`
- `MATCH (node_0:label8{})<-[*..]-(node_0:label9) WHERE node_0.prop7 = [ FALSE ] RETURN *`
- `MATCH (node_0:label8{})<-[*..]-(node_0:label9) RETURN *`

Fixes #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential null pointer dereference in algebraic expression handling.

* **Refactor**
  * Improved internal algebraic expression logic for variable-length operand isolation.
  * Enhanced optimization logic for traversal cost calculations.

* **Documentation**
  * Expanded documentation for internal algebraic expression utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->