### PR TITLE
Improve algo.SPpaths single shortest path performance

### DIFF
--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -355,22 +355,23 @@ Graph *Graph_New
 	return g ;
 }
 
-// get outgoing edges of node 'n'
-static void _GetOutgoingNodeEdges
+// get outgoing edges of node 'n' via an already-synchronized relation matrix
+static void _GetOutgoingNodeEdgesFromMatrix
 (
 	const Graph *g,  // graph to collect edges from
 	const Node *n,   // either source or destination node
+	Tensor R,        // already synchronized relation matrix for 'r'
 	RelationID r,    // relationship type
 	Edge **edges     // [output] array of edges
 ) {
 	ASSERT (g) ;
 	ASSERT (n) ;
+	ASSERT (R) ;
 	ASSERT (edges) ;
 	ASSERT (r != GRAPH_NO_RELATION && r != GRAPH_UNKNOWN_RELATION) ;
 
 	TensorIterator it ;
 	NodeID src_id = ENTITY_GET_ID (n) ;
-	Tensor R      = Graph_GetRelationMatrix (g, r, false) ;
 
 	Edge e = {.src_id = src_id, .relationID = r};
 
@@ -382,22 +383,35 @@ static void _GetOutgoingNodeEdges
 	}
 }
 
-// get incoming edges of node 'n'
-static void _GetIncomingNodeEdges
+// get outgoing edges of node 'n'
+static inline void _GetOutgoingNodeEdges
+(
+	const Graph *g,  // graph to collect edges from
+	const Node *n,   // either source or destination node
+	RelationID r,    // relationship type
+	Edge **edges     // [output] array of edges
+) {
+	Tensor R = Graph_GetRelationMatrix (g, r, false) ;
+	_GetOutgoingNodeEdgesFromMatrix (g, n, R, r, edges) ;
+}
+
+// get incoming edges of node 'n' via an already-synchronized relation matrix
+static void _GetIncomingNodeEdgesFromMatrix
 (
 	const Graph *g,        // graph to collect edges from
 	const Node *n,         // either source or destination node
+	Tensor T,              // already synchronized relation matrix for 'r'
 	RelationID r,          // relationship type
 	bool skip_self_edges,  // skip self referencing edges
 	Edge **edges           // [output] array of edges
 ) {
 	ASSERT (g     != NULL) ;
 	ASSERT (n     != NULL) ;
+	ASSERT (T     != NULL) ;
 	ASSERT (edges != NULL) ;
 	ASSERT (r != GRAPH_NO_RELATION && r != GRAPH_UNKNOWN_RELATION) ;
 
 	TensorIterator it ;
-	Tensor T       = Graph_GetRelationMatrix (g, r, false) ;
 	NodeID src_id  = INVALID_ENTITY_ID ;
 	NodeID dest_id = ENTITY_GET_ID (n) ;
 
@@ -414,6 +428,19 @@ static void _GetIncomingNodeEdges
 		ASSERT (e.attributes) ;
 		arr_append (*edges, e) ;
 	}
+}
+
+// get incoming edges of node 'n'
+static inline void _GetIncomingNodeEdges
+(
+	const Graph *g,        // graph to collect edges from
+	const Node *n,         // either source or destination node
+	RelationID r,          // relationship type
+	bool skip_self_edges,  // skip self referencing edges
+	Edge **edges           // [output] array of edges
+) {
+	Tensor T = Graph_GetRelationMatrix (g, r, false) ;
+	_GetIncomingNodeEdgesFromMatrix (g, n, T, r, skip_self_edges, edges) ;
 }
 
 // free every relation matrix
@@ -1339,6 +1366,52 @@ void Graph_GetNodeEdges
 				_GetIncomingNodeEdges (g, n, i, skip_self_edges, edges) ;
 			}
 		}
+	}
+}
+
+// retrieves all either incoming or outgoing edges of a specific relation type
+// to/from given node N, using an already-synchronized relation matrix
+//
+// unlike Graph_GetNodeEdges, this skips the relation-matrix lookup/sync (and
+// the lock it takes) on every call. callers that repeatedly query the same
+// relation across many nodes (e.g. a traversal's inner loop) should resolve
+// the matrix once up front via Graph_GetRelationMatrix and reuse it here.
+//
+// the matrix must have been synchronized while the caller held whatever lock
+// guarantees the graph is stable for as long as the matrix is reused (e.g. a
+// read query holding the graph's read lock) -- 'R' is not re-validated here
+void Graph_GetNodeEdgesFromMatrix
+(
+	const Graph *g,      // graph to collect edges from
+	const Node *n,       // either source or destination node
+	GRAPH_EDGE_DIR dir,  // edge direction ->, <-, <->
+	Tensor R,            // already synchronized relation matrix for 'r'
+	RelationID r,        // relationship type (must be a concrete relation)
+	Edge **edges         // [output] array of edges
+) {
+	ASSERT (g) ;
+	ASSERT (n) ;
+	ASSERT (R) ;
+	ASSERT (edges) ;
+	ASSERT (r != GRAPH_NO_RELATION && r != GRAPH_UNKNOWN_RELATION) ;
+
+	bool outgoing = (dir == GRAPH_EDGE_DIR_OUTGOING ||
+					 dir == GRAPH_EDGE_DIR_BOTH);
+
+	bool incoming = (dir == GRAPH_EDGE_DIR_INCOMING ||
+					 dir == GRAPH_EDGE_DIR_BOTH);
+
+	// when direction is BOTH to avoid duplication we want to skip over
+	// self referencing edges, as those will show up twice once for (a)->(a)
+	// and (a)<-(a)
+	bool skip_self_edges = (dir == GRAPH_EDGE_DIR_BOTH);
+
+	if (outgoing) {
+		_GetOutgoingNodeEdgesFromMatrix (g, n, R, r, edges) ;
+	}
+
+	if (incoming) {
+		_GetIncomingNodeEdgesFromMatrix (g, n, R, r, skip_self_edges, edges) ;
 	}
 }
 

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -419,6 +419,23 @@ void Graph_GetNodeEdges
 	Edge **edges          // array_t incoming/outgoing edges
 );
 
