### PR TITLE
fix(effects): fail gracefully on missing schema ID instead of segfaulting

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
           if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then

--- a/.github/workflows/release-ramp.yml
+++ b/.github/workflows/release-ramp.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           TAG="${{ steps.set_semver.outputs.TAG_NAME }}"
           echo "Tag: ${TAG}, version.h: ${FILE_VERSION}"

--- a/src/effects/effects_apply.c
+++ b/src/effects/effects_apply.c
@@ -64,6 +64,29 @@ static AttributeSet ReadAttributeSet
 	return attr_set;
 }
 
+// validate that an ID read from the effects stream refers to an existing
+// schema entry, if it does not the graph is out of sync with the effects
+// stream (e.g. a replicated query failed on this side), in which case we
+// log the problem and exit instead of dereferencing an invalid matrix
+static inline void ValidateSchemaID
+(
+	const Graph *g,     // graph to validate against
+	int id,             // schema ID read from the effects stream
+	SchemaType t        // schema type (label / relationship-type)
+) {
+	int count = (t == SCHEMA_EDGE)
+		? Graph_RelationTypeCount (g)
+		: Graph_LabelTypeCount (g) ;
+
+	if (unlikely (id < 0 || id >= count)) {
+		// graph/effects-stream out of sync
+		RedisModule_Log (NULL, "warning",
+				"GRAPH.EFFECT refers to a missing %s (id: %d), graph is out of sync with the effects stream",
+				(t == SCHEMA_EDGE) ? "relationship-type" : "label", id) ;
+		exit (1) ;
+	}
+}
+
 static void ApplyCreateNode
 (
 	FILE *stream,     // effects stream
@@ -89,8 +112,10 @@ static void ApplyCreateNode
 	//--------------------------------------------------------------------------
 
 	LabelID labels[lbl_count] ;
+	Graph *g = GraphContext_GetGraph (gc) ;
 	for (uint16_t i = 0; i < lbl_count; i++) {
 		fread_assert (labels + i, sizeof (LabelID), stream) ;
+		ValidateSchemaID (g, labels[i], SCHEMA_NODE) ;
 	}
 
 	//--------------------------------------------------------------------------
@@ -170,6 +195,8 @@ static void ApplyCreateEdge
 	RelationID r      = GRAPH_UNKNOWN_RELATION ;  // current edge relation id
 	RelationID prev_r = GRAPH_UNKNOWN_RELATION ;  // last processed relation id
 
+	Graph *g = GraphContext_GetGraph (gc) ;
+
 	// encoded edge struct
 	#pragma pack(push, 1)
 	struct {
@@ -187,6 +214,7 @@ static void ApplyCreateEdge
 
 		fread_assert(&_edge_desc, sizeof (_edge_desc), stream);
 		ASSERT(_edge_desc.rel_count == 1);
+		ValidateSchemaID (g, _edge_desc.r, SCHEMA_EDGE) ;
 
 		if (prev_r == GRAPH_UNKNOWN_RELATION) {
 			prev_r = _edge_desc.r ;

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -222,3 +222,75 @@ class testVecsim():
         except Exception as e:
             self.env.assertEqual("Vector dimension mismatch, expected 2 but got 3", str(e))
 
+    def test08_reindex_after_update_keeps_node(self):
+        # regression: updating a vector-indexed node must not drop it from the
+        # vector index.
+        #
+        # Every property write re-indexes the node as a RediSearch REPLACE, which
+        # allocates a new docId and appends a new vector while the previous vector
+        # must be removed from the HNSW graph. That removal only runs when the spec
+        # flag Index_HasVecSim is set; it was never set for indexes created through
+        # the low-level C API, so the old vector was never deleted. Stale vectors
+        # accumulated as orphans (docIds no longer resolving to a document) and
+        # shadowed the live entry, so the node became unfindable at small k - e.g.
+        # k=1 returned nothing after any update to the node.
+        g = Graph(self.conn, "vecsim_reindex")
+
+        v = [42.0, 42.0]
+        g.query("CREATE (:RUser {id: 1})")
+        g.create_node_vector_index("RUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_hits(q, k=1):
+            return len(query_node_vector_index(g, "RUser", "emb", k, q).result_set)
+
+        # insert the vector - baseline
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # re-SET the SAME value - node must still be found at k=1
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET an unrelated property (embedding untouched) - still found at k=1
+        g.query("MATCH (u:RUser) SET u.name = 'bob'")
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET a different value - found at the new location at k=1
+        v2 = [7.0, 7.0]
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v2)", params={'v2': v2})
+        self.env.assertEqual(knn_hits(v2), 1)
+
+    def test09_delete_removes_vector_from_index(self):
+        # regression: deleting a vector-indexed node must remove its vector from
+        # the HNSW graph, not leave it as an orphan.
+        #
+        # The low-level delete only dropped the doc-table entry and never removed
+        # the vector from VecSim, so a deleted node's vector lingered and shadowed
+        # a new node inserted at the same coordinates - the new node was
+        # unfindable at k=1.
+        g = Graph(self.conn, "vecsim_delete")
+
+        v = [42.0, 42.0]
+        g.create_node_vector_index("DUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_tags(q, k=1):
+            res = query_node_vector_index(g, "DUser", "emb", k, q).result_set
+            return [row[0].properties['tag'] for row in res]
+
+        # node A at v
+        g.query("CREATE (:DUser {tag: 'A', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['A'])
+
+        # delete A - nothing at v anymore
+        g.query("MATCH (u:DUser {tag: 'A'}) DELETE u")
+        self.env.assertEqual(knn_tags(v), [])
+
+        # a new node B at the SAME coordinates must be found, not shadowed by
+        # A's leftover vector
+        g.query("CREATE (:DUser {tag: 'B', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['B'])
+


### PR DESCRIPTION
## Summary
Fixes a SIGSEGV in `Graph_GetRelationMatrix` when a `GRAPH.EFFECT` payload references a label or relationship-type that does not exist in the graph. This happens in practice during AOF replay: a preceding replicated `LOAD CSV` query fails (its source file no longer exists in the container), so the relation schema is never created, and the effects payload that follows dereferences an invalid matrix pointer. The server enters a crash restart loop and the dataset cannot be loaded. Reproduced on 4.20.0, full crash report in #2201.

## Changes
* Added `ValidateSchemaID` to `effects_apply.c` which checks IDs read from the effects stream against `Graph_LabelTypeCount` / `Graph_RelationTypeCount`.
* `ApplyCreateNode` validates each label ID after reading it.
* `ApplyCreateEdge` validates the relation ID of each edge descriptor.
* On a miss the server logs a clear out of sync warning and exits with code 1, matching the existing effects version mismatch handling, instead of dereferencing an invalid pointer and producing a signal 11 bug report.

## Testing
* Reproduced the original crash with a real AOF: 4.20.0 exits 139 with a NULL dereference in `Graph_GetRelationMatrix+0x2c` right after the failed `LOAD CSV` replay (see #2201 for the full log and repro steps).
* Compile checked the modified translation unit; no new warnings introduced.
* No behavior change for valid effects streams: the validation only triggers when the referenced schema entry is absent, a state that previously always crashed.

## Memory / Performance Impact
Negligible. One branch (marked `unlikely`) per created edge descriptor and per label read during effects application.

## Related Issues
Closes #2201


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for schema identifiers when applying serialized graph changes.
  * Invalid label or relationship type identifiers are now detected before use, preventing unsafe graph updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->