### PR TITLE
ci: publish edge-rs to Docker Hub on trunk merges

### DIFF
--- a/.github/workflows/rust-push.yml
+++ b/.github/workflows/rust-push.yml
@@ -134,8 +134,9 @@ jobs:
   # Promote the merging PR's runtime RC images (rc-pr-<N>) to the edge-rs
   # channel on every trunk merge — same byte-identical retag, no rebuild.
   # `edge-rs` distinguishes the Rust port from the C port's `:edge` on the
-  # shared falkordb/falkordb Docker Hub repo. GHCR-only; Docker Hub publish
-  # happens at release time via release-image.yml.
+  # shared falkordb/falkordb repos, so publishing to BOTH registries cannot
+  # clobber the C channel. Bare `:latest` is untouched (that pointer only moves
+  # at 6.0 GA, via release-image.yml).
   promote-edge:
     needs: find-pr
     if: ${{ needs.find-pr.outputs.pr_n != '' && contains(fromJSON('["refs/heads/main","refs/heads/main-rs"]'), github.ref) }}
@@ -157,14 +158,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Promote rc-pr-${{ needs.find-pr.outputs.pr_n }} → edge-rs (${{ matrix.repo }})
         env:
           PR_NUM: ${{ needs.find-pr.outputs.pr_n }}
           REPO:   ${{ matrix.repo }}
         run: |
           set -euo pipefail
+          # One imagetools call fans the SAME multi-arch manifest out to both
+          # registries — still a retag, never a rebuild, so the bytes PR CI
+          # validated are the bytes that ship. Same pattern release-image.yml
+          # uses for semver tags.
           docker buildx imagetools create \
             -t "ghcr.io/falkordb/${REPO}:edge-rs" \
+            -t "docker.io/falkordb/${REPO}:edge-rs" \
             "ghcr.io/falkordb/${REPO}:rc-pr-${PR_NUM}"
 
   # Feed the canonical, continuously-updated A/B benchmark trend (production


### PR DESCRIPTION
Closes #2244

`promote-edge` retagged `rc-pr-<N>` → `edge-rs` on **GHCR only**, so Docker Hub consumers had no rolling Rust-engine tag to sit alongside the C engine's `:edge`. Its comment said as much ("GHCR-only; Docker Hub publish happens at release time") — that comment is now updated too.

## Change

- Adds a Docker Hub login step to `promote-edge`, the identical `docker/login-action` pattern `release-image.yml` already uses.
- Adds `-t docker.io/falkordb/${REPO}:edge-rs` to the **existing** `docker buildx imagetools create` call, so a single invocation fans the same multi-arch manifest out to both registries — exactly what `release-image.yml` does for semver tags.
- Applies to both image repos via the existing matrix: `falkordb` and `falkordb-server`.
- Remains a **retag, not a rebuild** — the bytes PR CI validated are the bytes that ship.

## Safety

- **No clobber risk.** The C port owns `:edge` on Docker Hub; the Rust port uses the distinct `:edge-rs`. Bare `:latest` is untouched — that pointer only moves at 6.0 GA, via `release-image.yml`.
- **No new secrets.** `DOCKER_USERNAME` / `DOCKER_PASSWORD` are the same names C's `release-image.yml` uses on `master`, and C already publishes to Docker Hub from this repo, so they are provisioned here.

## Verification

`actionlint` on `rust-push.yml` reports the same 14 pre-existing findings before and after this change — no new ones. Runtime behaviour is only observable on a trunk merge, when `edge-rs` should appear on both `ghcr.io/falkordb/*` and `docker.io/falkordb/*`.