+// get node edges of a specific relation, given an already-synchronized
+// relation matrix, skipping the per-call matrix lookup/sync (and its lock).
+// callers that repeatedly query the same relation (e.g. a traversal's inner
+// loop) should resolve the matrix once via Graph_GetRelationMatrix and reuse
+// it across calls -- safe only while the caller holds whatever lock
+// guarantees the graph is stable for that long (e.g. a read query's graph
+// read lock)
+void Graph_GetNodeEdgesFromMatrix
+(
+	const Graph *g,       // graph to get edges from
+	const Node *n,        // node to extract edges from
+	GRAPH_EDGE_DIR dir,   // edge direction
+	Tensor R,             // already synchronized relation matrix for 'edgeType'
+	RelationID edgeType,  // relation type (must be a concrete relation)
+	Edge **edges          // array_t incoming/outgoing edges
+);
+
 // returns node incoming/outgoing degree
 uint64_t Graph_GetNodeDegree
 (

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -46,6 +46,7 @@ typedef struct {
 	Graph *g;                    // graph to traverse
 	Edge *neighbors;             // reusable buffer of edges along the current path
 	int *relationIDs;            // edge type(s) to traverse
+	Tensor *relationMatrices;    // relation matrix per relationIDs entry, synced once up front
 	int relationCount;           // length of relationIDs
 	GRAPH_EDGE_DIR dir;          // traverse direction
 	uint minLen;                 // path minimum length
@@ -79,10 +80,11 @@ static void SinglePairCtx_Free
 		arr_free(ctx->levels[i]);
 	}
 
-	if(ctx->path)        Path_Free(ctx->path);
-	if(ctx->levels)      arr_free(ctx->levels);
-	if(ctx->neighbors)   arr_free(ctx->neighbors);
-	if(ctx->relationIDs) arr_free(ctx->relationIDs);
+	if(ctx->path)             Path_Free(ctx->path);
+	if(ctx->levels)           arr_free(ctx->levels);
+	if(ctx->neighbors)        arr_free(ctx->neighbors);
+	if(ctx->relationIDs)      arr_free(ctx->relationIDs);
+	if(ctx->relationMatrices) arr_free(ctx->relationMatrices);
 
 	if(ctx->path_count == 0 && ctx->array != NULL) {
 		arr_free(ctx->array);
@@ -184,6 +186,16 @@ static void SinglePairCtx_New
 	ctx->src            = *src;
 	ctx->dst            =  dst;
 
+	// resolve and synchronize each relation's matrix once, up front, instead
+	// of on every neighbor-expansion call during traversal: the procedure
+	// runs under the graph's read lock for its entire lifetime, so the
+	// matrices are guaranteed stable for as long as they're cached here
+	ctx->relationMatrices = arr_new(Tensor, relationCount);
+	for(int i = 0; i < relationCount; i++) {
+		Tensor R = Graph_GetRelationMatrix(g, relationIDs[i], false);
+		arr_append(ctx->relationMatrices, R);
+	}
+
 	_SinglePairCtx_EnsureLevelArrayCap(ctx, 0, 1);
 	_SinglePairCtx_AddConnectionToLevel(ctx, 0, src, NULL);
 }
@@ -274,9 +286,15 @@ static ProcedureResult validate_config
 			types_count = arr_len(types);
 		}
 	} else {
-		types_count = 1;
+		// no relTypes specified: traverse every relation type. expand to
+		// concrete relation ids up front (rather than passing the
+		// GRAPH_NO_RELATION wildcard through) so each one can be resolved
+		// to a matrix and cached once in SinglePairCtx_New below.
+		types_count = Graph_RelationTypeCount(g);
 		types = arr_new(int, types_count);
-		arr_append(types, GRAPH_NO_RELATION);
+		for(uint i = 0; i < types_count; i++) {
+			arr_append(types, (int)i);
+		}
 	}
 
 	SinglePairCtx_New(ctx, (Node *)start.ptrval, (Node *)end.ptrval, g, types,
@@ -346,7 +364,8 @@ static void addOutgoingNeighbors
 
 	// Get frontier neighbors.
 	for(int i = 0; i < ctx->relationCount; i++) {
-		Graph_GetNodeEdges(ctx->g, &frontier->node, GRAPH_EDGE_DIR_OUTGOING, ctx->relationIDs[i], &ctx->neighbors);
+		Graph_GetNodeEdgesFromMatrix(ctx->g, &frontier->node, GRAPH_EDGE_DIR_OUTGOING,
+				ctx->relationMatrices[i], ctx->relationIDs[i], &ctx->neighbors);
 	}
 
 	// Add unvisited neighbors to next level.
@@ -376,7 +395,8 @@ static void addIncomingNeighbors
 
 	// Get frontier neighbors.
 	for(int i = 0; i < ctx->relationCount; i++) {
-		Graph_GetNodeEdges(ctx->g, &frontier->node, GRAPH_EDGE_DIR_INCOMING, ctx->relationIDs[i], &ctx->neighbors);
+		Graph_GetNodeEdgesFromMatrix(ctx->g, &frontier->node, GRAPH_EDGE_DIR_INCOMING,
+				ctx->relationMatrices[i], ctx->relationIDs[i], &ctx->neighbors);
 	}
 
 	// Add unvisited neighbors to next level.
@@ -510,7 +530,8 @@ static void _find_bound_path
 
 			for(int d = 0; !found && d < ndirs; d++) {
 				for(int r = 0; r < ctx->relationCount; r++) {
-					Graph_GetNodeEdges(ctx->g, &curNode, dirs[d], ctx->relationIDs[r], &ctx->neighbors);
+					Graph_GetNodeEdgesFromMatrix(ctx->g, &curNode, dirs[d],
+							ctx->relationMatrices[r], ctx->relationIDs[r], &ctx->neighbors);
 				}
 
 				uint32_t n = arr_len(ctx->neighbors);
@@ -729,8 +750,8 @@ static void SPpaths_dijkstra_single
 		// 'cur'.
 		for (int d = 0; d < ndirs; d++) {
 			for (int r = 0; r < ctx->relationCount; r++) {
-				Graph_GetNodeEdges (ctx->g, &curNode, dirs [d],
-						ctx->relationIDs [r], &ctx->neighbors) ;
+				Graph_GetNodeEdgesFromMatrix (ctx->g, &curNode, dirs [d],
+						ctx->relationMatrices [r], ctx->relationIDs [r], &ctx->neighbors) ;
 			}
 
 			uint32_t n = arr_len (ctx->neighbors) ;

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -9,6 +9,7 @@
 #include "../value.h"
 #include "../util/arr.h"
 #include "../util/heap.h"
+#include "../util/dict.h"
 #include "../query_ctx.h"
 #include "../util/rmalloc.h"
 #include "../errors/errors.h"
@@ -49,6 +50,7 @@ typedef struct {
 	GRAPH_EDGE_DIR dir;          // traverse direction.
 	uint minLen;                 // path minimum length.
 	uint maxLen;                 // path max length.
+	Node src;                    // source node.
 	Node *dst;                   // destination node, defaults to NULL in case of general all paths execution.
 	AttributeID weight_prop;     // weight attribute id
 	AttributeID cost_prop;       // cost attribuite id
@@ -179,6 +181,7 @@ static void SinglePairCtx_New
 	ctx->levels         =  arr_new(LevelConnection *, 1);
 	ctx->path           =  Path_New(1);
 	ctx->neighbors      =  arr_new(Edge, 32);
+	ctx->src            = *src;
 	ctx->dst            =  dst;
 
 	_SinglePairCtx_EnsureLevelArrayCap(ctx, 0, 1);
@@ -437,6 +440,159 @@ static inline SIValue _get_value_or_default
 	return default_value ;
 }
 
+// predecessor of a node discovered by the BFS pre-pass in `_find_bound_path`
+typedef struct {
+	NodeID parent;  // node from which this node was first reached
+	Edge edge;      // edge connecting parent -> this node
+} BoundParentRecord;
+
+// quickly search for *some* concrete path from src to dst honoring
+// relTypes/relDirection/maxLen (weight and cost are ignored while
+// traversing) via a plain BFS.
+//
+// the result is used only to seed a tight initial bound for the exhaustive
+// weighted search below; because it is a real, concrete path (not an
+// estimate) its weight is always safe to use as an upper bound.
+//
+// *exists is set to false when no structural path can be found within
+// maxLen hops, in which case no path can exist regardless of maxCost
+// either, and the caller can skip the exhaustive search entirely.
+static void _find_bound_path
+(
+	SinglePairCtx *ctx,
+	bool *exists,
+	double *out_weight,
+	double *out_cost
+) {
+	*exists = false;
+
+	NodeID src_id = ENTITY_GET_ID(&ctx->src);
+	NodeID dst_id = ENTITY_GET_ID(ctx->dst);
+
+	if(src_id == dst_id) {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths bound pre-pass: src == dst (%llu), skipping",
+			(unsigned long long)src_id);
+		return;
+	}
+
+	// node -> 1-based index into 'records' (0 is reserved, unused, as
+	// HashTableFetchValue returns NULL for it same as for a missing key;
+	// src itself is inserted with value 0 and is never looked up, since
+	// backtracking stops as soon as it's reached).
+	// records is a single growable arena: one malloc/realloc for the whole
+	// pre-pass instead of one rm_malloc per discovered node.
+	dict *parents = HashTableCreate(&def_dt);
+	BoundParentRecord *records = arr_new(BoundParentRecord, 64);
+
+	NodeID *frontier = arr_new(NodeID, 1);
+	NodeID *next     = arr_new(NodeID, 0);
+	arr_append(frontier, src_id);
+
+	HashTableAdd(parents, (void *)(uintptr_t)src_id, (void *)(uintptr_t)0);
+
+	bool found = false;
+	uint32_t max_hops = ctx->maxLen - 1;
+
+	// direction(s) to expand on; depends only on ctx->dir, so compute once
+	// up front rather than per node/hop.
+	GRAPH_EDGE_DIR dirs[2];
+	int ndirs = 0;
+	if(ctx->dir == GRAPH_EDGE_DIR_OUTGOING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs[ndirs++] = GRAPH_EDGE_DIR_OUTGOING;
+	}
+	if(ctx->dir == GRAPH_EDGE_DIR_INCOMING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs[ndirs++] = GRAPH_EDGE_DIR_INCOMING;
+	}
+
+	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+		"SPpaths bound pre-pass: BFS src=%llu dst=%llu maxHops=%u dir=%d relCount=%d",
+		(unsigned long long)src_id, (unsigned long long)dst_id, max_hops,
+		(int)ctx->dir, ctx->relationCount);
+
+	for(uint32_t hop = 1; !found && hop <= max_hops && arr_len(frontier) > 0; hop++) {
+		for(uint32_t i = 0; !found && i < arr_len(frontier); i++) {
+			NodeID cur = frontier[i];
+			Node curNode = GE_NEW_NODE();
+			Graph_GetNode(ctx->g, cur, &curNode);
+
+			for(int d = 0; !found && d < ndirs; d++) {
+				for(int r = 0; r < ctx->relationCount; r++) {
+					Graph_GetNodeEdges(ctx->g, &curNode, dirs[d], ctx->relationIDs[r], &ctx->neighbors);
+				}
+
+				uint32_t n = arr_len(ctx->neighbors);
+				for(uint32_t j = 0; j < n; j++) {
+					NodeID nid = (dirs[d] == GRAPH_EDGE_DIR_OUTGOING)
+						? Edge_GetDestNodeID(ctx->neighbors + j)
+						: Edge_GetSrcNodeID(ctx->neighbors + j);
+
+					// single lookup that both checks membership and, if
+					// absent, reserves the slot -- avoids a separate
+					// find + add pair of hash lookups per candidate.
+					dictEntry *existing;
+					dictEntry *entry = HashTableAddRaw(parents, (void *)(uintptr_t)nid, &existing);
+					if(entry == NULL) continue;  // already visited
+
+					BoundParentRecord rec = { .parent = cur, .edge = ctx->neighbors[j] };
+					arr_append(records, rec);
+					HashTableSetVal(parents, entry, (void *)(uintptr_t)arr_len(records));
+					arr_append(next, nid);
+
+					if(nid == dst_id) {
+						found = true;
+						break;
+					}
+				}
+
+				arr_clear(ctx->neighbors);
+			}
+		}
+
+		NodeID *tmp = frontier;
+		frontier = next;
+		next = tmp;
+		arr_clear(next);
+	}
+
+	arr_free(frontier);
+	arr_free(next);
+
+	if(found) {
+		*exists = true;
+
+		double weight = 0;
+		double cost   = 0;
+		NodeID cur = dst_id;
+		while(cur != src_id) {
+			uintptr_t idx = (uintptr_t)HashTableFetchValue(parents, (void *)(uintptr_t)cur);
+			ASSERT(idx != 0);
+			BoundParentRecord *rec = records + (idx - 1);
+
+			SIValue c = _get_value_or_default((GraphEntity *)&rec->edge, ctx->cost_prop,   SI_LongVal(1));
+			SIValue w = _get_value_or_default((GraphEntity *)&rec->edge, ctx->weight_prop, SI_LongVal(1));
+			cost   += SI_GET_NUMERIC(c);
+			weight += SI_GET_NUMERIC(w);
+
+			cur = rec->parent;
+		}
+
+		*out_weight = weight;
+		*out_cost   = cost;
+
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths bound pre-pass: found concrete src->dst path, weight=%g cost=%g",
+			weight, cost);
+	} else {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths bound pre-pass: no structural path found within maxHops=%u",
+			max_hops);
+	}
+
+	arr_free(records);
+	HashTableRelease(parents);
+}
+
 // use DFS to find all paths from src to dst tracking cost and weight
 static void SPpaths_next
 (
@@ -456,6 +612,17 @@ static void SPpaths_next
 
 			bool frontierAlreadyOnPath =
 				Path_ContainsNode(ctx->path, ENTITY_GET_ID (&frontierNode));
+
+			// a self-loop (or duplicate relation ids) can surface the same
+			// edge as a candidate more than once; reject it exactly like a
+			// node cycle so it doesn't get traversed twice on one path.
+			if(!frontierAlreadyOnPath && depth > 0 &&
+				Path_ContainsEdge(ctx->path, ENTITY_GET_ID(&frontierConnection.edge))) {
+				RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+					"SPpaths: rejecting duplicate edge %llu already on path (depth=%u)",
+					(unsigned long long)ENTITY_GET_ID(&frontierConnection.edge), depth);
+				frontierAlreadyOnPath = true;
+			}
 
 			// don't allow cycles
 			if (frontierAlreadyOnPath) {
@@ -539,14 +706,15 @@ static int path_cmp
 // get all minimal paths (all paths with the same weight)
 static void SPpaths_all_minimal
 (
-	SinglePairCtx *ctx
+	SinglePairCtx *ctx,
+	double initial_bound
 ) {
 	// initialize array that contains the result
 	ctx->array = arr_new(WeightedPath, 0);
 
 	// get first path
 	WeightedPath p = {0};
-	double max_weight = DBL_MAX;
+	double max_weight = initial_bound;
 	SPpaths_next(ctx, &p, max_weight);
 
 	// iterate over all paths
@@ -575,7 +743,8 @@ static void SPpaths_all_minimal
 // find the single minimal weighted path
 static void SPpaths_single_minimal
 (
-	SinglePairCtx *ctx
+	SinglePairCtx *ctx,
+	double initial_bound
 ) {
 	// initialize the result path to worst path
 	ctx->single.path   = NULL;
@@ -584,7 +753,7 @@ static void SPpaths_single_minimal
 
 	// get first path
 	WeightedPath p = {0};
-	SPpaths_next(ctx, &p, DBL_MAX);
+	SPpaths_next(ctx, &p, initial_bound);
 
 	// iterate over all paths
 	while (p.path != NULL) {
@@ -621,14 +790,15 @@ static void inline _add_path
 // find k minimal weighted path (path can have different weight)
 static void SPpaths_k_minimal
 (
-	SinglePairCtx *ctx
+	SinglePairCtx *ctx,
+	double initial_bound
 ) {
 	// initialize heap that contains the result where top path is the highest weight
 	ctx->heap = Heap_new(path_cmp, NULL);
 
 	// get first path
 	WeightedPath p = {0};
-	double max_weight = DBL_MAX;
+	double max_weight = initial_bound;
 	SPpaths_next(ctx, &p, max_weight);
 
 	// iterate over all paths
@@ -692,12 +862,45 @@ static ProcedureResult Proc_SPpathsInvoke
 
 	_process_yield(single_pair_ctx, yield);
 
+	// quick pre-pass: does *any* structural path (honoring relTypes/
+	// relDirection/maxLen) exist between src and dst at all? if not, no
+	// path can exist regardless of maxCost either, so skip the exhaustive
+	// search entirely. if one is found and it also satisfies maxCost, its
+	// weight is a safe upper bound to seed the exhaustive search with.
+	bool   bound_exists;
+	double bound_weight;
+	double bound_cost;
+	_find_bound_path(single_pair_ctx, &bound_exists, &bound_weight, &bound_cost);
+
+	if(!bound_exists) {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths: bound pre-pass found no structural path, skipping exhaustive search");
+
+		if(single_pair_ctx->path_count == 0) {
+			single_pair_ctx->array = arr_new(WeightedPath, 0);
+		} else if(single_pair_ctx->path_count == 1) {
+			single_pair_ctx->single.path = NULL;
+		} else {
+			single_pair_ctx->heap = Heap_new(path_cmp, NULL);
+		}
+		return PROCEDURE_OK;
+	}
+
+	bool cost_feasible = (bound_cost <= single_pair_ctx->max_cost);
+	double initial_bound = cost_feasible ? bound_weight : DBL_MAX;
+
+	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+		"SPpaths: bound pre-pass weight=%g cost=%g maxCost=%g -> %s, seeding exhaustive search with max_weight=%g",
+		bound_weight, bound_cost, single_pair_ctx->max_cost,
+		cost_feasible ? "cost-feasible" : "exceeds maxCost, bound discarded",
+		initial_bound);
+
 	if(single_pair_ctx->path_count == 0) {
-		SPpaths_all_minimal(single_pair_ctx);
+		SPpaths_all_minimal(single_pair_ctx, initial_bound);
 	} else if(single_pair_ctx->path_count == 1) {
-		SPpaths_single_minimal(single_pair_ctx);
+		SPpaths_single_minimal(single_pair_ctx, initial_bound);
 	} else {
-		SPpaths_k_minimal(single_pair_ctx);
+		SPpaths_k_minimal(single_pair_ctx, initial_bound);
 	}
 
 	return PROCEDURE_OK;

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -593,6 +593,214 @@ static void _find_bound_path
 	HashTableRelease(parents);
 }
 
+// per-node label used by the Dijkstra fast path below
+typedef struct {
+	NodeID parent;    // predecessor in the shortest-path tree
+	Edge   edge;      // edge connecting parent -> this node
+	double weight;    // current best known weight to reach this node
+	bool   finalized; // true once popped from the heap with its optimal weight
+} DijkstraLabel;
+
+// heap entry: a candidate (node, weight) pair waiting to be finalized.
+// duplicate/stale entries for the same node are allowed (lazy deletion);
+// they're skipped at pop time via DijkstraLabel.finalized.
+typedef struct {
+	NodeID node;
+	double weight;  // weight at the time this entry was queued (heap key)
+} DijkstraItem;
+
+// Heap_* is a max-heap by 'cmp' (see path_cmp above); invert the comparison
+// so it behaves as a min-heap ordered by ascending weight.
+static int _dijkstra_cmp
+(
+	const void *a,
+	const void *b,
+	void *udata
+) {
+	const DijkstraItem *da = a;
+	const DijkstraItem *db = b;
+	return (da->weight < db->weight) - (da->weight > db->weight);
+}
+
+// exact single-shortest-path search via Dijkstra (label-setting, one
+// best-known weight per node, each node finalized exactly once).
+//
+// only valid when there is no maxCost constraint: with cost unconstrained,
+// weight alone determines optimality, so classic per-node dedup applies
+// and this always terminates in O((V+E) log V) -- unlike the DFS
+// enumeration below, which can blow up combinatorially on graphs with many
+// similar-weight alternative routes (e.g. dense/mesh-like road networks).
+//
+// ASSUMES weightProp is non-negative for every edge. Dijkstra's
+// "finalize once, never revisit" invariant is unsound with negative
+// weights (a node reached later via a heavier edge can hold a negative
+// edge that retroactively beats an already-finalized node), and this is
+// NOT detected or guarded against here: making that safe would require
+// giving up the early-termination-at-dst optimization (running to full
+// completion over the whole reachable component instead), which was
+// judged not worth it given weightProp values are expected to represent
+// real, non-negative quantities (distance, time, cost) in practice. if
+// negative weights are ever a real requirement, this function must not
+// be used as-is.
+static void SPpaths_dijkstra_single
+(
+	SinglePairCtx *ctx
+) {
+	NodeID src_id = ENTITY_GET_ID(&ctx->src);
+	NodeID dst_id = ENTITY_GET_ID(ctx->dst);
+
+	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+		"SPpaths: Dijkstra fast path src=%llu dst=%llu (unconstrained cost)",
+		(unsigned long long)src_id, (unsigned long long)dst_id);
+
+	dict *label_idx = HashTableCreate(&def_dt);  // node -> 1-based index into 'labels'
+	DijkstraLabel *labels = arr_new(DijkstraLabel, 64);
+	heap_t *heap = Heap_new(_dijkstra_cmp, NULL);
+
+	GRAPH_EDGE_DIR dirs[2];
+	int ndirs = 0;
+	if(ctx->dir == GRAPH_EDGE_DIR_OUTGOING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs[ndirs++] = GRAPH_EDGE_DIR_OUTGOING;
+	}
+	if(ctx->dir == GRAPH_EDGE_DIR_INCOMING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs[ndirs++] = GRAPH_EDGE_DIR_INCOMING;
+	}
+
+	// seed src with weight 0
+	DijkstraLabel src_label = { .parent = src_id, .weight = 0, .finalized = false };
+	arr_append(labels, src_label);
+	HashTableAdd(label_idx, (void *)(uintptr_t)src_id, (void *)(uintptr_t)arr_len(labels));
+
+	DijkstraItem *seed = rm_malloc(sizeof(DijkstraItem));
+	seed->node = src_id;
+	seed->weight = 0;
+	Heap_offer(&heap, seed);
+
+	bool found = false;
+
+	while(!found) {
+		DijkstraItem *item = Heap_poll(heap);
+		if(item == NULL) break;  // heap exhausted: dst is unreachable
+
+		NodeID cur = item->node;
+		rm_free(item);
+
+		uintptr_t cur_idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)cur);
+		ASSERT(cur_idx != 0);
+		if(labels[cur_idx - 1].finalized) continue;  // stale duplicate entry
+		labels[cur_idx - 1].finalized = true;
+
+		if(cur == dst_id) {
+			found = true;
+			break;
+		}
+
+		double cur_weight = labels[cur_idx - 1].weight;
+
+		Node curNode = GE_NEW_NODE();
+		Graph_GetNode(ctx->g, cur, &curNode);
+
+		for(int d = 0; d < ndirs; d++) {
+			for(int r = 0; r < ctx->relationCount; r++) {
+				Graph_GetNodeEdges(ctx->g, &curNode, dirs[d], ctx->relationIDs[r], &ctx->neighbors);
+			}
+
+			uint32_t n = arr_len(ctx->neighbors);
+			for(uint32_t j = 0; j < n; j++) {
+				Edge *e = ctx->neighbors + j;
+				NodeID nid = (dirs[d] == GRAPH_EDGE_DIR_OUTGOING)
+					? Edge_GetDestNodeID(e)
+					: Edge_GetSrcNodeID(e);
+
+				if(nid == cur) continue;  // ignore self-loops
+
+				// NOTE: weightProp is assumed non-negative here (see the
+				// function-level comment above); a negative value would
+				// silently make this search's result incorrect.
+				SIValue w = _get_value_or_default((GraphEntity *)e, ctx->weight_prop, SI_LongVal(1));
+				double new_weight = cur_weight + SI_GET_NUMERIC(w);
+
+				dictEntry *existing;
+				dictEntry *entry = HashTableAddRaw(label_idx, (void *)(uintptr_t)nid, &existing);
+				if(entry == NULL) {
+					// already labeled: improve in place if not yet finalized
+					uintptr_t idx = (uintptr_t)HashTableGetVal(existing);
+					DijkstraLabel *nlabel = labels + (idx - 1);
+					if(nlabel->finalized || new_weight >= nlabel->weight) continue;
+
+					nlabel->weight = new_weight;
+					nlabel->parent = cur;
+					nlabel->edge   = *e;
+				} else {
+					DijkstraLabel nlabel = { .parent = cur, .edge = *e, .weight = new_weight, .finalized = false };
+					arr_append(labels, nlabel);
+					HashTableSetVal(label_idx, entry, (void *)(uintptr_t)arr_len(labels));
+				}
+
+				DijkstraItem *qi = rm_malloc(sizeof(DijkstraItem));
+				qi->node = nid;
+				qi->weight = new_weight;
+				Heap_offer(&heap, qi);
+			}
+
+			arr_clear(ctx->neighbors);
+		}
+	}
+
+	// drain and free any remaining queued items
+	DijkstraItem *leftover;
+	while((leftover = Heap_poll(heap)) != NULL) rm_free(leftover);
+	Heap_free(heap);
+
+	if(!found) {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths: Dijkstra fast path found no path src=%llu dst=%llu",
+			(unsigned long long)src_id, (unsigned long long)dst_id);
+		arr_free(labels);
+		HashTableRelease(label_idx);
+		return;
+	}
+
+	// reconstruct the path by walking parent pointers from dst back to src
+	Path *path = Path_New(8);
+	double total_cost = 0;
+	NodeID cur = dst_id;
+	while(cur != src_id) {
+		uintptr_t idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)cur);
+		ASSERT(idx != 0);
+		DijkstraLabel *label = labels + (idx - 1);
+
+		Node n = GE_NEW_NODE();
+		Graph_GetNode(ctx->g, cur, &n);
+		Path_AppendNode(path, n);
+		Path_AppendEdge(path, label->edge);
+
+		SIValue c = _get_value_or_default((GraphEntity *)&label->edge, ctx->cost_prop, SI_LongVal(1));
+		total_cost += SI_GET_NUMERIC(c);
+
+		cur = label->parent;
+	}
+	Node srcNode = GE_NEW_NODE();
+	Graph_GetNode(ctx->g, src_id, &srcNode);
+	Path_AppendNode(path, srcNode);
+
+	Path_Reverse(path);
+
+	uintptr_t dst_idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)dst_id);
+	double total_weight = labels[dst_idx - 1].weight;
+
+	ctx->single.path   = path;
+	ctx->single.weight = total_weight;
+	ctx->single.cost   = total_cost;
+
+	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+		"SPpaths: Dijkstra fast path found src=%llu dst=%llu weight=%g cost=%g",
+		(unsigned long long)src_id, (unsigned long long)dst_id, total_weight, total_cost);
+
+	arr_free(labels);
+	HashTableRelease(label_idx);
+}
+
 // use DFS to find all paths from src to dst tracking cost and weight
 static void SPpaths_next
 (
@@ -790,15 +998,18 @@ static void inline _add_path
 // find k minimal weighted path (path can have different weight)
 static void SPpaths_k_minimal
 (
-	SinglePairCtx *ctx,
-	double initial_bound
+	SinglePairCtx *ctx
 ) {
 	// initialize heap that contains the result where top path is the highest weight
 	ctx->heap = Heap_new(path_cmp, NULL);
 
-	// get first path
+	// get first path. unlike the single/all-minimal cases, the pre-pass
+	// bound must NOT seed this search: we need to fill up to path_count
+	// candidates before weight can meaningfully bound anything, since the
+	// k best paths can legitimately span a range of weights above the
+	// single cheapest path found by the pre-pass.
 	WeightedPath p = {0};
-	double max_weight = initial_bound;
+	double max_weight = DBL_MAX;
 	SPpaths_next(ctx, &p, max_weight);
 
 	// iterate over all paths
@@ -862,6 +1073,27 @@ static ProcedureResult Proc_SPpathsInvoke
 
 	_process_yield(single_pair_ctx, yield);
 
+	// fast path: a single shortest path with no maxCost constraint is
+	// exactly what Dijkstra solves, in O((V+E) log V) instead of the
+	// exhaustive DFS enumeration below, which can blow up combinatorially
+	// on graphs with many similar-weight alternative routes. this makes
+	// the bound pre-pass unnecessary too, since Dijkstra finds the exact
+	// optimum (and unreachability) directly.
+	// NOTE: SPpaths_dijkstra_single assumes weightProp is non-negative for
+	// every edge (see its own comment for why this isn't detected/guarded).
+	// src == dst is degenerate: Dijkstra trivially "finds" the source at
+	// distance 0 with zero edges traversed, which would violate the
+	// minLen==1 contract (a path needs at least one edge, e.g. a genuine
+	// self-loop). Rather than special-casing that inside the search, just
+	// don't take the fast path here and let the exhaustive DFS (which
+	// already handles this correctly) run instead.
+	bool src_eq_dst = ENTITY_GET_ID(&single_pair_ctx->src) == ENTITY_GET_ID(single_pair_ctx->dst);
+
+	if(single_pair_ctx->path_count == 1 && single_pair_ctx->max_cost == DBL_MAX && !src_eq_dst) {
+		SPpaths_dijkstra_single(single_pair_ctx);
+		return PROCEDURE_OK;
+	}
+
 	// quick pre-pass: does *any* structural path (honoring relTypes/
 	// relDirection/maxLen) exist between src and dst at all? if not, no
 	// path can exist regardless of maxCost either, so skip the exhaustive
@@ -890,17 +1122,27 @@ static ProcedureResult Proc_SPpathsInvoke
 	double initial_bound = cost_feasible ? bound_weight : DBL_MAX;
 
 	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-		"SPpaths: bound pre-pass weight=%g cost=%g maxCost=%g -> %s, seeding exhaustive search with max_weight=%g",
+		"SPpaths: bound pre-pass weight=%g cost=%g maxCost=%g -> %s",
 		bound_weight, bound_cost, single_pair_ctx->max_cost,
-		cost_feasible ? "cost-feasible" : "exceeds maxCost, bound discarded",
-		initial_bound);
+		cost_feasible ? "cost-feasible" : "exceeds maxCost, bound discarded");
 
 	if(single_pair_ctx->path_count == 0) {
+		// all-minimal wants every tie at the true minimum weight; the
+		// pre-pass weight is a valid upper bound on that minimum (any tie
+		// is by definition <= it), so seeding is safe here.
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths: seeding all-minimal search with max_weight=%g", initial_bound);
 		SPpaths_all_minimal(single_pair_ctx, initial_bound);
 	} else if(single_pair_ctx->path_count == 1) {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+			"SPpaths: seeding single-minimal search with max_weight=%g", initial_bound);
 		SPpaths_single_minimal(single_pair_ctx, initial_bound);
 	} else {
-		SPpaths_k_minimal(single_pair_ctx, initial_bound);
+		// k-minimal needs to fill up to path_count candidates before
+		// weight can meaningfully bound anything -- those candidates can
+		// legitimately be heavier than the single path the pre-pass
+		// found, so the bound must not be applied here.
+		SPpaths_k_minimal(single_pair_ctx);
 	}
 
 	return PROCEDURE_OK;

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -18,6 +18,8 @@
 
 #include <float.h>
 
