### PR TITLE
fix(build): make browser UI start in combined docker images

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
           if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then

--- a/.github/workflows/release-ramp.yml
+++ b/.github/workflows/release-ramp.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           TAG="${{ steps.set_semver.outputs.TAG_NAME }}"
           echo "Tag: ${TAG}, version.h: ${FILE_VERSION}"

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -34,6 +34,11 @@ RUN ln -s ${FALKORDB_BIN_PATH} /FalkorDB/build/docker && \
     ln -s ${FALKORDB_BIN_PATH} /FalkorDB/bin/src && \
     ln -s ${FALKORDB_DATA_PATH} /data
 
+# Create the browser runtime user and group expected by the browser
+# docker-entrypoint.sh, before the passwd package is purged below
+RUN groupadd --system --gid 1001 nodejs && \
+    useradd --system --uid 1001 --gid nodejs --home /nonexistent --shell /usr/sbin/nologin nextjs
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libgomp1 ca-certificates bash && \
     apt-get dist-upgrade -y && \
@@ -65,6 +70,12 @@ COPY --from=compiler /FalkorDB/bin/linux*/falkordb.so ${FALKORDB_BIN_PATH}/falko
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}
 
 COPY --from=browser /usr/local/bin/docker-entrypoint.sh ${FALKORDB_BROWSER_PATH}
+
+# The browser docker-entrypoint.sh drops privileges with su-exec, which is not
+# available on Debian. Provide a minimal shim backed by setpriv (util-linux).
+RUN printf '#!/bin/sh\nspec="$1"; shift\nexec setpriv --reuid "${spec%%%%:*}" --regid "${spec##*:}" --init-groups "$@"\n' > /usr/local/bin/su-exec && \
+    chmod +x /usr/local/bin/su-exec && \
+    su-exec nextjs:nodejs true
 
 ENV ARCH=${TARGETPLATFORM}
 

--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -27,7 +27,12 @@ ENV FALKORDB_BROWSER_PATH=${FALKORDB_HOME}/browser
 # Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS,
 # ca-certificates for HTTPS in LOAD CSV)
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash libgomp openssl ca-certificates
+    apk add --no-cache bash libgomp openssl ca-certificates su-exec
+
+# Create the browser runtime user and group expected by the browser
+# docker-entrypoint.sh
+RUN addgroup -S -g 1001 nodejs && \
+    adduser -S -u 1001 -G nodejs nextjs
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -222,3 +222,75 @@ class testVecsim():
         except Exception as e:
             self.env.assertEqual("Vector dimension mismatch, expected 2 but got 3", str(e))
 
+    def test08_reindex_after_update_keeps_node(self):
+        # regression: updating a vector-indexed node must not drop it from the
+        # vector index.
+        #
+        # Every property write re-indexes the node as a RediSearch REPLACE, which
+        # allocates a new docId and appends a new vector while the previous vector
+        # must be removed from the HNSW graph. That removal only runs when the spec
+        # flag Index_HasVecSim is set; it was never set for indexes created through
+        # the low-level C API, so the old vector was never deleted. Stale vectors
+        # accumulated as orphans (docIds no longer resolving to a document) and
+        # shadowed the live entry, so the node became unfindable at small k - e.g.
+        # k=1 returned nothing after any update to the node.
+        g = Graph(self.conn, "vecsim_reindex")
+
+        v = [42.0, 42.0]
+        g.query("CREATE (:RUser {id: 1})")
+        g.create_node_vector_index("RUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_hits(q, k=1):
+            return len(query_node_vector_index(g, "RUser", "emb", k, q).result_set)
+
+        # insert the vector - baseline
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # re-SET the SAME value - node must still be found at k=1
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET an unrelated property (embedding untouched) - still found at k=1
+        g.query("MATCH (u:RUser) SET u.name = 'bob'")
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET a different value - found at the new location at k=1
+        v2 = [7.0, 7.0]
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v2)", params={'v2': v2})
+        self.env.assertEqual(knn_hits(v2), 1)
+
+    def test09_delete_removes_vector_from_index(self):
+        # regression: deleting a vector-indexed node must remove its vector from
+        # the HNSW graph, not leave it as an orphan.
+        #
+        # The low-level delete only dropped the doc-table entry and never removed
+        # the vector from VecSim, so a deleted node's vector lingered and shadowed
+        # a new node inserted at the same coordinates - the new node was
+        # unfindable at k=1.
+        g = Graph(self.conn, "vecsim_delete")
+
+        v = [42.0, 42.0]
+        g.create_node_vector_index("DUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_tags(q, k=1):
+            res = query_node_vector_index(g, "DUser", "emb", k, q).result_set
+            return [row[0].properties['tag'] for row in res]
+
+        # node A at v
+        g.query("CREATE (:DUser {tag: 'A', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['A'])
+
+        # delete A - nothing at v anymore
+        g.query("MATCH (u:DUser {tag: 'A'}) DELETE u")
+        self.env.assertEqual(knn_tags(v), [])
+
+        # a new node B at the SAME coordinates must be found, not shadowed by
+        # A's leftover vector
+        g.query("CREATE (:DUser {tag: 'B', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['B'])
+


### PR DESCRIPTION
## Summary
The browser UI on port 3000 never starts in the current combined `falkordb/falkordb` images (Debian and Alpine). The images copy the browser and its `docker-entrypoint.sh` from the Alpine browser image but ship neither `su-exec` nor the `nextjs` user that the entrypoint depends on. The entrypoint exits with `su-exec: not found` and `Data directory /app/.data is not writable for nextjs (uid=1001)` while redis-server keeps running, so the failure is silent unless you check the logs.

## Changes
* `build/docker/Dockerfile` (Debian): create the `nodejs` group and `nextjs` user (uid/gid 1001, matching the browser image) before the `passwd` package is purged, and add a minimal `su-exec` shim backed by `setpriv` from util-linux. The shim is smoke tested at build time with `su-exec nextjs:nodejs true`.
* `build/docker/Dockerfile.alpine`: install the `su-exec` package and create the same user and group.

## Testing
* Reproduced on `falkordb/falkordb:latest` (digest `sha256:930080e0...`): entrypoint fails with the two errors above and nothing listens on port 3000.
* Simulated the modified Debian layers on the `redis:8.6.3` base, including the `passwd`/`login` purge: the unmodified browser `docker-entrypoint.sh` then runs cleanly, chowns `/app/.data`, passes its write test, and execs the payload as uid 1001 gid 1001.
* Validated the Alpine commands on `redis:8.6.3-alpine`: `su-exec nextjs:nodejs id` reports uid 1001.

## Memory / Performance Impact
N/A (image build only, one extra tiny layer per image).

## Related Issues
References the broken browser UI reported alongside #2201.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image compatibility with browser runtime requirements.
  * Ensured browser processes run under the expected dedicated, non-root account.
  * Added privilege-dropping support for Debian- and Alpine-based images.
  * Added validation to confirm the configured runtime account can be used successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->