### PR TITLE
Queue on stub wait

### DIFF
--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -5,13 +5,8 @@
  */
 
 #include "RG.h"
-#include "commands.h"
-#include "../globals.h"
 #include "cmd_context.h"
 #include "../util/rmalloc.h"
-#include "../util/thpool/pool.h"
-#include "../errors/error_msgs.h"
-#include "../slow_log/slow_log.h"
 #include "../util/blocked_client.h"
 
 #include <stdatomic.h>
@@ -186,65 +181,6 @@ void CommandCtx_UnblockClient
 			cmd_ctx->ctx = NULL;
 		}
 	}
-}
-
-// invoked once, with the outcome, when a graph load that a query-family
-// command (`waiter`, a parked CommandCtx) was waiting on resolves: on
-// success the command is requeued from scratch according to its command
-// name, on failure a reply is emitted and the parked client is unblocked
-void CommandCtx_ResumeAfterGraphLoad
-(
-	CommandCtx *waiter,
-	bool        success
-) {
-	ASSERT (waiter != NULL) ;
-
-	CommandCtx *command_ctx = waiter ;
-
-	if (success) {
-		// requeue the right graph command according to the command's name
-		void (*handler) (void *) ;
-
-		switch (CommandFromString (CommandCtx_GetCommandName (command_ctx))) {
-			case CMD_QUERY:
-				handler = Graph_Query ;
-				break ;
-
-			case CMD_PROFILE:
-				handler = Graph_Profile ;
-				break ;
-
-			case CMD_EXPLAIN:
-				handler = Graph_Explain ;
-				break ;
-
-			default:
-				RedisModule_Assert ("unexpected command" && false) ;
-				break ;
-		}
-
-		// queue command
-		if (ThreadPool_AddWork (handler, command_ctx, false) !=
-				THPOOL_QUEUE_FULL) {
-			return ;
-		}
-
-		// pool queue is full - this is the thread pool's own general work
-		// queue (shared by every command, not just graph-loading waiters),
-		// a distinct resource from the per-graph load-wait list checked
-		// earlier in graphcontext_retrieve.c - fail the same way
-		// cmd_dispatcher.c does for that same condition
-		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
-		RedisModule_ReplyWithError (ctx, EMSG_MAX_PENDING_QUERIES) ;
-	} else {
-		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
-		RedisModule_ReplyWithErrorFormat (ctx,
-				"ERR graph: %s failed to load from disk",
-				RedisModule_StringPtrLen (command_ctx->rm_graph_name, NULL)) ;
-	}
-
-	CommandCtx_UnblockClient (command_ctx) ;
-	CommandCtx_Free (command_ctx) ;
 }
 
 void CommandCtx_Free

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -5,10 +5,12 @@
  */
 
 #include "RG.h"
+#include "commands.h"
 #include "cmd_context.h"
 #include "../globals.h"
 #include "../util/rmalloc.h"
 #include "../slow_log/slow_log.h"
+#include "../util/thpool/pool.h"
 #include "../util/blocked_client.h"
 
 #include <stdatomic.h>
@@ -183,6 +185,61 @@ void CommandCtx_UnblockClient
 			cmd_ctx->ctx = NULL;
 		}
 	}