+#define UNBOUNDED_PATH_LENGTH INT64_MAX -1
+
 // MATCH (n:L {v: 1}), (m:L {v: 5})
 // CALL algo.SPpaths({sourceNode: n,
 //					  targetNode: m,
@@ -49,8 +51,8 @@ typedef struct {
 	Tensor *relationMatrices;    // relation matrix per relationIDs entry, synced once up front
 	int relationCount;           // length of relationIDs
 	GRAPH_EDGE_DIR dir;          // traverse direction
-	uint minLen;                 // path minimum length
-	uint maxLen;                 // path max length
+	int64_t minLen;              // path minimum length
+	int64_t maxLen;              // path max length
 	Node src;                    // source node
 	Node *dst;                   // destination node, defaults to NULL in case of general all paths execution
 	AttributeID weight_prop;     // weight attribute id
@@ -169,22 +171,22 @@ static void SinglePairCtx_New
 	int *relationIDs,
 	int relationCount,
 	GRAPH_EDGE_DIR dir,
-	uint minLen,
-	uint maxLen
+	int64_t minLen,
+	int64_t maxLen
 ) {
-	ASSERT(src != NULL);
+	ASSERT (src != NULL) ;
 
-	ctx->g              =  g;
-	ctx->dir            =  dir;
-	ctx->minLen         =  minLen + 1;
-	ctx->maxLen         =  maxLen + 1;
-	ctx->relationIDs    =  relationIDs;
-	ctx->relationCount  =  relationCount;
-	ctx->levels         =  arr_new(LevelConnection *, 1);
-	ctx->path           =  Path_New(1);
-	ctx->neighbors      =  arr_new(Edge, 32);
-	ctx->src            = *src;
-	ctx->dst            =  dst;
+	ctx->g             = g ;
+	ctx->dir           = dir ;
+	ctx->minLen        = minLen + 1 ;
+	ctx->maxLen        = maxLen + 1 ;
+	ctx->relationIDs   = relationIDs ;
+	ctx->relationCount = relationCount ;
+	ctx->levels        = arr_new (LevelConnection *, 1) ;
+	ctx->path          = Path_New (1) ;
+	ctx->neighbors     = arr_new (Edge, 32) ;
+	ctx->src           = *src ;
+	ctx->dst           = dst ;
 
 	// resolve and synchronize each relation's matrix once, up front, instead
 	// of on every neighbor-expansion call during traversal: the procedure
@@ -216,16 +218,15 @@ static ProcedureResult validate_config
 	SIValue max_cost;             // maximum cost
 	SIValue path_count;           // # of paths to return
 	
-	bool start_exists         = MAP_GET(config, "sourceNode",   start);
-	bool end_exists           = MAP_GET(config, "targetNode",   end);
-	bool relationships_exists = MAP_GET(config, "relTypes",     relationships);
-	bool dir_exists           = MAP_GET(config, "relDirection", dir);
-	bool max_length_exists    = MAP_GET(config, "maxLen",       max_length);
-	bool weight_prop_exists   = MAP_GET(config, "weightProp",   weight_prop);
-	bool cost_prop_exists     = MAP_GET(config, "costProp",     cost_prop);
-	bool max_cost_exists      = MAP_GET(config, "maxCost",      max_cost);
-	bool path_count_exists    = MAP_GET(config, "pathCount",    path_count);
-	
+	bool start_exists         = MAP_GET (config, "sourceNode",   start) ;
+	bool end_exists           = MAP_GET (config, "targetNode",   end) ;
+	bool relationships_exists = MAP_GET (config, "relTypes",     relationships) ;
+	bool dir_exists           = MAP_GET (config, "relDirection", dir) ;
+	bool max_length_exists    = MAP_GET (config, "maxLen",       max_length) ;
+	bool weight_prop_exists   = MAP_GET (config, "weightProp",   weight_prop) ;
+	bool cost_prop_exists     = MAP_GET (config, "costProp",     cost_prop) ;
+	bool max_cost_exists      = MAP_GET (config, "maxCost",      max_cost) ;
+	bool path_count_exists    = MAP_GET (config, "pathCount",    path_count) ;
 
 	if(!start_exists || !end_exists) {
 		ErrorCtx_SetError(EMSG_SPPATH_REQUIRED);
@@ -254,13 +255,13 @@ static ProcedureResult validate_config
 		}
 	}
 
