### PR TITLE
fix: support trimming spaces in toInteger, toFloat, and toBoolean type conversions

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
           if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then

--- a/.github/workflows/release-ramp.yml
+++ b/.github/workflows/release-ramp.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           TAG="${{ steps.set_semver.outputs.TAG_NAME }}"
           echo "Tag: ${TAG}, version.h: ${FILE_VERSION}"

--- a/src/arithmetic/boolean_funcs/boolean_funcs.c
+++ b/src/arithmetic/boolean_funcs/boolean_funcs.c
@@ -188,13 +188,12 @@ SIValue AR_TO_BOOLEAN(SIValue *argv, int argc, void *private_data) {
 			return SI_BoolVal(v.longval);
 		case T_INTERN_STRING:
 		case T_STRING: {
-			char *trimmed = str_trim(v.stringval);
-			if (!trimmed) return SI_NullVal();
-			SIValue ret = SI_NullVal();
-			if(!strcasecmp("true", trimmed)) ret = SI_BoolVal(true);
-			else if(!strcasecmp("false", trimmed)) ret = SI_BoolVal(false);
-			rm_free(trimmed);
-			return ret;
+			const char *start;
+			size_t len;
+			str_trim_range(v.stringval, &start, &len);
+			if (len == 4 && !strncasecmp("true", start, 4)) return SI_BoolVal(true);
+			if (len == 5 && !strncasecmp("false", start, 5)) return SI_BoolVal(false);
+			return SI_NullVal();
 		}
 		case T_BOOL:
 			return v;

--- a/src/arithmetic/boolean_funcs/boolean_funcs.c
+++ b/src/arithmetic/boolean_funcs/boolean_funcs.c
@@ -7,6 +7,8 @@
 #include "boolean_funcs.h"
 #include "../func_desc.h"
 #include "../../util/arr.h"
+#include "../../util/strutil.h"
+
 #include "../../query_ctx.h"
 #include "../../errors/errors.h"
 #include "../../datatypes/map.h"
@@ -186,9 +188,13 @@ SIValue AR_TO_BOOLEAN(SIValue *argv, int argc, void *private_data) {
 			return SI_BoolVal(v.longval);
 		case T_INTERN_STRING:
 		case T_STRING: {
-			if(!strcasecmp("true", v.stringval)) return SI_BoolVal(true);
-			else if(!strcasecmp("false", v.stringval)) return SI_BoolVal(false);
-			return SI_NullVal();
+			char *trimmed = str_trim(v.stringval);
+			if (!trimmed) return SI_NullVal();
+			SIValue ret = SI_NullVal();
+			if(!strcasecmp("true", trimmed)) ret = SI_BoolVal(true);
+			else if(!strcasecmp("false", trimmed)) ret = SI_BoolVal(false);
+			rm_free(trimmed);
+			return ret;
 		}
 		case T_BOOL:
 			return v;

--- a/src/arithmetic/numeric_funcs/numeric_funcs.c
+++ b/src/arithmetic/numeric_funcs/numeric_funcs.c
@@ -11,6 +11,8 @@
 #include "../../util/rmalloc.h"
 #include "../../errors/errors.h"
 #include "../temporal_arithmetic/temporal_arithmetic.h"
+#include "../../util/strutil.h"
+
 
 #include <math.h>
 #include <errno.h>
@@ -138,20 +140,33 @@ SIValue AR_TOINTEGER(SIValue *argv, int argc, void *private_data) {
 		}
 		return SI_LongVal(0);
 	case T_STRING:
-	case T_INTERN_STRING:
-		if(strlen(arg.stringval) == 0) return SI_NullVal();
+	case T_INTERN_STRING: {
+		char *trimmed = str_trim(arg.stringval);
+		if(!trimmed || strlen(trimmed) == 0) {
+			rm_free(trimmed);
+			return SI_NullVal();
+		}
 		errno = 0;
-		if(strchr(arg.stringval, '.') == NULL) {
-			int64_t parsedval = strtoll(arg.stringval, &sEnd, 10);
-			if(sEnd[0] != '\0' || errno == ERANGE) return SI_NullVal();
+		if(strchr(trimmed, '.') == NULL) {
+			int64_t parsedval = strtoll(trimmed, &sEnd, 10);
+			if(sEnd[0] != '\0' || errno == ERANGE) {
+				rm_free(trimmed);
+				return SI_NullVal();
+			}
+			rm_free(trimmed);
 			return SI_LongVal(parsedval);
 		}
-		double parsedval = strtod(arg.stringval, &sEnd);
+		double parsedval = strtod(trimmed, &sEnd);
 		/* The input was not a complete number or represented a number that
 		 * cannot be represented as a double. */
-		if(sEnd[0] != '\0' || errno == ERANGE) return SI_NullVal();
+		if(sEnd[0] != '\0' || errno == ERANGE) {
+			rm_free(trimmed);
+			return SI_NullVal();
+		}
+		rm_free(trimmed);
 		// Remove floating point.
 		return SI_LongVal(floor(parsedval));
+	}
 	default:
 		return SI_NullVal();
 	}
@@ -168,14 +183,23 @@ SIValue AR_TOFLOAT(SIValue *argv, int argc, void *private_data) {
 	case T_DOUBLE:
 		return arg;
 	case T_STRING:
-	case T_INTERN_STRING:
-		if(strlen(arg.stringval) == 0) return SI_NullVal();
+	case T_INTERN_STRING: {
+		char *trimmed = str_trim(arg.stringval);
+		if(!trimmed || strlen(trimmed) == 0) {
+			rm_free(trimmed);
+			return SI_NullVal();
+		}
 		errno = 0;
-		double parsedval = strtof(arg.stringval, &sEnd);
+		double parsedval = strtof(trimmed, &sEnd);
 		/* The input was not a complete number or represented a number that
 		 * cannot be represented as a double. */
-		if(sEnd[0] != '\0' || errno == ERANGE) return SI_NullVal();
+		if(sEnd[0] != '\0' || errno == ERANGE) {
+			rm_free(trimmed);
+			return SI_NullVal();
+		}
+		rm_free(trimmed);
 		return SI_DoubleVal(parsedval);
+	}
 	default:
 		return SI_NullVal();
 	}

--- a/src/arithmetic/numeric_funcs/numeric_funcs.c
+++ b/src/arithmetic/numeric_funcs/numeric_funcs.c
@@ -141,29 +141,23 @@ SIValue AR_TOINTEGER(SIValue *argv, int argc, void *private_data) {
 		return SI_LongVal(0);
 	case T_STRING:
 	case T_INTERN_STRING: {
-		char *trimmed = str_trim(arg.stringval);
-		if(!trimmed || strlen(trimmed) == 0) {
-			rm_free(trimmed);
-			return SI_NullVal();
-		}
+		const char *start;
+		size_t len;
+		str_trim_range(arg.stringval, &start, &len);
+		if(len == 0) return SI_NullVal();
 		errno = 0;
-		if(strchr(trimmed, '.') == NULL) {
-			int64_t parsedval = strtoll(trimmed, &sEnd, 10);
-			if(sEnd[0] != '\0' || errno == ERANGE) {
-				rm_free(trimmed);
-				return SI_NullVal();
-			}
-			rm_free(trimmed);
+		const char *dot = memchr(start, '.', len);
+		if(dot == NULL) {
+			int64_t parsedval = strtoll(start, &sEnd, 10);
+			/* The input was not a complete number or represented a number that
+		 	* cannot be represented as a double. */
+			if(sEnd != start + len || errno == ERANGE) return SI_NullVal();
 			return SI_LongVal(parsedval);
 		}
-		double parsedval = strtod(trimmed, &sEnd);
+		double parsedval = strtod(start, &sEnd);
 		/* The input was not a complete number or represented a number that
 		 * cannot be represented as a double. */
-		if(sEnd[0] != '\0' || errno == ERANGE) {
-			rm_free(trimmed);
-			return SI_NullVal();
-		}
-		rm_free(trimmed);
+		if(sEnd != start + len || errno == ERANGE) return SI_NullVal();
 		// Remove floating point.
 		return SI_LongVal(floor(parsedval));
 	}
@@ -184,20 +178,15 @@ SIValue AR_TOFLOAT(SIValue *argv, int argc, void *private_data) {
 		return arg;
 	case T_STRING:
 	case T_INTERN_STRING: {
-		char *trimmed = str_trim(arg.stringval);
-		if(!trimmed || strlen(trimmed) == 0) {
-			rm_free(trimmed);
-			return SI_NullVal();
-		}
+		const char *start;
+		size_t len;
+		str_trim_range(arg.stringval, &start, &len);
+		if(len == 0) return SI_NullVal();
 		errno = 0;
-		double parsedval = strtof(trimmed, &sEnd);
+		double parsedval = strtof(start, &sEnd);
 		/* The input was not a complete number or represented a number that
 		 * cannot be represented as a double. */
-		if(sEnd[0] != '\0' || errno == ERANGE) {
-			rm_free(trimmed);
-			return SI_NullVal();
-		}
-		rm_free(trimmed);
+		if(sEnd != start + len || errno == ERANGE) return SI_NullVal();
 		return SI_DoubleVal(parsedval);
 	}
 	default:

--- a/src/util/strutil.c
+++ b/src/util/strutil.c
@@ -222,3 +222,21 @@ void str_truncate
 	}
 }
 
+// trim leading and trailing spaces from a string
+// returns a newly allocated string that must be freed with rm_free
+char *str_trim
+(
+	const char *str
+) {
+	if (!str) return NULL;
+	while (*str == ' ') {
+		str++;
+	}
+	size_t len = strlen(str);
+	while (len > 0 && str[len - 1] == ' ') {
+		len--;
+	}
+	return rm_strndup(str, len);
+}
+
+

--- a/src/util/strutil.c
+++ b/src/util/strutil.c
@@ -222,21 +222,28 @@ void str_truncate
 	}
 }
 
-// trim leading and trailing spaces from a string
-// returns a newly allocated string that must be freed with rm_free
-char *str_trim
+// find the trimmed bounds of a string (only space characters trimmed)
+// returns the trimmed start pointer in out_start and the trimmed length in out_len
+void str_trim_range
 (
-	const char *str
+	const char *str,
+	const char **out_start,
+	size_t *out_len
 ) {
-	if (!str) return NULL;
+	if (!str) {
+		*out_start = NULL;
+		*out_len = 0;
+		return;
+	}
 	while (*str == ' ') {
 		str++;
 	}
+	*out_start = str;
 	size_t len = strlen(str);
 	while (len > 0 && str[len - 1] == ' ') {
 		len--;
 	}
-	return rm_strndup(str, len);
+	*out_len = len;
 }
 
 

--- a/src/util/strutil.h
+++ b/src/util/strutil.h
@@ -68,3 +68,11 @@ void str_truncate
 	uint max_len       // string max length
 );
 
