### PR TITLE
abort and free unioned subqueries

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -55,33 +55,53 @@ void ExecutionPlan_PopulateExecutionPlan
 	}
 }
 
-static ExecutionPlan *_ExecutionPlan_UnionPlans(AST *ast) {
-	uint end_offset = 0;
-	uint start_offset = 0;
-	uint clause_count = cypher_ast_query_nclauses(ast->root);
-	uint *union_indices = AST_GetClauseIndices(ast, CYPHER_AST_UNION);
-	arr_append(union_indices, clause_count);
-	int union_count = arr_len(union_indices);
-	ASSERT(union_count > 1);
+static ExecutionPlan *_ExecutionPlan_UnionPlans
+(
+	AST *ast
+) {
+	uint end_offset   = 0 ;
+	uint start_offset = 0 ;
+	uint clause_count = cypher_ast_query_nclauses (ast->root) ;
+	uint *union_indices = AST_GetClauseIndices (ast, CYPHER_AST_UNION) ;
+	arr_append (union_indices, clause_count) ;
+	int union_count = arr_len (union_indices) ;
+	ASSERT (union_count > 1) ;
 
 	// Placeholder for each execution plan, these all will be joined
 	// via a single UNION operation
-	ExecutionPlan *plans[union_count];
+	ExecutionPlan *plans [union_count] ;
 
-	for(int i = 0; i < union_count; i++) {
+	int i = 0 ;
+	for (; i < union_count ; i++) {
 		// Create an AST segment from which we will build an execution plan.
-		end_offset = union_indices[i];
-		AST *ast_segment = AST_NewSegment(ast, start_offset, end_offset);
-		plans[i] = ExecutionPlan_FromTLS_AST();
-		AST_Free(ast_segment); // Free the AST segment.
+		end_offset = union_indices [i] ;
+		AST *ast_segment = AST_NewSegment (ast, start_offset, end_offset) ;
+		plans [i] = ExecutionPlan_FromTLS_AST () ;
+		AST_Free (ast_segment) ; // free the AST segment
 
-		// Next segment starts where this one ends.
-		start_offset = union_indices[i] + 1;
+		// check if the sub query triggered an error
+		// if so clean up and return
+		if (ErrorCtx_EncounteredError ()) {
+			break ;
+		}
+
+		// next segment starts where this one ends
+		start_offset = union_indices [i] + 1 ;
 	}
 
-	QueryCtx_SetAST(ast); // AST segments have been freed, set master AST in QueryCtx.
+	QueryCtx_SetAST (ast); // AST segments have been freed, set master AST in QueryCtx
 
-	arr_free(union_indices);
+	arr_free (union_indices) ;
+
+	if (ErrorCtx_EncounteredError ()) {
+		// clean up
+		while (i >= 0) {
+			ExecutionPlan_Free (plans [i]) ;
+			i-- ;
+		}
+
+		return NULL ;
+	}
 
 	/* Join streams:
 	 * MATCH (a) RETURN a UNION MATCH (a) RETURN a ....
@@ -99,7 +119,7 @@ static ExecutionPlan *_ExecutionPlan_UnionPlans(AST *ast) {
 	OpBase *parent = results_op;
 	ExecutionPlan_UpdateRoot(plan, results_op);
 
-	// Introduce distinct only if `ALL` isn't specified.
+	// introduce distinct only if `ALL` isn't specified
 	const cypher_astnode_t *union_clause = AST_GetClause(ast, CYPHER_AST_UNION,
 														 NULL);
 	if(!cypher_ast_union_has_all(union_clause)) {
@@ -139,7 +159,7 @@ static ExecutionPlan *_ExecutionPlan_UnionPlans(AST *ast) {
 		ExecutionPlan_AddOp(join_op, sub_plan->root);
 	}
 
-	return plan;
+	return plan ;
 }
 
 static ExecutionPlan *_process_segment

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -94,13 +94,16 @@ static ExecutionPlan *_ExecutionPlan_UnionPlans
 	arr_free (union_indices) ;
 
 	if (ErrorCtx_EncounteredError ()) {
+		ExecutionPlan *err_plan = plans [i] ;
+		i-- ;
+
 		// clean up
 		while (i >= 0) {
 			ExecutionPlan_Free (plans [i]) ;
 			i-- ;
 		}
 
-		return NULL ;
+		return err_plan ;
 	}
 
 	/* Join streams:

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -172,3 +172,47 @@ class testUnion(FlowTestsBase):
         self.env.assertEquals(len(result.result_set), 1)
         self.env.assertEquals(result.result_set, [[0]])
         self.env.assertEquals(result.nodes_created, 2)
+
+    def test10_union_invalid_sub_query(self):
+        """
+        make sure a union query with an invalid sub-query fails gracefully
+        """
+
+        # WHERE EXISTS((p)-->() ) is invalid, we do not support passing
+        # traversal patterns into the exists function
+
+        q = """MATCH (p)
+               WHERE EXISTS((p)-->() )
+               RETURN 1 AS x
+
+               UNION
+
+               MATCH (p)
+               WITH p
+               RETURN 2 AS x"""
+
+        try:
+            self.graph.query(q)
+            # fail if query did not returned an error
+            self.env.assertFalse(True)
+        except Exception:
+            pass
+
+        # reverse sub-queries
+        q = """MATCH (p)
+               WITH p
+               RETURN 2 AS x
+
+               UNION
+
+               MATCH (p)
+               WHERE EXISTS((p)-->() )
+               RETURN 1 AS x"""
+
+        try:
+            self.graph.query(q)
+            # fail if query did not returned an error
+            self.env.assertFalse(True)
+        except Exception:
+            pass
+


### PR DESCRIPTION
Resolve: #2144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error detection and handling for `UNION` queries so invalid subqueries reliably trigger failures instead of continuing with execution.

* **Tests**
  * Added a new flow test covering invalid `UNION` subquery clauses to ensure the system correctly raises errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->