### PR TITLE
Fix optimizer rewrite

### DIFF
--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -35,11 +35,11 @@ static inline AlgebraicExpression *_ParentTraverseAE
 (
 	OpBase *parent
 ) {
-	ASSERT(parent != NULL);
+	ASSERT (parent != NULL) ;
 	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
 		return ((OpCondTraverse*) parent)->ae;
 	}
-	ASSERT(parent->type == OPType_EXPAND_INTO);
+	ASSERT (parent->type == OPType_EXPAND_INTO);
 	return ((OpExpandInto*) parent)->ae;
 }
 
@@ -48,21 +48,21 @@ static inline void _SetParentTraverseAE
 	OpBase *parent,
 	AlgebraicExpression *ae
 ) {
-	ASSERT(parent != NULL);
+	ASSERT (parent != NULL) ;
 	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
 		((OpCondTraverse*) parent)->ae = ae;
 	} else {
-		ASSERT(parent->type == OPType_EXPAND_INTO);
+		ASSERT (parent->type == OPType_EXPAND_INTO) ;
 		((OpExpandInto*) parent)->ae = ae;
 	}
 }
 
 static void _removeRedundantTraversal(ExecutionPlan *plan, OpCondTraverse *traverse) {
-	AlgebraicExpression *ae =  traverse->ae;
-	if(AlgebraicExpression_OperandCount(ae) == 1 &&
-	   !strcmp(AlgebraicExpression_Src(ae), AlgebraicExpression_Dest(ae))) {
-		ExecutionPlan_RemoveOp(plan, (OpBase *)traverse);
-		OpBase_Free((OpBase *)traverse);
+	AlgebraicExpression *ae =  traverse->ae ;
+	if(AlgebraicExpression_OperandCount (ae) == 1 &&
+	   !strcmp(AlgebraicExpression_Src (ae), AlgebraicExpression_Dest (ae))) {
+		ExecutionPlan_RemoveOp (plan, (OpBase *) traverse);
+		OpBase_Free ((OpBase *) traverse) ;
 	}
 }
 
@@ -223,7 +223,9 @@ void reduceVarLenTraverseDestLabel
 
 		const char *orig_src = AlgebraicExpression_Src (parent_ae) ;
 		const char *orig_dest = AlgebraicExpression_Dest (parent_ae) ;
-		AlgebraicExpression *ae = AlgebraicExpression_Clone (parent_ae) ;
+
+		// shallow copy, will clone if a change is planned for the AE
+		AlgebraicExpression *ae = parent_ae ;
 		bool stripped = false ;
 
 		// strip diagonal source operands that belong to dest_alias; source is
@@ -237,18 +239,23 @@ void reduceVarLenTraverseDestLabel
 				break ;
 			}
 
-			stripped = true ;
-			AlgebraicExpression_Free (
-					AlgebraicExpression_RemoveSource (&ae)) ;
+			if (!stripped) {
+				ae = AlgebraicExpression_Clone (parent_ae) ;
+				stripped = true ;
+			}
+
+			AlgebraicExpression_Free (AlgebraicExpression_RemoveSource (&ae)) ;
 		}
 
 		if (!stripped) {
-			AlgebraicExpression_Free (ae) ;
 			continue ;
 		}
 
 		// rewrite must not alter traversal endpoints; otherwise op metadata
 		// (src/dest record indices) becomes inconsistent with the expression.