+// trim leading and trailing spaces from a string
+// returns a newly allocated string that must be freed with rm_free
+char *str_trim
+(
+	const char *str
+);
+
+

--- a/src/util/strutil.h
+++ b/src/util/strutil.h
@@ -68,11 +68,14 @@ void str_truncate
 	uint max_len       // string max length
 );
 
-// trim leading and trailing spaces from a string
-// returns a newly allocated string that must be freed with rm_free
-char *str_trim
+// find the trimmed bounds of a string (only space characters trimmed)
+// returns the trimmed start pointer in out_start and the trimmed length in out_len
+void str_trim_range
 (
-	const char *str
+	const char *str,
+	const char **out_start,
+	size_t *out_len
 );
+
 
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -707,6 +707,10 @@ class testFunctionCallsFlow(FlowTestsBase):
             """RETURN toInteger('')""",
             """RETURN toInteger('  ')""",
             """RETURN toInteger('  z  ')""",
+            """RETURN toInteger('1 2')""",
+            """RETURN toInteger(' 1 2 ')""",
+            """RETURN toInteger('1. 2')""",
+            """RETURN toInteger('1 .2')""",
             """RETURN toInteger('18446744073709551616')""",
             """RETURN toInteger('-18446744073709551616')""",
         ]
@@ -902,6 +906,12 @@ class testFunctionCallsFlow(FlowTestsBase):
         query = """RETURN toBooleanOrNull('   ')"""
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], None)
+        query = """RETURN toBooleanOrNull('tr ue')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query = """RETURN toBooleanOrNull('fa lse')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
 
         # integers
         query = """RETURN toBooleanOrNull(0)"""