+}
+
+// invoked once, with the outcome, when a graph load that a query-family
+// command (`waiter`, a parked CommandCtx) was waiting on resolves: on
+// success the command is requeued from scratch according to its command
+// name, on failure a reply is emitted and the parked client is unblocked
+void CommandCtx_ResumeAfterGraphLoad
+(
+	void *waiter,
+	bool  success
+) {
+	ASSERT (waiter != NULL) ;
+
+	CommandCtx *command_ctx = (CommandCtx *)waiter ;
+
+	if (success) {
+		// requeue the right graph command according to the command's name
+		void (*handler) (void *) ;
+
+		switch (CommandFromString (CommandCtx_GetCommandName (command_ctx))) {
+			case: CMD_QUERY:
+				handler = Graph_Query ;
+				  break ;
+
+			case CMD_PROFILE:
+				handler = Graph_Profile ;
+				break ;
+
+			case CMD_EXPLAIN:
+				handler = Graph_Explain ;
+				break ;
+
+			default:
+				RedisModule_Assert ("unexpected command" && false) ;
+				break ;
+		}
+
+		// queue command
+		if (ThreadPool_AddWork (handler, command_ctx, false) !=
+				THPOOL_QUEUE_FULL) {
+			return ;
+		}
+
+		// pool queue is full - fail the same way cmd_dispatcher.c does
+		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
+		RedisModule_ReplyWithError (ctx, "Max pending queries exceeded") ;
+	} else {
+		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
+		RedisModule_ReplyWithErrorFormat (ctx,
+				"ERR graph: %s failed to load from disk",
+				RedisModule_StringPtrLen (command_ctx->rm_graph_name, NULL)) ;
+	}
+
+	CommandCtx_UnblockClient (command_ctx) ;
+	CommandCtx_Free (command_ctx) ;
 }
 
 void CommandCtx_Free

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -194,12 +194,12 @@ void CommandCtx_UnblockClient
 // name, on failure a reply is emitted and the parked client is unblocked
 void CommandCtx_ResumeAfterGraphLoad
 (
-	void *waiter,
-	bool  success
+	CommandCtx *waiter,
+	bool        success
 ) {
 	ASSERT (waiter != NULL) ;
 
-	CommandCtx *command_ctx = (CommandCtx *)waiter ;
+	CommandCtx *command_ctx = waiter ;
 
 	if (success) {
 		// requeue the right graph command according to the command's name

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -6,11 +6,12 @@
 
 #include "RG.h"
 #include "commands.h"
-#include "cmd_context.h"
 #include "../globals.h"
+#include "cmd_context.h"
 #include "../util/rmalloc.h"
-#include "../slow_log/slow_log.h"
 #include "../util/thpool/pool.h"
+#include "../errors/error_msgs.h"
+#include "../slow_log/slow_log.h"
 #include "../util/blocked_client.h"
 
 #include <stdatomic.h>
@@ -205,9 +206,9 @@ void CommandCtx_ResumeAfterGraphLoad
 		void (*handler) (void *) ;
 
 		switch (CommandFromString (CommandCtx_GetCommandName (command_ctx))) {
-			case: CMD_QUERY:
+			case CMD_QUERY:
 				handler = Graph_Query ;
-				  break ;
+				break ;
 
 			case CMD_PROFILE:
 				handler = Graph_Profile ;
@@ -228,9 +229,13 @@ void CommandCtx_ResumeAfterGraphLoad
 			return ;
 		}
 
-		// pool queue is full - fail the same way cmd_dispatcher.c does
+		// pool queue is full - this is the thread pool's own general work
+		// queue (shared by every command, not just graph-loading waiters),
+		// a distinct resource from the per-graph load-wait list checked
+		// earlier in graphcontext_retrieve.c - fail the same way
+		// cmd_dispatcher.c does for that same condition
 		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
-		RedisModule_ReplyWithError (ctx, "Max pending queries exceeded") ;
+		RedisModule_ReplyWithError (ctx, EMSG_MAX_PENDING_QUERIES) ;
 	} else {
 		RedisModuleCtx *ctx = CommandCtx_GetRedisCtx (command_ctx) ;
 		RedisModule_ReplyWithErrorFormat (ctx,

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -129,8 +129,8 @@ void CommandCtx_UnblockClient
 // name, on failure a reply is emitted and the parked client is unblocked
 void CommandCtx_ResumeAfterGraphLoad
 (
-	void *waiter,
-	bool  success
+	CommandCtx *waiter,
+	bool        success
 );
 
 // free command context

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -123,16 +123,6 @@ void CommandCtx_UnblockClient
 	CommandCtx *cmd_ctx
 );
 
-// invoked once, with the outcome, when a graph load that a query-family
-// command (`waiter`, a parked CommandCtx) was waiting on resolves: on
-// success the command is requeued from scratch according to its command
-// name, on failure a reply is emitted and the parked client is unblocked
-void CommandCtx_ResumeAfterGraphLoad
-(
-	CommandCtx *waiter,
-	bool        success
-);
-
 // free command context
 void CommandCtx_Free
 (

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -123,6 +123,16 @@ void CommandCtx_UnblockClient
 	CommandCtx *cmd_ctx
 );
 
+// invoked once, with the outcome, when a graph load that a query-family
+// command (`waiter`, a parked CommandCtx) was waiting on resolves: on
+// success the command is requeued from scratch according to its command
+// name, on failure a reply is emitted and the parked client is unblocked
+void CommandCtx_ResumeAfterGraphLoad
+(
+	void *waiter,
+	bool  success
+);
+
 // free command context
 void CommandCtx_Free
 (

--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -9,9 +9,15 @@
 #include "graph/graphcontext.h"
 #include "query_ctx.h"
 #include "resultset/resultset.h"
+#include "../enterprise_api.h"
 
 // graphContext type as it is registered at Redis
 extern RedisModuleType *GraphContextRedisModuleType;
+
+// offloaded-graph-stub type, exported by the enterprise module via its
+// shared API - resolved lazily; stays NULL when that module isn't loaded
+// (community edition)
+static GraphStubType_Get_t GraphStubType_Get = NULL;
 
 // delete graph, removing the key from Redis and
 // freeing every resource allocated by the graph
@@ -32,7 +38,17 @@ int Graph_Delete
 	// remove graph from keyspace
 	RedisModuleKey *key = RedisModule_OpenKey(ctx, key_name, REDISMODULE_WRITE);
 	if(key != NULL) {
-		if(RedisModule_ModuleTypeGetType(key) == GraphContextRedisModuleType) {
+		RedisModuleType *type = RedisModule_ModuleTypeGetType(key);
+
+		if(GraphStubType_Get == NULL) {
+			GraphStubType_Get = RedisModule_GetSharedAPI(ctx, "GraphStubType_Get");
+		}
+
+		// a stub (offloaded graph) can be deleted outright, without first
+		// loading it - it is not registered in the global graph registry,
+		// so no ref count / untracking is involved
+		if(type == GraphContextRedisModuleType ||
+		   (GraphStubType_Get != NULL && type == GraphStubType_Get())) {
 			deleted = true;
 			RedisModule_DeleteKey(key);  // untrack graph & decreases graph ref count
 			RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -8,6 +8,7 @@
 #include "commands.h"
 #include "cmd_context.h"
 #include "../util/thpool/pool.h"
+#include "../errors/error_msgs.h"
 #include "../util/simple_timer.h"
 #include "../util/blocked_client.h"
 #include "../configuration/config.h"
@@ -272,7 +273,7 @@ int CommandDispatch
 			// report an error once our workers thread pool internal queue
 			// is full, this error usually happens when the server is
 			// under heavy load and is unable to catch up
-			RedisModule_ReplyWithError (ctx, "Max pending queries exceeded") ;
+			RedisModule_ReplyWithError (ctx, EMSG_MAX_PENDING_QUERIES) ;
 
 			// release the GraphContext, as we increased its reference count
 			// when retrieving it

--- a/src/commands/cmd_effect.c
+++ b/src/commands/cmd_effect.c
@@ -6,7 +6,7 @@
 
 #include "RG.h"
 #include "../effects/effects.h"
-#include "../graph/graphcontext.h"
+#include "../graph/graphcontext_retrieve.h"
 
 // GRAPH.EFFECT command handler
 int Graph_Effect
@@ -20,10 +20,31 @@ int Graph_Effect
 		return RedisModule_WrongArity (ctx) ;
 	}
 
-	// get graph context
+	// get graph context - never fails due to mere contention with another
+	// load (see GraphContext_RetrieveOrForce); reaching gc == NULL means a
+	// genuine, unrecoverable failure: a missing/corrupt dump, OOM, or a
+	// concurrent GRAPH.OFFLOAD of this graph still in flight (the one case
+	// that cannot be bypassed, since there is nothing yet to load)
 	GraphContext *gc = NULL ;
-	GraphContext_Retrieve (ctx, argv[1], false, true, true, &gc) ;
-	ASSERT (gc != NULL) ;
+	GraphContext_RetrieveOrForce (ctx, argv[1], false, true, &gc) ;
+
+	if (gc == NULL) {
+		// applying an effect only happens while replicating a write from
+		// the master; silently dropping it here would let this replica's
+		// data diverge from the master without either side noticing.
+		// Crashing is the safer failure mode: a replication resync
+		// (partial or full) on restart brings this replica back to a
+		// correct, consistent state. Use RELEASE_ASSERT, not ASSERT - the
+		// latter is a no-op in release builds, which would fall through to
+		// an undiagnosable NULL-deref crash a few lines below instead.
+		RedisModule_Log (ctx, REDISMODULE_LOGLEVEL_WARNING,
+				"GRAPH.EFFECT: failed to retrieve graph: %s - crashing to "
+				"force a replication resync rather than risk silent "
+				"master/replica divergence",
+				RedisModule_StringPtrLen (argv[1], NULL)) ;
+	}
+
+	RELEASE_ASSERT (gc != NULL) ;
 
 	// lock graph for writing
 	GraphContext_AcquireWriteLock (gc) ;

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -34,6 +34,9 @@ void Graph_Explain
 	ExecutionCtx   *exec_ctx    = NULL ;
 	QueryCtx       *query_ctx   = QueryCtx_GetQueryCtx () ;
 
+	// graph.explain shouldn't be executing on the main thread
+	ASSERT (command_ctx->thread != EXEC_THREAD_MAIN) ;
+
 	Globals_TrackCommandCtx (command_ctx) ;
 
 	if (gc == NULL) {

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -11,6 +11,7 @@
 #include "../index/index.h"
 #include "../util/rmalloc.h"
 #include "../errors/errors.h"
+#include "../graph/graphcontext_retrieve.h"
 #include "../execution_plan/execution_plan.h"
 
 // builds an execution plan but does not execute it
@@ -18,6 +19,11 @@
 // Args:
 // argv[1] graph name
 // argv[2] query
+//
+// optnone: see the identical comment on _query in cmd_query.c - the same
+// "goto cleanup" / llvm.assume miscompilation risk applies here now that
+// this function also has a GraphContext_RetrieveOrQueue failure path
+__attribute__((optnone))
 void Graph_Explain
 (
 	void *args
@@ -29,8 +35,30 @@ void Graph_Explain
 	ExecutionCtx   *exec_ctx    = NULL ;
 	QueryCtx       *query_ctx   = QueryCtx_GetQueryCtx () ;
 
-	QueryCtx_SetGlobalExecutionCtx (command_ctx) ;
 	Globals_TrackCommandCtx (command_ctx) ;
+
+	if (gc == NULL) {
+		GraphRetrieveStatus status = GraphContext_RetrieveOrQueue (ctx,
+				command_ctx->rm_graph_name, true, false, command_ctx, &gc) ;
+
+		if (status == GraphRetrieve_LOADING) {
+			// parked behind another thread's in-flight load of this graph;
+			// CommandCtx_ResumeAfterGraphLoad will resubmit (or fail) this
+			// command once that load resolves - undo this attempt's
+			// thread-local setup, leave the CommandCtx / blocked client alone
+			Globals_UntrackCommandCtx (command_ctx) ;
+			QueryCtx_Free () ;
+			return ;
+		}
+
+		if (status != GraphRetrieve_RETRIEVED) {
+			goto cleanup ;
+		}
+
+		CommandCtx_SetGraphContext (command_ctx, gc) ;
+	}
+
+	QueryCtx_SetGlobalExecutionCtx (command_ctx) ;
 
 	// retrieve the required execution items and information:
 	// 1. Execution plan
@@ -79,7 +107,11 @@ cleanup:
 	}
 
 	ExecutionCtx_Free (exec_ctx) ;
-	GraphContext_DecreaseRefCount (gc) ;
+
+	if (gc) {
+		GraphContext_DecreaseRefCount (gc) ;
+	}
+
 	Globals_UntrackCommandCtx (command_ctx) ;
 	CommandCtx_UnblockClient (command_ctx) ;
 	CommandCtx_Free (command_ctx) ;

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -9,7 +9,6 @@
 #include "../query_ctx.h"
 #include "execution_ctx.h"
 #include "../index/index.h"
-#include "../util/rmalloc.h"
 #include "../errors/errors.h"
 #include "../graph/graphcontext_retrieve.h"
 #include "../execution_plan/execution_plan.h"
@@ -39,13 +38,14 @@ void Graph_Explain
 
 	if (gc == NULL) {
 		GraphRetrieveStatus status = GraphContext_RetrieveOrQueue (ctx,
-				command_ctx->rm_graph_name, true, false, command_ctx, &gc) ;
+				command_ctx->rm_graph_name, true, false, Graph_Explain,
+				command_ctx, &gc) ;
 
 		if (status == GraphRetrieve_LOADING) {
 			// parked behind another thread's in-flight load of this graph;
-			// CommandCtx_ResumeAfterGraphLoad will resubmit (or fail) this
-			// command once that load resolves - undo this attempt's
-			// thread-local setup, leave the CommandCtx / blocked client alone
+			// Graph_Explain will be resubmitted once that load resolves -
+			// undo this attempt's thread-local setup, leave the CommandCtx /
+			// blocked client alone
 			Globals_UntrackCommandCtx (command_ctx) ;
 			QueryCtx_Free () ;
 			return ;

--- a/src/commands/cmd_list.c
+++ b/src/commands/cmd_list.c
@@ -7,7 +7,39 @@
 #include "RG.h"
 #include "../globals.h"
 #include "../redismodule.h"
+#include "../enterprise_api.h"
 #include "../graph/graphcontext.h"
+
+// offloaded-graph-stub type, exported by the enterprise module via its
+// shared API - resolved lazily; stays NULL when that module isn't loaded
+// (community edition)
+static GraphStubType_Get_t GraphStubType_Get = NULL;
+
+// state threaded through the keyspace scan used to pick out stub keys
+typedef struct {
+	RedisModuleCtx   *ctx;
+	RedisModuleType  *stub_type;
+	uint64_t         n;
+} StubScanCtx;
+
+static void _collect_stub_name
+(
+	RedisModuleCtx *ctx,
+	RedisModuleString *keyname,
+	RedisModuleKey *key,
+	void *privdata
+) {
+	StubScanCtx *sctx = privdata;
+
+	if(RedisModule_ModuleTypeGetType(key) != sctx->stub_type) {
+		return;
+	}
+
+	size_t len;
+	const char *name = RedisModule_StringPtrLen(keyname, &len);
+	RedisModule_ReplyWithStringBuffer(sctx->ctx, name, len);
+	sctx->n++;
+}
 
 int Graph_List
 (
@@ -15,29 +47,49 @@ int Graph_List
 	RedisModuleString **argv,
 	int argc
 ) {
-	ASSERT(ctx != NULL);
+	ASSERT (ctx != NULL) ;
 
-	if(argc != 1) {
-		return RedisModule_WrongArity(ctx);
+	if (argc != 1) {
+		return RedisModule_WrongArity (ctx) ;
 	}
 
-	KeySpaceGraphIterator it;
-	Globals_ScanGraphs(&it);
-	RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+	KeySpaceGraphIterator it ;
+	Globals_ScanGraphs (&it) ;
+	RedisModule_ReplyWithArray (ctx, REDISMODULE_POSTPONED_LEN) ;
 
-	// reply with each graph name
-	uint64_t     n   = 0;
-	GraphContext *gc = NULL;
+	// reply with each live graph name
+	uint64_t     n   = Globals_GraphsCount () ;
+	GraphContext *gc = NULL ;
 
-	while((gc = GraphIterator_Next(&it)) != NULL) {
-		const char *name = GraphContext_GetName(gc);
-		RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name));
-		n++;
-		GraphContext_DecreaseRefCount(gc);
+	while ((gc = GraphIterator_Next (&it)) != NULL) {
+		const char *name = GraphContext_GetName (gc) ;
+		RedisModule_ReplyWithStringBuffer (ctx, name, strlen (name)) ;
+		GraphContext_DecreaseRefCount (gc) ;
 	}
 
-	RedisModule_ReplySetArrayLength(ctx, n);
+	// merge in offloaded graphs (stubs), if the enterprise module that
+	// owns them is loaded - stubs aren't registered in the global graph
+	// registry, so they're only discoverable via a keyspace scan
+	if (GraphStubType_Get == NULL) {
+		GraphStubType_Get = RedisModule_GetSharedAPI (ctx, "GraphStubType_Get") ;
+	}
 
-	return REDISMODULE_OK;
+	if (GraphStubType_Get != NULL) {
+		StubScanCtx sctx = {
+			.ctx       = ctx,
+			.stub_type = GraphStubType_Get (),
+			.n         = 0
+		};
+
+		RedisModuleScanCursor *cursor = RedisModule_ScanCursorCreate () ;
+		while (RedisModule_Scan (ctx, cursor, _collect_stub_name, &sctx)) ;
+		RedisModule_ScanCursorDestroy (cursor) ;
+
+		n += sctx.n ;
+	}
+
+	RedisModule_ReplySetArrayLength (ctx, n) ;
+
+	return REDISMODULE_OK ;
 }
 

--- a/src/commands/cmd_memory.c
+++ b/src/commands/cmd_memory.c
@@ -4,10 +4,16 @@
  */
 
 #include "cmd_memory.h"
-#include "../errors/error_msgs.h"
+#include "../enterprise_api.h"
 #include "../util/thpool/pool.h"
+#include "../errors/error_msgs.h"
 #include "../graph/graphcontext.h"
 #include "../graph/graph_memoryUsage.h"
+
+// offloaded-graph-stub type, exported by the enterprise module via its
+// shared API - resolved lazily; stays NULL when that module isn't loaded
+// (community edition)
+static GraphStubType_Get_t GraphStubType_Get = NULL ;
 
 // GRAPH.MEMORY command context
 typedef struct {
@@ -40,6 +46,31 @@ static void _Graph_Memory
 	//--------------------------------------------------------------------------
 	// get graph key
 	//--------------------------------------------------------------------------
+
+	// an offloaded stub consumes no RAM right now - check the key's type
+	// directly (mirrors cmd_delete.c) so this never triggers a disk load
+	// just to answer GRAPH.MEMORY, even for a graph that got offloaded
+	// after Graph_Memory blocked the client but before this worker got to
+	// run
+	RedisModule_ThreadSafeContextLock (rm_ctx) ;
+	RedisModuleKey  *rkey = RedisModule_OpenKey (rm_ctx, ctx->graph_id,
+			REDISMODULE_READ) ;
+	RedisModuleType *type = RedisModule_ModuleTypeGetType (rkey) ;
+	if (GraphStubType_Get == NULL) {
+		GraphStubType_Get = RedisModule_GetSharedAPI (rm_ctx, "GraphStubType_Get") ;
+	}
+	bool is_stub = (GraphStubType_Get != NULL && type == GraphStubType_Get ()) ;
+	RedisModule_CloseKey (rkey) ;
+	RedisModule_ThreadSafeContextUnlock (rm_ctx) ;
+
+	if (is_stub) {
+		// a stub isn't loaded, so it consumes no RAM right now - report a
+		// plain 0 rather than the full USAGE breakdown map (there is
+		// nothing to break down), and never call GraphContext_Retrieve
+		// for it
+		RedisModule_ReplyWithLongLong (rm_ctx, 0) ;
+		goto cleanup ;
+	}
 
 	GraphContext *gc = NULL ;
 	GraphContext_Retrieve (rm_ctx, ctx->graph_id, true, false, true, &gc) ;

--- a/src/commands/cmd_memory.c
+++ b/src/commands/cmd_memory.c
@@ -22,78 +22,12 @@ typedef struct {
 	RedisModuleBlockedClient *bc;  // blocked client
 } GraphMemoryCtx;
 
-// GRAPH.MEMORY USAGE internal command handler
-// the function is executed on a reader thread to avoid blocking the main thread
-static void _Graph_Memory
+static void _Replay
 (
-	void *_ctx  // command context
+	RedisModuleCtx *rm_ctx,
+	MemoryUsageResult result,
+	GraphContext *gc
 ) {
-	ASSERT (_ctx != NULL) ;
-
-	GraphMemoryCtx           *ctx    = (GraphMemoryCtx*)_ctx ;
-	int64_t                  samples = ctx->samples ;
-	RedisModuleBlockedClient *bc     = ctx->bc ;
-	RedisModuleCtx           *rm_ctx = RedisModule_GetThreadSafeContext (bc) ;
-
-	//--------------------------------------------------------------------------
-	// compute graph memory usage
-	//--------------------------------------------------------------------------
-
-	// declare result before any goto so cleanup can safely arr_free the arrays
-	// (arr_free checks for NULL, so zero-initialized pointers are safe)
-	MemoryUsageResult result = {0} ;
-
-	//--------------------------------------------------------------------------
-	// get graph key
-	//--------------------------------------------------------------------------
-
-	// an offloaded stub consumes no RAM right now - check the key's type
-	// directly (mirrors cmd_delete.c) so this never triggers a disk load
-	// just to answer GRAPH.MEMORY, even for a graph that got offloaded
-	// after Graph_Memory blocked the client but before this worker got to
-	// run
-	RedisModule_ThreadSafeContextLock (rm_ctx) ;
-	RedisModuleKey  *rkey = RedisModule_OpenKey (rm_ctx, ctx->graph_id,
-			REDISMODULE_READ) ;
-	RedisModuleType *type = RedisModule_ModuleTypeGetType (rkey) ;
-	if (GraphStubType_Get == NULL) {
-		GraphStubType_Get = RedisModule_GetSharedAPI (rm_ctx, "GraphStubType_Get") ;
-	}
-	bool is_stub = (GraphStubType_Get != NULL && type == GraphStubType_Get ()) ;
-	RedisModule_CloseKey (rkey) ;
-	RedisModule_ThreadSafeContextUnlock (rm_ctx) ;
-
-	if (is_stub) {
-		// a stub isn't loaded, so it consumes no RAM right now - report a
-		// plain 0 rather than the full USAGE breakdown map (there is
-		// nothing to break down), and never call GraphContext_Retrieve
-		// for it
-		RedisModule_ReplyWithLongLong (rm_ctx, 0) ;
-		goto cleanup ;
-	}
-
-	GraphContext *gc = NULL ;
-	GraphContext_Retrieve (rm_ctx, ctx->graph_id, true, false, true, &gc) ;
-	if (gc == NULL) {
-		// error alreay emitted by GraphContext_Retrieve
-		goto cleanup ;
-	}
-
-	result.edge_attr_by_type_sz  = arr_new (size_t, 0) ;
-	result.node_attr_by_label_sz = arr_new (size_t, 0) ;
-
-	// acquire read lock
-	GraphContext_AcquireReadLock (gc) ;
-
-	GraphContext_EstimateMemoryUsage (gc, samples, &result) ;
-
-	// release read lock
-	GraphContext_ReleaseReadLock (gc) ;
-
-	//--------------------------------------------------------------------------
-	// reply to caller
-	//--------------------------------------------------------------------------
-
 	// reply structure:
 	// {
 	//    total_graph_sz_mb: <total_graph_sz_mb>
@@ -173,12 +107,84 @@ static void _Graph_Memory
 	// indices_sz_mb
 	RedisModule_ReplyWithCString  (rm_ctx, "indices_sz_mb") ;
 	RedisModule_ReplyWithLongLong (rm_ctx, result.indices_sz) ;
+}
+
+// GRAPH.MEMORY USAGE internal command handler
+// the function is executed on a reader thread to avoid blocking the main thread
+static void _Graph_Memory
+(
+	void *_ctx  // command context
+) {
+	ASSERT (_ctx != NULL) ;
+
+	GraphMemoryCtx           *ctx    = (GraphMemoryCtx*)_ctx ;
+	int64_t                  samples = ctx->samples ;
+	RedisModuleBlockedClient *bc     = ctx->bc ;
+	RedisModuleCtx           *rm_ctx = RedisModule_GetThreadSafeContext (bc) ;
+
+	//--------------------------------------------------------------------------
+	// compute graph memory usage
+	//--------------------------------------------------------------------------
+
+	// declare result before any goto so cleanup can safely arr_free the arrays
+	// (arr_free checks for NULL, so zero-initialized pointers are safe)
+	MemoryUsageResult result = {0} ;
+
+	//--------------------------------------------------------------------------
+	// get graph key
+	//--------------------------------------------------------------------------
+
+	// an offloaded stub consumes no RAM right now - check the key's type
+	// directly (mirrors cmd_delete.c) so this never triggers a disk load
+	// just to answer GRAPH.MEMORY, even for a graph that got offloaded
+	// after Graph_Memory blocked the client but before this worker got to
+	// run
+	RedisModule_ThreadSafeContextLock (rm_ctx) ;
+	RedisModuleKey  *rkey = RedisModule_OpenKey (rm_ctx, ctx->graph_id,
+			REDISMODULE_READ) ;
+	RedisModuleType *type = RedisModule_ModuleTypeGetType (rkey) ;
+	if (GraphStubType_Get == NULL) {
+		GraphStubType_Get = RedisModule_GetSharedAPI (rm_ctx, "GraphStubType_Get") ;
+	}
+	bool is_stub = (GraphStubType_Get != NULL && type == GraphStubType_Get ()) ;
+	RedisModule_CloseKey (rkey) ;
+	RedisModule_ThreadSafeContextUnlock (rm_ctx) ;
+
+	if (is_stub) {
+		// a stub isn't loaded, so it consumes no RAM right now - report a
+		// plain 0 rather than the full USAGE breakdown map (there is
+		// nothing to break down), and never call GraphContext_Retrieve
+		// for it
+		RedisModule_ReplyWithLongLong (rm_ctx, 0) ;
+		goto cleanup ;
+	}
+
+	GraphContext *gc = NULL ;
+	GraphContext_Retrieve (rm_ctx, ctx->graph_id, true, false, true, &gc) ;
+	if (gc == NULL) {
+		// error alreay emitted by GraphContext_Retrieve
+		goto cleanup ;
+	}
+
+	result.edge_attr_by_type_sz  = arr_new (size_t, 0) ;
+	result.node_attr_by_label_sz = arr_new (size_t, 0) ;
+
+	// acquire read lock
+	GraphContext_AcquireReadLock (gc) ;
+
+	GraphContext_EstimateMemoryUsage (gc, samples, &result) ;
+
+cleanup:
+	// reply to caller
+	_Replay (rm_ctx, result, gc) ;
 
 	// counter to GraphContext_Retrieve
 	// held until here so schema name lookups above are not use-after-free
-	GraphContext_DecreaseRefCount (gc) ;
+	if (gc != NULL) {
+		GraphContext_ReleaseReadLock  (gc) ;
+		GraphContext_DecreaseRefCount (gc) ;
+	}
 
-cleanup:
 	RedisModule_FreeString (rm_ctx, ctx->graph_id) ;
 
 	// unblock client

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -20,6 +20,7 @@
 #include "../effects/effects.h"
 #include "../util/cache/cache.h"
 #include "../configuration/config.h"
+#include "../graph/graphcontext_retrieve.h"
 #include "../execution_plan/execution_plan.h"
 
 // GraphQueryCtx stores the allocations required to execute a query
@@ -414,10 +415,59 @@ void _query
 	Globals_TrackCommandCtx (command_ctx) ;
 
 	if (gc == NULL) {
-		if (GraphContext_Retrieve (ctx, command_ctx->rm_graph_name, true, false,
-					true, &gc) != GraphRetrieve_RETRIEVED) {
+		GraphRetrieveStatus status ;
+
+		if (command_ctx->thread == EXEC_THREAD_MAIN) {
+			// main-thread commands (replicated / MULTI / LUA /
+			// DENY_BLOCKING / LOADING) have no blocked client to park
+			// behind another load and later resume via the thread pool -
+			// queueing here would silently never reply if parked, and for
+			// a replicated write, failing outright on mere contention with
+			// another load risks exactly the divergence
+			// GraphContext_RetrieveOrForce exists to prevent. Only a
+			// genuine failure (or a concurrent offload still in flight)
+			// reaches the failure branch below.
+			status = GraphContext_RetrieveOrForce (ctx,
+					command_ctx->rm_graph_name, true, false, &gc) ;
+		} else {
+			status = GraphContext_RetrieveOrQueue (ctx,
+					command_ctx->rm_graph_name, true, false, command_ctx, &gc) ;
+		}
+
+		if (status == GraphRetrieve_LOADING) {
+			// parked behind another thread's in-flight load of this graph
+			// (only reachable via the queueing path above);
+			// CommandCtx_ResumeAfterGraphLoad will resubmit (or fail) this
+			// command once that load resolves - undo this attempt's
+			// thread-local setup, leave the CommandCtx / blocked client alone
+			Globals_UntrackCommandCtx (command_ctx) ;
+			QueryCtx_Free () ;
+			return ;
+		}
+
+		if (status != GraphRetrieve_RETRIEVED) {
+			if (command_ctx->replicated_command) {
+				// this write already applied on the master; silently
+				// failing to retrieve its graph here would let this
+				// replica's data diverge without either side noticing.
+				// Crashing is the safer failure mode: a replication resync
+				// (partial or full) on restart brings this replica back to
+				// a correct, consistent state. Use RELEASE_ASSERT, not
+				// ASSERT - the latter is a no-op in release builds, which
+				// would fall through to an undiagnosable crash instead.
+				RedisModule_Log (ctx, REDISMODULE_LOGLEVEL_WARNING,
+						"GRAPH.QUERY: failed to retrieve graph: %s while "
+						"replicating - crashing to force a replication "
+						"resync rather than risk silent master/replica "
+						"divergence",
+						RedisModule_StringPtrLen (command_ctx->rm_graph_name,
+							NULL)) ;
+				RELEASE_ASSERT (status == GraphRetrieve_RETRIEVED) ;
+			}
+
 			goto cleanup ;
 		}
+
 		CommandCtx_SetGraphContext (command_ctx, gc) ;
 	}
 

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -5,9 +5,9 @@
  */
 
 #include "RG.h"
+#include "commands.h"
 #include "../ast/ast.h"
 #include "cmd_context.h"
-#include "../util/arr.h"
 #include "cron/cron.h"
 #include "../globals.h"
 #include "../query_ctx.h"
@@ -18,7 +18,6 @@
 #include "../errors/errors.h"
 #include "index_operations.h"
 #include "../effects/effects.h"
-#include "../util/cache/cache.h"
 #include "../configuration/config.h"
 #include "../graph/graphcontext_retrieve.h"
 #include "../execution_plan/execution_plan.h"
@@ -430,15 +429,16 @@ void _query
 			status = GraphContext_RetrieveOrForce (ctx,
 					command_ctx->rm_graph_name, true, false, &gc) ;
 		} else {
+			void (*handler) (void *) = profile ? Graph_Profile : Graph_Query ;
 			status = GraphContext_RetrieveOrQueue (ctx,
-					command_ctx->rm_graph_name, true, false, command_ctx, &gc) ;
+					command_ctx->rm_graph_name, true, false, handler,
+					command_ctx, &gc) ;
 		}
 
 		if (status == GraphRetrieve_LOADING) {
 			// parked behind another thread's in-flight load of this graph
-			// (only reachable via the queueing path above);
-			// CommandCtx_ResumeAfterGraphLoad will resubmit (or fail) this
-			// command once that load resolves - undo this attempt's
+			// (only reachable via the queueing path above); `handler` will
+			// be resubmitted once that load resolves - undo this attempt's
 			// thread-local setup, leave the CommandCtx / blocked client alone
 			Globals_UntrackCommandCtx (command_ctx) ;
 			QueryCtx_Free () ;

--- a/src/commands/cmd_slowlog.c
+++ b/src/commands/cmd_slowlog.c
@@ -6,8 +6,14 @@
 
 #include "RG.h"
 #include "../redismodule.h"
+#include "../enterprise_api.h"
 #include "../slow_log/slow_log.h"
 #include "../graph/graphcontext.h"
+
+// offloaded-graph-stub type, exported by the enterprise module via its
+// shared API - resolved lazily; stays NULL when that module isn't loaded
+// (community edition)
+static GraphStubType_Get_t GraphStubType_Get = NULL ;
 
 // usage:
 // GRAPH.SLOWLOG G
@@ -29,10 +35,43 @@ int Graph_Slowlog
 		return REDISMODULE_OK;
 	}
 
+	// validate the subcommand before touching the keyspace at all - this is
+	// a syntax check, applies the same way regardless of the key's type or
+	// existence
+	bool reset = false ;
+	if (argc == 3) {
+		const char *sub_cmd = RedisModule_StringPtrLen (argv[2], NULL) ;
+		if (strcasecmp (sub_cmd, "reset") != 0) {
+			RedisModule_ReplyWithError (ctx, "Unknown subcommand") ;
+			return REDISMODULE_OK ;
+		}
+		reset = true ;
+	}
+
 	// get a hold of the graph key
 	RedisModuleString *key = argv [1] ;
+
+	// an offloaded stub has no slowlog history - answer directly without
+	// paying for a disk load
+	RedisModuleKey  *rkey = RedisModule_OpenKey (ctx, key, REDISMODULE_READ) ;
+	RedisModuleType *type = RedisModule_ModuleTypeGetType (rkey) ;
+	if (GraphStubType_Get == NULL) {
+		GraphStubType_Get = RedisModule_GetSharedAPI (ctx, "GraphStubType_Get") ;
+	}
+	bool is_stub = (GraphStubType_Get != NULL && type == GraphStubType_Get ()) ;
+	RedisModule_CloseKey (rkey) ;
+
+	if (is_stub) {
+		if (reset) {
+			RedisModule_ReplyWithSimpleString (ctx, "OK") ;
+		} else {
+			RedisModule_ReplyWithArray (ctx, 0) ;
+		}
+		return REDISMODULE_OK ;
+	}
+
 	GraphContext *gc = NULL ;
-	GraphContext_Retrieve (ctx, key, false, false, true, &gc) ;
+	GraphContext_Retrieve (ctx, key, false, false, false, &gc) ;
 	if (gc == NULL) {
 		// if GraphContext is null, key access failed and an error been emitted
 		return REDISMODULE_OK ;
@@ -40,25 +79,16 @@ int Graph_Slowlog
 
 	SlowLog *slowlog = GraphContext_GetSlowLog (gc) ;
 
-	// handle subcommand e.g. GRAPH.SLOWLOG G RESET
-	if(argc == 3) {
-		const char *sub_cmd = RedisModule_StringPtrLen(argv[2], NULL);
-		if(strcasecmp(sub_cmd, "reset") == 0) {
-			SlowLog_Clear(slowlog);
-			RedisModule_ReplyWithSimpleString(ctx, "OK");
-		} else {
-			// unknown subcommand
-			RedisModule_ReplyWithError(ctx, "Unknown subcommand");
-		}
-		goto cleanup;
+	if (reset) {
+		SlowLog_Clear (slowlog) ;
+		RedisModule_ReplyWithSimpleString (ctx, "OK") ;
+	} else {
+		// reply with slowlog
+		SlowLog_Replay (slowlog, ctx) ;
 	}
 
-	// reply with slowlog
-	SlowLog_Replay(slowlog, ctx);
+	GraphContext_DecreaseRefCount (gc) ;
 
-cleanup:
-	GraphContext_DecreaseRefCount(gc);
-
-	return REDISMODULE_OK;
+	return REDISMODULE_OK ;
 }
 

--- a/src/enterprise_api.h
+++ b/src/enterprise_api.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "redismodule.h"
+
+#include <stdbool.h>
+
+//------------------------------------------------------------------------------
+// Enterprise - FalkorDB exported API
+//
+// function pointer types for APIs the enterprise module exports via
+// RedisModule_GetSharedAPI. Any translation unit that needs to resolve one
+// of these should include this header rather than redeclaring the typedef
+// locally, so the signatures can't drift out of sync between call sites.
+//------------------------------------------------------------------------------
+
+// result of an attempt to load an offloaded graph stub from disk
+typedef enum {
+    GraphLoad_SUCCESS,      // graph restored from disk successfully
+    GraphLoad_LOADING,      // another load for this key is already in progress
+    GraphLoad_OFFLOADING,   // an offload for this key is already in progress
+    GraphLoad_KEY_MISSING,  // key does not exist
+    GraphLoad_NOT_STUB,     // key exists but is not an offloaded graph stub
+    GraphLoad_DUMP_MISSING, // stub is valid but its dump file was not found
+    GraphLoad_OOM,          // not enough memory to hold the loaded graph
+    GraphLoad_ERR,          // all other failures
+} GraphLoadResult ;
+
+// "GraphStubType_Get" - returns the RedisModuleType representing an
+// offloaded graph stub
+typedef RedisModuleType *(*GraphStubType_Get_t) (void) ;
+
+// "graph_load" - loads an offloaded graph stub from disk, replacing the
+// stub key's value with a live GraphContext
+typedef GraphLoadResult (*graph_load_t)
+(
+    RedisModuleCtx    *ctx,
+    RedisModuleString *key_name,
+    bool              from_thread,
+	bool              force,
+	bool              bypass_claim
+) ;

--- a/src/errors/error_msgs.h
+++ b/src/errors/error_msgs.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #define EMSG_GRAPH_EXISTS "Graph %s already exists"
+#define EMSG_GRAPH_LOAD_QUEUE_FULL "ERR too many queries waiting for graph: %s to finish loading"
+#define EMSG_MAX_PENDING_QUERIES "Max pending queries exceeded"
 #define EMSG_EMPTY_KEY "Encountered an empty key when opened key %s"
 #define EMSG_NON_GRAPH_KEY "Encountered a non-graph value type when opened key %s"
 #define EMSG_DIFFERENT_VALUE "Encountered different graph value when opened key %s"

--- a/src/graph/graph_load_queue.c
+++ b/src/graph/graph_load_queue.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "RG.h"
+#include "graph_load_queue.h"
+#include "../util/arr.h"
+#include "../util/dict.h"
+#include "../util/rmalloc.h"
+#include "../configuration/config.h"
+
+#include <pthread.h>
+
+// a single parked waiter
+typedef struct {
+	void               *waiter ;  // opaque handle, owned by the caller
+	GraphLoadWaiterCB   cb ;      // invoked once, on drain
+} Waiter ;
+
+// graph name (owned copy) -> arr_t of Waiter, parked behind the owner
+static dict            *_entries = NULL ;
+static pthread_mutex_t  _lock     = PTHREAD_MUTEX_INITIALIZER ;
+
+GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
+(
+	const char        *graph_name,
+	void              *waiter,
+	GraphLoadWaiterCB  cb
+) {
+	ASSERT (graph_name != NULL) ;
+	ASSERT (waiter     != NULL) ;
+	ASSERT (cb         != NULL) ;
+
+	GraphLoadQueueStatus status ;
+
+	pthread_mutex_lock (&_lock) ;
+
+	if (_entries == NULL) {
+		_entries = HashTableCreate (&string_dt) ;
+	}
+
+	dictEntry *de = HashTableFind (_entries, graph_name) ;
+
+	if (de == NULL) {
+		// no load currently in flight for this graph - caller becomes owner
+		Waiter *waiters = arr_new (Waiter, 0) ;
+		HashTableAdd (_entries, rm_strdup (graph_name), waiters) ;
+		status = GraphLoadQueue_OWNER ;
+	} else {
+		Waiter *waiters = HashTableGetVal (de) ;
+
+		uint64_t cap = 0 ;
+		bool res = Config_Option_get (Config_MAX_QUEUED_QUERIES, &cap) ;
+		ASSERT (res) ;
+
+		if ((uint64_t) arr_len (waiters) >= cap) {
+			status = GraphLoadQueue_FULL ;
+		} else {
+			Waiter w = { .waiter = waiter, .cb = cb } ;
+			arr_append (waiters, w) ;  // may reallocate - write the pointer back
+			HashTableSetVal (_entries, de, waiters) ;
+			status = GraphLoadQueue_PARKED ;
+		}
+	}
+
+	pthread_mutex_unlock (&_lock) ;
+
+	return status ;
+}
+
+void GraphLoadQueue_Drain
+(
+	const char *graph_name,
+	bool        success
+) {
+	ASSERT (graph_name != NULL) ;
+	ASSERT (_entries    != NULL) ;
+
+	pthread_mutex_lock (&_lock) ;
+
+	dictEntry *de = HashTableUnlink (_entries, graph_name) ;
+	ASSERT (de != NULL) ;  // Drain is only called by a thread that owns this entry
+
+	Waiter *waiters = HashTableGetVal (de) ;
+	rm_free (HashTableGetKey (de)) ;
+	HashTableFreeUnlinkedEntry (_entries, de) ;
+
+	pthread_mutex_unlock (&_lock) ;
+
+	uint32_t n = arr_len (waiters) ;
+	for (uint32_t i = 0 ; i < n ; i++) {
+		waiters[i].cb (waiters[i].waiter, success) ;
+	}
+
+	arr_free (waiters) ;
+}

--- a/src/graph/graph_load_queue.c
+++ b/src/graph/graph_load_queue.c
@@ -8,14 +8,15 @@
 #include "../util/arr.h"
 #include "../util/dict.h"
 #include "../util/rmalloc.h"
+#include "../util/thpool/pool.h"
 #include "../configuration/config.h"
 
 #include <pthread.h>
 
 // a single parked waiter
 typedef struct {
-	CommandCtx         *waiter ;  // parked command context, owned by the caller
-	GraphLoadWaiterCB   cb ;      // invoked once, on drain
+	void (*handler) (void *) ;  // resubmitted to the thread pool on drain
+	void  *arg ;                // passed to `handler` on drain
 } Waiter ;
 
 // graph name (owned copy) -> arr_t of Waiter, parked behind the owner
@@ -24,13 +25,13 @@ static pthread_mutex_t  _lock     = PTHREAD_MUTEX_INITIALIZER ;
 
 GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 (
-	const char        *graph_name,
-	CommandCtx        *waiter,
-	GraphLoadWaiterCB  cb
+	const char *graph_name,
+	void      (*handler) (void *),
+	void       *arg
 ) {
 	ASSERT (graph_name != NULL) ;
-	ASSERT (waiter     != NULL) ;
-	ASSERT (cb         != NULL) ;
+	ASSERT (handler     != NULL) ;
+	ASSERT (arg         != NULL) ;
 
 	GraphLoadQueueStatus status ;
 
@@ -57,7 +58,7 @@ GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 		if ((uint64_t) arr_len (waiters) >= cap) {
 			status = GraphLoadQueue_FULL ;
 		} else {
-			Waiter w = { .waiter = waiter, .cb = cb } ;
+			Waiter w = { .handler = handler, .arg = arg } ;
 			arr_append (waiters, w) ;  // may reallocate - write the pointer back
 			HashTableSetVal (_entries, de, waiters) ;
 			status = GraphLoadQueue_PARKED ;
@@ -71,8 +72,7 @@ GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 
 void GraphLoadQueue_Drain
 (
-	const char *graph_name,
-	bool        success
+	const char *graph_name
 ) {
 	ASSERT (graph_name != NULL) ;
 	ASSERT (_entries    != NULL) ;
@@ -90,7 +90,10 @@ void GraphLoadQueue_Drain
 
 	uint32_t n = arr_len (waiters) ;
 	for (uint32_t i = 0 ; i < n ; i++) {
-		waiters[i].cb (waiters[i].waiter, success) ;
+		// force=true - these waiters were already accepted into the
+		// per-graph wait list (a separate capacity from the thread pool's
+		// own work queue) and must not be silently dropped
+		ThreadPool_AddWork (waiters[i].handler, waiters[i].arg, true) ;
 	}
 
 	arr_free (waiters) ;
@@ -110,10 +113,8 @@ void GraphLoadQueue_Free (void) {
 		Waiter *waiters = HashTableGetVal (de) ;
 		uint32_t n = arr_len (waiters) ;
 		for (uint32_t i = 0 ; i < n ; i++) {
-			// success=false - there is no real load outcome left to report;
-			// same as any other failed drain, this replies with an error and
-			// frees the CommandCtx
-			waiters[i].cb (waiters[i].waiter, false) ;
+			// same as a normal drain - resubmit, force=true
+			ThreadPool_AddWork (waiters[i].handler, waiters[i].arg, true) ;
 		}
 
 		arr_free (waiters) ;
@@ -124,3 +125,4 @@ void GraphLoadQueue_Free (void) {
 	HashTableRelease (_entries) ;
 	_entries = NULL ;
 }
+

--- a/src/graph/graph_load_queue.c
+++ b/src/graph/graph_load_queue.c
@@ -75,7 +75,10 @@ void GraphLoadQueue_Drain
 	const char *graph_name
 ) {
 	ASSERT (graph_name != NULL) ;
-	ASSERT (_entries    != NULL) ;
+
+	if (_entries == NULL) {
+		return ;
+	}
 
 	pthread_mutex_lock (&_lock) ;
 
@@ -104,6 +107,8 @@ void GraphLoadQueue_Free (void) {
 		return ;
 	}
 
+	pthread_mutex_lock (&_lock) ;
+
 	dictIterator *iter = HashTableGetIterator (_entries) ;
 	dictEntry *de ;
 
@@ -124,5 +129,7 @@ void GraphLoadQueue_Free (void) {
 
 	HashTableRelease (_entries) ;
 	_entries = NULL ;
+
+	pthread_mutex_unlock  (&_lock) ;
 }
 

--- a/src/graph/graph_load_queue.c
+++ b/src/graph/graph_load_queue.c
@@ -14,7 +14,7 @@
 
 // a single parked waiter
 typedef struct {
-	void               *waiter ;  // opaque handle, owned by the caller
+	CommandCtx         *waiter ;  // parked command context, owned by the caller
 	GraphLoadWaiterCB   cb ;      // invoked once, on drain
 } Waiter ;
 
@@ -25,7 +25,7 @@ static pthread_mutex_t  _lock     = PTHREAD_MUTEX_INITIALIZER ;
 GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 (
 	const char        *graph_name,
-	void              *waiter,
+	CommandCtx        *waiter,
 	GraphLoadWaiterCB  cb
 ) {
 	ASSERT (graph_name != NULL) ;
@@ -94,4 +94,33 @@ void GraphLoadQueue_Drain
 	}
 
 	arr_free (waiters) ;
+}
+
+void GraphLoadQueue_Free (void) {
+	if (_entries == NULL) {
+		return ;
+	}
+
+	dictIterator *iter = HashTableGetIterator (_entries) ;
+	dictEntry *de ;
+
+	while ((de = HashTableNext (iter)) != NULL) {
+		rm_free (HashTableGetKey (de)) ;
+
+		Waiter *waiters = HashTableGetVal (de) ;
+		uint32_t n = arr_len (waiters) ;
+		for (uint32_t i = 0 ; i < n ; i++) {
+			// success=false - there is no real load outcome left to report;
+			// same as any other failed drain, this replies with an error and
+			// frees the CommandCtx
+			waiters[i].cb (waiters[i].waiter, false) ;
+		}
+
+		arr_free (waiters) ;
+	}
+
+	HashTableReleaseIterator (iter) ;
+
+	HashTableRelease (_entries) ;
+	_entries = NULL ;
 }

--- a/src/graph/graph_load_queue.h
+++ b/src/graph/graph_load_queue.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "../commands/cmd_context.h"
+
 #include <stdbool.h>
 
 //------------------------------------------------------------------------------
@@ -21,8 +23,7 @@
 // registering as a waiter, have the owner finish and drain an empty list —
 // the two operations are atomic with respect to each other.
 //
-// This module knows nothing about CommandCtx / the thread pool / Redis
-// replies — waiters are opaque pointers paired with a caller-supplied
+// Waiters are parked CommandCtx pointers paired with a caller-supplied
 // callback, invoked once, exactly one time, when the wait ends.
 //------------------------------------------------------------------------------
 
@@ -53,7 +54,7 @@ typedef void (*GraphLoadWaiterCB)
 GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 (
 	const char        *graph_name,
-	void              *waiter,
+	CommandCtx        *waiter,
 	GraphLoadWaiterCB  cb
 ) ;
 
@@ -66,3 +67,13 @@ void GraphLoadQueue_Drain
 	const char *graph_name,
 	bool        success
 ) ;
+
+// release every resource held by this module: any graph names and waiter
+// lists still tracked (e.g. loads that never drained because the server
+// shut down mid-flight), and the registry itself
+// each remaining waiter's callback is still invoked, with success=false -
+// same as a normal failed drain, this replies with an error and frees the
+// CommandCtx; there is simply no real load outcome left to report
+// not thread-safe with concurrent GraphLoadQueue_AcquireOrWait / _Drain
+// calls - intended for server shutdown only
+void GraphLoadQueue_Free (void) ;

--- a/src/graph/graph_load_queue.h
+++ b/src/graph/graph_load_queue.h
@@ -5,10 +5,6 @@
 
 #pragma once
 
-#include "../commands/cmd_context.h"
-
-#include <stdbool.h>
-
 //------------------------------------------------------------------------------
 // Per-graph coordination for concurrent loads of an offloaded stub
 //
@@ -23,57 +19,54 @@
 // registering as a waiter, have the owner finish and drain an empty list —
 // the two operations are atomic with respect to each other.
 //
-// Waiters are parked CommandCtx pointers paired with a caller-supplied
-// callback, invoked once, exactly one time, when the wait ends.
+// Waiters are parked as a generic (handler, arg) pair - e.g. a command's
+// top-level entry point paired with its CommandCtx - so any caller that may
+// get parked behind an in-flight load can be resumed the same way: by
+// resubmitting `handler(arg)` to the thread pool, as if freshly dispatched.
+// Each parked waiter is resumed exactly once.
 //------------------------------------------------------------------------------
 
 typedef enum {
 	GraphLoadQueue_OWNER,   // no load is currently in flight for this graph;
 	                        // caller must perform the load itself and, once
 	                        // it resolves, call GraphLoadQueue_Drain exactly
-	                        // once with the outcome
+	                        // once
 	GraphLoadQueue_PARKED,  // another thread already owns the in-flight load;
-	                        // `waiter` was parked, `cb` will be invoked
-	                        // exactly once with the outcome once the owner
-	                        // calls GraphLoadQueue_Drain
+	                        // (`handler`, `arg`) was parked and will be
+	                        // resubmitted to the thread pool exactly once,
+	                        // once the owner calls GraphLoadQueue_Drain
 	GraphLoadQueue_FULL,    // another thread owns the in-flight load and the
 	                        // per-graph wait list is already at capacity;
-	                        // `waiter` was NOT parked, caller must handle it
+	                        // (`handler`, `arg`) was NOT parked, caller must
+	                        // handle it
 } GraphLoadQueueStatus ;
 
-// invoked once for a parked waiter when the in-flight load it was waiting on
-// completes; `success` reflects whether the load succeeded
-typedef void (*GraphLoadWaiterCB)
-(
-	CommandCtx *waiter,
-	bool        success
-) ;
-
-// attempt to become the load owner for `graph_name`, or park `waiter` behind
-// whichever thread already owns it
+// attempt to become the load owner for `graph_name`, or park (`handler`,
+// `arg`) behind whichever thread already owns it
 GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
 (
-	const char        *graph_name,
-	CommandCtx        *waiter,
-	GraphLoadWaiterCB  cb
+	const char *graph_name,
+	void      (*handler) (void *),  // resubmitted to the thread pool on drain
+	void       *arg                 // passed to `handler` on drain
 ) ;
 
 // called exactly once, by the thread for which GraphLoadQueue_AcquireOrWait
-// returned GraphLoadQueue_OWNER, once its load attempt resolves; wakes every
-// waiter parked on `graph_name` with `success`, then clears bookkeeping for
-// `graph_name` so the next load attempt starts a fresh round
+// returned GraphLoadQueue_OWNER, once its load attempt resolves; resubmits
+// every waiter parked on `graph_name` to the thread pool (regardless of the
+// load's outcome - each resumed handler re-discovers that outcome itself,
+// e.g. by re-attempting the retrieval it was parked behind), then clears
+// bookkeeping for `graph_name` so the next load attempt starts a fresh round
 void GraphLoadQueue_Drain
 (
-	const char *graph_name,
-	bool        success
+	const char *graph_name
 ) ;
 
 // release every resource held by this module: any graph names and waiter
 // lists still tracked (e.g. loads that never drained because the server
 // shut down mid-flight), and the registry itself
-// each remaining waiter's callback is still invoked, with success=false -
-// same as a normal failed drain, this replies with an error and frees the
-// CommandCtx; there is simply no real load outcome left to report
+// each remaining waiter is still resubmitted to the thread pool, same as a
+// normal drain
 // not thread-safe with concurrent GraphLoadQueue_AcquireOrWait / _Drain
 // calls - intended for server shutdown only
 void GraphLoadQueue_Free (void) ;
+

--- a/src/graph/graph_load_queue.h
+++ b/src/graph/graph_load_queue.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+//------------------------------------------------------------------------------
+// Per-graph coordination for concurrent loads of an offloaded stub
+//
+// The first thread to reach a given stub becomes its load "owner" and is the
+// one that actually performs the load (i.e. calls graph_load). Every other
+// thread that reaches the same stub while the owner's load is still in
+// flight parks itself here (keyed by graph name) instead of failing
+// outright, and is woken once the owner's load resolves.
+//
+// Owner-election and parking share a single lock, so there is no gap in
+// which a thread can observe "someone else owns this load" and then, before
+// registering as a waiter, have the owner finish and drain an empty list —
+// the two operations are atomic with respect to each other.
+//
+// This module knows nothing about CommandCtx / the thread pool / Redis
+// replies — waiters are opaque pointers paired with a caller-supplied
+// callback, invoked once, exactly one time, when the wait ends.
+//------------------------------------------------------------------------------
+
+typedef enum {
+	GraphLoadQueue_OWNER,   // no load is currently in flight for this graph;
+	                        // caller must perform the load itself and, once
+	                        // it resolves, call GraphLoadQueue_Drain exactly
+	                        // once with the outcome
+	GraphLoadQueue_PARKED,  // another thread already owns the in-flight load;
+	                        // `waiter` was parked, `cb` will be invoked
+	                        // exactly once with the outcome once the owner
+	                        // calls GraphLoadQueue_Drain
+	GraphLoadQueue_FULL,    // another thread owns the in-flight load and the
+	                        // per-graph wait list is already at capacity;
+	                        // `waiter` was NOT parked, caller must handle it
+} GraphLoadQueueStatus ;
+
+// invoked once for a parked waiter when the in-flight load it was waiting on
+// completes; `success` reflects whether the load succeeded
+typedef void (*GraphLoadWaiterCB)
+(
+	void *waiter,
+	bool  success
+) ;
+
+// attempt to become the load owner for `graph_name`, or park `waiter` behind
+// whichever thread already owns it
+GraphLoadQueueStatus GraphLoadQueue_AcquireOrWait
+(
+	const char        *graph_name,
+	void              *waiter,
+	GraphLoadWaiterCB  cb
+) ;
+
+// called exactly once, by the thread for which GraphLoadQueue_AcquireOrWait
+// returned GraphLoadQueue_OWNER, once its load attempt resolves; wakes every
+// waiter parked on `graph_name` with `success`, then clears bookkeeping for
+// `graph_name` so the next load attempt starts a fresh round
+void GraphLoadQueue_Drain
+(
+	const char *graph_name,
+	bool        success
+) ;

--- a/src/graph/graph_load_queue.h
+++ b/src/graph/graph_load_queue.h
@@ -45,8 +45,8 @@ typedef enum {
 // completes; `success` reflects whether the load succeeded
 typedef void (*GraphLoadWaiterCB)
 (
-	void *waiter,
-	bool  success
+	CommandCtx *waiter,
+	bool        success
 ) ;
 
 // attempt to become the load owner for `graph_name`, or park `waiter` behind

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -60,11 +60,21 @@ typedef enum {
 	GraphRetrieve_RETRIEVED,  // gc is valid, ref count incremented
 	GraphRetrieve_FAILED,     // error emitted, gc is NULL
 	GraphRetrieve_OFFLOADED,  // graph is offloaded
+	GraphRetrieve_LOADING,    // graph is offloaded and already being loaded
+	                          // by another thread; no reply emitted, caller
+	                          // decides how to proceed (e.g. queue and retry)
+	                          // only ever returned by
+	                          // GraphContext_RetrieveOrQueue (see
+	                          // graphcontext_retrieve.h) - GraphContext_Retrieve
+	                          // itself folds this case into GraphRetrieve_FAILED
 } GraphRetrieveStatus ;
 
 // Retrieve the GraphContext for graphID.
 // On success sets *gc and returns GraphRetrieve_RETRIEVED.
-// On error emits a reply and returns GraphRetrieve_FAILED.
+// On error emits a reply and returns GraphRetrieve_FAILED. This includes the
+// case where load_from_disk=true and another thread is already loading this
+// stub - there is no queueing here, it is treated as a regular failure; see
+// GraphContext_RetrieveOrQueue (graphcontext_retrieve.h) for that.
 // When load_from_disk=false and the graph is a stub, returns
 // GraphRetrieve_OFFLOADED with no error reply.
 // When load_from_disk=true the function loads the graph from disk and

--- a/src/graph/graphcontext_retrieve.c
+++ b/src/graph/graphcontext_retrieve.c
@@ -5,9 +5,11 @@
 
 #include "RG.h"
 #include "graphcontext.h"
-#include "graph_load_queue.h"
-#include "graphcontext_retrieve.h"
 #include "../redismodule.h"
+#include "graph_load_queue.h"
+#include "../enterprise_api.h"
+#include "../errors/error_msgs.h"
+#include "graphcontext_retrieve.h"
 
 extern uint aux_field_counter ;
 extern pthread_t MAIN_THREAD_ID;  // redis main thread ID
@@ -17,32 +19,6 @@ extern RedisModuleType *GraphContextRedisModuleType ;
 
 // stub type representing a graph that has been offloaded to disk
 static RedisModuleType *GraphStubType = NULL ;
-
-//------------------------------------------------------------------------------
-// Enterprise - FalkorDB exported API — function pointer types
-//------------------------------------------------------------------------------
-
-typedef enum {
-    GraphLoad_SUCCESS,      // graph restored from disk successfully
-    GraphLoad_LOADING,      // another load for this key is already in progress
-    GraphLoad_OFFLOADING,   // an offload for this key is already in progress
-    GraphLoad_KEY_MISSING,  // key does not exist
-    GraphLoad_NOT_STUB,     // key exists but is not an offloaded graph stub
-    GraphLoad_DUMP_MISSING, // stub is valid but its dump file was not found
-    GraphLoad_OOM,          // not enough memory to hold the loaded graph
-    GraphLoad_ERR,          // all other failures
-} GraphLoadResult ;
-
-typedef RedisModuleType* (*GraphStubType_Get_t) (void) ;
-
-typedef GraphLoadResult (*graph_load_t)
-(
-    RedisModuleCtx    *ctx,
-    RedisModuleString *key_name,
-    bool              from_thread,
-	bool              force,
-	bool              bypass_claim
-) ;
 
 //------------------------------------------------------------------------------
 // Enterprise - FalkorDB exported API — function pointers
@@ -319,8 +295,7 @@ static GraphRetrieveStatus _GraphContext_Retrieve
 	}
 
 	if (qstatus == GraphLoadQueue_FULL) {
-		RedisModule_ReplyWithErrorFormat (ctx,
-				"ERR too many queries waiting for graph: %s to finish loading",
+		RedisModule_ReplyWithErrorFormat (ctx, EMSG_GRAPH_LOAD_QUEUE_FULL,
 				graph_name) ;
 		return GraphRetrieve_FAILED ;
 	}

--- a/src/graph/graphcontext_retrieve.c
+++ b/src/graph/graphcontext_retrieve.c
@@ -97,8 +97,8 @@ void GraphContext_SetKey
 // failure was already logged server-side by graph_load itself
 static void _reply_graph_load_error
 (
-	RedisModuleCtx  *ctx,
-	const char      *graph_name,
+	RedisModuleCtx *ctx,
+	const char *graph_name,
 	GraphLoadResult result
 ) {
 	switch (result) {
@@ -167,19 +167,20 @@ static void _reply_graph_load_error
 // nothing yet to load in that case
 static GraphRetrieveStatus _GraphContext_Retrieve
 (
-	RedisModuleCtx    *ctx,             // Redis module context
-	RedisModuleString *graphID,         // key identifying the graph
-	bool               readOnly,        // if true, opens the key in read mode
-	bool               shouldCreate,    // create new graph if the key is absent
-	bool               load_from_disk,  // load graph from disk if offloaded
-	CommandCtx        *command_ctx,     // parked if the graph is being loaded
-	bool               bypass_claim,    // never fail due to contention
-	GraphContext     **gc               // out: graph context on success
+	RedisModuleCtx *ctx,         // Redis module context
+	RedisModuleString *graphID,  // key identifying the graph
+	bool readOnly,               // if true, opens the key in read mode
+	bool shouldCreate,           // create new graph if the key is absent
+	bool load_from_disk,         // load graph from disk if offloaded
+	void (*handler) (void *),    // resubmitted if the graph is loading
+	void *arg,                   // passed to `handler` if parked
+	bool bypass_claim,           // never fail due to contention
+	GraphContext **gc            // out: graph context on success
 ) {
 	ASSERT (gc      != NULL) ;
 	ASSERT (ctx     != NULL) ;
 	ASSERT (graphID != NULL) ;
-	ASSERT (!(command_ctx != NULL && bypass_claim)) ;
+	ASSERT (!(handler != NULL && bypass_claim)) ;
 
 	*gc = NULL ;
 
@@ -270,14 +271,14 @@ static GraphRetrieveStatus _GraphContext_Retrieve
 
 	const char *graph_name = RedisModule_StringPtrLen (graphID, NULL) ;
 
-	if (command_ctx == NULL) {
+	if (handler == NULL) {
 		// legacy path, or bypass_claim (GraphContext_RetrieveOrForce)
 		GraphLoadResult result =
 			graph_load (ctx, graphID, from_thread, false, bypass_claim) ;
 
 		if (result == GraphLoad_SUCCESS) {
 			return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-					false, NULL, false, gc) ;
+					false, NULL, NULL, false, gc) ;
 		}
 
 		_reply_graph_load_error (ctx, graph_name, result) ;
@@ -288,7 +289,7 @@ static GraphRetrieveStatus _GraphContext_Retrieve
 	// queueing path: become the owner of this graph's load, or park behind
 	// whichever thread already owns it
 	GraphLoadQueueStatus qstatus = GraphLoadQueue_AcquireOrWait (graph_name,
-			command_ctx, CommandCtx_ResumeAfterGraphLoad) ;
+			handler, arg) ;
 
 	if (qstatus == GraphLoadQueue_PARKED) {
 		return GraphRetrieve_LOADING ;  // parked; caller does nothing further
@@ -304,12 +305,13 @@ static GraphRetrieveStatus _GraphContext_Retrieve
 	GraphLoadResult result = graph_load (ctx, graphID, from_thread, false,
 			false) ;
 
-	// wake everyone parked behind us with our own outcome
-	GraphLoadQueue_Drain (graph_name, result == GraphLoad_SUCCESS) ;
+	// wake everyone parked behind us - each resumed call re-discovers our
+	// outcome itself when it re-enters this function
+	GraphLoadQueue_Drain (graph_name) ;
 
 	if (result == GraphLoad_SUCCESS) {
 		return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-				false, NULL, false, gc) ;
+				false, NULL, NULL, false, gc) ;
 	}
 
 	_reply_graph_load_error (ctx, graph_name, result) ;
@@ -326,38 +328,40 @@ static GraphRetrieveStatus _GraphContext_Retrieve
 // must be called from the Redis main thread when load_from_disk=false
 GraphRetrieveStatus GraphContext_Retrieve
 (
-	RedisModuleCtx    *ctx,             // Redis module context
-	RedisModuleString *graphID,         // key identifying the graph
-	bool               readOnly,        // if true, opens the key in read mode
-	bool               shouldCreate,    // create new graph if the key is absent
-	bool               load_from_disk,  // load graph from disk if offloaded
-	GraphContext     **gc               // out: graph context on success
+	RedisModuleCtx *ctx,         // Redis module context
+	RedisModuleString *graphID,  // key identifying the graph
+	bool readOnly,               // if true, opens the key in read mode
+	bool shouldCreate,           // create new graph if the key is absent
+	bool load_from_disk,         // load graph from disk if offloaded
+	GraphContext **gc            // out: graph context on success
 ) {
 	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-			load_from_disk, NULL, false, gc) ;
+			load_from_disk, NULL, NULL, false, gc) ;
 }
 
 // Like GraphContext_Retrieve, always attempting to load
 // the graph from disk if it is offloaded, but with different handling of
 // concurrent loads: if another thread is already loading this stub,
-// `command_ctx` is parked instead of GraphRetrieve_LOADING being returned
-// immediately. Once that in-flight load resolves,
-// CommandCtx_ResumeAfterGraphLoad (see cmd_context.h) is invoked with
-// `command_ctx` - the caller must not touch it again until then.
+// (`handler`, `arg`) is parked instead of GraphRetrieve_LOADING being
+// returned immediately. Once that in-flight load resolves, `handler(arg)`
+// is resubmitted to the thread pool - as if freshly dispatched - the caller
+// must not touch `arg` again until then.
 // may be called from any thread
 GraphRetrieveStatus GraphContext_RetrieveOrQueue
 (
-	RedisModuleCtx    *ctx,
+	RedisModuleCtx *ctx,
 	RedisModuleString *graphID,
-	bool               readOnly,
-	bool               shouldCreate,
-	CommandCtx        *command_ctx,
-	GraphContext     **gc
+	bool readOnly,
+	bool shouldCreate,
+	void (*handler) (void *),
+	void *arg,
+	GraphContext **gc
 ) {
-	ASSERT (command_ctx != NULL) ;
+	ASSERT (handler != NULL) ;
+	ASSERT (arg     != NULL) ;
 
 	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-			true, command_ctx, false, gc) ;
+			true, handler, arg, false, gc) ;
 }
 
 // Like GraphContext_Retrieve, always attempting to load
@@ -374,13 +378,13 @@ GraphRetrieveStatus GraphContext_RetrieveOrQueue
 // May be called from any thread.
 GraphRetrieveStatus GraphContext_RetrieveOrForce
 (
-	RedisModuleCtx    *ctx,
+	RedisModuleCtx *ctx,
 	RedisModuleString *graphID,
-	bool               readOnly,
-	bool               shouldCreate,
-	GraphContext     **gc
+	bool readOnly,
+	bool shouldCreate,
+	GraphContext **gc
 ) {
 	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-			true, NULL, true, gc) ;
+			true, NULL, NULL, true, gc) ;
 }
 

--- a/src/graph/graphcontext_retrieve.c
+++ b/src/graph/graphcontext_retrieve.c
@@ -5,6 +5,8 @@
 
 #include "RG.h"
 #include "graphcontext.h"
+#include "graph_load_queue.h"
+#include "graphcontext_retrieve.h"
 #include "../redismodule.h"
 
 extern uint aux_field_counter ;
@@ -21,11 +23,14 @@ static RedisModuleType *GraphStubType = NULL ;
 //------------------------------------------------------------------------------
 
 typedef enum {
-    GraphLoad_SUCCESS,  // graph restored from disk successfully
-    GraphLoad_LOADING,  // a load for this key is already in progress
-    GraphLoad_MISSING,  // key or dump file does not exist
-    GraphLoad_OOM,      // not enough memory to hold the loaded graph
-    GraphLoad_ERR,      // all other failures
+    GraphLoad_SUCCESS,      // graph restored from disk successfully
+    GraphLoad_LOADING,      // another load for this key is already in progress
+    GraphLoad_OFFLOADING,   // an offload for this key is already in progress
+    GraphLoad_KEY_MISSING,  // key does not exist
+    GraphLoad_NOT_STUB,     // key exists but is not an offloaded graph stub
+    GraphLoad_DUMP_MISSING, // stub is valid but its dump file was not found
+    GraphLoad_OOM,          // not enough memory to hold the loaded graph
+    GraphLoad_ERR,          // all other failures
 } GraphLoadResult ;
 
 typedef RedisModuleType* (*GraphStubType_Get_t) (void) ;
@@ -35,7 +40,8 @@ typedef GraphLoadResult (*graph_load_t)
     RedisModuleCtx    *ctx,
     RedisModuleString *key_name,
     bool              from_thread,
-	bool              force
+	bool              force,
+	bool              bypass_claim
 ) ;
 
 //------------------------------------------------------------------------------
@@ -110,25 +116,94 @@ void GraphContext_SetKey
 	RedisModule_CloseKey (key) ;
 }
 
-// retrieve the GraphContext for graphID
-// on success sets *gc and returns GraphRetrieve_RETRIEVED
-// on error emits a reply and returns GraphRetrieve_FAILED
-// when load_from_disk=false and the graph is a stub, returns
-// GraphRetrieve_OFFLOADED with no error reply
-// may be called from any thread when load_from_disk=true
-// must be called from the Redis main thread when load_from_disk=false
-GraphRetrieveStatus GraphContext_Retrieve
+// emits an appropriate error reply for a graph_load failure result
+// (never called with GraphLoad_SUCCESS); full diagnostic detail for the
+// failure was already logged server-side by graph_load itself
+static void _reply_graph_load_error
+(
+	RedisModuleCtx  *ctx,
+	const char      *graph_name,
+	GraphLoadResult result
+) {
+	switch (result) {
+		case GraphLoad_LOADING:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR graph: %s is currently being loaded, please retry",
+					graph_name) ;
+			break ;
+
+		case GraphLoad_OFFLOADING:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR graph: %s is currently being offloaded, please retry",
+					graph_name) ;
+			break ;
+
+		case GraphLoad_KEY_MISSING:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR graph: %s does not exist", graph_name) ;
+			break ;
+
+		case GraphLoad_NOT_STUB:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR graph: %s is not an offloaded graph stub", graph_name) ;
+			break ;
+
+		case GraphLoad_DUMP_MISSING:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR dump file for graph: %s not found", graph_name) ;
+			break ;
+
+		case GraphLoad_OOM:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR not enough memory to load graph: %s", graph_name) ;
+			break ;
+
+		case GraphLoad_SUCCESS:
+			ASSERT ("_reply_graph_load_error called with GraphLoad_SUCCESS" && false) ;
+			break ;
+
+		case GraphLoad_ERR:
+		default:
+			RedisModule_ReplyWithErrorFormat (ctx,
+					"ERR failed to load graph: %s", graph_name) ;
+			break ;
+	}
+}
+
+// shared implementation backing GraphContext_Retrieve,
+// GraphContext_RetrieveOrQueue and GraphContext_RetrieveOrForce
+//
+// command_ctx and bypass_claim are mutually exclusive - at most one may be
+// set/true on any given call
+//
+// when command_ctx is NULL and bypass_claim is false: legacy behavior - on
+// contention, an error is replied and GraphRetrieve_FAILED is returned
+//
+// when command_ctx is non-NULL (load_from_disk is implicitly true): this
+// call either becomes the owner of the graph's load (and performs it), or
+// parks `command_ctx` behind whichever thread already owns it - see
+// graph_load_queue.h
+//
+// when bypass_claim is true (load_from_disk is implicitly true): never
+// returns GraphRetrieve_FAILED due to another load being in flight - an
+// independent load is attempted regardless (see graph_load.h in the
+// enterprise repo); an in-flight offload is never bypassed, since there is
+// nothing yet to load in that case
+static GraphRetrieveStatus _GraphContext_Retrieve
 (
 	RedisModuleCtx    *ctx,             // Redis module context
 	RedisModuleString *graphID,         // key identifying the graph
 	bool               readOnly,        // if true, opens the key in read mode
 	bool               shouldCreate,    // create new graph if the key is absent
 	bool               load_from_disk,  // load graph from disk if offloaded
+	CommandCtx        *command_ctx,     // parked if the graph is being loaded
+	bool               bypass_claim,    // never fail due to contention
 	GraphContext     **gc               // out: graph context on success
 ) {
 	ASSERT (gc      != NULL) ;
 	ASSERT (ctx     != NULL) ;
 	ASSERT (graphID != NULL) ;
+	ASSERT (!(command_ctx != NULL && bypass_claim)) ;
 
 	*gc = NULL ;
 
@@ -217,11 +292,120 @@ GraphRetrieveStatus GraphContext_Retrieve
 	// on success, recursive call re-enters Phase 1 to fetch the live graph
 	//--------------------------------------------------------------------------
 
-	if (graph_load (ctx, graphID, from_thread, false) == GraphLoad_SUCCESS) {
-		return GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
-				false, gc) ;
+	const char *graph_name = RedisModule_StringPtrLen (graphID, NULL) ;
+
+	if (command_ctx == NULL) {
+		// legacy path, or bypass_claim (GraphContext_RetrieveOrForce)
+		GraphLoadResult result =
+			graph_load (ctx, graphID, from_thread, false, bypass_claim) ;
+
+		if (result == GraphLoad_SUCCESS) {
+			return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
+					false, NULL, false, gc) ;
+		}
+
+		_reply_graph_load_error (ctx, graph_name, result) ;
+
+		return GraphRetrieve_FAILED ;
 	}
 
+	// queueing path: become the owner of this graph's load, or park behind
+	// whichever thread already owns it
+	GraphLoadQueueStatus qstatus = GraphLoadQueue_AcquireOrWait (graph_name,
+			command_ctx, CommandCtx_ResumeAfterGraphLoad) ;
+
+	if (qstatus == GraphLoadQueue_PARKED) {
+		return GraphRetrieve_LOADING ;  // parked; caller does nothing further
+	}
+
+	if (qstatus == GraphLoadQueue_FULL) {
+		RedisModule_ReplyWithErrorFormat (ctx,
+				"ERR too many queries waiting for graph: %s to finish loading",
+				graph_name) ;
+		return GraphRetrieve_FAILED ;
+	}
+
+	// qstatus == GraphLoadQueue_OWNER: perform the load ourselves
+	GraphLoadResult result = graph_load (ctx, graphID, from_thread, false,
+			false) ;
+
+	// wake everyone parked behind us with our own outcome
+	GraphLoadQueue_Drain (graph_name, result == GraphLoad_SUCCESS) ;
+
+	if (result == GraphLoad_SUCCESS) {
+		return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
+				false, NULL, false, gc) ;
+	}
+
+	_reply_graph_load_error (ctx, graph_name, result) ;
+
 	return GraphRetrieve_FAILED ;
+}
+
+// retrieve the GraphContext for graphID
+// on success sets *gc and returns GraphRetrieve_RETRIEVED
+// on error emits a reply and returns GraphRetrieve_FAILED
+// when load_from_disk=false and the graph is a stub, returns
+// GraphRetrieve_OFFLOADED with no error reply
+// may be called from any thread when load_from_disk=true
+// must be called from the Redis main thread when load_from_disk=false
+GraphRetrieveStatus GraphContext_Retrieve
+(
+	RedisModuleCtx    *ctx,             // Redis module context
+	RedisModuleString *graphID,         // key identifying the graph
+	bool               readOnly,        // if true, opens the key in read mode
+	bool               shouldCreate,    // create new graph if the key is absent
+	bool               load_from_disk,  // load graph from disk if offloaded
+	GraphContext     **gc               // out: graph context on success
+) {
+	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
+			load_from_disk, NULL, false, gc) ;
+}
+
+// Like GraphContext_Retrieve, always attempting to load
+// the graph from disk if it is offloaded, but with different handling of
+// concurrent loads: if another thread is already loading this stub,
+// `command_ctx` is parked instead of GraphRetrieve_LOADING being returned
+// immediately. Once that in-flight load resolves,
+// CommandCtx_ResumeAfterGraphLoad (see cmd_context.h) is invoked with
+// `command_ctx` - the caller must not touch it again until then.
+// may be called from any thread
+GraphRetrieveStatus GraphContext_RetrieveOrQueue
+(
+	RedisModuleCtx    *ctx,
+	RedisModuleString *graphID,
+	bool               readOnly,
+	bool               shouldCreate,
+	CommandCtx        *command_ctx,
+	GraphContext     **gc
+) {
+	ASSERT (command_ctx != NULL) ;
+
+	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
+			true, command_ctx, false, gc) ;
+}
+
+// Like GraphContext_Retrieve, always attempting to load
+// the graph from disk if it is offloaded, but never failing due to another
+// load being in flight: an independent load is attempted regardless (see
+// bypass_claim in the enterprise repo's graph_load.h), so
+// GraphRetrieve_FAILED is only ever returned for a genuine failure (missing
+// dump, OOM, corruption, etc.), never for mere contention with another
+// load. An in-flight offload is never bypassed, since there is nothing yet
+// to load in that case, so this may still fail while a concurrent offload
+// of the same graph is in progress.
+// For use by callers that cannot tolerate a transient retrieval failure -
+// e.g. GRAPH.EFFECT, where a failure risks master/replica divergence.
+// May be called from any thread.
+GraphRetrieveStatus GraphContext_RetrieveOrForce
+(
+	RedisModuleCtx    *ctx,
+	RedisModuleString *graphID,
+	bool               readOnly,
+	bool               shouldCreate,
+	GraphContext     **gc
+) {
+	return _GraphContext_Retrieve (ctx, graphID, readOnly, shouldCreate,
+			true, NULL, true, gc) ;
 }
 