-	int64_t max_length_val = LONG_MAX - 1;
-	if(max_length_exists) {
-		if(SI_TYPE(max_length) != T_INT64) {
-			ErrorCtx_SetError(EMSG_MUST_BE, "maxLen", "integer");
-			return false;
+	int64_t max_length_val = UNBOUNDED_PATH_LENGTH ;
+	if (max_length_exists) {
+		if (SI_TYPE (max_length) != T_INT64) {
+			ErrorCtx_SetError (EMSG_MUST_BE, "maxLen", "integer") ;
+			return false ;
 		}
-		max_length_val = SI_GET_NUMERIC(max_length);
+		max_length_val = SI_GET_NUMERIC (max_length) ;
 	}
 
 	GraphContext *gc = QueryCtx_GetGraphCtx();
@@ -486,8 +487,8 @@ static void _find_bound_path
 ) {
 	*exists = false;
 
-	NodeID src_id = ENTITY_GET_ID(&ctx->src);
-	NodeID dst_id = ENTITY_GET_ID(ctx->dst);
+	NodeID src_id = ENTITY_GET_ID (&ctx->src) ;
+	NodeID dst_id = ENTITY_GET_ID (ctx->dst)  ;
 
 	if (src_id == dst_id) {
 		return ;
@@ -1183,9 +1184,10 @@ static ProcedureResult Proc_SPpathsInvoke
 		(ENTITY_GET_ID (&single_pair_ctx->src) ==
 		 ENTITY_GET_ID (single_pair_ctx->dst)) ;
 
-	if (src_eq_dst == false              &&
-		single_pair_ctx->path_count == 1 &&
-		single_pair_ctx->max_cost == DBL_MAX) {
+	if (src_eq_dst == false                    &&
+		single_pair_ctx->path_count == 1       &&
+		single_pair_ctx->max_cost   == DBL_MAX &&
+		single_pair_ctx->maxLen     == UNBOUNDED_PATH_LENGTH + 1) {
 		SPpaths_dijkstra_single (single_pair_ctx) ;
 		return PROCEDURE_OK ;
 	}
@@ -1195,26 +1197,27 @@ static ProcedureResult Proc_SPpathsInvoke
 	// path can exist regardless of maxCost either, so skip the exhaustive
 	// search entirely. if one is found and it also satisfies maxCost, its
 	// weight is a safe upper bound to seed the exhaustive search with.
-	bool   bound_exists;
-	double bound_weight;
-	double bound_cost;
-	_find_bound_path(single_pair_ctx, &bound_exists, &bound_weight, &bound_cost);
+	double bound_cost ;
+	bool   bound_exists ;
+	double bound_weight ;
+	_find_bound_path (single_pair_ctx, &bound_exists, &bound_weight,
+			&bound_cost) ;
 
-	if(!bound_exists) {
+	if (!bound_exists) {
 		if(single_pair_ctx->path_count == 0) {
-			single_pair_ctx->array = arr_new(WeightedPath, 0);
+			single_pair_ctx->array = arr_new (WeightedPath, 0) ;
 		} else if(single_pair_ctx->path_count == 1) {
 			single_pair_ctx->single.path = NULL;
 		} else {
-			single_pair_ctx->heap = Heap_new(path_cmp, NULL);
+			single_pair_ctx->heap = Heap_new (path_cmp, NULL) ;
 		}
-		return PROCEDURE_OK;
+		return PROCEDURE_OK ;
 	}
 
-	bool cost_feasible = (bound_cost <= single_pair_ctx->max_cost);
-	double initial_bound = cost_feasible ? bound_weight : DBL_MAX;
+	bool cost_feasible = (bound_cost <= single_pair_ctx->max_cost) ;
+	double initial_bound = cost_feasible ? bound_weight : DBL_MAX ;
 
-	if(single_pair_ctx->path_count == 0) {
+	if (single_pair_ctx->path_count == 0) {
 		// all-minimal wants every tie at the true minimum weight; the
 		// pre-pass weight is a valid upper bound on that minimum (any tie
 		// is by definition <= it), so seeding is safe here.

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -41,21 +41,21 @@ typedef struct {
 } LevelConnection;
 
 typedef struct {
-	LevelConnection **levels;    // nodes reached at depth i, and edges leading to them.
-	Path *path;                  // current path.
-	Graph *g;                    // graph to traverse.
-	Edge *neighbors;             // reusable buffer of edges along the current path.
-	int *relationIDs;            // edge type(s) to traverse.
-	int relationCount;           // length of relationIDs.
-	GRAPH_EDGE_DIR dir;          // traverse direction.
-	uint minLen;                 // path minimum length.
-	uint maxLen;                 // path max length.
-	Node src;                    // source node.
-	Node *dst;                   // destination node, defaults to NULL in case of general all paths execution.
+	LevelConnection **levels;    // nodes reached at depth i, and edges leading to them
+	Path *path;                  // current path
+	Graph *g;                    // graph to traverse
+	Edge *neighbors;             // reusable buffer of edges along the current path
+	int *relationIDs;            // edge type(s) to traverse
+	int relationCount;           // length of relationIDs
+	GRAPH_EDGE_DIR dir;          // traverse direction
+	uint minLen;                 // path minimum length
+	uint maxLen;                 // path max length
+	Node src;                    // source node
+	Node *dst;                   // destination node, defaults to NULL in case of general all paths execution
 	AttributeID weight_prop;     // weight attribute id
 	AttributeID cost_prop;       // cost attribuite id
 	double max_cost;             // maximum cost of path
-	uint64_t path_count;         // path to return
+	uint64_t path_count;         // number of paths to return
 	union {
 		WeightedPath single;     // path_count == 1
 		heap_t *heap;            // in case path_count > 1
@@ -469,11 +469,8 @@ static void _find_bound_path
 	NodeID src_id = ENTITY_GET_ID(&ctx->src);
 	NodeID dst_id = ENTITY_GET_ID(ctx->dst);
 
-	if(src_id == dst_id) {
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths bound pre-pass: src == dst (%llu), skipping",
-			(unsigned long long)src_id);
-		return;
+	if (src_id == dst_id) {
+		return ;
 	}
 
 	// node -> 1-based index into 'records' (0 is reserved, unused, as
@@ -505,12 +502,7 @@ static void _find_bound_path
 		dirs[ndirs++] = GRAPH_EDGE_DIR_INCOMING;
 	}
 
-	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-		"SPpaths bound pre-pass: BFS src=%llu dst=%llu maxHops=%u dir=%d relCount=%d",
-		(unsigned long long)src_id, (unsigned long long)dst_id, max_hops,
-		(int)ctx->dir, ctx->relationCount);
-
-	for(uint32_t hop = 1; !found && hop <= max_hops && arr_len(frontier) > 0; hop++) {
+	for (uint32_t hop = 1; !found && hop <= max_hops && arr_len(frontier) > 0; hop++) {
 		for(uint32_t i = 0; !found && i < arr_len(frontier); i++) {
 			NodeID cur = frontier[i];
 			Node curNode = GE_NEW_NODE();
@@ -579,18 +571,10 @@ static void _find_bound_path
 
 		*out_weight = weight;
 		*out_cost   = cost;
-
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths bound pre-pass: found concrete src->dst path, weight=%g cost=%g",
-			weight, cost);
-	} else {
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths bound pre-pass: no structural path found within maxHops=%u",
-			max_hops);
 	}
 
-	arr_free(records);
-	HashTableRelease(parents);
+	arr_free (records) ;
+	HashTableRelease (parents) ;
 }
 
 // per-node label used by the Dijkstra fast path below
@@ -617,9 +601,9 @@ static int _dijkstra_cmp
 	const void *b,
 	void *udata
 ) {
-	const DijkstraItem *da = a;
-	const DijkstraItem *db = b;
-	return (da->weight < db->weight) - (da->weight > db->weight);
+	const DijkstraItem *da = a ;
+	const DijkstraItem *db = b ;
+	return (da->weight < db->weight) - (da->weight > db->weight) ;
 }
 
 // exact single-shortest-path search via Dijkstra (label-setting, one
@@ -646,159 +630,249 @@ static void SPpaths_dijkstra_single
 (
 	SinglePairCtx *ctx
 ) {
-	NodeID src_id = ENTITY_GET_ID(&ctx->src);
-	NodeID dst_id = ENTITY_GET_ID(ctx->dst);
+	NodeID src_id = ENTITY_GET_ID (&ctx->src) ;
+	NodeID dst_id = ENTITY_GET_ID (ctx->dst) ;
 
-	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-		"SPpaths: Dijkstra fast path src=%llu dst=%llu (unconstrained cost)",
-		(unsigned long long)src_id, (unsigned long long)dst_id);
+	// 'labels' holds one DijkstraLabel per node ever discovered (tentative
+	// or finalized best-known distance, its parent and connecting edge).
+	// 'label_idx' maps a node id to its 1-based slot in 'labels' (0 means
+	// "not yet discovered"), since NodeIDs aren't dense/small enough to
+	// index 'labels' directly.
+	// 'heap' is the Dijkstra priority queue: pending (node, weight)
+	// candidates ordered so the next Heap_poll always returns the
+	// smallest-weight candidate discovered so far.
+	dict *label_idx       = HashTableCreate (&def_dt);
+	DijkstraLabel *labels = arr_new (DijkstraLabel, 64) ;
+	heap_t *heap          = Heap_new (_dijkstra_cmp, NULL) ;
 
-	dict *label_idx = HashTableCreate(&def_dt);  // node -> 1-based index into 'labels'
-	DijkstraLabel *labels = arr_new(DijkstraLabel, 64);
-	heap_t *heap = Heap_new(_dijkstra_cmp, NULL);
-
-	GRAPH_EDGE_DIR dirs[2];
+	// build the list of edge directions to expand through when scanning a
+	// node's neighbors: OUTGOING, INCOMING, or both, per the query's
+	// requested traversal direction.
 	int ndirs = 0;
-	if(ctx->dir == GRAPH_EDGE_DIR_OUTGOING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
-		dirs[ndirs++] = GRAPH_EDGE_DIR_OUTGOING;
+	GRAPH_EDGE_DIR dirs [2] ;
+	if (ctx->dir == GRAPH_EDGE_DIR_OUTGOING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs [ndirs++] = GRAPH_EDGE_DIR_OUTGOING ;
 	}
-	if(ctx->dir == GRAPH_EDGE_DIR_INCOMING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
-		dirs[ndirs++] = GRAPH_EDGE_DIR_INCOMING;
+	if (ctx->dir == GRAPH_EDGE_DIR_INCOMING || ctx->dir == GRAPH_EDGE_DIR_BOTH) {
+		dirs [ndirs++] = GRAPH_EDGE_DIR_INCOMING ;
 	}
 
-	// seed src with weight 0
-	DijkstraLabel src_label = { .parent = src_id, .weight = 0, .finalized = false };
-	arr_append(labels, src_label);
-	HashTableAdd(label_idx, (void *)(uintptr_t)src_id, (void *)(uintptr_t)arr_len(labels));
+	// initialization: seed the source node with distance 0 and no parent
+	// (it parents itself, which also makes the path-reconstruction loop's
+	// "cur != src_id" stop condition correct). every other node is
+	// implicitly at distance +inf until first discovered below.
+	DijkstraLabel src_label =
+		{ .parent = src_id, .weight = 0, .finalized = false } ;
 
-	DijkstraItem *seed = rm_malloc(sizeof(DijkstraItem));
-	seed->node = src_id;
-	seed->weight = 0;
-	Heap_offer(&heap, seed);
+	arr_append (labels, src_label) ;
+	HashTableAdd (label_idx, (void *)(uintptr_t)src_id,
+			(void *)(uintptr_t)arr_len (labels)) ;
 
-	bool found = false;
+	// push the source onto the priority queue so the main loop below has
+	// somewhere to start.
+	DijkstraItem *seed = rm_malloc (sizeof (DijkstraItem)) ;
+	seed->node   = src_id ;
+	seed->weight = 0 ;
 
-	while(!found) {
-		DijkstraItem *item = Heap_poll(heap);
-		if(item == NULL) break;  // heap exhausted: dst is unreachable
+	Heap_offer (&heap, seed) ;
 
-		NodeID cur = item->node;
-		rm_free(item);
+	bool found = false ;
 
-		uintptr_t cur_idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)cur);
-		ASSERT(cur_idx != 0);
-		if(labels[cur_idx - 1].finalized) continue;  // stale duplicate entry
-		labels[cur_idx - 1].finalized = true;
-
-		if(cur == dst_id) {
-			found = true;
-			break;
+	// main Dijkstra loop: repeatedly extract the not-yet-finalized node
+	// with the smallest tentative distance and finalize it -- that
+	// distance is now guaranteed optimal, since all edge weights are
+	// non-negative and every unexplored candidate is at least as large.
+	// stops either when dst is finalized (found) or the heap empties
+	// (dst unreachable from src).
+	while (!found) {
+		// extract the minimum-weight candidate. this may be a stale
+		// duplicate left over from a relaxation performed after this
+		// entry was queued (see the lazy-deletion note on DijkstraItem);
+		// staleness is detected below via the label's 'finalized' flag
+		// rather than by removing superseded heap entries in place.
+		DijkstraItem *item = Heap_poll (heap) ;
+		if (item == NULL) {
+			break ;  // heap exhausted: dst is unreachable
 		}
 
-		double cur_weight = labels[cur_idx - 1].weight;
+		NodeID cur = item->node ;
+		rm_free (item) ;
 
-		Node curNode = GE_NEW_NODE();
-		Graph_GetNode(ctx->g, cur, &curNode);
+		uintptr_t cur_idx =
+			(uintptr_t)HashTableFetchValue (label_idx, (void *)(uintptr_t)cur) ;
 
-		for(int d = 0; d < ndirs; d++) {
-			for(int r = 0; r < ctx->relationCount; r++) {
-				Graph_GetNodeEdges(ctx->g, &curNode, dirs[d], ctx->relationIDs[r], &ctx->neighbors);
+		ASSERT (cur_idx != 0) ;
+		if (labels [cur_idx - 1].finalized) {
+			continue ;  // stale duplicate entry
+		}
+
+		// finalize 'cur': its current label weight is its true shortest
+		// distance from src and will never be improved again (label
+		// setting -- each node is finalized exactly once).
+		labels [cur_idx - 1].finalized = true ;
+
+		// dst just got finalized, its shortest path is settled: stop
+		// early instead of exploring the rest of the reachable graph.
+		if (cur == dst_id) {
+			found = true ;
+			break ;
+		}
+
+		double cur_weight = labels [cur_idx - 1].weight ;
+
+		Node curNode = GE_NEW_NODE () ;
+		Graph_GetNode (ctx->g, cur, &curNode) ;
+
+		// relaxation step: examine every edge leaving (or entering, per
+		// 'dirs') 'cur', across every relationship type the query allows,
+		// and try to improve each neighbor's tentative distance through
+		// 'cur'.
+		for (int d = 0; d < ndirs; d++) {
+			for (int r = 0; r < ctx->relationCount; r++) {
+				Graph_GetNodeEdges (ctx->g, &curNode, dirs [d],
+						ctx->relationIDs [r], &ctx->neighbors) ;
 			}
 
-			uint32_t n = arr_len(ctx->neighbors);
-			for(uint32_t j = 0; j < n; j++) {
-				Edge *e = ctx->neighbors + j;
-				NodeID nid = (dirs[d] == GRAPH_EDGE_DIR_OUTGOING)
-					? Edge_GetDestNodeID(e)
-					: Edge_GetSrcNodeID(e);
+			uint32_t n = arr_len (ctx->neighbors) ;
+			for (uint32_t j = 0; j < n; j++) {
+				Edge *e = ctx->neighbors + j ;
+				NodeID nid = (dirs [d] == GRAPH_EDGE_DIR_OUTGOING)
+					? Edge_GetDestNodeID (e)
+					: Edge_GetSrcNodeID (e) ;
 
-				if(nid == cur) continue;  // ignore self-loops
+				if (nid == cur) {
+					continue ;  // ignore self-loops
+				}
 
+				// candidate distance to 'nid' going through 'cur' via
+				// this edge: cur's finalized distance plus the edge's
+				// weight.
 				// NOTE: weightProp is assumed non-negative here (see the
 				// function-level comment above); a negative value would
 				// silently make this search's result incorrect.
-				SIValue w = _get_value_or_default((GraphEntity *)e, ctx->weight_prop, SI_LongVal(1));
-				double new_weight = cur_weight + SI_GET_NUMERIC(w);
+				SIValue w = _get_value_or_default ((GraphEntity *)e,
+						ctx->weight_prop, SI_LongVal (1)) ;
+				double new_weight = cur_weight + SI_GET_NUMERIC (w) ;
 
-				dictEntry *existing;
-				dictEntry *entry = HashTableAddRaw(label_idx, (void *)(uintptr_t)nid, &existing);
-				if(entry == NULL) {
-					// already labeled: improve in place if not yet finalized
-					uintptr_t idx = (uintptr_t)HashTableGetVal(existing);
-					DijkstraLabel *nlabel = labels + (idx - 1);
-					if(nlabel->finalized || new_weight >= nlabel->weight) continue;
+				// look up (or reserve) 'nid's slot in 'labels': HashTableAddRaw
+				// returns a fresh entry (entry != NULL) the first time 'nid'
+				// is seen, or NULL with 'existing' set to the prior entry if
+				// 'nid' already has a label.
+				dictEntry *existing ;
+				dictEntry *entry = HashTableAddRaw (label_idx,
+						(void *)(uintptr_t)nid, &existing) ;
 
-					nlabel->weight = new_weight;
-					nlabel->parent = cur;
-					nlabel->edge   = *e;
+				if (entry == NULL) {
+					// 'nid' already labeled: this is the relaxation
+					// comparison proper. skip if it's already finalized
+					// (its distance is final and can't improve) or if
+					// going through 'cur' isn't strictly better than what
+					// it already has.
+					uintptr_t idx = (uintptr_t)HashTableGetVal (existing) ;
+					DijkstraLabel *nlabel = labels + (idx - 1) ;
+					if (nlabel->finalized || new_weight >= nlabel->weight) {
+						continue ;
+					}
+
+					// found a strictly shorter route to 'nid' through
+					// 'cur': update its label in place with the new best
+					// distance, parent and connecting edge.
+					nlabel->edge   = *e ;
+					nlabel->parent = cur ;
+					nlabel->weight = new_weight ;
 				} else {
-					DijkstraLabel nlabel = { .parent = cur, .edge = *e, .weight = new_weight, .finalized = false };
-					arr_append(labels, nlabel);
-					HashTableSetVal(label_idx, entry, (void *)(uintptr_t)arr_len(labels));
+					// first time 'nid' is discovered: create its label
+					// with 'cur' as parent and 'new_weight' as its (so
+					// far unbeaten) tentative distance.
+					DijkstraLabel nlabel = { .parent = cur, .edge = *e,
+						.weight = new_weight, .finalized = false } ;
+
+					arr_append (labels, nlabel) ;
+					HashTableSetVal (label_idx, entry,
+							(void *)(uintptr_t)arr_len (labels)) ;
 				}
 
-				DijkstraItem *qi = rm_malloc(sizeof(DijkstraItem));
-				qi->node = nid;
-				qi->weight = new_weight;
-				Heap_offer(&heap, qi);
+				// queue (or re-queue) 'nid' at its updated tentative
+				// weight. any older, now-superseded heap entry for 'nid'
+				// is left in place and simply skipped later as a stale
+				// duplicate once popped.
+				DijkstraItem *qi = rm_malloc (sizeof (DijkstraItem)) ;
+				qi->node   = nid ;
+				qi->weight = new_weight ;
+				Heap_offer (&heap, qi) ;
 			}
 
-			arr_clear(ctx->neighbors);
+			arr_clear (ctx->neighbors) ;
 		}
 	}
 
-	// drain and free any remaining queued items
-	DijkstraItem *leftover;
-	while((leftover = Heap_poll(heap)) != NULL) rm_free(leftover);
-	Heap_free(heap);
+	// search is over (dst found or heap exhausted): drain and free any
+	// remaining queued items before freeing the heap itself.
+	DijkstraItem *leftover ;
+	while ((leftover = Heap_poll (heap)) != NULL) {
+		rm_free (leftover) ;
+	}
+	Heap_free (heap) ;
 
-	if(!found) {
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths: Dijkstra fast path found no path src=%llu dst=%llu",
-			(unsigned long long)src_id, (unsigned long long)dst_id);
-		arr_free(labels);
-		HashTableRelease(label_idx);
-		return;
+	if (!found) {
+		// dst is unreachable from src: nothing to report, leave
+		// ctx->single at its caller-initialized "no path" state.
+		arr_free (labels) ;
+		HashTableRelease (label_idx) ;
+		return ;
 	}
 
-	// reconstruct the path by walking parent pointers from dst back to src
-	Path *path = Path_New(8);
-	double total_cost = 0;
-	NodeID cur = dst_id;
-	while(cur != src_id) {
-		uintptr_t idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)cur);
-		ASSERT(idx != 0);
-		DijkstraLabel *label = labels + (idx - 1);
+	// reconstruct the path by walking parent pointers from dst back to
+	// src, one finalized label at a time, accumulating cost_prop along
+	// the way (weight_prop was already accumulated into each label's
+	// 'weight' during the relaxation loop above, so total_weight is just
+	// read off dst's label once the walk is done).
+	NodeID cur = dst_id ;
+	double total_cost = 0 ;
+	Path *path = Path_New (8) ;
 
-		Node n = GE_NEW_NODE();
-		Graph_GetNode(ctx->g, cur, &n);
-		Path_AppendNode(path, n);
-		Path_AppendEdge(path, label->edge);
+	while (cur != src_id) {
+		uintptr_t idx =
+			(uintptr_t)HashTableFetchValue (label_idx, (void *)(uintptr_t)cur) ;
+		ASSERT (idx != 0) ;
+		DijkstraLabel *label = labels + (idx - 1) ;
 
-		SIValue c = _get_value_or_default((GraphEntity *)&label->edge, ctx->cost_prop, SI_LongVal(1));
-		total_cost += SI_GET_NUMERIC(c);
+		// append 'cur' and the edge that reached it from its parent; the
+		// path is being built tail-first (dst towards src) and will be
+		// reversed once the walk reaches src.
+		Node n = GE_NEW_NODE () ;
+		Graph_GetNode (ctx->g, cur, &n) ;
+		Path_AppendNode (path, n) ;
+		Path_AppendEdge (path, label->edge) ;
 
-		cur = label->parent;
+		SIValue c =
+			_get_value_or_default ((GraphEntity *)&label->edge, ctx->cost_prop,
+					SI_LongVal (1)) ;
+		total_cost += SI_GET_NUMERIC (c) ;
+
+		cur = label->parent ;
 	}
-	Node srcNode = GE_NEW_NODE();
-	Graph_GetNode(ctx->g, src_id, &srcNode);
-	Path_AppendNode(path, srcNode);
 
-	Path_Reverse(path);
+	// walk terminated at src: append it (it has no incoming edge on this
+	// path) and flip the path from dst->src order into src->dst order.
+	Node srcNode = GE_NEW_NODE () ;
+	Graph_GetNode (ctx->g, src_id, &srcNode) ;
+	Path_AppendNode (path, srcNode) ;
 
-	uintptr_t dst_idx = (uintptr_t)HashTableFetchValue(label_idx, (void *)(uintptr_t)dst_id);
-	double total_weight = labels[dst_idx - 1].weight;
+	Path_Reverse (path) ;
 
-	ctx->single.path   = path;
-	ctx->single.weight = total_weight;
-	ctx->single.cost   = total_cost;
+	// dst's finalized label already holds the total shortest weight from
+	// src, accumulated incrementally throughout the relaxation loop.
+	uintptr_t dst_idx =
+		(uintptr_t)HashTableFetchValue (label_idx, (void *)(uintptr_t)dst_id) ;
+	double total_weight = labels [dst_idx - 1].weight ;
 
-	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-		"SPpaths: Dijkstra fast path found src=%llu dst=%llu weight=%g cost=%g",
-		(unsigned long long)src_id, (unsigned long long)dst_id, total_weight, total_cost);
+	ctx->single.path   = path ;
+	ctx->single.cost   = total_cost ;
+	ctx->single.weight = total_weight ;
 
-	arr_free(labels);
-	HashTableRelease(label_idx);
+	arr_free (labels) ;
+	HashTableRelease (label_idx) ;
 }
 
 // use DFS to find all paths from src to dst tracking cost and weight
@@ -826,9 +900,6 @@ static void SPpaths_next
 			// node cycle so it doesn't get traversed twice on one path.
 			if(!frontierAlreadyOnPath && depth > 0 &&
 				Path_ContainsEdge(ctx->path, ENTITY_GET_ID(&frontierConnection.edge))) {
-				RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-					"SPpaths: rejecting duplicate edge %llu already on path (depth=%u)",
-					(unsigned long long)ENTITY_GET_ID(&frontierConnection.edge), depth);
 				frontierAlreadyOnPath = true;
 			}
 
@@ -1064,14 +1135,14 @@ static ProcedureResult Proc_SPpathsInvoke
 	const SIValue *args,
 	const char **yield
 ) {
-	SinglePairCtx *single_pair_ctx = rm_calloc(1, sizeof(SinglePairCtx));
-	if(!validate_config(args[0], single_pair_ctx)) {
-		SinglePairCtx_Free(single_pair_ctx);
-		return PROCEDURE_ERR;
+	SinglePairCtx *single_pair_ctx = rm_calloc (1, sizeof (SinglePairCtx)) ;
+	if (!validate_config (args [0], single_pair_ctx)) {
+		SinglePairCtx_Free (single_pair_ctx) ;
+		return PROCEDURE_ERR ;
 	}
-	ctx->privateData = single_pair_ctx;
 
-	_process_yield(single_pair_ctx, yield);
+	ctx->privateData = single_pair_ctx ;
+	_process_yield (single_pair_ctx, yield) ;
 
 	// fast path: a single shortest path with no maxCost constraint is
 	// exactly what Dijkstra solves, in O((V+E) log V) instead of the
@@ -1087,11 +1158,15 @@ static ProcedureResult Proc_SPpathsInvoke
 	// self-loop). Rather than special-casing that inside the search, just
 	// don't take the fast path here and let the exhaustive DFS (which
 	// already handles this correctly) run instead.
-	bool src_eq_dst = ENTITY_GET_ID(&single_pair_ctx->src) == ENTITY_GET_ID(single_pair_ctx->dst);
+	bool src_eq_dst =
+		(ENTITY_GET_ID (&single_pair_ctx->src) ==
+		 ENTITY_GET_ID (single_pair_ctx->dst)) ;
 
-	if(single_pair_ctx->path_count == 1 && single_pair_ctx->max_cost == DBL_MAX && !src_eq_dst) {
-		SPpaths_dijkstra_single(single_pair_ctx);
-		return PROCEDURE_OK;
+	if (src_eq_dst == false              &&
+		single_pair_ctx->path_count == 1 &&
+		single_pair_ctx->max_cost == DBL_MAX) {
+		SPpaths_dijkstra_single (single_pair_ctx) ;
+		return PROCEDURE_OK ;
 	}
 
 	// quick pre-pass: does *any* structural path (honoring relTypes/
@@ -1105,9 +1180,6 @@ static ProcedureResult Proc_SPpathsInvoke
 	_find_bound_path(single_pair_ctx, &bound_exists, &bound_weight, &bound_cost);
 
 	if(!bound_exists) {
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths: bound pre-pass found no structural path, skipping exhaustive search");
-
 		if(single_pair_ctx->path_count == 0) {
 			single_pair_ctx->array = arr_new(WeightedPath, 0);
 		} else if(single_pair_ctx->path_count == 1) {
@@ -1121,21 +1193,12 @@ static ProcedureResult Proc_SPpathsInvoke
 	bool cost_feasible = (bound_cost <= single_pair_ctx->max_cost);
 	double initial_bound = cost_feasible ? bound_weight : DBL_MAX;
 
-	RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-		"SPpaths: bound pre-pass weight=%g cost=%g maxCost=%g -> %s",
-		bound_weight, bound_cost, single_pair_ctx->max_cost,
-		cost_feasible ? "cost-feasible" : "exceeds maxCost, bound discarded");
-
 	if(single_pair_ctx->path_count == 0) {
 		// all-minimal wants every tie at the true minimum weight; the
 		// pre-pass weight is a valid upper bound on that minimum (any tie
 		// is by definition <= it), so seeding is safe here.
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths: seeding all-minimal search with max_weight=%g", initial_bound);
 		SPpaths_all_minimal(single_pair_ctx, initial_bound);
 	} else if(single_pair_ctx->path_count == 1) {
-		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
-			"SPpaths: seeding single-minimal search with max_weight=%g", initial_bound);
 		SPpaths_single_minimal(single_pair_ctx, initial_bound);
 	} else {
 		// k-minimal needs to fill up to path_count candidates before
@@ -1190,29 +1253,25 @@ static ProcedureResult Proc_SPpathsFree
 (
 	ProcedureCtx *ctx
 ) {
-	SinglePairCtx *single_pair_ctx = ctx->privateData;
-	SinglePairCtx_Free(single_pair_ctx);
-	return PROCEDURE_OK;
+	ASSERT (ctx != NULL) ;
+
+	SinglePairCtx *single_pair_ctx = ctx->privateData ;
+	SinglePairCtx_Free (single_pair_ctx) ;
+
+	return PROCEDURE_OK ;
 }
 
-ProcedureCtx *Proc_SPpathCtx() {
-	void *privateData = NULL;
-	ProcedureOutput output;
-	ProcedureOutput *outputs = arr_new(ProcedureOutput, 3);
-	output = (ProcedureOutput){.name = "path", .type = T_PATH};
-	arr_append(outputs, output);
-	output = (ProcedureOutput){.name = "pathWeight", .type = T_DOUBLE};
-	arr_append(outputs, output);
-	output = (ProcedureOutput){.name = "pathCost", .type = T_DOUBLE};
-	arr_append(outputs, output);
+ProcedureCtx *Proc_SPpathCtx (void) {
+	ProcedureOutput output ;
+	void *privateData = NULL ;
 
-	ProcedureCtx *ctx = ProcCtxNew("algo.SPpaths",
-								   1,
-								   outputs,
-								   Proc_SPpathsStep,
-								   Proc_SPpathsInvoke,
-								   Proc_SPpathsFree,
-								   privateData,
-								   true);
-	return ctx;
+	ProcedureOutput *outputs = arr_newlen (ProcedureOutput, 3) ;
+
+	outputs [0] = (ProcedureOutput) {.name = "path",       .type = T_PATH} ;
+	outputs [1] = (ProcedureOutput) {.name = "pathWeight", .type = T_DOUBLE} ;
+	outputs [2] = (ProcedureOutput) {.name = "pathCost",   .type = T_DOUBLE} ;
+
+	return ProcCtxNew ("algo.SPpaths", 1, outputs, Proc_SPpathsStep,
+			Proc_SPpathsInvoke, Proc_SPpathsFree, privateData, true) ;
 }
+

--- a/tests/flow/test_path_algorithms.py
+++ b/tests/flow/test_path_algorithms.py
@@ -1,6 +1,8 @@
 from common import *
 from index_utils import *
 from functools import cmp_to_key
+import heapq
+import random
 
 NODES = 20    # node count
 EDGES = 200   # edge count
@@ -617,3 +619,154 @@ class testAllShortestPaths():
         # would otherwise mishandle (trivially "finding" src at distance 0).
         result = self.sp_query(self.n, self.n, None, 3, None, 1, None)
         self.env.assertEquals(len(result.result_set), 0)
+
+    #-------------------------------------------------------------------------
+    # Dijkstra fast-path (SPpaths_dijkstra_single) correctness on structured
+    # graphs: pathCount==1 with no maxCost is exactly the condition that
+    # routes into the Dijkstra fast path (see the dispatch check in
+    # Proc_SPpathsInvoke). Each test below builds a graph with a known,
+    # hand-designed topology, computes all-pairs shortest distances with an
+    # independent Python Dijkstra implementation, then asks algo.SPpaths for
+    # every (src, dst) combination in a single query and checks that every
+    # reachable pair's pathWeight matches the reference exactly, and that
+    # every unreachable pair yields no result at all.
+    #-------------------------------------------------------------------------
+
+    def _dijkstra_all_pairs(self, n_nodes, edges):
+        # independent reference implementation: all-pairs shortest distances
+        # over a directed, non-negatively weighted graph given as a list of
+        # (u, v, weight) edges. returns {src: {dst: dist, ...}, ...}, where
+        # unreachable dst's are simply absent from the inner dict.
+        adj = [[] for _ in range(n_nodes)]
+        for u, v, w in edges:
+            adj[u].append((v, w))
+
+        all_dist = {}
+        for src in range(n_nodes):
+            dist = {src: 0}
+            pq = [(0, src)]
+            while pq:
+                d, u = heapq.heappop(pq)
+                if d > dist.get(u, float('inf')):
+                    continue  # stale heap entry, already finalized cheaper
+                for v, w in adj[u]:
+                    nd = d + w
+                    if nd < dist.get(v, float('inf')):
+                        dist[v] = nd
+                        heapq.heappush(pq, (nd, v))
+            all_dist[src] = dist
+
+        return all_dist
+
+    def _verify_dijkstra_all_pairs(self, graph_name, n_nodes, edges):
+        # build a directed weighted graph from `edges` (nodes labeled :DK
+        # with an 'id' property 0..n_nodes-1, edges typed :DE with a
+        # 'weight' property), then validate algo.SPpaths' Dijkstra fast
+        # path (pathCount: 1, no maxCost) against the independent reference
+        # in self._dijkstra_all_pairs for every (src, dst) combination.
+        g = self.db.select_graph(graph_name)
+        g.query(f"UNWIND range(0, {n_nodes - 1}) AS x CREATE (:DK {{id: x}})")
+
+        if edges:
+            rows = ", ".join(f"[{u}, {v}, {w}]" for u, v, w in edges)
+            g.query(f"""
+                UNWIND [{rows}] AS e
+                MATCH (a:DK {{id: e[0]}}), (b:DK {{id: e[1]}})
+                CREATE (a)-[:DE {{weight: e[2]}}]->(b)
+            """)
+
+        # one query drives algo.SPpaths once per (n, m) row produced by the
+        # outer MATCH, covering every ordered pair in a single round trip;
+        # unreachable pairs simply yield no row (CALL acts like an inner
+        # join), so they never appear in 'actual' below.
+        result = g.query("""
+            MATCH (n:DK), (m:DK)
+            WHERE n.id <> m.id
+            CALL algo.SPpaths({
+                sourceNode: n,
+                targetNode: m,
+                weightProp: 'weight',
+                pathCount: 1
+            }) YIELD pathWeight
+            RETURN n.id, m.id, pathWeight
+        """)
+
+        actual = {(row[0], row[1]): row[2] for row in result.result_set}
+        expected = self._dijkstra_all_pairs(n_nodes, edges)
+
+        for src in range(n_nodes):
+            for dst in range(n_nodes):
+                if src == dst:
+                    continue
+
+                key = (src, dst)
+                exp_weight = expected[src].get(dst)
+
+                if exp_weight is None:
+                    # no path should have been found for this pair
+                    self.env.assertNotContains(key, actual)
+                else:
+                    self.env.assertContains(key, actual)
+                    self.env.assertAlmostEqual(actual[key], exp_weight, delta=1e-9)
+
+    def test14_dijkstra_line_graph(self):
+        # simple directed line 0->1->2->...->(n-1) with strictly increasing
+        # weights. exactly one path exists between any (src, dst) pair, and
+        # only "forward" pairs are reachable at all -- a baseline sanity
+        # check for path composition, weight accumulation, and correct
+        # rejection of unreachable (backward) pairs.
+        n = 8
+        edges = [(i, i + 1, i + 1) for i in range(n - 1)]
+        self._verify_dijkstra_all_pairs("dijkstra_line", n, edges)
+
+    def test15_dijkstra_diamond_graph(self):
+        # a DAG made of two chained "diamonds", each offering a cheap and an
+        # expensive parallel route between the same pair of nodes:
+        #   0 -> 1 -> 3 -> 4 -> 6 -> 7   (cheap branch: weight 1 each hop)
+        #   0 -> 2 -> 3 -> 5 -> 6 -> 7   (expensive branch: weight 5 each hop)
+        # Dijkstra must independently pick the cheap branch at each diamond.
+        edges = [
+            (0, 1, 1), (0, 2, 5),
+            (1, 3, 1), (2, 3, 1),
+            (3, 4, 1), (3, 5, 5),
+            (4, 6, 1), (5, 6, 1),
+            (6, 7, 1),
+        ]
+        self._verify_dijkstra_all_pairs("dijkstra_diamond", 8, edges)
+
+    def test16_dijkstra_grid_graph(self):
+        # a 4x4 grid with only rightward/downward edges and randomized
+        # weights: many equal-length alternative routes exist between any
+        # two nodes on the same diagonal, forcing Dijkstra to actually
+        # compare weights rather than just hop count. reversed (backward)
+        # pairs are unreachable, exercising that path too.
+        random.seed(1234)
+        rows, cols = 4, 4
+
+        def node_id(r, c):
+            return r * cols + c
+
+        edges = []
+        for r in range(rows):
+            for c in range(cols):
+                if c + 1 < cols:
+                    edges.append((node_id(r, c), node_id(r, c + 1), random.randint(1, 9)))
+                if r + 1 < rows:
+                    edges.append((node_id(r, c), node_id(r + 1, c), random.randint(1, 9)))
+
+        self._verify_dijkstra_all_pairs("dijkstra_grid", rows * cols, edges)
+
+    def test17_dijkstra_dense_cyclic_graph(self):
+        # a dense graph with edges in both directions between most node
+        # pairs, forming many cycles. exercises Dijkstra's finalize-once
+        # invariant and lazy heap-deletion under heavy relabeling: many
+        # nodes get repeatedly relaxed and re-queued before the true
+        # minimum is found.
+        n = 10
+        edges = []
+        for u in range(n):
+            for v in range(n):
+                if u != v and (u + v) % 3 != 0:
+                    edges.append((u, v, ((u * 7 + v * 13) % 11) + 1))
+
+        self._verify_dijkstra_all_pairs("dijkstra_dense", n, edges)

--- a/tests/flow/test_path_algorithms.py
+++ b/tests/flow/test_path_algorithms.py
@@ -508,3 +508,112 @@ class testAllShortestPaths():
         self.env.assertGreater(ss_result.result_set[0][0], ss_result.result_set[1][0])
         self.env.assertAlmostEqual(ss_result.result_set[0][0], 0.2, delta=1e-9)
         self.env.assertAlmostEqual(ss_result.result_set[1][0], 0.1, delta=1e-9)
+
+    def test09_sp_dijkstra_unconstrained_cost(self):
+        # pathCount == 1 with no maxCost set routes through the Dijkstra
+        # fast path (SPpaths_dijkstra_single) instead of the DFS-based
+        # search used everywhere else in this file. Verify it agrees with
+        # the true minimum-weight path, computed independently via a fully
+        # unconstrained Cypher variable-length match (no cost filtering).
+        query = f"""
+        MATCH (n:L {{v: {self.n}}}), (m:L {{v: {self.m}}})
+        MATCH p=(n)-[:E*1..3]->(m)
+        RETURN p,
+               reduce(weight = 0, r in relationships(p) | weight + r.weight) AS weight"""
+        result = self.graph.query(query)
+        candidates = [p for p in result.result_set
+                      if len(p[0].nodes()) == len(set(node.id for node in p[0].nodes()))]
+        min_weight = min(p[1] for p in candidates)
+
+        results = [
+            self.sp_query(self.n, self.m, ["E"], 3, None, 1, None),
+            self.sp_query(self.n, self.m, None, 3, None, 1, None)
+        ]
+
+        for result in results:
+            self.env.assertEquals(len(result.result_set), 1)
+            self.env.assertAlmostEqual(result.result_set[0][1], min_weight, delta=1e-9)
+
+    def test11_sp_unreachable(self):
+        # two nodes with no path between them at all: the BFS bound
+        # pre-pass (finite maxCost) and Dijkstra (unconstrained maxCost)
+        # must both report "no path" cleanly rather than erroring or
+        # hanging, regardless of pathCount.
+        g = self.db.select_graph("unreachable_graph")
+        g.query("CREATE (x:UR {id: 'X'}), (y:UR {id: 'Y'})")
+
+        def ur_query(path_count, max_cost):
+            args = ["sourceNode: src", "targetNode: dst", "weightProp: 'w'"]
+            if max_cost is not None:
+                args.append(f"maxCost: {max_cost}")
+            args.append(f"pathCount: {path_count}")
+            return g.query(f"""
+                MATCH (src:UR {{id: 'X'}}), (dst:UR {{id: 'Y'}})
+                CALL algo.SPpaths({{{", ".join(args)}}}) YIELD path
+                RETURN path
+            """)
+
+        # pathCount==1, unconstrained cost -> Dijkstra "not found" branch
+        self.env.assertEquals(len(ur_query(1, None).result_set), 0)
+        # pathCount==1, finite maxCost -> pre-pass short-circuit
+        self.env.assertEquals(len(ur_query(1, 100).result_set), 0)
+        # pathCount==0 (all-minimal), finite maxCost -> pre-pass short-circuit
+        self.env.assertEquals(len(ur_query(0, 100).result_set), 0)
+        # pathCount>1 (k-minimal), finite maxCost -> pre-pass short-circuit
+        self.env.assertEquals(len(ur_query(3, 100).result_set), 0)
+
+    def test12_sp_duplicate_edges(self):
+        # (a) a self-loop combined with relDirection: 'both' can surface
+        # the same edge as a candidate via both the outgoing and incoming
+        # scan; it must be rejected like any other cycle, not corrupt or
+        # duplicate the result.
+        g = self.db.select_graph("selfloop_graph")
+        g.query("""
+            CREATE (a:SL {id: 'A'}),
+                   (b:SL {id: 'B'}),
+                   (a)-[:SLR {weight: 1}]->(a),
+                   (a)-[:SLR {weight: 1}]->(b)
+        """)
+
+        result = g.query("""
+            MATCH (src:SL {id: 'A'}), (dst:SL {id: 'B'})
+            CALL algo.SPpaths({
+                sourceNode: src,
+                targetNode: dst,
+                weightProp: 'weight',
+                relDirection: 'both',
+                pathCount: 1
+            }) YIELD path, pathWeight
+            RETURN pathWeight, length(path)
+        """)
+
+        self.env.assertEquals(len(result.result_set), 1)
+        self.env.assertAlmostEqual(result.result_set[0][0], 1, delta=1e-9)
+        self.env.assertEquals(result.result_set[0][1], 1)
+
+        # (b) listing the same relationship type twice in relTypes must
+        # not double-count a path in the k-minimal results (previously,
+        # duplicate relation ids could surface a node/edge as a candidate
+        # twice, letting the same path be re-derived and returned again
+        # after the DFS backtracked through it).
+        expected_len = min(len(self.sp_paths), 3)
+        dup = self.sp_query(self.n, self.m, ["E", "E"], 3, self.max_cost, 3, None)
+        single = self.sp_query(self.n, self.m, ["E"], 3, self.max_cost, 3, None)
+
+        self.env.assertEquals(len(dup.result_set), expected_len)
+        self.env.assertEquals(len(single.result_set), expected_len)
+        for row in dup.result_set:
+            self.env.assertContains(row, single.result_set)
+
+    def test13_sp_src_eq_dst(self):
+        # sourceNode == targetNode is degenerate: minLen==1 requires at
+        # least one edge, so this must always return no results, whether
+        # or not a self-loop exists, and regardless of which code path
+        # handles it (Dijkstra fast path vs. DFS).
+        result = self.sp_query(self.n, self.n, ["E"], 3, self.max_cost, 1, None)
+        self.env.assertEquals(len(result.result_set), 0)
+
+        # unconstrained cost -- this is exactly the case SPpaths_dijkstra_single
+        # would otherwise mishandle (trivially "finding" src at distance 0).
+        result = self.sp_query(self.n, self.n, None, 3, None, 1, None)
+        self.env.assertEquals(len(result.result_set), 0)

--- a/tests/flow/test_path_algorithms.py
+++ b/tests/flow/test_path_algorithms.py
@@ -536,7 +536,7 @@ class testAllShortestPaths():
             self.env.assertEquals(len(result.result_set), 1)
             self.env.assertAlmostEqual(result.result_set[0][1], min_weight, delta=1e-9)
 
-    def test11_sp_unreachable(self):
+    def test10_sp_unreachable(self):
         # two nodes with no path between them at all: the BFS bound
         # pre-pass (finite maxCost) and Dijkstra (unconstrained maxCost)
         # must both report "no path" cleanly rather than erroring or
@@ -564,7 +564,7 @@ class testAllShortestPaths():
         # pathCount>1 (k-minimal), finite maxCost -> pre-pass short-circuit
         self.env.assertEquals(len(ur_query(3, 100).result_set), 0)
 
-    def test12_sp_duplicate_edges(self):
+    def test11_sp_duplicate_edges(self):
         # (a) a self-loop combined with relDirection: 'both' can surface
         # the same edge as a candidate via both the outgoing and incoming
         # scan; it must be rejected like any other cycle, not corrupt or
@@ -607,7 +607,7 @@ class testAllShortestPaths():
         for row in dup.result_set:
             self.env.assertContains(row, single.result_set)
 
-    def test13_sp_src_eq_dst(self):
+    def test12_sp_src_eq_dst(self):
         # sourceNode == targetNode is degenerate: minLen==1 requires at
         # least one edge, so this must always return no results, whether
         # or not a self-loop exists, and regardless of which code path
@@ -709,7 +709,7 @@ class testAllShortestPaths():
                     self.env.assertContains(key, actual)
                     self.env.assertAlmostEqual(actual[key], exp_weight, delta=1e-9)
 
-    def test14_dijkstra_line_graph(self):
+    def test13_dijkstra_line_graph(self):
         # simple directed line 0->1->2->...->(n-1) with strictly increasing
         # weights. exactly one path exists between any (src, dst) pair, and
         # only "forward" pairs are reachable at all -- a baseline sanity
@@ -719,7 +719,7 @@ class testAllShortestPaths():
         edges = [(i, i + 1, i + 1) for i in range(n - 1)]
         self._verify_dijkstra_all_pairs("dijkstra_line", n, edges)
 
-    def test15_dijkstra_diamond_graph(self):
+    def test14_dijkstra_diamond_graph(self):
         # a DAG made of two chained "diamonds", each offering a cheap and an
         # expensive parallel route between the same pair of nodes:
         #   0 -> 1 -> 3 -> 4 -> 6 -> 7   (cheap branch: weight 1 each hop)
@@ -734,7 +734,7 @@ class testAllShortestPaths():
         ]
         self._verify_dijkstra_all_pairs("dijkstra_diamond", 8, edges)
 
-    def test16_dijkstra_grid_graph(self):
+    def test15_dijkstra_grid_graph(self):
         # a 4x4 grid with only rightward/downward edges and randomized
         # weights: many equal-length alternative routes exist between any
         # two nodes on the same diagonal, forcing Dijkstra to actually
@@ -756,7 +756,7 @@ class testAllShortestPaths():
 
         self._verify_dijkstra_all_pairs("dijkstra_grid", rows * cols, edges)
 
-    def test17_dijkstra_dense_cyclic_graph(self):
+    def test16_dijkstra_dense_cyclic_graph(self):
         # a dense graph with edges in both directions between most node
         # pairs, forming many cycles. exercises Dijkstra's finalize-once
         # invariant and lazy heap-deletion under heavy relabeling: many


### PR DESCRIPTION
Resolve #2162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance / Behavior**
  * Improved constrained weighted path search with reused adjacency/edge lookup and a structural reachability pre-check to tighten bounds.
  * Added an exact Dijkstra fast path for eligible single shortest-path queries to return correct minimum path weights.
* **Bug Fixes**
  * Prevented duplicate/degenerate edge candidates from corrupting k-minimal results.
  * Ensured unreachable source/target pairs return zero results and refined source=target handling to respect minimum length semantics.
* **Tests**
  * Added Dijkstra-dispatch correctness checks (including unreachable cases) and expanded coverage for multiple graph shapes and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->