### PR TITLE
Fix vector-indexed nodes disappearing from KNN after update/delete

### DIFF
--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -222,3 +222,75 @@ class testVecsim():
         except Exception as e:
             self.env.assertEqual("Vector dimension mismatch, expected 2 but got 3", str(e))
 
+    def test08_reindex_after_update_keeps_node(self):
+        # regression: updating a vector-indexed node must not drop it from the
+        # vector index.
+        #
+        # Every property write re-indexes the node as a RediSearch REPLACE, which
+        # allocates a new docId and appends a new vector while the previous vector
+        # must be removed from the HNSW graph. That removal only runs when the spec
+        # flag Index_HasVecSim is set; it was never set for indexes created through
+        # the low-level C API, so the old vector was never deleted. Stale vectors
+        # accumulated as orphans (docIds no longer resolving to a document) and
+        # shadowed the live entry, so the node became unfindable at small k - e.g.
+        # k=1 returned nothing after any update to the node.
+        g = Graph(self.conn, "vecsim_reindex")
+
+        v = [42.0, 42.0]
+        g.query("CREATE (:RUser {id: 1})")
+        g.create_node_vector_index("RUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_hits(q, k=1):
+            return len(query_node_vector_index(g, "RUser", "emb", k, q).result_set)
+
+        # insert the vector - baseline
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # re-SET the SAME value - node must still be found at k=1
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET an unrelated property (embedding untouched) - still found at k=1
+        g.query("MATCH (u:RUser) SET u.name = 'bob'")
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET a different value - found at the new location at k=1
+        v2 = [7.0, 7.0]
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v2)", params={'v2': v2})
+        self.env.assertEqual(knn_hits(v2), 1)
+
+    def test09_delete_removes_vector_from_index(self):
+        # regression: deleting a vector-indexed node must remove its vector from
+        # the HNSW graph, not leave it as an orphan.
+        #
+        # The low-level delete only dropped the doc-table entry and never removed
+        # the vector from VecSim, so a deleted node's vector lingered and shadowed
+        # a new node inserted at the same coordinates - the new node was
+        # unfindable at k=1.
+        g = Graph(self.conn, "vecsim_delete")
+
+        v = [42.0, 42.0]
+        g.create_node_vector_index("DUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_tags(q, k=1):
+            res = query_node_vector_index(g, "DUser", "emb", k, q).result_set
+            return [row[0].properties['tag'] for row in res]
+
+        # node A at v
+        g.query("CREATE (:DUser {tag: 'A', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['A'])
+
+        # delete A - nothing at v anymore
+        g.query("MATCH (u:DUser {tag: 'A'}) DELETE u")
+        self.env.assertEqual(knn_tags(v), [])
+
+        # a new node B at the SAME coordinates must be found, not shadowed by
+        # A's leftover vector
+        g.query("CREATE (:DUser {tag: 'B', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['B'])
+


### PR DESCRIPTION
## Problem

A node indexed by a vector index "disappears" from `db.idx.vector.queryNodes` (KNN) after **any** update to it, and after a node is deleted a new node inserted at the same coordinates is unfindable. With the default `k=1` the query returns 0 results even though the property is present.

## Root cause

Vector removal from the HNSW graph was never happening for indexes created through the RediSearch low-level C API (which is how FalkorDB creates them):

1. **Update:** every write re-indexes the node as a RediSearch REPLACE, which mints a new docId and appends a new vector — the old vector must be removed, but that removal is gated on the spec flag `Index_HasVecSim`, which `RediSearch_CreateField(RSFLDTYPE_VECTOR)` never set (only the textual `FT.CREATE … VECTOR` parser did).
2. **Delete:** the LLAPI `RediSearch_DeleteDocument` only removed the doc-table entry and never removed the vector at all (unlike the command-layer `IndexSpec_DeleteDoc`).

Either way the old vectors linger as orphans (docIds that no longer resolve to a document) and shadow live entries in KNN, so fewer than `k` results come back.

## Fix

Vendored RediSearch bump to **FalkorDB/RediSearch#23**, which:
- sets `Index_HasVecSim` in the vector branch of `RediSearch_CreateField`, and
- removes the document's vectors in `RediSearch_DeleteDocument` (guarded by `Index_HasVecSim`, mirroring `IndexSpec_DeleteDoc`).

## Tests

`tests/flow/test_vecsim.py`:
- **test08** — re-SET (same value, different value, unrelated property) keeps the node findable at `k=1`.
- **test09** — deleting a node removes its vector, so a new node at the same coordinates is found (not shadowed).

Both **fail against the pre-fix submodule** (`test08`: `0 == 1`; `test09`: `[] == ['B']`) and **pass with the bump**; the existing `test01`–`test07` are unaffected.

## Merge order

Depends on FalkorDB/RediSearch#23. This bumps the submodule to the fix branch commit; once #23 merges into `vector-low-level-api`, re-point the submodule to the merge commit if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to confirm `k=1` nearest-neighbor results stay correct after a vector update that triggers reindexing.
  * Added regression coverage to verify deleting a node fully removes its vector from the index, with no lingering/shadowing behavior when re-inserting at the same coordinates.
* **Maintenance**
  * Updated the embedded search dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->