--- a/src/graph/graphcontext_retrieve.h
+++ b/src/graph/graphcontext_retrieve.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+#pragma once
+
+#include "graphcontext.h"
+#include "../commands/cmd_context.h"
+
+// Like GraphContext_Retrieve (see graphcontext.h), always attempting to load
+// the graph from disk if it is offloaded, but with different handling of
+// concurrent loads: if another thread is already loading this stub,
+// `command_ctx` is parked instead of GraphRetrieve_LOADING being returned
+// immediately. Once that in-flight load resolves, CommandCtx_ResumeAfterGraphLoad
+// (see cmd_context.h) is invoked with `command_ctx` - the caller must not
+// touch it again until then.
+// May be called from any thread.
+GraphRetrieveStatus GraphContext_RetrieveOrQueue
+(
+	RedisModuleCtx    *ctx,             // Redis module context
+	RedisModuleString *graphID,         // key identifying the graph
+	bool               readOnly,        // if true, opens the key in read mode
+	bool               shouldCreate,    // create new graph if the key is absent
+	CommandCtx        *command_ctx,     // parked if the graph is being loaded
+	GraphContext     **gc               // out: graph context on success
+) ;
+
+// Like GraphContext_Retrieve (see graphcontext.h), always attempting to load
+// the graph from disk if it is offloaded, but never failing due to another
+// load being in flight: an independent load is attempted regardless (see
+// bypass_claim in the enterprise repo's graph_load.h), so
+// GraphRetrieve_FAILED is only ever returned for a genuine failure (missing
+// dump, OOM, corruption, etc.), never for mere contention with another
+// load. An in-flight offload is never bypassed, since there is nothing yet
+// to load in that case, so this may still fail while a concurrent offload
+// of the same graph is in progress.
+// For use by callers that cannot tolerate a transient retrieval failure -
+// e.g. GRAPH.EFFECT, where a failure risks master/replica divergence.
+// May be called from any thread.
+GraphRetrieveStatus GraphContext_RetrieveOrForce
+(
+	RedisModuleCtx    *ctx,             // Redis module context
+	RedisModuleString *graphID,         // key identifying the graph
+	bool               readOnly,        // if true, opens the key in read mode
+	bool               shouldCreate,    // create new graph if the key is absent
+	GraphContext     **gc               // out: graph context on success
+) ;