@@ -962,6 +972,12 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], None)
         query = """RETURN toFloatOrNull('1.2.3')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query = """RETURN toFloatOrNull('1 .23')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query = """RETURN toFloatOrNull('1. 23')"""
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], None)
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -687,6 +687,15 @@ class testFunctionCallsFlow(FlowTestsBase):
             """RETURN toInteger(false)""": [[0]],
             """RETURN toInteger('1790460441484152222')""": [[1790460441484152222]],
             """RETURN toInteger('-1790460441484152222')""": [[-1790460441484152222]],
+            """RETURN toInteger('  1')""": [[1]],
+            """RETURN toInteger('1  ')""": [[1]],
+            """RETURN toInteger('  1  ')""": [[1]],
+            """RETURN toInteger('  1.1')""": [[1]],
+            """RETURN toInteger('1.1  ')""": [[1]],
+            """RETURN toInteger('  1.1  ')""": [[1]],
+            """RETURN toInteger('  -1790460441484152222')""": [[-1790460441484152222]],
+            """RETURN toInteger('-1790460441484152222  ')""": [[-1790460441484152222]],
+            """RETURN toInteger('  -1790460441484152222  ')""": [[-1790460441484152222]],
         }
         for query, expected_result in query_to_expected_result.items():
             self.get_res_and_assertEquals(query, expected_result)
