### PR TITLE
ci: verify Docker image and edge browser connectivity after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,6 +499,55 @@ jobs:
         if: matrix.platform.use_docker && matrix.build_type == 'release'
         run: docker load --input /tmp/falkordb-${{ matrix.platform.suffix }}.tar
 
+      - name: Build edge-browser image for smoke test
+        if: matrix.platform.use_docker && matrix.build_type == 'release' && env.BROWSER_TAG != 'edge'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: /FalkorDB
+          file: /FalkorDB/build/docker/${{ steps.dockerfile.outputs.final }}
+          platforms: linux/${{ matrix.platform.arch }}
+          load: true
+          tags: falkordb/falkordb-${{ matrix.platform.suffix }}:edge-smoke
+          build-args: |
+            BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler-${{ matrix.platform.suffix }}
+            TARGETPLATFORM=linux/${{ matrix.platform.arch }}
+            BROWSER_TAG=edge
+
+      - name: Smoke test image (DB + browser connectivity)
+        if: matrix.platform.use_docker && matrix.build_type == 'release'
+        run: |
+          smoke_test() {
+            IMAGE=$1
+            LABEL=$2
+            echo "=== Smoke testing ${LABEL} (${IMAGE}) ==="
+            docker run -d --name smoke -p 6379:6379 -p 3000:3000 "${IMAGE}"
+
+            echo "Waiting for FalkorDB module to load..."
+            if ! timeout 60 sh -c 'until docker exec smoke redis-cli GRAPH.QUERY smoke "RETURN 1" >/dev/null 2>&1; do sleep 2; done'; then
+              echo "::error::[${LABEL}] FalkorDB did not respond to GRAPH.QUERY within 60s"
+              docker logs smoke
+              exit 1
+            fi
+
+            echo "Waiting for browser on port 3000..."
+            if ! timeout 60 sh -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 2; done'; then
+              echo "::error::[${LABEL}] Browser UI did not respond on port 3000 within 60s"
+              docker logs smoke
+              exit 1
+            fi
+
+            echo "[${LABEL}] Smoke test passed: DB and browser are up"
+            docker rm -f smoke
+          }
+
+          # Test the image as it will be shipped (browser tag: ${{ env.BROWSER_TAG }})
+          smoke_test falkordb/falkordb-${{ matrix.platform.suffix }} "browser:${{ env.BROWSER_TAG }}"
+
+          # Also test with the edge browser, unless the shipped image already uses it
+          if [[ "${{ env.BROWSER_TAG }}" != "edge" ]]; then
+            smoke_test falkordb/falkordb-${{ matrix.platform.suffix }}:edge-smoke "browser:edge"
+          fi
+
       - name: Upload base image
         if: matrix.platform.use_docker && matrix.build_type == 'release'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -520,31 +520,37 @@ jobs:
             IMAGE=$1
             LABEL=$2
             echo "=== Smoke testing ${LABEL} (${IMAGE}) ==="
-            docker run -d --name smoke -p 6379:6379 -p 3000:3000 "${IMAGE}"
+            docker rm -f smoke >/dev/null 2>&1 || true
+            if ! docker run -d --name smoke -p 6379:6379 -p 3000:3000 "${IMAGE}"; then
+              echo "::error::[${LABEL}] Failed to start container from ${IMAGE}"
+              exit 1
+            fi
 
             echo "Waiting for FalkorDB module to load..."
             if ! timeout 60 sh -c 'until docker exec smoke redis-cli GRAPH.QUERY smoke "RETURN 1" >/dev/null 2>&1; do sleep 2; done'; then
               echo "::error::[${LABEL}] FalkorDB did not respond to GRAPH.QUERY within 60s"
-              docker logs smoke
+              docker logs smoke || true
+              docker rm -f smoke >/dev/null 2>&1 || true
               exit 1
             fi
 
             echo "Waiting for browser on port 3000..."
             if ! timeout 60 sh -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 2; done'; then
               echo "::error::[${LABEL}] Browser UI did not respond on port 3000 within 60s"
-              docker logs smoke
+              docker logs smoke || true
+              docker rm -f smoke >/dev/null 2>&1 || true
               exit 1
             fi
 
             echo "[${LABEL}] Smoke test passed: DB and browser are up"
-            docker rm -f smoke
+            docker rm -f smoke >/dev/null 2>&1 || true
           }
 
-          # Test the image as it will be shipped (browser tag: ${{ env.BROWSER_TAG }})
-          smoke_test falkordb/falkordb-${{ matrix.platform.suffix }} "browser:${{ env.BROWSER_TAG }}"
+          # Test the image as it will be shipped (BROWSER_TAG comes from GITHUB_ENV)
+          smoke_test falkordb/falkordb-${{ matrix.platform.suffix }} "browser:${BROWSER_TAG}"
 
           # Also test with the edge browser, unless the shipped image already uses it
-          if [[ "${{ env.BROWSER_TAG }}" != "edge" ]]; then
+          if [[ "${BROWSER_TAG}" != "edge" ]]; then
             smoke_test falkordb/falkordb-${{ matrix.platform.suffix }}:edge-smoke "browser:edge"
           fi
 


### PR DESCRIPTION
## What
Adds a post-build smoke test to the CI build workflow that verifies the built Docker image actually works before it ships.

## Checks per platform (release builds)
1. **Shipped image** (bundled browser tag, `latest` on PRs/releases, `edge` on master):
   - FalkorDB responds to `GRAPH.QUERY` (redis up + module loaded)
   - Browser UI responds on port 3000 (HTTP connectivity)
2. **Edge browser variant**: rebuilds the same image with `BROWSER_TAG=edge` (cached layers, cheap) and runs the same DB + browser connectivity checks

Container logs are dumped on failure and the job fails if any check times out (60s).

## Why
Validated locally: browser 2.2.0 (both `latest` and `edge`) currently fails to start inside the FalkorDB image (`su-exec: not found`), which this test catches. Without it, a broken browser would ship silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added post-build smoke tests for the released Docker images.
  * Validates service readiness by checking backend module availability and that the browser UI loads successfully.
  * When applicable, also runs the same validation against the edge browser variant.
  * On failures or readiness timeouts, collects container logs and fails the build with clear error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->