### PR TITLE
Fix variable-length traversal under-returning bounded ranges (convergent diamond)

### DIFF
--- a/src/algorithms/all_neighbors.c
+++ b/src/algorithms/all_neighbors.c
@@ -125,12 +125,19 @@ EntityID AllNeighborsCtx_NextNeighbor
 			continue;
 		}
 
-		// update visited path, replace frontier with current node
+
+		// The invariant is that 'visited_nodes' always contains all nodes
+		// that are currently on the 'visited' path stack.
+		// (node in 'visited' iff node is in 'visited_nodes')
+		// Note:Leaf nodes (nodes at max len) should never be pushed onto the 'visited' path stack,
+		// so they are never in 'visited_nodes' - they will never show up
+		// on the path stack when backtracking.
 		bool visited =
-			HashTableAdd(ctx->visited_nodes, (void*)(dest_id), NULL) != DICT_OK;
+			HashTableFind(ctx->visited_nodes, (void*)(dest_id)) != NULL;
 
 		if(ctx->current_level < ctx->minLen && !visited) {
 			arr_append(ctx->visited, dest_id);
+			HashTableAdd(ctx->visited_nodes, (void*)(dest_id), NULL);
 			// continue traversing
 			_AllNeighborsCtx_CollectNeighbors(ctx, dest_id);
 			continue;
@@ -140,6 +147,7 @@ EntityID AllNeighborsCtx_NextNeighbor
 		// see if we should expand further?
 		if(ctx->current_level < ctx->maxLen && !visited) {
 			arr_append(ctx->visited, dest_id);
+			HashTableAdd(ctx->visited_nodes, (void*)(dest_id), NULL);
 			// we can expand further
 			_AllNeighborsCtx_CollectNeighbors(ctx, dest_id);
 		}
@@ -168,4 +176,3 @@ void AllNeighborsCtx_Free
 
 	rm_free(ctx);
 }
-

--- a/src/algorithms/all_neighbors.c
+++ b/src/algorithms/all_neighbors.c
@@ -126,12 +126,11 @@ EntityID AllNeighborsCtx_NextNeighbor
 		}
 
 
-		// The invariant is that 'visited_nodes' always contains all nodes
-		// that are currently on the 'visited' path stack.
-		// (node in 'visited' iff node is in 'visited_nodes')
-		// Note:Leaf nodes (nodes at max len) should never be pushed onto the 'visited' path stack,
-		// so they are never in 'visited_nodes' - they will never show up
-		// on the path stack when backtracking.
+		// Invariant: 'visited_nodes' mirrors the 'visited' path stack.
+		// (node is in 'visited' iff it is in 'visited_nodes')
+		// Note: Leaf nodes (nodes at maxLen) should never be pushed onto the
+		// 'visited' path stack, so they are never added to 'visited_nodes' and
+		// will never show up on the path stack when backtracking.
 		bool visited =
 			HashTableFind(ctx->visited_nodes, (void*)(dest_id)) != NULL;
 

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -561,3 +561,52 @@ class testVariableLengthTraversals(FlowTestsBase):
         result = self.graph.query(q)
         self.env.assertEquals(result.result_set, [])
 
