### PR TITLE
Fix zero-stream CartesianProduct depletion

### DIFF
--- a/src/execution_plan/ops/op_cartesian_product.c
+++ b/src/execution_plan/ops/op_cartesian_product.c
@@ -134,6 +134,10 @@ static Record CartesianProductConsume
 		return _YieldRecord(opBase);
 	}
 
+	// A zero-stream cartesian product is an identity stream: it emits one
+	// empty record on its first consume and then depletes.
+	if(op->op.childCount == 0) return NULL;
+
 	// pull from first stream
 	child = op->op.children[0];
 	childRecord = OpBase_Consume(child);
@@ -199,4 +203,3 @@ static void CartesianProductFree
 		rm_free(op->records);
 	}
 }
-

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -361,3 +361,19 @@ class testOptionalFlow(FlowTestsBase):
 
         self.env.assertEquals(len(res), 10)
 
+    def test28_optional_with_alias_cartesian_product(self):
+        # Regression test for issue #1280: carrying n0 through WITH as alias4
+        # and matching both variables must not crash.
+        self.graph.delete()
+
+        query = """OPTIONAL MATCH (n0)
+                   WITH *, n0 AS alias4
+                   MATCH (n0), (alias4)
+                   RETURN n0"""
+
+        self.graph.query(query)
+
+        self.graph.query("CREATE ()")
+
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(len(actual_result.result_set), 1)


### PR DESCRIPTION
/claim #1280

## Summary
- make a zero-stream CartesianProduct emit its identity row once and then deplete instead of reading child 0 on the next consume
- add a regression test for the reported `OPTIONAL MATCH ... WITH *, n0 AS alias4 ... MATCH (n0), (alias4)` query shape

## Testing
- `git diff --check`
- `python3 -m py_compile tests/flow/test_optional_match.py`
- `make flow-tests TEST=tests/flow/test_optional_match.py` was attempted, but local execution is blocked before compilation because required submodules are unavailable: `deps/rax/rax.c` is missing after the recursive submodule fetch stalled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the Cartesian product operation when it encounters an empty child scenario.

* **Tests**
  * Added a regression test covering optional match queries that carry a variable through `WITH` as an alias, then combine it in a subsequent mandatory match—ensuring stable results even after creating an empty node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->