+		// TODO: this optimization is not nessesarily incorrect, but we skip it
+		// to avoid having to modify the src and dest in the op. In the future,
+		// it may be worth it to propogate this change instead.
 		if (AlgebraicExpression_OperandCount (ae) > 0 &&
 			(strcmp (orig_src, AlgebraicExpression_Src (ae)) != 0 ||
 			 strcmp (orig_dest, AlgebraicExpression_Dest (ae)) != 0)) {

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -31,38 +31,12 @@ static inline bool _isInSubExecutionPlan(OpBase *op) {
 	return ExecutionPlan_LocateOp(op, OPType_ARGUMENT) != NULL;
 }
 
-static inline AlgebraicExpression *_ParentTraverseAE
-(
-	OpBase *parent
-) {
-	ASSERT (parent != NULL) ;
-	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
-		return ((OpCondTraverse*) parent)->ae;
-	}
-	ASSERT (parent->type == OPType_EXPAND_INTO);
-	return ((OpExpandInto*) parent)->ae;
-}
-
-static inline void _SetParentTraverseAE
-(
-	OpBase *parent,
-	AlgebraicExpression *ae
-) {
-	ASSERT (parent != NULL) ;
-	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
-		((OpCondTraverse*) parent)->ae = ae;
-	} else {
-		ASSERT (parent->type == OPType_EXPAND_INTO) ;
-		((OpExpandInto*) parent)->ae = ae;
-	}
-}
-
 static void _removeRedundantTraversal(ExecutionPlan *plan, OpCondTraverse *traverse) {
-	AlgebraicExpression *ae =  traverse->ae ;
-	if(AlgebraicExpression_OperandCount (ae) == 1 &&
-	   !strcmp(AlgebraicExpression_Src (ae), AlgebraicExpression_Dest (ae))) {
-		ExecutionPlan_RemoveOp (plan, (OpBase *) traverse);
-		OpBase_Free ((OpBase *) traverse) ;
+	AlgebraicExpression *ae =  traverse->ae;
+	if(AlgebraicExpression_OperandCount(ae) == 1 &&
+	   !strcmp(AlgebraicExpression_Src(ae), AlgebraicExpression_Dest(ae))) {
+		ExecutionPlan_RemoveOp(plan, (OpBase *)traverse);
+		OpBase_Free((OpBase *)traverse);
 	}
 }
 
@@ -214,57 +188,41 @@ void reduceVarLenTraverseDestLabel
 			continue ;
 		}
 
-		AlgebraicExpression *parent_ae = _ParentTraverseAE (parent) ;
-		ASSERT (parent_ae != NULL) ;
+		AlgebraicExpression *ae = NULL ;
 
-		if (strcmp (AlgebraicExpression_Src (parent_ae), dest_alias) != 0) {
+		if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
+			ae = ((OpCondTraverse*) parent)->ae ;
+		} else {
+			ae = ((OpExpandInto*) parent)->ae ;
+		}
+		ASSERT (ae != NULL) ;
+
+		if (strcmp (AlgebraicExpression_Src (ae), dest_alias) != 0) {
 			continue ;
 		}
 