--- a/src/graph/graphcontext_retrieve.h
+++ b/src/graph/graphcontext_retrieve.h
@@ -6,24 +6,26 @@
 #pragma once
 
 #include "graphcontext.h"
-#include "../commands/cmd_context.h"
 
 // Like GraphContext_Retrieve (see graphcontext.h), always attempting to load
 // the graph from disk if it is offloaded, but with different handling of
 // concurrent loads: if another thread is already loading this stub,
-// `command_ctx` is parked instead of GraphRetrieve_LOADING being returned
-// immediately. Once that in-flight load resolves, CommandCtx_ResumeAfterGraphLoad
-// (see cmd_context.h) is invoked with `command_ctx` - the caller must not
-// touch it again until then.
+// (`handler`, `arg`) is parked instead of GraphRetrieve_LOADING being
+// returned immediately. Once that in-flight load resolves, `handler(arg)`
+// is resubmitted to the thread pool - as if freshly dispatched - so the
+// caller must not touch `arg` again until then. This lets the resumed call
+// re-discover the load's outcome itself (already loaded vs. still a stub)
+// rather than being told.
 // May be called from any thread.
 GraphRetrieveStatus GraphContext_RetrieveOrQueue
 (
-	RedisModuleCtx    *ctx,             // Redis module context
-	RedisModuleString *graphID,         // key identifying the graph
-	bool               readOnly,        // if true, opens the key in read mode
-	bool               shouldCreate,    // create new graph if the key is absent
-	CommandCtx        *command_ctx,     // parked if the graph is being loaded
-	GraphContext     **gc               // out: graph context on success
+	RedisModuleCtx *ctx,         // Redis module context
+	RedisModuleString *graphID,  // key identifying the graph
+	bool readOnly,               // if true, opens the key in read mode
+	bool shouldCreate,           // create new graph if the key is absent
+	void (*handler) (void *),    // resubmitted if the graph is loading
+	void *arg,                   // passed to `handler` if parked
+	GraphContext **gc            // out: graph context on success
 ) ;
 
 // Like GraphContext_Retrieve (see graphcontext.h), always attempting to load
