### PR TITLE
Simplify docker-compose.yml for falkordb services

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,33 +1,19 @@
 services:
   falkordb-server:
     image: falkordb/falkordb-server:latest
-    container_name: falkordb-server
-    ports:
-      - "6379:6379"
-    networks:
-      - falkordb-network
     restart: unless-stopped
-    environment:
-      - REDIS_ARGS=/etc/falkordb/falkordb.conf
+    expose:
+      - "6379"
     volumes:
       - falkordb-data:/data
-      - ./falkordb.conf:/etc/falkordb/falkordb.conf:ro
 
   falkordb-browser:
     image: falkordb/falkordb-browser:latest
-    container_name: falkordb-browser
+    restart: unless-stopped
     ports:
       - "3000:3000"
-    networks:
-      - falkordb-network
-    restart: unless-stopped
     depends_on:
       - falkordb-server
 
-networks:
-  falkordb-network:
-    driver: bridge
-
 volumes:
   falkordb-data:
-    driver: local


### PR DESCRIPTION
Removed unnecessary container names, networks, and environment variables from the docker-compose configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Docker Compose setup.
  * Improved service isolation by keeping the database accessible internally while retaining browser access on port 3000.
  * Preserved persistent database storage across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->