-		const char *orig_src = AlgebraicExpression_Src (parent_ae) ;
-		const char *orig_dest = AlgebraicExpression_Dest (parent_ae) ;
-
-		// shallow copy, will clone if a change is planned for the AE
-		AlgebraicExpression *ae = parent_ae ;
-		bool stripped = false ;
-
-		// strip diagonal source operands that belong to dest_alias; source is
-		// evaluated semantically (transpose-aware), not by leftmost operand.
+		// strip every leading diagonal operand that belongs to dest_alias —
+		// these are the label matrices CondVarLenTraverse already enforces
 		while (AlgebraicExpression_OperandCount (ae) > 0) {
+			// find source (aware of transpose)
 			const AlgebraicExpression *src_operand =
-				AlgebraicExpression_SrcOperand (ae) ;
-			if (src_operand == NULL                            ||
-				!AlgebraicExpression_Diagonal (src_operand)    ||
+				AlgebraicExpression_SrcOperand(ae) ;
+
+			if (src_operand == NULL ||
+				!AlgebraicExpression_Diagonal (src_operand) ||
 				strcmp (AlgebraicExpression_Src (ae), dest_alias) != 0) {
 				break ;
-			}
-
-			if (!stripped) {
-				ae = AlgebraicExpression_Clone (parent_ae) ;
-				stripped = true ;
 			}
 
 			AlgebraicExpression_Free (AlgebraicExpression_RemoveSource (&ae)) ;
 		}
 
-		if (!stripped) {
-			continue ;
+		// update operation's algebraic expression
+		if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
+			((OpCondTraverse*) parent)->ae = ae ;
+		} else {
+			((OpExpandInto*) parent)->ae = ae ;
 		}
-
-		// rewrite must not alter traversal endpoints; otherwise op metadata
-		// (src/dest record indices) becomes inconsistent with the expression.
-		// TODO: this optimization is not nessesarily incorrect, but we skip it
-		// to avoid having to modify the src and dest in the op. In the future,
-		// it may be worth it to propogate this change instead.
-		if (AlgebraicExpression_OperandCount (ae) > 0 &&
-			(strcmp (orig_src, AlgebraicExpression_Src (ae)) != 0 ||
-			 strcmp (orig_dest, AlgebraicExpression_Dest (ae)) != 0)) {
-			AlgebraicExpression_Free (ae) ;
-			continue ;
-		}
-
-		_SetParentTraverseAE (parent, ae) ;
-		AlgebraicExpression_Free (parent_ae) ;
 
 		// if the entire AE was label diagonals, the CondTraverse is now empty
 		// and must be removed from the plan

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -31,6 +31,32 @@ static inline bool _isInSubExecutionPlan(OpBase *op) {
 	return ExecutionPlan_LocateOp(op, OPType_ARGUMENT) != NULL;
 }
 
+static inline AlgebraicExpression *_ParentTraverseAE
+(
+	OpBase *parent
+) {
+	ASSERT(parent != NULL);
+	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
+		return ((OpCondTraverse*) parent)->ae;
+	}
+	ASSERT(parent->type == OPType_EXPAND_INTO);
+	return ((OpExpandInto*) parent)->ae;
+}
+
+static inline void _SetParentTraverseAE
+(
+	OpBase *parent,
+	AlgebraicExpression *ae
+) {
+	ASSERT(parent != NULL);
+	if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
+		((OpCondTraverse*) parent)->ae = ae;
+	} else {
+		ASSERT(parent->type == OPType_EXPAND_INTO);
+		((OpExpandInto*) parent)->ae = ae;
+	}
+}
+
 static void _removeRedundantTraversal(ExecutionPlan *plan, OpCondTraverse *traverse) {
 	AlgebraicExpression *ae =  traverse->ae;
 	if(AlgebraicExpression_OperandCount(ae) == 1 &&
@@ -188,34 +214,50 @@ void reduceVarLenTraverseDestLabel
 			continue ;
 		}
 
-		AlgebraicExpression *ae = NULL ;
+		AlgebraicExpression *parent_ae = _ParentTraverseAE (parent) ;
+		ASSERT (parent_ae != NULL) ;
 
-		if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
-			ae = ((OpCondTraverse*) parent)->ae ;
-		} else {
-			ae = ((OpExpandInto*) parent)->ae ;
-		}
-		ASSERT (ae != NULL) ;
-
-		if (strcmp (AlgebraicExpression_Src (ae), dest_alias) != 0) {
+		if (strcmp (AlgebraicExpression_Src (parent_ae), dest_alias) != 0) {
 			continue ;
 		}
 
-		// strip every leading diagonal operand that belongs to dest_alias —
-		// these are the label matrices CondVarLenTraverse already enforces
-		while (AlgebraicExpression_OperandCount (ae) > 0    &&
-				AlgebraicExpression_DiagonalOperand (ae, 0) &&
-				strcmp (AlgebraicExpression_Src (ae), dest_alias) == 0) {
+		const char *orig_src = AlgebraicExpression_Src (parent_ae) ;
+		const char *orig_dest = AlgebraicExpression_Dest (parent_ae) ;
+		AlgebraicExpression *ae = AlgebraicExpression_Clone (parent_ae) ;
+		bool stripped = false ;
+
+		// strip diagonal source operands that belong to dest_alias; source is
+		// evaluated semantically (transpose-aware), not by leftmost operand.
+		while (AlgebraicExpression_OperandCount (ae) > 0) {
+			const AlgebraicExpression *src_operand =
+				AlgebraicExpression_SrcOperand (ae) ;
+			if (src_operand == NULL                            ||
+				!AlgebraicExpression_Diagonal (src_operand)    ||
+				strcmp (AlgebraicExpression_Src (ae), dest_alias) != 0) {
+				break ;
+			}
+
+			stripped = true ;
 			AlgebraicExpression_Free (
 					AlgebraicExpression_RemoveSource (&ae)) ;
 		}
 
-		// update operation's algebraic expression
-		if (parent->type == OPType_CONDITIONAL_TRAVERSE) {
-			((OpCondTraverse*) parent)->ae = ae ;
-		} else {
-			((OpExpandInto*) parent)->ae = ae ;
+		if (!stripped) {
+			AlgebraicExpression_Free (ae) ;
+			continue ;
 		}
+
+		// rewrite must not alter traversal endpoints; otherwise op metadata
+		// (src/dest record indices) becomes inconsistent with the expression.
+		if (AlgebraicExpression_OperandCount (ae) > 0 &&
+			(strcmp (orig_src, AlgebraicExpression_Src (ae)) != 0 ||
+			 strcmp (orig_dest, AlgebraicExpression_Dest (ae)) != 0)) {
+			AlgebraicExpression_Free (ae) ;
+			continue ;
+		}
+
+		_SetParentTraverseAE (parent, ae) ;
+		AlgebraicExpression_Free (parent_ae) ;
 
 		// if the entire AE was label diagonals, the CondTraverse is now empty
 		// and must be removed from the plan

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -548,3 +548,19 @@ class testVariableLengthTraversals(FlowTestsBase):
         count = self.graph.query(q).result_set[0][0]
         self.env.assertEquals(count, 16)
 
+    def test17_var_len_planner_alias_consistency(self):
+        # Regression: planner-time rewrite must keep aliases consistent for
+        # subsequent CondTraverse reconstruction on EXPLAIN/QUERY.
+        self.graph.delete()
+        self.graph.query("CREATE (:__seed__)")
+
+        q = """MATCH (:B)<--()-->(:E)-[*0..]->(d:D)
+               MATCH (p)-->()
+               WHERE p.k = d.k
+               RETURN 1"""
+
+        plan = self.graph.explain(q)
+        self.env.assertEquals(plan.structured_plan.name, "Results")
+
+        result = self.graph.query(q)
+        self.env.assertEquals(result.result_set, [])

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -552,15 +552,11 @@ class testVariableLengthTraversals(FlowTestsBase):
         # Regression: planner-time rewrite must keep aliases consistent for
         # subsequent CondTraverse reconstruction on EXPLAIN/QUERY.
         self.graph.delete()
-        self.graph.query("CREATE (:__seed__)")
 
         q = """MATCH (:B)<--()-->(:E)-[*0..]->(d:D)
                MATCH (p)-->()
                WHERE p.k = d.k
                RETURN 1"""
-
-        plan = self.graph.explain(q)
-        self.env.assertEquals(plan.structured_plan.name, "Results")
 
         result = self.graph.query(q)
         self.env.assertEquals(result.result_set, [])

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -564,3 +564,4 @@ class testVariableLengthTraversals(FlowTestsBase):
 
         result = self.graph.query(q)
         self.env.assertEquals(result.result_set, [])
+


### PR DESCRIPTION
fixes #2146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of variable-length traversal algebra rewriting to maintain correct alignment between traversal endpoint labels and execution metadata, reducing plan/execution mismatches in alias-based scenarios.

* **Tests**
  * Added a regression test for variable-length traversals that use planner-time aliases in join predicates, verifying `QUERY` returns an empty `result_set` (and avoiding unintended `EXPLAIN` discrepancies).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->