@@ -40,9 +42,10 @@ GraphRetrieveStatus GraphContext_RetrieveOrQueue
 // May be called from any thread.
 GraphRetrieveStatus GraphContext_RetrieveOrForce
 (
-	RedisModuleCtx    *ctx,             // Redis module context
-	RedisModuleString *graphID,         // key identifying the graph
-	bool               readOnly,        // if true, opens the key in read mode
-	bool               shouldCreate,    // create new graph if the key is absent
-	GraphContext     **gc               // out: graph context on success
+	RedisModuleCtx *ctx,         // Redis module context
+	RedisModuleString *graphID,  // key identifying the graph
+	bool readOnly,               // if true, opens the key in read mode
+	bool shouldCreate,           // create new graph if the key is absent
+	GraphContext **gc            // out: graph context on success
 ) ;
+

--- a/src/module.c
+++ b/src/module.c
@@ -81,6 +81,7 @@ static int _ExportAPIs
 	EXPORT_API ("GraphContext_MemoryUsage",       GraphContext_MemoryUsage)
 	EXPORT_API ("RdbLoadGraphContext_latest",     RdbLoadGraphContext_latest)
 	EXPORT_API ("GraphContext_DecreaseRefCount",  GraphContext_DecreaseRefCount)
+	EXPORT_API ("GraphContextRedisModuleType_Get", GraphContextRedisModuleType_Get)
 
 #undef EXPORT_API
 