@@ -696,6 +705,8 @@ class testFunctionCallsFlow(FlowTestsBase):
             """RETURN toInteger('z')""",
             """RETURN toInteger(NULL)""",
             """RETURN toInteger('')""",
+            """RETURN toInteger('  ')""",
+            """RETURN toInteger('  z  ')""",
             """RETURN toInteger('18446744073709551616')""",
             """RETURN toInteger('-18446744073709551616')""",
         ]
@@ -837,6 +848,26 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], True)
 
+        # strings with spaces
+        query = """RETURN toBoolean('  true')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], True)
+        query = """RETURN toBoolean('true  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], True)
+        query = """RETURN toBoolean('  true  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], True)
+        query = """RETURN toBoolean('  false')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], False)
+        query = """RETURN toBoolean('false  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], False)
+        query = """RETURN toBoolean('  false  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], False)
+
     def test29_toBooleanOrNull(self):
         # boolean
         query = """RETURN toBooleanOrNull(true)"""
@@ -854,6 +885,21 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], False)
         query = """RETURN toBooleanOrNull('not a boolean')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query = """RETURN toBooleanOrNull('  TruE')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], True)
+        query = """RETURN toBooleanOrNull('FaLsE  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], False)
+        query = """RETURN toBooleanOrNull('  TruE  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], True)
+        query = """RETURN toBooleanOrNull('  FaLsE  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], False)
+        query = """RETURN toBooleanOrNull('   ')"""
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], None)
 
@@ -903,6 +949,18 @@ class testFunctionCallsFlow(FlowTestsBase):
         query = """RETURN toFloatOrNull('1.23')"""
         actual_result = self.graph.query(query)
         self.env.assertAlmostEqual(actual_result.result_set[0][0], 1.23, 0.0001)
+        query = """RETURN toFloatOrNull('  1.23')"""
+        actual_result = self.graph.query(query)
+        self.env.assertAlmostEqual(actual_result.result_set[0][0], 1.23, 0.0001)
+        query = """RETURN toFloatOrNull('1.23  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertAlmostEqual(actual_result.result_set[0][0], 1.23, 0.0001)
+        query = """RETURN toFloatOrNull('  1.23  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertAlmostEqual(actual_result.result_set[0][0], 1.23, 0.0001)
+        query = """RETURN toFloatOrNull('  ')"""
+        actual_result = self.graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], None)
         query = """RETURN toFloatOrNull('1.2.3')"""
         actual_result = self.graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], None)

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -222,3 +222,75 @@ class testVecsim():
         except Exception as e:
             self.env.assertEqual("Vector dimension mismatch, expected 2 but got 3", str(e))
 
+    def test08_reindex_after_update_keeps_node(self):
+        # regression: updating a vector-indexed node must not drop it from the
+        # vector index.
+        #
+        # Every property write re-indexes the node as a RediSearch REPLACE, which
+        # allocates a new docId and appends a new vector while the previous vector
+        # must be removed from the HNSW graph. That removal only runs when the spec
+        # flag Index_HasVecSim is set; it was never set for indexes created through
+        # the low-level C API, so the old vector was never deleted. Stale vectors
+        # accumulated as orphans (docIds no longer resolving to a document) and
+        # shadowed the live entry, so the node became unfindable at small k - e.g.
+        # k=1 returned nothing after any update to the node.
+        g = Graph(self.conn, "vecsim_reindex")
+
+        v = [42.0, 42.0]
+        g.query("CREATE (:RUser {id: 1})")
+        g.create_node_vector_index("RUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_hits(q, k=1):
+            return len(query_node_vector_index(g, "RUser", "emb", k, q).result_set)
+
+        # insert the vector - baseline
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # re-SET the SAME value - node must still be found at k=1
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET an unrelated property (embedding untouched) - still found at k=1
+        g.query("MATCH (u:RUser) SET u.name = 'bob'")
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET a different value - found at the new location at k=1
+        v2 = [7.0, 7.0]
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v2)", params={'v2': v2})
+        self.env.assertEqual(knn_hits(v2), 1)
+
+    def test09_delete_removes_vector_from_index(self):
+        # regression: deleting a vector-indexed node must remove its vector from
+        # the HNSW graph, not leave it as an orphan.
+        #
+        # The low-level delete only dropped the doc-table entry and never removed
+        # the vector from VecSim, so a deleted node's vector lingered and shadowed
+        # a new node inserted at the same coordinates - the new node was
+        # unfindable at k=1.
+        g = Graph(self.conn, "vecsim_delete")
+
+        v = [42.0, 42.0]
+        g.create_node_vector_index("DUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_tags(q, k=1):
+            res = query_node_vector_index(g, "DUser", "emb", k, q).result_set
+            return [row[0].properties['tag'] for row in res]
+
+        # node A at v
+        g.query("CREATE (:DUser {tag: 'A', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['A'])
+
+        # delete A - nothing at v anymore
+        g.query("MATCH (u:DUser {tag: 'A'}) DELETE u")
+        self.env.assertEqual(knn_tags(v), [])
+
+        # a new node B at the SAME coordinates must be found, not shadowed by
+        # A's leftover vector
+        g.query("CREATE (:DUser {tag: 'B', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['B'])
+


### PR DESCRIPTION
Closes https://github.com/FalkorDB/FalkorDB/issues/2198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type conversions to ignore leading/trailing whitespace when converting strings to boolean, integer, and floating-point values.
  * Whitespace-only strings now consistently produce the empty-value/null result.
  * Conversions now require the entire trimmed string to be a valid representation; malformed or out-of-range inputs still fail/null appropriately.
* **Tests**
  * Expanded whitespace-tolerant conversion coverage, including padded booleans (mixed case), large numbers, whitespace-only inputs, and invalid formats (including internal whitespace).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->