+    def test18_convergent_diamond_range(self):
+        """
+        a bounded range pattern [:F*1..2] must return a SUPERSET of the
+        exact-length pattern [:F*2..2].
+
+        regression test for a bug in the optimized (single relationship type,
+        no filter, edge not referenced) variable length traversal path which
+        uses AllNeighborsCtx. a node reachable at BOTH depth 1 and depth 2 from
+        the source (a "convergent diamond") could be returned first as a leaf at
+        the maximum depth and leak into the visited set, after which it was no
+        longer expanded when reached at a shallower depth on another path -
+        silently dropping its descendants.
+
+        the bug only manifested on the typed (optimized) path; the untyped path
+        uses AllPathsCtx and was always correct, so we assert both agree.
+        """
+
+        self.graph.delete()
+
+        # convergent diamond, ids and insertion order both matter:
+        #   5 -> 4349        (depth-1)
+        #   5 -> 8798        (depth-1)
+        #   8798 -> 4349     (4349 is ALSO reachable at depth 2)
+        #   4349 -> 765      (depth-2 leaf)
+        #   4349 -> 775      (depth-2 leaf)
+        edges = [(5, 4349), (5, 8798), (4349, 765), (4349, 775), (8798, 4349)]
+        pairs = ",".join(f"[{a},{b}]" for a, b in edges)
+        self.graph.query(
+            f"UNWIND [{pairs}] AS e "
+            "MERGE (x:U {id:e[0]}) MERGE (y:U {id:e[1]}) MERGE (x)-[:F]->(y)")
+
+        def endpoints(pattern):
+            q = (f"MATCH (a:U {{id:5}})-{pattern}->(b:U) "
+                 "RETURN DISTINCT b.id ORDER BY b.id")
+            return [row[0] for row in self.graph.query(q).result_set]
+
+        typed_1_2   = endpoints("[:F*1..2]")  # optimized path
+        typed_2_2   = endpoints("[:F*2..2]")
+        untyped_1_2 = endpoints("[*1..2]")    # AllPathsCtx path
+
+        # range [1..2] must contain every endpoint of exact-length [2..2]
+        self.env.assertTrue(set(typed_2_2).issubset(set(typed_1_2)))
+
+        # typed and untyped traversals must agree
+        self.env.assertEquals(typed_1_2, untyped_1_2)
+
+        # explicit expected endpoints: depth-1 {4349, 8798} + depth-2 {765, 775, 4349}
+        self.env.assertEquals(typed_1_2, [765, 775, 4349, 8798])
+


### PR DESCRIPTION
## Problem

A bounded variable-length pattern like `-[:F*1..2]->` could return a **strict subset** of the exact-length pattern `-[:F*2..2]->`, silently dropping reachable endpoints. Since `*1..2` must contain every endpoint of `*2..2`, this is a clear correctness bug.

It only affected the **optimized** variable-length traversal path (`AllNeighborsCtx`), selected for a single relationship type with no filter, edge unreferenced, and a directed traversal. The untyped / multi-type path uses `AllPathsCtx` and was always correct — which is why removing the edge type made the bug disappear.

Closes #2157.

## Root cause

`AllNeighborsCtx` runs an iterative DFS and tracks the nodes on the current path in two structures that must stay in sync:

- `visited` — the path stack
- `visited_nodes` — a hash set mirroring the stack, for O(1) cycle checks

`visited_nodes` was updated **unconditionally** (via the side effect of `HashTableAdd`), but a node was only pushed onto the `visited` stack — and therefore only ever removed from `visited_nodes` on backtrack — when it was expanded (`current_level < maxLen`). A node returned at `maxLen` (a leaf) was added to the set but never removed, **leaking** it.

Once leaked, that node was treated as "already on the path" when later reached at a shallower depth on another path, so it was not expanded and all of its descendants were dropped. In the convergent diamond, `4349` is first reached as a depth-2 leaf (`5→8798→4349`) and leaks; the later depth-1 visit (`5→4349`) is then not expanded, dropping `765` and `775`.

## Fix

Keep `visited_nodes` a faithful mirror of the `visited` stack: add to the set exactly where we push onto the stack, and test membership with `HashTableFind` instead of relying on `HashTableAdd`'s side effect. Leaf nodes are added to neither structure, so they no longer leak.

## Testing

- Reproduced the drop and confirmed the fix restores correct results across ranges `*1..1 … *1..5`, including cycles; typed and untyped traversals now agree.
- Added regression test `test18_convergent_diamond_range`.
- Variable-length traversal flow suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable-length traversal behavior by ensuring “visited” tracking is consistent while expanding paths.
  * Fixed a regression in bounded range traversals where endpoints could be missing or mismatched when the same node is reachable at different depths.

* **Tests**
  * Added a regression test using a convergent diamond graph to validate endpoint correctness for typed vs. untyped bounded range traversals (including ordered results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->