### PR TITLE
Remove support for multiple property assignments in inline property maps

### DIFF
--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -184,14 +184,38 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 
 	FT_FilterNode *root = NULL;
 	uint nelems = cypher_ast_map_nentries(props);
+	const char **keys = arr_new(const char *, nelems);
+	const cypher_astnode_t **vals = arr_new(const cypher_astnode_t *, nelems);
+
+	// Inline map properties follow last-write-wins semantics.
 	for(uint i = 0; i < nelems; i ++) {
 		// key is of type CYPHER_AST_PROP_NAME
 		const char *prop = cypher_ast_prop_name_get_value(cypher_ast_map_get_key(props, i));
-
-		AR_ExpNode *graph_entity = AR_EXP_NewVariableOperandNode(alias);
-		AR_ExpNode *lhs = AR_EXP_NewAttributeAccessNode(graph_entity, prop);
 		// val is of type CYPHER_AST_EXPRESSION
 		const cypher_astnode_t *val = cypher_ast_map_get_value(props, i);
+
+		uint count = arr_len(keys);
+		uint j;
+		for(j = 0; j < count; j++) {
+			if(strcmp(prop, keys[j]) == 0) {
+				break;
+			}
+		}
+
+		if(j == count) {
+			arr_append(keys, prop);
+			arr_append(vals, val);
+		} else {
+			vals[j] = val;
+		}
+	}
+
+	uint count = arr_len(keys);
+	for(uint i = 0; i < count; i++) {
+		const char *prop = keys[i];
+		AR_ExpNode *graph_entity = AR_EXP_NewVariableOperandNode(alias);
+		AR_ExpNode *lhs = AR_EXP_NewAttributeAccessNode(graph_entity, prop);
+		const cypher_astnode_t *val = vals[i];
 		AR_ExpNode *rhs = AR_EXP_FromASTNode(val);
 		/* TODO In a query like:
 		 * "MATCH (r:person {name:"Roi"}) RETURN r"
@@ -200,6 +224,10 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 		FT_FilterNode *t = FilterTree_CreatePredicateFilter(OP_EQUAL, lhs, rhs);
 		_FT_Append(&root, t);
 	}
+
+	arr_free(keys);
+	arr_free(vals);
+
 	return root;
 }
 
@@ -372,4 +400,3 @@ FT_FilterNode *AST_BuildFilterTreeFromClauses
 
 	return filter_tree;
 }
-

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -184,39 +184,14 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 
 	FT_FilterNode *root = NULL;
 	uint nelems = cypher_ast_map_nentries(props);
-	const char **keys = arr_new(const char *, nelems);
-	const cypher_astnode_t **vals = arr_new(const cypher_astnode_t *, nelems);
-
-	// Inline map properties follow last-write-wins semantics.
 	for(uint i = 0; i < nelems; i ++) {
 		// key is of type CYPHER_AST_PROP_NAME
 		const char *prop = cypher_ast_prop_name_get_value(cypher_ast_map_get_key(props, i));
-		// val is of type CYPHER_AST_EXPRESSION
-		const cypher_astnode_t *val = cypher_ast_map_get_value(props, i);
 
-		uint count = arr_len(keys);
-		uint j;
-		for(j = 0; j < count; j++) {
-			if(strcmp(prop, keys[j]) == 0) {
-				break;
-			}
-		}
-
-		if(j == count) {
-			arr_append(keys, prop);
-			arr_append(vals, val);
-		} else {
-			// duplicate: overwrite old value
-			vals[j] = val;
-		}
-	}
-
-	uint count = arr_len(keys);
-	for(uint i = 0; i < count; i++) {
-		const char *prop = keys[i];
 		AR_ExpNode *graph_entity = AR_EXP_NewVariableOperandNode(alias);
 		AR_ExpNode *lhs = AR_EXP_NewAttributeAccessNode(graph_entity, prop);
-		const cypher_astnode_t *val = vals[i];
+		// val is of type CYPHER_AST_EXPRESSION
+		const cypher_astnode_t *val = cypher_ast_map_get_value(props, i);
 		AR_ExpNode *rhs = AR_EXP_FromASTNode(val);
 		/* TODO In a query like:
 		 * "MATCH (r:person {name:"Roi"}) RETURN r"
@@ -225,10 +200,6 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 		FT_FilterNode *t = FilterTree_CreatePredicateFilter(OP_EQUAL, lhs, rhs);
 		_FT_Append(&root, t);
 	}
-
-	arr_free(keys);
-	arr_free(vals);
-
 	return root;
 }
 

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -206,6 +206,7 @@ static FT_FilterNode *_convertInlinedProperties(const cypher_astnode_t *entity,
 			arr_append(keys, prop);
 			arr_append(vals, val);
 		} else {
+			// duplicate: overwrite old value
 			vals[j] = val;
 		}
 	}
@@ -400,3 +401,4 @@ FT_FilterNode *AST_BuildFilterTreeFromClauses
 
 	return filter_tree;
 }
+

--- a/src/ast/ast_shared.c
+++ b/src/ast/ast_shared.c
@@ -99,8 +99,6 @@ PropertyMap *PropertyMap_New
 	//--------------------------------------------------------------------------
 
 	for (uint prop_idx = 0; prop_idx < prop_count; prop_idx++) {
-		uint insert_idx = prop_idx;
-
 		const cypher_astnode_t *ast_key =
 			cypher_ast_map_get_key (props, prop_idx) ;
 
@@ -113,29 +111,9 @@ PropertyMap *PropertyMap_New
 		AR_ExpNode *exp =
 			AR_EXP_FromASTNode (ast_value) ;
 
-		//----------------------------------------------------------------------
-		// handle duplicates
-		//----------------------------------------------------------------------
-
-		uint count = arr_len (m->keys) ;
-		for (uint i = 0; i < count; i++) {
-			if (strcmp (attr, m->keys[i]) == 0) {
-				// duplicate!
-				insert_idx = i ;
-				break ;
-			}
-		}
-
-		if (insert_idx == prop_idx) {
-			// new entry
-			arr_append (m->keys, attr) ;
-			arr_append (m->values, exp) ;
-			arr_append (m->attr_ids, GraphContext_GetAttributeID (gc, attr)) ;
-		} else {
-			// replace duplicate
-			AR_EXP_Free (m->values[insert_idx]) ;
-			m->values[insert_idx] = exp ;
-		}
+		arr_append (m->keys, attr) ;
+		arr_append (m->values, exp) ;
+		arr_append (m->attr_ids, GraphContext_GetAttributeID (gc, attr)) ;
 	}
 
 	return m ;

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -931,6 +931,7 @@ static AST_Validation _ValidateInlinedProperties
 	// traverse map entries
 	uint prop_count = cypher_ast_map_nentries(props);
 	for(uint i = 0; i < prop_count; i++) {
+		const char *key = cypher_ast_prop_name_get_value(cypher_ast_map_get_key(props, i));
 		const cypher_astnode_t *prop_val = cypher_ast_map_get_value(props, i);
 		const cypher_astnode_t **patterns = AST_GetTypedNodes(prop_val, CYPHER_AST_PATTERN_PATH);
 		uint patterns_count = arr_len(patterns);
@@ -940,6 +941,16 @@ static AST_Validation _ValidateInlinedProperties
 			// MATCH (a {prop: ()-[]->()}) RETURN a
 			ErrorCtx_SetError(EMSG_UNHANDLED_TYPE_INLINE_PROPERTIES);
 			return AST_INVALID;
+		}
+
+		// Error if there are duplicate inlined properties
+		uint j = 0;
+		for(; j < i; j++) {
+			const char *prev_key = cypher_ast_prop_name_get_value(cypher_ast_map_get_key(props, j));
+			if(strcmp(key, prev_key) == 0) {
+				ErrorCtx_SetError(EMSG_DUPLICATE_INLINE_PROPERTY, key);
+				return AST_INVALID;
+			}
 		}
 	}
 

--- a/src/errors/error_msgs.h
+++ b/src/errors/error_msgs.h
@@ -49,6 +49,7 @@
 #define EMSG_INVALID_USAGE_OF_DISTINCT_STAR_PARAMETER "Cannot specify both DISTINCT and * in COUNT(DISTINCT *)"
 #define EMSG_MISSING_EVAL_EXP_IN_REDUCE "No eval expression given in reduce"
 #define EMSG_UNHANDLED_TYPE_INLINE_PROPERTIES "Encountered unhandled type in inlined properties."
+#define EMSG_DUPLICATE_INLINE_PROPERTY "Duplicate property key '%s' in inline property map"
 #define EMSG_CREATE_DIRECTED_RELATIONSHIP "Only directed relationships are supported in CREATE"
 #define EMSG_SAME_ALIAS_NODE_RELATIONSHIP "The alias '%s' was specified for both a node and a relationship."
 #define EMSG_SAME_ALIAS_MULTIPLE_PATTERNS "Cannot use the same relationship variable '%s' for multiple patterns."

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -109,18 +109,14 @@ class testGraphCreationFlow(FlowTestsBase):
             except redis.exceptions.ResponseError as e:
                 self.env.assertContains("Property values can only be of primitive types or arrays of primitive types", str(e))
 
-    # test creating a node with multiple attributes with the same name
-    # expecting node with single attribute 'name' with the last mentioned value 'B'
+    # Duplicate inline properties should fail validation.
     def test08_create_node_with_2_attr_same_name(self):
         query = """CREATE (a:N {name:'A', name:'B'})"""
-        result = self.graph.query(query)
-        self.env.assertEquals(result.nodes_created, 1)
-        self.env.assertEquals(result.properties_set, 1)
-
-        query = """MATCH (a:N) RETURN a.name"""
-        result = self.graph.query(query)
-        expected_result = [['B']]
-        self.env.assertEquals(result.result_set, expected_result)
+        try:
+            self.graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertContains("Duplicate property key 'name' in inline property map", str(e))
 
     # test creating a node with some alias, and then creating an edge that touches that node
     # "variable redeclared" error should return only if the relation alias was already declared

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -269,9 +269,11 @@ class testOptionalFlow(FlowTestsBase):
         self.graph.delete()
         self.graph.query("CREATE ()-[:A]->()")
         query = """OPTIONAL MATCH (), ({x:0, x:1}) RETURN 0"""
-        actual_result = self.graph.query(query)
-        expected_result = [[0]]
-        self.env.assertEquals(actual_result.result_set, expected_result)
+        try:
+            self.graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertContains("Duplicate property key 'x' in inline property map", str(e))
 
     def test24_optional_no_matchings(self):
         # due to delayed init within the Apply op this used to crash the server

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -698,3 +698,29 @@ class testQueryValidationFlow(FlowTestsBase):
 
         q = "OPTIONAL MATCH (a) RETURN a UNION MATCH (a) RETURN a"
         self.graph.query(q)
+
+    # Regression test for issue #2196:
+    # MERGE with duplicate property keys followed by ON MATCH SET should not
+    # crash the server.
+    def test46_merge_duplicate_property_keys_on_match_set(self):
+        self.graph.query("CREATE (), ()")
+
+        queries = [
+            """MATCH () MERGE (b{x:1,x:2})""",
+            """MATCH () MERGE (b{x:1,x:2}) ON MATCH SET b.id=3""",
+            """OPTIONAL MATCH(a)
+                MERGE(b{x:1,x:2})<-[:S]-(c)
+                ON MATCH SET a:L""",
+        ]
+
+        for q in queries:
+            try:
+                self.graph.query(q)
+            except redis.exceptions.ResponseError:
+                # Query may fail validation, but should not crash the server.
+                continue
+
+        # Server should remain responsive after both queries.
+        res = self.graph.query("RETURN 1")
+        self.env.assertEquals(res.result_set, [[1]])
+

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -699,16 +699,14 @@ class testQueryValidationFlow(FlowTestsBase):
         q = "OPTIONAL MATCH (a) RETURN a UNION MATCH (a) RETURN a"
         self.graph.query(q)
 
-    # Regression test for issue #2196:
-    # MERGE with duplicate property keys followed by ON MATCH SET should not
-    # crash the server.
+    # Duplicate inline property assignments should fail at validation time.
     def test46_merge_duplicate_property_keys_on_match_set(self):
         self.graph.query("CREATE (), ()")
 
         queries = [
             """MATCH () MERGE (b{x:1,x:2})""",
             """MATCH () MERGE (b{x:1,x:2}) ON MATCH SET b.id=3""",
-            """OPTIONAL MATCH(a)
+            """OPTIONAL MATCH (a)
                 MERGE(b{x:1,x:2})<-[:S]-(c)
                 ON MATCH SET a:L""",
         ]
@@ -716,11 +714,11 @@ class testQueryValidationFlow(FlowTestsBase):
         for q in queries:
             try:
                 self.graph.query(q)
-            except redis.exceptions.ResponseError:
-                # Query may fail validation, but should not crash the server.
-                continue
+                self.env.assertTrue(False)
+            except redis.exceptions.ResponseError as e:
+                self.env.assertContains("Duplicate property key 'x' in inline property map", str(e))
 
-        # Server should remain responsive after both queries.
+        # Server should remain responsive after all failed queries.
         res = self.graph.query("RETURN 1")
         self.env.assertEquals(res.result_set, [[1]])
 


### PR DESCRIPTION
fix #2196
This is a breaking change
We now refuse queries where inline property maps have multiple assignments for one alias (old logic was last-write-wins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate property keys in inline property maps are now rejected with a clear error message.
  * Validation is consistent across `CREATE`, `MERGE`, and `OPTIONAL MATCH` so invalid queries fail reliably.
  * Rejected queries no longer impact server responsiveness.

* **Tests**
  * Added regression coverage to ensure duplicate-key errors are raised and handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->