--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -5,7 +5,6 @@
  */
 
 #include "RG.h"
-#include "module_event_handlers.h"
 #include "LAGraph.h"
 #include "globals.h"
 #include "util/uuid.h"
@@ -15,6 +14,8 @@
 #include "util/redis_version.h"
 #include "graph/graphcontext.h"
 #include "configuration/config.h"
+#include "module_event_handlers.h"
+#include "graph/graph_load_queue.h"
 #include "serializers/graphmeta_type.h"
 #include "serializers/graphcontext_type.h"
 
@@ -357,6 +358,9 @@ static void _ShutdownEventHandler
 	if (!getenv("RS_GLOBAL_DTORS")) {  // used only with sanitizer or valgrind
 		return; 
 	}
+
+	// drain any graph loads still parked waiting on another thread's load
+	GraphLoadQueue_Free () ;
 
 	// stop cron
 	Cron_Stop () ;

--- a/src/serializers/graphcontext_type.c
+++ b/src/serializers/graphcontext_type.c
@@ -22,6 +22,16 @@ void ModuleEventHandler_AUXAfterKeyspaceEvent(void);
 // declaration of the type for redis registration
 RedisModuleType *GraphContextRedisModuleType;
 
+// returns the RedisModuleType* used to tag keys holding a live GraphContext
+// exported as a shared API so the enterprise graph-offloading module can
+// test RedisModule_ModuleTypeGetType(key) == GraphContextRedisModuleType_Get()
+// to tell "this key is a live graph" apart from "this key holds some other,
+// unrelated Redis type" - mirrors GraphStubType_Get, which exposes the
+// enterprise module's stub type to core in the opposite direction
+RedisModuleType *GraphContextRedisModuleType_Get (void) {
+	return GraphContextRedisModuleType ;
+}
+
 static void *_GraphContextType_RdbLoad
 (
 	RedisModuleIO *rdb,

--- a/src/serializers/graphcontext_type.h
+++ b/src/serializers/graphcontext_type.h
@@ -20,3 +20,11 @@ int GraphContextType_Register
 	RedisModuleCtx *ctx
 );
 
+// returns the RedisModuleType* used to tag keys holding a live GraphContext
+// exported as a shared API so the enterprise graph-offloading module can
+// test RedisModule_ModuleTypeGetType(key) == GraphContextRedisModuleType_Get()
+// to tell "this key is a live graph" apart from "this key holds some other,
+// unrelated Redis type" - mirrors GraphStubType_Get, which exposes the
+// enterprise module's stub type to core in the opposite direction
+RedisModuleType *GraphContextRedisModuleType_Get (void) ;
+


### PR DESCRIPTION
Resolve: #2229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinated queuing/parking for offloaded graph loads with callback-based command-context resumption.
  * `Graph.List` can optionally include offloaded graph stub names when the enterprise API is available.
  * `Graph.Delete` now supports deleting offloaded graph stubs.
  * Added enterprise shared APIs for identifying live-graph keys and loading/replacing offloaded stubs.
* **Bug Fixes**
  * Improved `Graph.Query`, `Graph.Profile`, and `Graph.Explain` behavior while graphs are loading; safer handling of contention.
  * `Graph.Effect` now avoids hangs under retrieval contention.
  * Standardized errors when pending work queues are full.
* **Chores**
  * Pending graph-load waiters are cleaned up during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->