### PR TITLE
Delete detect deleted entity

### DIFF
--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -21,6 +21,19 @@ static Record DeleteConsume(OpBase *opBase);
 static OpBase *DeleteClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void DeleteFree(OpBase *opBase);
 
+// _Graph_EntityIsDeleted is used as a pre check for candidate entities
+// prior to actually deleting them, the delete operation considers an entity to
+// be marked as deleted if:
+// 1. its attribute-set is NULL (cheap check)
+// 2. the datablock marked that entity as deleted
+static inline bool _Graph_EntityIsDeleted
+(
+	GraphEntity *e
+) {
+	ASSERT (e != NULL) ;
+	return (e->attributes == NULL || DataBlock_ItemIsDeleted (e->attributes)) ;
+}
+
 static void _BulkDeleteEntities
 (
 	OpDelete *op
@@ -165,7 +178,7 @@ static void _DeleteEntities
 			EntityID eid = ENTITY_GET_ID (e) ;
 
 			// edge shouldn't be already deleted
-			ASSERT (!Graph_EntityIsDeleted ((GraphEntity *)e)) ;
+			ASSERT (!_Graph_EntityIsDeleted ((GraphEntity *)e)) ;
 
 			if (!roaring64_bitmap_add_checked (op->edge_bitmap, eid)) {
 				// duplicated edge, remove it
@@ -250,7 +263,7 @@ static inline void _CollectDeletedEntities
 			Node *n = (Node *)value.ptrval ;
 
 			// skip duplicated & deleted nodes
-			if (!Graph_EntityIsDeleted ((GraphEntity *)n) &&
+			if (!_Graph_EntityIsDeleted ((GraphEntity *)n) &&
 				roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 				arr_append (op->deleted_nodes, *n) ;
 			}
@@ -260,7 +273,7 @@ static inline void _CollectDeletedEntities
 			Edge *e = (Edge *)value.ptrval ;
 
 			// skip already deleted edges
-			if (!Graph_EntityIsDeleted ((GraphEntity *)e)                &&
+			if (!_Graph_EntityIsDeleted ((GraphEntity *)e)               &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->src_id)  &&
 				!roaring64_bitmap_contains (op->node_bitmap, e->dest_id) &&
 				roaring64_bitmap_add_checked (op->edge_bitmap, ENTITY_GET_ID (e))) {
@@ -277,7 +290,7 @@ static inline void _CollectDeletedEntities
 				Node *n = Path_GetNode (p, j) ;
 
 				// skip duplicated & deleted nodes
-				if (!Graph_EntityIsDeleted ((GraphEntity *)n) &&
+				if (!_Graph_EntityIsDeleted ((GraphEntity *)n) &&
 					roaring64_bitmap_add_checked (op->node_bitmap, ENTITY_GET_ID (n))) {
 					arr_append (op->deleted_nodes, *n) ;
 				}

--- a/src/execution_plan/ops/shared/update_functions.c
+++ b/src/execution_plan/ops/shared/update_functions.c
@@ -83,6 +83,19 @@ static void _WriteUpdatesToEffectsBuffer
 	}
 }
 
+// _Graph_EntityIsDeleted is used as a pre check for candidate entities
+// prior to actually deleting them, the delete operation considers an entity to
+// be marked as deleted if:
+// 1. its attribute-set is NULL (cheap check)
+// 2. the datablock marked that entity as deleted
+static inline bool _Graph_EntityIsDeleted
+(
+	GraphEntity *e
+) {
+	ASSERT (e != NULL) ;
+	return (e->attributes == NULL || DataBlock_ItemIsDeleted (e->attributes)) ;
+}
+
 static void _ClearAttributeSet
 (
 	GraphEntity *e,
@@ -840,7 +853,7 @@ bool EvalUpdates
 			// deletion takes precedence over update
 			// if attributes is NULL, the entity was deleted earlier in the
 			// query.
-			if (unlikely (entity->attributes == NULL || Graph_EntityIsDeleted (entity))) {
+			if (unlikely (_Graph_EntityIsDeleted(entity))) {
 				continue ;
 			}
 

--- a/src/execution_plan/ops/shared/update_functions.c
+++ b/src/execution_plan/ops/shared/update_functions.c
@@ -838,7 +838,9 @@ bool EvalUpdates
 
 			// a concurrently deleted entity is silently skipped
 			// deletion takes precedence over update
-			if (unlikely (Graph_EntityIsDeleted (entity))) {
+			// if attributes is NULL, the entity was deleted earlier in the
+			// query.
+			if (unlikely (entity->attributes == NULL || Graph_EntityIsDeleted (entity))) {
 				continue ;
 			}
 

--- a/tests/flow/test_access_del_entity.py
+++ b/tests/flow/test_access_del_entity.py
@@ -213,6 +213,57 @@ class testAccessDelNode():
         self.env.assertEquals(nodes[2].properties['v'], 'c')
         self.env.assertIn('C', nodes[2].labels)
 
+    def test10_delete_deleted_endpoint(self):
+        # startNode/endNode can materialize a deleted endpoint as a node with
+        # NULL attributes. Deleting that stale value should be a no-op.
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a)
+               WITH r, a
+               DETACH DELETE a
+               WITH startNode(r) AS ec
+               DETACH DELETE ec"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 1)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+        q = """CREATE (a:Start)-[r:R]->(b:End)
+               WITH r, b
+               DETACH DELETE b
+               WITH endNode(r) AS ec
+               DETACH DELETE ec"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 2)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a), (b:Valid)
+               WITH r, a, b
+               DETACH DELETE a
+               WITH startNode(r) AS ec, b
+               DETACH DELETE ec, b"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 2)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 2)
+        self.env.assertEquals(res.relationships_deleted, 1)
+
+    def test11_update_deleted_endpoint(self):
+        # Updating a deleted endpoint materialized by startNode/endNode should
+        # be a no-op rather than dereferencing its NULL attributes.
+        q = """CREATE (a:EdgeCluster)-[r:R]->(a)
+               WITH r, a
+               DETACH DELETE a
+               WITH startNode(r) AS ec
+               SET ec.v = 1"""
+        res = self.graph.query(q)
+        self.env.assertEquals(res.nodes_created, 1)
+        self.env.assertEquals(res.relationships_created, 1)
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
+        self.env.assertEquals(res.properties_set, 0)
+
 class testAccessDelEdge():
     def __init__(self):
         GRAPH_ID = "access_del_edge"


### PR DESCRIPTION
Fixes https://github.com/FalkorDB/FalkorDB/issues/2049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented delete planning and update staging from reprocessing entities already considered deleted during the same query.
  - Added a lightweight pre-check so entities with missing attributes are treated as deleted and skipped.
  - Ensured deleting or updating endpoints already materialized as deleted nodes/relationships is a no-op.

- **Tests**
  - Added flow coverage for repeated deletion and updates targeting already-deleted endpoint nodes/relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->