### PR TITLE
feat(cow_btree): point lookups, memory accounting, tuple cursor + narrowable doc width

### DIFF
--- a/graph/src/index/falkordb/data_structures/cow_btree/cursor.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/cursor.rs
@@ -8,10 +8,11 @@ use super::node::{Branch, Node};
 use super::read_width;
 
 /// What a [`RangeIter`] yields per entry. The default [`DocExtract`] yields the
-/// doc id only (the index's need); [`TupleExtract`] yields the full `(key, doc)`
-/// pair for consumers (e.g. the relationship tensor's edge-id store) that must
-/// recover the key. A doc-only cursor can skip reading the key on a wholly
-/// in-range leaf; a tuple cursor always reads it (`NEEDS_KEY`).
+/// doc id only, which is all the index needs; [`TupleExtract`] yields the full
+/// `(key, doc)` pair for a consumer that must recover the indexed value too.
+/// A doc-only cursor can skip reading the key on a wholly in-range leaf; a tuple
+/// cursor always reads it (`NEEDS_KEY`) — which is the whole reason the two are
+/// separate.
 pub trait Extract {
     type Item;
     /// Whether `next` must read the entry key even on a wholly-in-range leaf.

--- a/graph/src/index/falkordb/data_structures/cow_btree/cursor.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/cursor.rs
@@ -1,16 +1,66 @@
 //! The lazy range cursor: a droppable iterator over the doc ids in a key range, owning a snapshot.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use super::leaf::Leaf;
 use super::node::{Branch, Node};
 use super::read_width;
 
-/// A lazy, droppable cursor over the doc ids in a key range. Owns a snapshot of the tree.
-pub struct RangeIter<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
-    _root: Node<LEAF_MAX, BRANCH_MAX>, // keeps the snapshot (and all its pages) alive for the cursor's lifetime
-    stack: Vec<(Arc<Branch<LEAF_MAX, BRANCH_MAX>>, usize)>, // (branch, next child index to descend)
-    leaf: Option<Leaf<LEAF_MAX>>,
+/// What a [`RangeIter`] yields per entry. The default [`DocExtract`] yields the
+/// doc id only (the index's need); [`TupleExtract`] yields the full `(key, doc)`
+/// pair for consumers (e.g. the relationship tensor's edge-id store) that must
+/// recover the key. A doc-only cursor can skip reading the key on a wholly
+/// in-range leaf; a tuple cursor always reads it (`NEEDS_KEY`).
+pub trait Extract {
+    type Item;
+    /// Whether `next` must read the entry key even on a wholly-in-range leaf.
+    const NEEDS_KEY: bool;
+    fn make(
+        key: u64,
+        doc: u64,
+    ) -> Self::Item;
+}
+
+/// Yields the doc id only (default — the index query path).
+pub struct DocExtract;
+impl Extract for DocExtract {
+    type Item = u64;
+    const NEEDS_KEY: bool = false;
+    #[inline]
+    fn make(
+        _key: u64,
+        doc: u64,
+    ) -> u64 {
+        doc
+    }
+}
+
+/// Yields the full `(key, doc)` tuple.
+pub struct TupleExtract;
+impl Extract for TupleExtract {
+    type Item = (u64, u64);
+    const NEEDS_KEY: bool = true;
+    #[inline]
+    fn make(
+        key: u64,
+        doc: u64,
+    ) -> (u64, u64) {
+        (key, doc)
+    }
+}
+
+/// A lazy, droppable cursor over the entries in a key range. Owns a snapshot of
+/// the tree. Yields per [`Extract`] `E` (doc id by default).
+pub struct RangeIter<
+    const LEAF_MAX: usize,
+    const BRANCH_MAX: usize,
+    const DOC_BYTES: usize,
+    E: Extract = DocExtract,
+> {
+    _root: Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>, // keeps the snapshot (and all its pages) alive for the cursor's lifetime
+    stack: Vec<(Arc<Branch<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>, usize)>, // (branch, next child index to descend)
+    leaf: Option<Leaf<LEAF_MAX, DOC_BYTES>>,
     leaf_count: usize, // entry count of `leaf`, read once per leaf rather than per entry
     whole: bool,       // every entry of `leaf` is `<= hi_key` ⇒ skip the per-entry bound check
     // Cached doc decode layout `(base, stride, width)` for the current leaf — read once in `set_leaf`
@@ -22,11 +72,14 @@ pub struct RangeIter<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
     doc_width: usize,
     pos: usize,
     hi_key: u64, // inclusive upper key bound (the doc half of the bound is always `u64::MAX`)
+    _extract: PhantomData<E>,
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> RangeIter<LEAF_MAX, BRANCH_MAX> {
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize, E: Extract>
+    RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES, E>
+{
     pub(super) fn new(
-        root: &Node<LEAF_MAX, BRANCH_MAX>,
+        root: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
         lo: (u64, u64),
         hi_key: u64,
     ) -> Self {
@@ -41,6 +94,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> RangeIter<LEAF_MAX, BRANCH_
             doc_width: 0,
             pos: 0,
             hi_key,
+            _extract: PhantomData,
         };
         let mut node = root.clone();
         loop {
@@ -67,7 +121,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> RangeIter<LEAF_MAX, BRANCH_
     /// per-entry checks.
     fn set_leaf(
         &mut self,
-        leaf: Leaf<LEAF_MAX>,
+        leaf: Leaf<LEAF_MAX, DOC_BYTES>,
         pos: usize,
     ) {
         let count = leaf.count();
@@ -84,7 +138,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> RangeIter<LEAF_MAX, BRANCH_
     /// Descend a node's left spine to its first leaf, pushing branch frames.
     fn descend_left(
         &mut self,
-        mut node: Node<LEAF_MAX, BRANCH_MAX>,
+        mut node: Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
     ) {
         loop {
             match node {
@@ -118,28 +172,33 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> RangeIter<LEAF_MAX, BRANCH_
     }
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Iterator for RangeIter<LEAF_MAX, BRANCH_MAX> {
-    type Item = u64; // doc id
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize, E: Extract> Iterator
+    for RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES, E>
+{
+    type Item = E::Item;
 
-    fn next(&mut self) -> Option<u64> {
+    fn next(&mut self) -> Option<E::Item> {
         loop {
             let leaf = self.leaf.as_ref()?; // no current leaf ⇒ the scan is exhausted
             if self.pos < self.leaf_count {
+                // Read the key only when the extract yields it, or on a boundary leaf where the
+                // per-entry bound must be checked. Interior leaves are wholly in range (`self.whole`);
+                // the doc half of the bound is always `MAX`, so `(key, doc) > hi` reduces to
+                // `key > hi_key`.
+                let need_key = E::NEEDS_KEY || !self.whole;
+                let key = if need_key { leaf.key(self.pos) } else { 0 };
+                if !self.whole && key > self.hi_key {
+                    self.leaf = None;
+                    return None; // walked past the range
+                }
                 // Cached layout ⇒ no per-entry offset recompute (matters for the compact format).
                 let doc = read_width(
                     leaf.raw(),
                     self.doc_base + self.pos * self.doc_stride,
                     self.doc_width,
                 );
-                // Interior leaves are wholly in range (`self.whole`); only a boundary leaf needs the
-                // per-entry check. The doc half of the bound is always `MAX`, so the lexicographic
-                // `(key, doc) > hi` reduces to `key > hi_key`.
-                if !self.whole && leaf.key(self.pos) > self.hi_key {
-                    self.leaf = None;
-                    return None; // walked past the range
-                }
                 self.pos += 1;
-                return Some(doc);
+                return Some(E::make(key, doc));
             }
             self.advance_leaf(); // consumed this leaf ⇒ move on; the loop re-checks at the top
         }

--- a/graph/src/index/falkordb/data_structures/cow_btree/leaf/aos.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/leaf/aos.rs
@@ -1,53 +1,46 @@
-//! The array-of-structs (AoS) leaf encoding: contiguous `(key, doc)` tuples, 16 B/entry.
+//! The array-of-structs (AoS) leaf encoding: contiguous `(key, doc)` tuples,
+//! `FIELD + DOC_BYTES` B/entry (12 B for a 4-byte doc, 16 B for the full u64).
 
 use std::sync::Arc;
 
-use super::super::{FIELD, STRIDE, read_u64};
+use super::super::{FIELD, doc_le_bytes, read_u64, read_width};
 use super::merge_walk;
 
-/// An array-of-structs leaf page: a tag-free `Arc<[u8]>` of `[(key:8, doc:8) × n]`, data at byte 0.
+/// An array-of-structs leaf page: a tag-free `Arc<[u8]>` of `[(key:8, doc:DOC_BYTES) × n]`, data at byte 0.
 #[derive(Clone)]
-pub struct AosLeaf(pub(crate) Arc<[u8]>);
+pub struct AosLeaf<const DOC_BYTES: usize>(pub(crate) Arc<[u8]>);
 
-impl AosLeaf {
+impl<const DOC_BYTES: usize> AosLeaf<DOC_BYTES> {
+    /// Byte stride of one `(key, doc)` entry: an 8-byte key beside a `DOC_BYTES`-byte doc.
+    const STRIDE: usize = FIELD + DOC_BYTES;
+
     /// Number of `(key, doc)` entries — the buffer is tag-free `[(key, doc) × n]`, so `len / STRIDE`.
     pub(super) fn count(&self) -> usize {
-        self.0.len() / STRIDE
+        self.0.len() / Self::STRIDE
     }
 
-    /// Read the little-endian `u64` field at entry `i`'s offset `off_in_entry` (0 for the key, `FIELD`
-    /// for the doc). Data is at byte 0 (the buffer is tag-free), so the absolute offset is
-    /// `STRIDE * i + off_in_entry`.
-    fn read(
-        &self,
-        i: usize,
-        off_in_entry: usize,
-    ) -> u64 {
-        read_u64(&self.0, STRIDE * i + off_in_entry)
-    }
-
-    /// Key of entry `i`.
+    /// Key of entry `i` (a full little-endian `u64` at the entry's start).
     pub(super) fn key(
         &self,
         i: usize,
     ) -> u64 {
-        self.read(i, 0)
+        read_u64(&self.0, Self::STRIDE * i)
     }
 
-    /// Doc of entry `i`.
+    /// Doc of entry `i` (a `DOC_BYTES`-wide little-endian int at offset `FIELD`, zero-extended to `u64`).
     pub(super) fn doc(
         &self,
         i: usize,
     ) -> u64 {
-        self.read(i, FIELD)
+        read_width(&self.0, Self::STRIDE * i + FIELD, DOC_BYTES)
     }
 
     /// Encode sorted `pairs` into the tag-free `[(key, doc) × n]` layout.
     pub(super) fn build(pairs: &[(u64, u64)]) -> Self {
-        let mut buf = Vec::with_capacity(pairs.len() * STRIDE);
+        let mut buf = Vec::with_capacity(pairs.len() * Self::STRIDE);
         for &(key, doc) in pairs {
             buf.extend_from_slice(&key.to_le_bytes());
-            buf.extend_from_slice(&doc.to_le_bytes());
+            buf.extend_from_slice(&doc_le_bytes::<DOC_BYTES>(doc));
         }
         Self(Arc::from(buf.as_slice()))
     }
@@ -55,14 +48,12 @@ impl AosLeaf {
     /// Two-pointer merge of `self`'s entries with a sorted `batch` into a single new tag-free AoS page — no
     /// `Vec<(u64, u64)>`, no sort, one allocation. Exact `(key, doc)` duplicates are dropped (re-adding an
     /// existing tuple is a no-op). The caller guarantees the result fits (`count + batch.len() <= LEAF_MAX`).
-    /// (A galloping block-copy was tried here but only helped tiny batches and regressed large ones — AoS has
-    /// no per-entry decode for it to amortize, unlike the compact merges — so the simple walk stays.)
     pub(super) fn merge_batch(
         &self,
         batch: &[(u64, u64)],
     ) -> Self {
         let count = self.count();
-        let mut buf = Vec::with_capacity(self.0.len() + batch.len() * STRIDE);
+        let mut buf = Vec::with_capacity(self.0.len() + batch.len() * Self::STRIDE);
         merge_walk(
             count,
             |i| self.key(i),
@@ -70,7 +61,7 @@ impl AosLeaf {
             batch,
             |key, doc, _| {
                 buf.extend_from_slice(&key.to_le_bytes());
-                buf.extend_from_slice(&doc.to_le_bytes());
+                buf.extend_from_slice(&doc_le_bytes::<DOC_BYTES>(doc));
             },
         );
         Self(Arc::from(buf.as_slice()))

--- a/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use super::{FIELD, doc_le_bytes, read_u64, read_width};
+use super::{FIELD, doc_le_bytes};
 
 mod aos;
 mod compact;
@@ -238,38 +238,6 @@ impl<const LEAF_MAX: usize, const DOC_BYTES: usize> Leaf<LEAF_MAX, DOC_BYTES> {
     /// Decode to the owned `(key, doc)` pairs the mutation paths (insert/remove/merge) work in.
     pub(super) fn to_pairs(&self) -> Vec<(u64, u64)> {
         self.iter().collect()
-    }
-
-    /// Call `f(key, doc)` for every entry in stored order. Unlike [`Leaf::iter`], the format is matched
-    /// **once per leaf** (not per entry), and the common AoS page reads its contiguous `(key, doc)` tuples
-    /// in a tight loop — so a bulk full-scan (`CowBTree::for_each_tuple`) avoids the per-entry enum dispatch
-    /// and per-item `Iterator::next` overhead the lazy cursor pays. Hot path for `iter_edges` / MSF rebuild.
-    pub(super) fn for_each_tuple<F: FnMut(u64, u64)>(
-        &self,
-        mut f: F,
-    ) {
-        match self {
-            Self::Aos(l) => {
-                let b = &l.0;
-                let n = b.len() / (FIELD + DOC_BYTES);
-                for i in 0..n {
-                    f(
-                        read_u64(b, i * (FIELD + DOC_BYTES)),
-                        read_width(b, i * (FIELD + DOC_BYTES) + FIELD, DOC_BYTES),
-                    );
-                }
-            }
-            Self::Compact(l) => {
-                for i in 0..l.count() {
-                    f(l.key(i), l.doc(i));
-                }
-            }
-            Self::CompactIndexed(l) => {
-                for i in 0..l.count() {
-                    f(l.key(i), l.doc(i));
-                }
-            }
-        }
     }
 
     /// Build a leaf from sorted `(key, doc)` pairs, choosing [`LeafFormat::Aos`] or [`LeafFormat::Compact`]

--- a/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
@@ -231,7 +231,7 @@ impl<const LEAF_MAX: usize, const DOC_BYTES: usize> Leaf<LEAF_MAX, DOC_BYTES> {
     /// Iterate the leaf's `(key, doc)` pairs in stored order. Used by `to_pairs` (mutation rebuilds) and
     /// tests — a cold path; the range cursor has its own decode. Re-derives offsets per entry (no cached
     /// scan state), which is fine off the hot path and lets one method serve all three formats.
-    fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
+    pub(super) fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
         (0..self.count()).map(move |i| (self.key(i), self.doc(i)))
     }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/leaf/mod.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use super::{FIELD, STRIDE};
+use super::{FIELD, doc_le_bytes, read_u64, read_width};
 
 mod aos;
 mod compact;
@@ -148,24 +148,24 @@ fn merge_walk(
 /// is [`Leaf::from_parts`] — a copy, never a (de)serialization. These newtypes are the one place that knows
 /// the byte layout; the enum dispatches to them, so a tree may freely mix the formats.
 #[derive(Clone)]
-pub(super) enum Leaf<const LEAF_MAX: usize> {
-    Aos(AosLeaf),
+pub(super) enum Leaf<const LEAF_MAX: usize, const DOC_BYTES: usize> {
+    Aos(AosLeaf<DOC_BYTES>),
     Compact(CompactLeaf),
     CompactIndexed(CompactIndexedLeaf),
 }
 
 /// Outcome of inserting into a single leaf: the replacement leaf if it still fits, or the two halves plus
 /// their separator if it overflowed and split. (`None` from [`Leaf::insert`] means the tuple was present.)
-pub(super) enum LeafInsert<const LEAF_MAX: usize> {
-    Fit(Leaf<LEAF_MAX>),
+pub(super) enum LeafInsert<const LEAF_MAX: usize, const DOC_BYTES: usize> {
+    Fit(Leaf<LEAF_MAX, DOC_BYTES>),
     Split {
-        left: Leaf<LEAF_MAX>,
+        left: Leaf<LEAF_MAX, DOC_BYTES>,
         sep: (u64, u64),
-        right: Leaf<LEAF_MAX>,
+        right: Leaf<LEAF_MAX, DOC_BYTES>,
     },
 }
 
-impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
+impl<const LEAF_MAX: usize, const DOC_BYTES: usize> Leaf<LEAF_MAX, DOC_BYTES> {
     /// This leaf's serialized encoding (carried out of band, see [`LeafFormat`]). The two compact in-RAM
     /// types share one on-disk format — index presence lives in the buffer — so both map to `Compact`.
     /// Test-only for now (paired with [`CowBTree::leaves`]); the durable-write path re-exposes it on disk.
@@ -213,7 +213,7 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
     /// The doc array's `(base, stride, width)` — read once per leaf by the cursor's per-entry doc reads.
     pub(super) fn doc_layout(&self) -> (usize, usize, usize) {
         match self {
-            Self::Aos(_) => (FIELD, STRIDE, FIELD),
+            Self::Aos(_) => (FIELD, FIELD + DOC_BYTES, DOC_BYTES),
             Self::Compact(l) => l.doc_layout(),
             Self::CompactIndexed(l) => l.doc_layout(),
         }
@@ -240,12 +240,44 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
         self.iter().collect()
     }
 
+    /// Call `f(key, doc)` for every entry in stored order. Unlike [`Leaf::iter`], the format is matched
+    /// **once per leaf** (not per entry), and the common AoS page reads its contiguous `(key, doc)` tuples
+    /// in a tight loop — so a bulk full-scan (`CowBTree::for_each_tuple`) avoids the per-entry enum dispatch
+    /// and per-item `Iterator::next` overhead the lazy cursor pays. Hot path for `iter_edges` / MSF rebuild.
+    pub(super) fn for_each_tuple<F: FnMut(u64, u64)>(
+        &self,
+        mut f: F,
+    ) {
+        match self {
+            Self::Aos(l) => {
+                let b = &l.0;
+                let n = b.len() / (FIELD + DOC_BYTES);
+                for i in 0..n {
+                    f(
+                        read_u64(b, i * (FIELD + DOC_BYTES)),
+                        read_width(b, i * (FIELD + DOC_BYTES) + FIELD, DOC_BYTES),
+                    );
+                }
+            }
+            Self::Compact(l) => {
+                for i in 0..l.count() {
+                    f(l.key(i), l.doc(i));
+                }
+            }
+            Self::CompactIndexed(l) => {
+                for i in 0..l.count() {
+                    f(l.key(i), l.doc(i));
+                }
+            }
+        }
+    }
+
     /// Build a leaf from sorted `(key, doc)` pairs, choosing [`LeafFormat::Aos`] or [`LeafFormat::Compact`]
     /// per the data.
     ///
     /// The choice is a closed-form size comparison; the widths are always one of {1, 2, 4, 8}, so the only
     /// free variables are `count` and the data:
-    /// - AoS:                `count·STRIDE`
+    /// - AoS:                `count·(FIELD + DOC_BYTES)`
     /// - compact, no-dedup:  `BODY_OFFSET + count·value_width + count·doc_width`
     /// - compact, dedup:     `BODY_OFFSET + distinct·value_width + count (index) + count·doc_width`
     ///
@@ -261,7 +293,7 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
     pub(super) fn from_pairs(pairs: &[(u64, u64)]) -> Self {
         let count = pairs.len();
         if count == 0 {
-            return Self::Aos(AosLeaf::build(pairs));
+            return Self::Aos(AosLeaf::<DOC_BYTES>::build(pairs));
         }
         // One pass for the two data-dependent inputs — the distinct-value count (runs, since sorted) and the
         // max doc. (The value range needs no scan; it's read O(1) from the sorted ends just below.)
@@ -285,7 +317,7 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
             + distinct_count * value_width
             + if deduplicated { count } else { 0 }
             + count * doc_width;
-        let aos_size = count * STRIDE;
+        let aos_size = count * (FIELD + DOC_BYTES);
         // Pick compact only when it saves at least COMPACT_MIN_SAVING_BPE bytes *per entry* over AoS — the
         // floor (see the const) skips marginal wins whose extra build cost isn't worth the memory saved.
         if compact_size + COMPACT_MIN_SAVING_BPE * count <= aos_size {
@@ -308,7 +340,7 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
                 ))
             }
         } else {
-            Self::Aos(AosLeaf::build(pairs))
+            Self::Aos(AosLeaf::<DOC_BYTES>::build(pairs))
         }
     }
 
@@ -374,7 +406,7 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
         &self,
         key: u64,
         doc: u64,
-    ) -> Option<LeafInsert<LEAF_MAX>> {
+    ) -> Option<LeafInsert<LEAF_MAX, DOC_BYTES>> {
         let count = self.count();
         let pos = self.lower_bound_entry(key, doc);
         if pos < count && self.key(pos) == key && self.doc(pos) == doc {
@@ -385,11 +417,11 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
             // `count + 1 <= LEAF_MAX`, so the result still fits one page.
             match self {
                 Self::Aos(aos) => {
-                    let cut = pos * STRIDE; // memcpy prefix + tuple + suffix; data at byte 0 (tag-free)
-                    let mut buf = Vec::with_capacity(aos.0.len() + STRIDE);
+                    let cut = pos * (FIELD + DOC_BYTES); // memcpy prefix + tuple + suffix; data at byte 0 (tag-free)
+                    let mut buf = Vec::with_capacity(aos.0.len() + (FIELD + DOC_BYTES));
                     buf.extend_from_slice(&aos.0[..cut]);
                     buf.extend_from_slice(&key.to_le_bytes());
-                    buf.extend_from_slice(&doc.to_le_bytes());
+                    buf.extend_from_slice(&doc_le_bytes::<DOC_BYTES>(doc));
                     buf.extend_from_slice(&aos.0[cut..]);
                     return Some(LeafInsert::Fit(Self::Aos(AosLeaf(Arc::from(
                         buf.as_slice(),
@@ -443,10 +475,10 @@ impl<const LEAF_MAX: usize> Leaf<LEAF_MAX> {
         let new_count = count - 1;
         let leaf = match self {
             Self::Aos(aos) => {
-                let cut = pos * STRIDE; // data at byte 0 (tag-free)
-                let mut buf = Vec::with_capacity(aos.0.len() - STRIDE);
+                let cut = pos * (FIELD + DOC_BYTES); // data at byte 0 (tag-free)
+                let mut buf = Vec::with_capacity(aos.0.len() - (FIELD + DOC_BYTES));
                 buf.extend_from_slice(&aos.0[..cut]);
-                buf.extend_from_slice(&aos.0[cut + STRIDE..]);
+                buf.extend_from_slice(&aos.0[cut + (FIELD + DOC_BYTES)..]);
                 Self::Aos(AosLeaf(Arc::from(buf.as_slice())))
             }
             // Cut the entry in place (no decode). Indexed leaves only when the result stays validly indexed

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -1,6 +1,6 @@
 //! A copy-on-write B⁺-tree of compact `(key, doc)` tuple pages.
 //!
-//! This is the in-RAM core structure for the native numeric index.
+//! This is the in-RAM core structure for the index.
 //! It is a persistent, copy-on-write B⁺-tree (in the immutable-snapshot sense), specialised for the index's
 //! needs:
 //!
@@ -258,6 +258,36 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
             true
         } else {
             false
+        }
+    }
+
+    /// Remove a batch of `(key, doc)` tuples, given **sorted ascending**, copying only the pages the
+    /// batch touches — every untouched subtree is shared by `Arc`, so peak memory is proportional to
+    /// the touched pages, not the tree. Under-filled pages are merged back to minimum fill, so the tree
+    /// stays as compact as repeated [`remove`](Self::remove) would leave it. The natural consumer of
+    /// the runtime's columnar mass-delete / mass-update column.
+    pub fn remove_batch(
+        &mut self,
+        sorted_removes: &[(u64, u64)],
+    ) {
+        if sorted_removes.is_empty() {
+            return;
+        }
+        // Enforced in all builds: out-of-order input would mis-subtract and silently keep or drop the
+        // wrong tuples. The O(n) check is dwarfed by the O(n) rebuild.
+        assert!(
+            sorted_removes.windows(2).all(|w| w[0] <= w[1]),
+            "remove_batch input must be sorted"
+        );
+        self.root = self.root.remove_batch(sorted_removes);
+        // A branch root that merged down to a single child loses a level.
+        while let Node::Branch(branch) = &self.root {
+            if branch.children.len() == 1 {
+                let only_child = branch.children[0].clone();
+                self.root = only_child;
+            } else {
+                break;
+            }
         }
     }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -136,6 +136,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> Def
                 LEAF_MAX >= 2 && LEAF_MAX <= 256 && BRANCH_MAX >= 3,
                 "LEAF_MAX must be 2..=256 (compact index is u8); BRANCH_MAX >= 3 (the pack_branches BRANCH_MAX+1 split needs >= 3)"
             );
+            assert!(
+                DOC_BYTES >= 1 && DOC_BYTES <= FIELD,
+                "DOC_BYTES must be 1..=8: it is the AoS doc field width, and doc_le_bytes slices u64::to_le_bytes() at it (0 stores no doc at all; > 8 indexes past the array)"
+            );
         }
         Self {
             root: Node::Leaf(Leaf::from_pairs(&[])),
@@ -154,6 +158,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                 LEAF_MAX >= 2 && LEAF_MAX <= 256 && BRANCH_MAX >= 3,
                 "LEAF_MAX must be 2..=256 (compact index is u8); BRANCH_MAX >= 3 (the pack_branches BRANCH_MAX+1 split needs >= 3)"
             );
+            assert!(
+                DOC_BYTES >= 1 && DOC_BYTES <= FIELD,
+                "DOC_BYTES must be 1..=8: it is the AoS doc field width, and doc_le_bytes slices u64::to_le_bytes() at it (0 stores no doc at all; > 8 indexes past the array)"
+            );
         }
         Self::default()
     }
@@ -167,6 +175,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
             assert!(
                 LEAF_MAX >= 2 && LEAF_MAX <= 256 && BRANCH_MAX >= 3,
                 "LEAF_MAX must be 2..=256 (compact index is u8); BRANCH_MAX >= 3 (the pack_branches BRANCH_MAX+1 split needs >= 3)"
+            );
+            assert!(
+                DOC_BYTES >= 1 && DOC_BYTES <= FIELD,
+                "DOC_BYTES must be 1..=8: it is the AoS doc field width, and doc_le_bytes slices u64::to_le_bytes() at it (0 stores no doc at all; > 8 indexes past the array)"
             );
         }
         // Enforced in all builds (not just `debug`): a violation silently corrupts the tree — the
@@ -345,31 +357,6 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
         RangeIter::new(&self.root, (lo, 0), hi)
     }
 
-    /// Call `f(key, doc)` for every tuple in the tree, in `(key, doc)` order. A bulk full-scan that
-    /// matches each leaf's format once and runs a tight inner loop — faster than collecting the lazy
-    /// [`range_tuples`](Self::range_tuples) cursor when the whole tree is consumed (`iter_edges`, the MSF
-    /// rebuild). No allocation, no per-entry `Iterator::next` dispatch.
-    pub fn for_each_tuple<F: FnMut(u64, u64)>(
-        &self,
-        mut f: F,
-    ) {
-        fn walk<
-            F: FnMut(u64, u64),
-            const LEAF_MAX: usize,
-            const BRANCH_MAX: usize,
-            const DOC_BYTES: usize,
-        >(
-            node: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
-            f: &mut F,
-        ) {
-            match node {
-                Node::Leaf(leaf) => leaf.for_each_tuple(&mut *f),
-                Node::Branch(branch) => branch.children.iter().for_each(|c| walk(c, f)),
-            }
-        }
-        walk(&self.root, &mut f);
-    }
-
     /// Approximate resident heap bytes: the sum of every leaf's byte blob plus branch child/separator
     /// vectors. Walks all pages (`O(pages)`), so call it off hot paths (memory reporting).
     #[must_use]
@@ -379,12 +366,15 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
             acc: &mut usize,
         ) {
             match node {
+                // A leaf blob is an `Arc<[u8]>` — exact-sized, so its length *is* its allocation.
                 Node::Leaf(leaf) => *acc += leaf.raw().len(),
                 Node::Branch(branch) => {
-                    // `seps` is `Vec<(u64, u64)>` — each separator is a full
+                    // `capacity`, not `len`: what is resident is what was allocated, and unlike the
+                    // leaves these are `Vec`s — a branch that has split or absorbed inserts keeps
+                    // spare slots. `seps` is `Vec<(u64, u64)>` — each separator is a full
                     // `(key, doc)` pair, not a bare key.
-                    *acc += branch.seps.len() * std::mem::size_of::<(u64, u64)>()
-                        + branch.children.len()
+                    *acc += branch.seps.capacity() * std::mem::size_of::<(u64, u64)>()
+                        + branch.children.capacity()
                             * std::mem::size_of::<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>();
                     branch.children.iter().for_each(|c| walk(c, acc));
                 }

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -289,12 +289,20 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
         key: u64,
     ) -> Option<u64> {
         let mut node = &self.root;
-        // The first entry immediately to the right of the descent path. When a
-        // key's entries begin exactly at a child boundary (the key is the min of
+        // The subtree immediately to the right of the descent path. When a key's
+        // entries begin exactly at a child boundary (the key is the min of
         // `children[ci + 1]`), `child_index(key, 0)` steers into the *previous*
-        // child, whose leaf then has no matching entry — the answer is this
-        // recorded separator. (The cursor instead advances leaves via its stack.)
-        let mut right_sep: Option<(u64, u64)> = None;
+        // child, whose leaf then has no matching entry — the answer is that
+        // subtree's minimum. (The cursor instead advances leaves via its stack.)
+        //
+        // It has to be the subtree, not the separator standing in for it. A
+        // separator is only guaranteed to be a valid *routing* boundary, not a
+        // live `min(children[ci + 1])`: removing a child's minimum without
+        // triggering a rebalance leaves the separator naming a tuple that is no
+        // longer in the tree, and reading a doc straight out of it hands back a
+        // deleted entry. Re-deriving the minimum is one extra walk down a left
+        // spine, and only on the miss path.
+        let mut right_subtree: Option<&Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>> = None;
         loop {
             match node {
                 Node::Leaf(leaf) => {
@@ -302,13 +310,18 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                     if pos < leaf.count() && leaf.key(pos) == key {
                         return Some(leaf.doc(pos));
                     }
-                    // Overshot this leaf: the next entry is the right separator.
-                    return right_sep.filter(|s| s.0 == key).map(|s| s.1);
+                    // Overshot this leaf: the next entry in key order is that minimum.
+                    return right_subtree
+                        .map(Node::min)
+                        .filter(|&(k, _)| k == key)
+                        .map(|(_, doc)| doc);
                 }
                 Node::Branch(branch) => {
                     let ci = branch.child_index(key, 0);
-                    if ci < branch.seps.len() {
-                        right_sep = Some(branch.seps[ci]); // == min(children[ci + 1])
+                    if ci + 1 < branch.children.len() {
+                        // Deeper levels overwrite shallower ones, which is what we want:
+                        // the nearest right neighbour is the deepest one on the path.
+                        right_subtree = Some(&branch.children[ci + 1]);
                     }
                     node = &branch.children[ci];
                 }

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -36,7 +36,7 @@ mod node;
 #[cfg(test)]
 mod tests;
 
-pub use cursor::RangeIter;
+pub use cursor::{DocExtract, Extract, RangeIter, TupleExtract};
 use leaf::Leaf;
 pub use leaf::LeafFormat;
 use node::{Branch, Node, Split, build_root};
@@ -53,10 +53,25 @@ use node::{Branch, Node, Split, build_root};
 // Max children per branch page (fan-out) is the `BRANCH_MAX` const generic on [`CowBTree`] (default 256):
 // a branch splits on overflow and merges below `BRANCH_MAX / 2`.
 
-/// Byte width of one `u64` field (a key or a doc).
+/// Byte width of the `u64` key field.
 const FIELD: usize = std::mem::size_of::<u64>();
-/// Byte stride of one `(key, doc)` entry in the [`AosLeaf`] layout.
-const STRIDE: usize = 2 * FIELD;
+
+/// Little-endian `DOC_BYTES` bytes of `doc` for the [`AosLeaf`] layout. The AoS
+/// entry is `key:8 + doc:DOC_BYTES`, so a tree built with `DOC_BYTES = 4` stores
+/// 12 B/entry (docs — node/edge ids — are u32-ranged) while `DOC_BYTES = 8`
+/// keeps the full-width 16 B/entry. Panics if `doc` does not fit the configured
+/// width: ids are width-bounded by construction, so a loud failure beats
+/// silently truncating an id.
+fn doc_le_bytes<const DOC_BYTES: usize>(doc: u64) -> [u8; DOC_BYTES] {
+    let le = doc.to_le_bytes();
+    assert!(
+        le[DOC_BYTES..].iter().all(|&b| b == 0),
+        "cow_btree doc exceeds the configured doc width (DOC_BYTES)"
+    );
+    let mut out = [0u8; DOC_BYTES];
+    out.copy_from_slice(&le[..DOC_BYTES]);
+    out
+}
 
 /// Read the little-endian `u64` at byte offset `off`. The `unwrap` is infallible: `b[off..off + FIELD]`
 /// is always exactly `FIELD` bytes; an out-of-bounds `off` means a malformed page — a build bug, since the
@@ -104,11 +119,17 @@ fn read_width(
 /// [`CowBTree::new`] / [`CowBTree::from_sorted`] / `Default` trips any out-of-range monomorphization that
 /// builds a tree.
 #[derive(Clone)]
-pub struct CowBTree<const LEAF_MAX: usize = 256, const BRANCH_MAX: usize = 256> {
-    root: Node<LEAF_MAX, BRANCH_MAX>,
+pub struct CowBTree<
+    const LEAF_MAX: usize = 256,
+    const BRANCH_MAX: usize = 256,
+    const DOC_BYTES: usize = 8,
+> {
+    root: Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Default for CowBTree<LEAF_MAX, BRANCH_MAX> {
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> Default
+    for CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
+{
     fn default() -> Self {
         const {
             assert!(
@@ -122,7 +143,9 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Default for CowBTree<LEAF_M
     }
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_MAX> {
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
+    CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
+{
     /// An empty tree.
     #[must_use]
     pub fn new() -> Self {
@@ -156,7 +179,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
         if pairs.is_empty() {
             return Self::default();
         }
-        let leaves: Vec<Node<LEAF_MAX, BRANCH_MAX>> = pairs
+        let leaves: Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>> = pairs
             .chunks(LEAF_MAX)
             .map(|chunk| Node::Leaf(Leaf::from_pairs(chunk)))
             .collect();
@@ -165,13 +188,16 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
         }
     }
 
-    /// Insert a single `(key, doc)`. Idempotent: inserting an existing tuple is a no-op.
+    /// Insert a single `(key, doc)`. Idempotent: inserting an existing tuple is a no-op. Returns
+    /// `true` iff the tuple was newly inserted (so callers can maintain an exact live count).
+    #[must_use]
     pub fn insert(
         &mut self,
         key: u64,
         doc: u64,
-    ) {
-        if let Some(Split { sep, right }) = self.root.insert_one(key, doc) {
+    ) -> bool {
+        let (inserted, split) = self.root.insert_one(key, doc);
+        if let Some(Split { sep, right }) = split {
             // The root split — grow a fresh level above the two halves.
             let left = std::mem::replace(&mut self.root, Node::Leaf(Leaf::from_pairs(&[])));
             self.root = Node::Branch(Arc::new(Branch {
@@ -179,6 +205,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
                 children: vec![left, right],
             }));
         }
+        inserted
     }
 
     /// Apply a batch of `(key, doc)` adds **sorted ascending**, copying each touched page once.
@@ -199,12 +226,13 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
     }
 
     /// Remove a single `(key, doc)`; merges underflowing pages so the tree stays compact. A missing
-    /// tuple is a no-op.
+    /// tuple is a no-op. Returns `true` iff a tuple was actually removed (for exact-count callers).
+    #[must_use]
     pub fn remove(
         &mut self,
         key: u64,
         doc: u64,
-    ) {
+    ) -> bool {
         if self.root.remove_one(key, doc).is_some() {
             // A branch root that shrank to a single child loses a level.
             while let Node::Branch(branch) = &self.root {
@@ -215,6 +243,9 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
                     break;
                 }
             }
+            true
+        } else {
+            false
         }
     }
 
@@ -225,7 +256,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
         &self,
         lo: u64,
         hi: u64,
-    ) -> RangeIter<LEAF_MAX, BRANCH_MAX> {
+    ) -> RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
         RangeIter::new(&self.root, (lo, 0), hi)
     }
 
@@ -234,16 +265,125 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
     pub fn point(
         &self,
         key: u64,
-    ) -> RangeIter<LEAF_MAX, BRANCH_MAX> {
+    ) -> RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
         self.range(key, key)
+    }
+
+    /// Whether any doc is stored under `key`. Descends to the first matching entry
+    /// and stops — no full point scan.
+    #[must_use]
+    pub fn contains_key(
+        &self,
+        key: u64,
+    ) -> bool {
+        self.first_doc(key).is_some()
+    }
+
+    /// The smallest doc stored under `key`, or `None`. A direct reference-descent
+    /// to the leaf — unlike [`point`](Self::point) it clones no page `Arc`s and
+    /// allocates no cursor stack, so it's the cheap primitive for the hot
+    /// "one representative edge per pair" lookups (traversal / expand-into).
+    #[must_use]
+    pub fn first_doc(
+        &self,
+        key: u64,
+    ) -> Option<u64> {
+        let mut node = &self.root;
+        // The first entry immediately to the right of the descent path. When a
+        // key's entries begin exactly at a child boundary (the key is the min of
+        // `children[ci + 1]`), `child_index(key, 0)` steers into the *previous*
+        // child, whose leaf then has no matching entry — the answer is this
+        // recorded separator. (The cursor instead advances leaves via its stack.)
+        let mut right_sep: Option<(u64, u64)> = None;
+        loop {
+            match node {
+                Node::Leaf(leaf) => {
+                    let pos = leaf.lower_bound(key);
+                    if pos < leaf.count() && leaf.key(pos) == key {
+                        return Some(leaf.doc(pos));
+                    }
+                    // Overshot this leaf: the next entry is the right separator.
+                    return right_sep.filter(|s| s.0 == key).map(|s| s.1);
+                }
+                Node::Branch(branch) => {
+                    let ci = branch.child_index(key, 0);
+                    if ci < branch.seps.len() {
+                        right_sep = Some(branch.seps[ci]); // == min(children[ci + 1])
+                    }
+                    node = &branch.children[ci];
+                }
+            }
+        }
+    }
+
+    /// Lazily iterate the full `(key, doc)` tuples whose key lies in `[lo, hi]`, in `(key, doc)` order.
+    /// Like [`range`](Self::range) but yields the key too — for consumers that must recover it (e.g. the
+    /// relationship tensor's edge-id store rebuilding `(src, dst, edge_id)`). Owns a snapshot.
+    #[must_use]
+    pub fn range_tuples(
+        &self,
+        lo: u64,
+        hi: u64,
+    ) -> RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES, TupleExtract> {
+        RangeIter::new(&self.root, (lo, 0), hi)
+    }
+
+    /// Call `f(key, doc)` for every tuple in the tree, in `(key, doc)` order. A bulk full-scan that
+    /// matches each leaf's format once and runs a tight inner loop — faster than collecting the lazy
+    /// [`range_tuples`](Self::range_tuples) cursor when the whole tree is consumed (`iter_edges`, the MSF
+    /// rebuild). No allocation, no per-entry `Iterator::next` dispatch.
+    pub fn for_each_tuple<F: FnMut(u64, u64)>(
+        &self,
+        mut f: F,
+    ) {
+        fn walk<
+            F: FnMut(u64, u64),
+            const LEAF_MAX: usize,
+            const BRANCH_MAX: usize,
+            const DOC_BYTES: usize,
+        >(
+            node: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
+            f: &mut F,
+        ) {
+            match node {
+                Node::Leaf(leaf) => leaf.for_each_tuple(&mut *f),
+                Node::Branch(branch) => branch.children.iter().for_each(|c| walk(c, f)),
+            }
+        }
+        walk(&self.root, &mut f);
+    }
+
+    /// Approximate resident heap bytes: the sum of every leaf's byte blob plus branch child/separator
+    /// vectors. Walks all pages (`O(pages)`), so call it off hot paths (memory reporting).
+    #[must_use]
+    pub fn heap_bytes(&self) -> usize {
+        fn walk<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+            node: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
+            acc: &mut usize,
+        ) {
+            match node {
+                Node::Leaf(leaf) => *acc += leaf.raw().len(),
+                Node::Branch(branch) => {
+                    // `seps` is `Vec<(u64, u64)>` — each separator is a full
+                    // `(key, doc)` pair, not a bare key.
+                    *acc += branch.seps.len() * std::mem::size_of::<(u64, u64)>()
+                        + branch.children.len()
+                            * std::mem::size_of::<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>();
+                    branch.children.iter().for_each(|c| walk(c, acc));
+                }
+            }
+        }
+        let mut acc = 0;
+        walk(&self.root, &mut acc);
+        acc
     }
 
     /// Total number of live tuples. Test-only (`O(n)` page walk) — prefer [`is_empty`] in non-test code.
     #[cfg(test)]
     #[must_use]
     pub fn len(&self) -> usize {
-        fn count<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-            node: &Node<LEAF_MAX, BRANCH_MAX>
+        fn count<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+            node: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
         ) -> usize {
             match node {
                 Node::Leaf(leaf) => leaf.count(),
@@ -268,8 +408,8 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> CowBTree<LEAF_MAX, BRANCH_M
     #[cfg(test)]
     #[must_use]
     pub fn leaves(&self) -> Vec<(LeafFormat, Arc<[u8]>)> {
-        fn walk<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-            node: &Node<LEAF_MAX, BRANCH_MAX>,
+        fn walk<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+            node: &Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
             out: &mut Vec<(LeafFormat, Arc<[u8]>)>,
         ) {
             match node {

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -311,6 +311,15 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
         self.range(key, key)
     }
 
+    /// Whether the root is a branch rather than a single leaf — tests that need to exercise the
+    /// branch-routing paths assert on this, so they cannot silently pass on a tree too small to
+    /// have any.
+    #[cfg(test)]
+    #[must_use]
+    pub fn root_is_branch(&self) -> bool {
+        matches!(self.root, Node::Branch(_))
+    }
+
     /// Whether any doc is stored under `key`. Descends to the first matching entry
     /// and stops — no full point scan.
     #[must_use]

--- a/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/mod.rs
@@ -281,8 +281,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
 
     /// The smallest doc stored under `key`, or `None`. A direct reference-descent
     /// to the leaf — unlike [`point`](Self::point) it clones no page `Arc`s and
-    /// allocates no cursor stack, so it's the cheap primitive for the hot
-    /// "one representative edge per pair" lookups (traversal / expand-into).
+    /// allocates no cursor stack, so it is the cheap way to ask "is there one, and
+    /// which" without building a cursor.
+    ///
+    /// Reached in production only through [`contains_key`](Self::contains_key).
     #[must_use]
     pub fn first_doc(
         &self,
@@ -330,8 +332,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
     }
 
     /// Lazily iterate the full `(key, doc)` tuples whose key lies in `[lo, hi]`, in `(key, doc)` order.
-    /// Like [`range`](Self::range) but yields the key too — for consumers that must recover it (e.g. the
-    /// relationship tensor's edge-id store rebuilding `(src, dst, edge_id)`). Owns a snapshot.
+    /// Like [`range`](Self::range) but yields the key too, for a consumer that must recover the
+    /// indexed value and not just the entity. Owns a snapshot.
+    ///
+    /// No caller today — the numeric index reads docs only.
     #[must_use]
     pub fn range_tuples(
         &self,

--- a/graph/src/index/falkordb/data_structures/cow_btree/node.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/node.rs
@@ -156,7 +156,11 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
     Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
 {
     /// The minimum `(key, doc)` in this subtree — walk the left spine down to its first leaf.
-    fn min(&self) -> (u64, u64) {
+    ///
+    /// Panics on an empty subtree. That is the tree's invariant, not an assumption: `strip_empty`
+    /// drops emptied children along with their separator, so only a whole-tree root leaf is ever
+    /// empty, and a root leaf is never reached through a branch.
+    pub(super) fn min(&self) -> (u64, u64) {
         let mut node = self;
         loop {
             match node {

--- a/graph/src/index/falkordb/data_structures/cow_btree/node.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/node.rs
@@ -98,6 +98,65 @@ pub(super) fn build_root<const LEAF_MAX: usize, const BRANCH_MAX: usize, const D
         .unwrap_or_else(|| Node::Leaf(Leaf::from_pairs(&[])))
 }
 
+/// Merge under-full adjacent children left-to-right (re-checking a merged node) so the child list
+/// regains minimum fill after a batch removal — the batch analog of [`Branch::rebalance`]. Each
+/// [`Node::combine`] either fuses the pair into one node (dropping the inter-pair separator) or
+/// rebalances them into two (updating it). A merge that itself stays under-full (a nearly-empty
+/// subtree draining) shrinks the list further and, if the whole branch drops below minimum, propagates
+/// up as this branch's own underflow — resolved by the parent's merge or the root-level level-collapse.
+fn merge_underfull<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    children: &mut Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>,
+    seps: &mut Vec<(u64, u64)>,
+) {
+    let mut i = 0;
+    while children.len() > 1 && i < children.len() {
+        if !children[i].is_underfull() {
+            i += 1;
+            continue;
+        }
+        // Pair the under-full child with its right neighbour, or its left when it is the last.
+        let (left, right) = if i + 1 < children.len() {
+            (i, i + 1)
+        } else {
+            (i - 1, i)
+        };
+        match children[left].combine(seps[left], &children[right]) {
+            Combined::One(merged) => {
+                children[left] = merged;
+                children.remove(right);
+                seps.remove(left);
+                i = left; // the merged node may still be under-full — re-check it
+            }
+            Combined::Two(new_left, sep, new_right) => {
+                children[left] = new_left;
+                children[right] = new_right;
+                seps[left] = sep;
+                i = right; // `new_left` is now min-full
+            }
+        }
+    }
+}
+
+/// Drop children that hold nothing (all their tuples were removed) along with the matching separator.
+/// Dropping child `i` fuses its two boundaries into one: keep the far side, drop the near separator
+/// (`seps[i]` for a non-last child, else the trailing separator).
+fn strip_empty<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    children: &mut Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>,
+    seps: &mut Vec<(u64, u64)>,
+) {
+    let mut i = 0;
+    while i < children.len() {
+        if children[i].is_empty_node() {
+            if !seps.is_empty() {
+                seps.remove(i.min(seps.len() - 1));
+            }
+            children.remove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
 impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
     Branch<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
 {
@@ -401,6 +460,84 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                 Some(branch.children.len() < BRANCH_MAX / 2)
             }
         }
+    }
+
+    /// Remove a sorted `batch` (every entry routing into this subtree) by **copying only the nodes the
+    /// batch touches** — every untouched subtree is shared by `Arc` clone, never materialized, so peak
+    /// memory is proportional to the *touched* pages, not the tree. Removal only shrinks, so this
+    /// returns a single replacement node (no split fragments); under-filled children left behind are
+    /// merged by [`merge_underfull`] so the tree stays compact.
+    pub(super) fn remove_batch(
+        &self,
+        batch: &[(u64, u64)],
+    ) -> Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
+        match self {
+            Node::Leaf(leaf) => {
+                // Subtract the sorted `batch` from this sorted page — a linear merge-walk — and rebuild
+                // just this one leaf. Iterate the page's pairs directly; no full `to_pairs` copy.
+                let mut survivors = Vec::with_capacity(leaf.count());
+                let mut bi = 0usize;
+                for pair in leaf.iter() {
+                    while bi < batch.len() && batch[bi] < pair {
+                        bi += 1;
+                    }
+                    if bi < batch.len() && batch[bi] == pair {
+                        continue; // this tuple is removed
+                    }
+                    survivors.push(pair);
+                }
+                Node::Leaf(Leaf::from_pairs(&survivors))
+            }
+            Node::Branch(branch) => {
+                // Hand each child the slice of `batch` that routes into it (one linear sweep against the
+                // separators, as in `apply_batch`), recursing only into touched children — others share
+                // by `Arc`. Separators need no rewrite: removal only raises a child's min and lowers its
+                // max, so every boundary `max(left) < sep <= min(right)` still holds.
+                let mut children = Vec::with_capacity(branch.children.len());
+                let mut seps = branch.seps.clone();
+                let mut cursor = 0usize;
+                for (child_idx, child) in branch.children.iter().enumerate() {
+                    let child_upper = branch
+                        .seps
+                        .get(child_idx)
+                        .copied()
+                        .unwrap_or((u64::MAX, u64::MAX));
+                    let start = cursor;
+                    while cursor < batch.len() && batch[cursor] < child_upper {
+                        cursor += 1;
+                    }
+                    let for_child = &batch[start..cursor];
+                    if for_child.is_empty() {
+                        children.push(child.clone()); // nothing routes here ⇒ share the page
+                    } else {
+                        children.push(child.remove_batch(for_child));
+                    }
+                }
+                // A child that emptied entirely has nothing to merge into a sibling — drop it (with
+                // its separator). If every child emptied, the whole subtree collapses to one leaf.
+                strip_empty(&mut children, &mut seps);
+                if children.is_empty() {
+                    return Node::Leaf(Leaf::from_pairs(&[]));
+                }
+                // Merge any child that merely under-filled back to minimum.
+                merge_underfull(&mut children, &mut seps);
+                Node::Branch(Arc::new(Branch { seps, children }))
+            }
+        }
+    }
+
+    /// Whether this node dropped below its minimum fill (so a parent must merge it).
+    fn is_underfull(&self) -> bool {
+        match self {
+            Node::Leaf(leaf) => leaf.count() < LEAF_MAX / 2,
+            Node::Branch(branch) => branch.children.len() < BRANCH_MAX / 2,
+        }
+    }
+
+    /// Whether this node holds nothing. After a batch removal only ever an all-emptied leaf — an
+    /// emptied branch is returned as an empty leaf, never a childless branch.
+    fn is_empty_node(&self) -> bool {
+        matches!(self, Node::Leaf(leaf) if leaf.count() == 0)
     }
 }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/node.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/node.rs
@@ -98,41 +98,63 @@ pub(super) fn build_root<const LEAF_MAX: usize, const BRANCH_MAX: usize, const D
         .unwrap_or_else(|| Node::Leaf(Leaf::from_pairs(&[])))
 }
 
+/// Repair one under-full child by combining it with an adjacent sibling, returning the index to
+/// examine next. The single shared step behind both removal paths: [`Branch::rebalance`] applies it
+/// once to a known child, [`merge_underfull`] loops it until every child is min-full.
+///
+/// The caller must guarantee `children.len() >= 2` — with no sibling there is nothing to combine, and
+/// the under-flow has to propagate to the parent instead.
+///
+/// [`Node::combine`] re-splits the pair in sorted order, so the merged / new-left node keeps the
+/// pair's minimum (`min(new left) == min(old left)`). That is why only the **inter-pair** separator
+/// `seps[left]` is ever touched: the separators bracketing the pair from outside
+/// (`seps[left - 1] == min(left)`, and `seps[right]`) still point at unchanged minima, so they stay
+/// valid without being rewritten.
+fn combine_with_sibling<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    children: &mut Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>,
+    seps: &mut Vec<(u64, u64)>,
+    child_idx: usize,
+) -> usize {
+    debug_assert!(children.len() >= 2, "combine needs a sibling to pair with");
+    // Pair the under-full child with its right neighbour, or its left when it is the last.
+    let (left, right) = if child_idx + 1 < children.len() {
+        (child_idx, child_idx + 1)
+    } else {
+        (child_idx - 1, child_idx)
+    };
+    match children[left].combine(seps[left], &children[right]) {
+        Combined::One(merged) => {
+            // Merge: the inter-pair separator vanishes along with the absorbed right child.
+            children[left] = merged;
+            children.remove(right);
+            seps.remove(left);
+            left // the merged node may still be under-full — re-check it
+        }
+        Combined::Two(new_left, sep, new_right) => {
+            // Borrow: only the inter-pair separator moves — to the rebalanced right node's new min.
+            children[left] = new_left;
+            children[right] = new_right;
+            seps[left] = sep;
+            right // `new_left` is now min-full
+        }
+    }
+}
+
 /// Merge under-full adjacent children left-to-right (re-checking a merged node) so the child list
-/// regains minimum fill after a batch removal — the batch analog of [`Branch::rebalance`]. Each
-/// [`Node::combine`] either fuses the pair into one node (dropping the inter-pair separator) or
-/// rebalances them into two (updating it). A merge that itself stays under-full (a nearly-empty
-/// subtree draining) shrinks the list further and, if the whole branch drops below minimum, propagates
-/// up as this branch's own underflow — resolved by the parent's merge or the root-level level-collapse.
+/// regains minimum fill after a batch removal — the batch analog of [`Branch::rebalance`], over the
+/// same [`combine_with_sibling`] step. A merge that itself stays under-full (a nearly-empty subtree
+/// draining) shrinks the list further and, if the whole branch drops below minimum, propagates up as
+/// this branch's own underflow — resolved by the parent's merge or the root-level level-collapse.
 fn merge_underfull<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
     children: &mut Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>,
     seps: &mut Vec<(u64, u64)>,
 ) {
     let mut i = 0;
     while children.len() > 1 && i < children.len() {
-        if !children[i].is_underfull() {
-            i += 1;
-            continue;
-        }
-        // Pair the under-full child with its right neighbour, or its left when it is the last.
-        let (left, right) = if i + 1 < children.len() {
-            (i, i + 1)
+        if children[i].is_underfull() {
+            i = combine_with_sibling(children, seps, i);
         } else {
-            (i - 1, i)
-        };
-        match children[left].combine(seps[left], &children[right]) {
-            Combined::One(merged) => {
-                children[left] = merged;
-                children.remove(right);
-                seps.remove(left);
-                i = left; // the merged node may still be under-full — re-check it
-            }
-            Combined::Two(new_left, sep, new_right) => {
-                children[left] = new_left;
-                children[right] = new_right;
-                seps[left] = sep;
-                i = right; // `new_left` is now min-full
-            }
+            i += 1;
         }
     }
 }
@@ -169,6 +191,13 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
         self.seps.partition_point(|&sep| sep <= (key, doc))
     }
 
+    /// Whether this branch dropped below its minimum fan-out, so a parent must merge it. The one
+    /// definition of the branch threshold — [`Node::is_underfull`] and [`Node::remove_one`] both
+    /// report through here rather than restating `BRANCH_MAX / 2`.
+    fn is_underfull(&self) -> bool {
+        self.children.len() < BRANCH_MAX / 2
+    }
+
     /// Repair this branch **in place** after its child `child_idx` underflowed, by combining that
     /// child with an adjacent sibling — either merging the pair into one node (dropping a separator)
     /// or re-balancing them into two (updating the separator).
@@ -183,31 +212,10 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
         if self.children.len() < 2 {
             return;
         }
-        // Pair the underflowed child with its right neighbour when there is one, otherwise its left.
-        let (left_idx, right_idx) = if child_idx + 1 < self.children.len() {
-            (child_idx, child_idx + 1)
-        } else {
-            (child_idx - 1, child_idx)
-        };
-        // `combine` re-splits the pair in sorted order, so the merged / new-left node keeps the pair's
-        // minimum (`min(new left) == min(old left)`). That is why only the **inter-pair** separator
-        // `seps[left_idx]` is ever touched below: the separators bracketing the pair from outside
-        // (`seps[left_idx - 1] == min(left)` and `seps[right_idx]`, untouched) still point at unchanged
-        // minima, so they stay valid without being rewritten.
-        match self.children[left_idx].combine(self.seps[left_idx], &self.children[right_idx]) {
-            Combined::One(merged) => {
-                // Merge: the inter-pair separator vanishes along with the absorbed right child.
-                self.children[left_idx] = merged;
-                self.children.remove(right_idx);
-                self.seps.remove(left_idx);
-            }
-            Combined::Two(left, sep, right) => {
-                // Borrow: only the inter-pair separator moves — to the rebalanced right node's new min.
-                self.children[left_idx] = left;
-                self.children[right_idx] = right;
-                self.seps[left_idx] = sep;
-            }
-        }
+        // One repair, then stop: the single-key path removes one tuple, so at most one child can have
+        // underflowed. The batch path loops the same step (see [`merge_underfull`]) because a batch can
+        // underflow several children at once, and fusing a pair can leave the result under-full again.
+        let _ = combine_with_sibling(&mut self.children, &mut self.seps, child_idx);
     }
 }
 
@@ -462,7 +470,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                 if branch.children[child_idx].remove_one(key, doc)? {
                     branch.rebalance(child_idx);
                 }
-                Some(branch.children.len() < BRANCH_MAX / 2)
+                Some(branch.is_underfull())
             }
         }
     }
@@ -538,7 +546,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
     fn is_underfull(&self) -> bool {
         match self {
             Node::Leaf(leaf) => leaf.count() < LEAF_MAX / 2,
-            Node::Branch(branch) => branch.children.len() < BRANCH_MAX / 2,
+            Node::Branch(branch) => branch.is_underfull(),
         }
     }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/node.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/node.rs
@@ -4,43 +4,43 @@
 use std::sync::Arc;
 
 use super::leaf::{AosLeaf, Leaf, LeafInsert};
-use super::{FIELD, STRIDE, read_u64};
+use super::{FIELD, read_u64, read_width};
 
 /// A tree node: either a leaf (a byte blob of sorted tuples) or an internal branch.
 ///
 /// Both variants are `Arc`-wrapped, so cloning a node — and therefore a whole tree version — is an
 /// `O(1)` reference-count bump that shares all underlying pages.
 #[derive(Clone)]
-pub(super) enum Node<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
+pub(super) enum Node<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> {
     /// A leaf page of sorted `(key, doc)` tuples — see [`Leaf`].
-    Leaf(Leaf<LEAF_MAX>),
-    Branch(Arc<Branch<LEAF_MAX, BRANCH_MAX>>),
+    Leaf(Leaf<LEAF_MAX, DOC_BYTES>),
+    Branch(Arc<Branch<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>),
 }
 
 /// An internal node: separator keys plus child pointers. `seps[i]` is the minimum `(key, doc)` of
 /// `children[i + 1]`, so `seps.len() == children.len() - 1`.
 #[derive(Clone)]
-pub(super) struct Branch<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
+pub(super) struct Branch<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> {
     pub(super) seps: Vec<(u64, u64)>,
-    pub(super) children: Vec<Node<LEAF_MAX, BRANCH_MAX>>,
+    pub(super) children: Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>,
 }
 
 // ---- node-operation results ------------------------------------------------------------------
 
 /// A node that split under an insert: the new right sibling plus the separator promoted to the parent.
-pub(super) struct Split<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
+pub(super) struct Split<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> {
     pub(super) sep: (u64, u64),
-    pub(super) right: Node<LEAF_MAX, BRANCH_MAX>,
+    pub(super) right: Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
 }
 
 /// Outcome of combining two siblings: a single merged node, or two re-balanced nodes plus their new
 /// separator.
-enum Combined<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
-    One(Node<LEAF_MAX, BRANCH_MAX>),
+enum Combined<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize> {
+    One(Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>),
     Two(
-        Node<LEAF_MAX, BRANCH_MAX>,
+        Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
         (u64, u64),
-        Node<LEAF_MAX, BRANCH_MAX>,
+        Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
     ),
 }
 
@@ -53,9 +53,9 @@ enum Combined<const LEAF_MAX: usize, const BRANCH_MAX: usize> {
 /// later delete that underflowed its only child could not rebalance it (see [`Branch::rebalance`]). The
 /// only way `chunks(BRANCH_MAX)` would leave a singleton is a trailing remainder of exactly 1, i.e. an
 /// input length of `BRANCH_MAX + 1`; that case is split as `BRANCH_MAX - 1` + `2` instead.
-fn pack_branches<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-    children: &[Node<LEAF_MAX, BRANCH_MAX>]
-) -> Vec<Node<LEAF_MAX, BRANCH_MAX>> {
+fn pack_branches<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    children: &[Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>]
+) -> Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>> {
     // One branch per chunk of up to `BRANCH_MAX` children, so the count is known up front.
     let mut packed = Vec::with_capacity(children.len().div_ceil(BRANCH_MAX));
     let mut rest = children;
@@ -87,9 +87,9 @@ fn pack_branches<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
 
 /// Stitch a flat list of node fragments into a single root, packing branch levels bottom-up until
 /// one node remains. An empty list becomes an empty leaf.
-pub(super) fn build_root<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-    mut fragments: Vec<Node<LEAF_MAX, BRANCH_MAX>>
-) -> Node<LEAF_MAX, BRANCH_MAX> {
+pub(super) fn build_root<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    mut fragments: Vec<Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>
+) -> Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
     while fragments.len() > 1 {
         fragments = pack_branches(&fragments);
     }
@@ -98,7 +98,9 @@ pub(super) fn build_root<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
         .unwrap_or_else(|| Node::Leaf(Leaf::from_pairs(&[])))
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Branch<LEAF_MAX, BRANCH_MAX> {
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
+    Branch<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
+{
     /// Index of the child that an entry `(key, doc)` routes into — the number of separators `<=` it.
     pub(super) fn child_index(
         &self,
@@ -150,7 +152,9 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Branch<LEAF_MAX, BRANCH_MAX
     }
 }
 
-impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> {
+impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
+    Node<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
+{
     /// The minimum `(key, doc)` in this subtree — walk the left spine down to its first leaf.
     fn min(&self) -> (u64, u64) {
         let mut node = self;
@@ -220,32 +224,39 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> 
     /// cloned into a private copy before it is mutated (see [`make_private`]), so the committed version a
     /// reader may hold is never disturbed. Returns `Some(Split)` when the node split (the parent must take
     /// in the new right sibling), else `None`. Idempotent: inserting an already-present tuple is a no-op.
+    ///
+    /// Returns `(inserted, split)`: `inserted` is `false` when the tuple was already present (a no-op
+    /// on content), so callers can maintain an exact live count; `split` is `Some` when the node split.
     pub(super) fn insert_one(
         &mut self,
         key: u64,
         doc: u64,
-    ) -> Option<Split<LEAF_MAX, BRANCH_MAX>> {
+    ) -> (bool, Option<Split<LEAF_MAX, BRANCH_MAX, DOC_BYTES>>) {
         match self {
             // The leaf owns the encoding-specific work (an AoS leaf splices its bytes; see [`Leaf::insert`]).
-            Self::Leaf(leaf) => match leaf.insert(key, doc)? {
-                LeafInsert::Fit(new) => {
+            Self::Leaf(leaf) => match leaf.insert(key, doc) {
+                None => (false, None), // already present
+                Some(LeafInsert::Fit(new)) => {
                     *leaf = new;
-                    None
+                    (true, None)
                 }
-                LeafInsert::Split { left, sep, right } => {
+                Some(LeafInsert::Split { left, sep, right }) => {
                     *leaf = left;
-                    Some(Split {
-                        sep,
-                        right: Self::Leaf(right),
-                    })
+                    (
+                        true,
+                        Some(Split {
+                            sep,
+                            right: Self::Leaf(right),
+                        }),
+                    )
                 }
             },
             Self::Branch(branch_arc) => {
                 let branch = make_private(branch_arc); // CoW: clone the shared branch, mutate the copy
                 let child_idx = branch.child_index(key, doc);
-                let Some(Split { sep, right }) = branch.children[child_idx].insert_one(key, doc)
-                else {
-                    return None; // absorbed below — nothing to insert here
+                let (inserted, child_split) = branch.children[child_idx].insert_one(key, doc);
+                let Some(Split { sep, right }) = child_split else {
+                    return (inserted, None); // absorbed below — nothing to insert here
                 };
                 // The child split — take in the promoted separator and the new right sibling beside it.
                 branch.seps.insert(child_idx, sep);
@@ -253,7 +264,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> 
                 #[cfg(test)]
                 cow_gate::park_if(key); // test-only: parks AFTER the working copy is mutated
                 if branch.children.len() <= BRANCH_MAX {
-                    None
+                    (inserted, None)
                 } else {
                     // This branch overflowed in turn: keep the left half, promote the middle
                     // separator (it moves up, into neither side), hand the right half up.
@@ -261,13 +272,16 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> 
                     let right_children = branch.children.split_off(mid);
                     let right_seps = branch.seps.split_off(mid);
                     let promoted = branch.seps.pop().unwrap(); // the separator between the two halves
-                    Some(Split {
-                        sep: promoted,
-                        right: Self::Branch(Arc::new(Branch {
-                            seps: right_seps,
-                            children: right_children,
-                        })),
-                    })
+                    (
+                        inserted,
+                        Some(Split {
+                            sep: promoted,
+                            right: Self::Branch(Arc::new(Branch {
+                                seps: right_seps,
+                                children: right_children,
+                            })),
+                        }),
+                    )
                 }
             }
         }
@@ -280,7 +294,7 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> 
         &self,
         sep: (u64, u64),
         right: &Self,
-    ) -> Combined<LEAF_MAX, BRANCH_MAX> {
+    ) -> Combined<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
         match (self, right) {
             (Self::Leaf(left_leaf), Self::Leaf(right_leaf)) => {
                 // Two AoS leaves are tag-free `[(key, doc) × n]` and the siblings are ordered, so the join
@@ -337,21 +351,24 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize> Node<LEAF_MAX, BRANCH_MAX> 
 
     /// Join two ordered AoS sibling leaves. Their buffers are tag-free `[(key, doc) × n]` and `left`
     /// precedes `right`, so the merge is a plain byte concat — no decode. If the result overflows
-    /// `LEAF_MAX` we split at the midpoint entry; the fixed `STRIDE` makes that a balanced split (both
+    /// `LEAF_MAX` we split at the midpoint entry; the fixed `(FIELD + DOC_BYTES)` makes that a balanced split (both
     /// halves `>= LEAF_MAX / 2`), and `mid_sep` (the first entry of the right half) is the new separator.
     fn aos_combine(
-        left: &AosLeaf,
-        right: &AosLeaf,
-    ) -> Combined<LEAF_MAX, BRANCH_MAX> {
+        left: &AosLeaf<DOC_BYTES>,
+        right: &AosLeaf<DOC_BYTES>,
+    ) -> Combined<LEAF_MAX, BRANCH_MAX, DOC_BYTES> {
         let mut buf = Vec::with_capacity(left.0.len() + right.0.len());
         buf.extend_from_slice(&left.0);
         buf.extend_from_slice(&right.0);
         let leaf = |bytes: Vec<u8>| Self::Leaf(Leaf::Aos(AosLeaf(bytes.into())));
-        if buf.len() / STRIDE <= LEAF_MAX {
+        if buf.len() / (FIELD + DOC_BYTES) <= LEAF_MAX {
             Combined::One(leaf(buf))
         } else {
-            let split = buf.len() / STRIDE / 2 * STRIDE;
-            let mid_sep = (read_u64(&buf, split), read_u64(&buf, split + FIELD));
+            let split = buf.len() / (FIELD + DOC_BYTES) / 2 * (FIELD + DOC_BYTES);
+            let mid_sep = (
+                read_u64(&buf, split),
+                read_width(&buf, split + FIELD, DOC_BYTES),
+            );
             let right_buf = buf.split_off(split);
             Combined::Two(leaf(buf), mid_sep, leaf(right_buf))
         }

--- a/graph/src/index/falkordb/data_structures/cow_btree/node.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/node.rs
@@ -260,16 +260,21 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                 // (touched ones recurse, untouched share by Arc), so the O(children) walk is unavoidable.)
                 let mut cursor = 0usize;
                 for (child_idx, child) in branch.children.iter().enumerate() {
-                    // Each child owns keys strictly below its right separator; the last child (no separator)
-                    // owns everything remaining.
-                    let child_upper = branch
-                        .seps
-                        .get(child_idx)
-                        .copied()
-                        .unwrap_or((u64::MAX, u64::MAX));
+                    // Each child owns keys strictly below its right separator; the last child (no
+                    // separator) owns everything remaining.
+                    //
+                    // The last child is handled by taking the rest of the batch outright, NOT by
+                    // comparing against a `(u64::MAX, u64::MAX)` sentinel: `<` against that
+                    // sentinel excludes an entry exactly equal to it, so the maximal tuple would
+                    // route nowhere and be silently dropped.
                     let start = cursor;
-                    while cursor < batch.len() && batch[cursor] < child_upper {
-                        cursor += 1;
+                    if child_idx + 1 == branch.children.len() {
+                        cursor = batch.len();
+                    } else {
+                        let child_upper = branch.seps[child_idx];
+                        while cursor < batch.len() && batch[cursor] < child_upper {
+                            cursor += 1;
+                        }
                     }
                     let for_child = &batch[start..cursor];
                     if for_child.is_empty() {
@@ -497,14 +502,17 @@ impl<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>
                 let mut seps = branch.seps.clone();
                 let mut cursor = 0usize;
                 for (child_idx, child) in branch.children.iter().enumerate() {
-                    let child_upper = branch
-                        .seps
-                        .get(child_idx)
-                        .copied()
-                        .unwrap_or((u64::MAX, u64::MAX));
+                    // Last child takes the remainder outright — see the note in `apply_batch`: a
+                    // `<` against a `(u64::MAX, u64::MAX)` sentinel silently skips the maximal
+                    // tuple.
                     let start = cursor;
-                    while cursor < batch.len() && batch[cursor] < child_upper {
-                        cursor += 1;
+                    if child_idx + 1 == branch.children.len() {
+                        cursor = batch.len();
+                    } else {
+                        let child_upper = branch.seps[child_idx];
+                        while cursor < batch.len() && batch[cursor] < child_upper {
+                            cursor += 1;
+                        }
                     }
                     let for_child = &batch[start..cursor];
                     if for_child.is_empty() {

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1,3 +1,7 @@
+// Many tests drive `insert`/`remove` (now `#[must_use]` for their exact-count
+// bool) purely for their side effect and assert on the tree afterwards.
+#![allow(unused_must_use)]
+
 use super::*;
 use std::collections::BTreeSet;
 
@@ -9,8 +13,8 @@ fn splitmix(mut z: u64) -> u64 {
 }
 
 /// Sorted doc ids the tree yields for `[lo, hi]`.
-fn tree_range<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-    t: &CowBTree<LEAF_MAX, BRANCH_MAX>,
+fn tree_range<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    t: &CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>,
     lo: u64,
     hi: u64,
 ) -> Vec<u64> {
@@ -32,13 +36,13 @@ fn ref_range(
 /// The full `(key, doc)` multiset the tree stores, decoded straight from the leaf bytes (so it verifies
 /// the *value* column, not just docs — a full-range cursor scan skips key reads on interior leaves).
 /// Generic over `LEAF_MAX` so the const-generic parity test can drive a non-default leaf size through it.
-fn tree_pairs<const LEAF_MAX: usize, const BRANCH_MAX: usize>(
-    t: &CowBTree<LEAF_MAX, BRANCH_MAX>
+fn tree_pairs<const LEAF_MAX: usize, const BRANCH_MAX: usize, const DOC_BYTES: usize>(
+    t: &CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>
 ) -> Vec<(u64, u64)> {
     let mut v: Vec<(u64, u64)> = t
         .leaves()
         .into_iter()
-        .flat_map(|(fmt, bytes)| Leaf::<LEAF_MAX>::from_parts(fmt, bytes).to_pairs())
+        .flat_map(|(fmt, bytes)| Leaf::<LEAF_MAX, DOC_BYTES>::from_parts(fmt, bytes).to_pairs())
         .collect();
     v.sort_unstable();
     v
@@ -53,6 +57,77 @@ fn empty_and_single() {
     assert_eq!(t.len(), 1);
     assert_eq!(t.point(5).collect::<Vec<_>>(), vec![50]);
     assert_eq!(t.point(6).count(), 0);
+}
+
+/// `first_doc(k)` must equal the smallest doc for `k` in the `BTreeSet` oracle
+/// (independent of the cursor, so a shared bug can't hide both), and also agree
+/// with the range cursor — for every present key plus its absent neighbours and
+/// the `u64::MAX` sentinel. Shared across the format-specific tests so the cheap
+/// representative-edge lookup is exercised on AoS, Compact, and CompactIndexed
+/// leaves at both doc widths.
+fn assert_first_doc_matches<const L: usize, const B: usize, const D: usize>(
+    t: &CowBTree<L, B, D>,
+    r: &BTreeSet<(u64, u64)>,
+) {
+    let ref_first = |k: u64| r.range((k, 0)..=(k, u64::MAX)).next().map(|&(_, d)| d);
+    let keys: BTreeSet<u64> = r.iter().map(|&(k, _)| k).collect();
+    for &k in &keys {
+        assert_eq!(t.first_doc(k), ref_first(k), "first_doc({k}) vs oracle");
+        assert_eq!(
+            t.first_doc(k),
+            t.point(k).next(),
+            "first_doc({k}) vs cursor"
+        );
+        for kk in [k.wrapping_sub(1), k + 1] {
+            if !keys.contains(&kk) {
+                assert_eq!(
+                    t.first_doc(kk),
+                    ref_first(kk),
+                    "first_doc({kk}) absent vs oracle"
+                );
+            }
+        }
+    }
+    assert_eq!(
+        t.first_doc(u64::MAX),
+        ref_first(u64::MAX),
+        "first_doc(u64::MAX)"
+    );
+}
+
+#[test]
+fn first_doc_matches_reference_across_configs() {
+    // Empty + single-entry edge cases.
+    assert_first_doc_matches(&CowBTree::<4, 4, 8>::new(), &BTreeSet::new());
+    let mut one = CowBTree::<4, 4, 4>::new();
+    one.insert(7, 42);
+    assert_first_doc_matches(&one, &[(7u64, 42u64)].into_iter().collect());
+
+    // Small fan-out => deep trees with many leaf/branch boundaries; heavy key
+    // collisions => multi-doc keys; docs strictly > 0 to exercise the case where
+    // a key's first entry is the min of a child (the boundary path a naive
+    // stackless descent gets wrong). Both doc widths (incl. the store's u32).
+    for seed in 0..10u64 {
+        let mut z = seed.wrapping_add(1);
+        let mut pairs = Vec::new();
+        for _ in 0..600 {
+            z = splitmix(z);
+            let k = z % 80;
+            z = splitmix(z);
+            let d = (z % 400) + 1;
+            pairs.push((k, d));
+        }
+        let mut r: BTreeSet<(u64, u64)> = BTreeSet::new();
+        let mut t8 = CowBTree::<4, 4, 8>::new();
+        let mut t4 = CowBTree::<4, 4, 4>::new();
+        for &(k, d) in &pairs {
+            t8.insert(k, d);
+            t4.insert(k, d);
+            r.insert((k, d));
+        }
+        assert_first_doc_matches(&t8, &r);
+        assert_first_doc_matches(&t4, &r);
+    }
 }
 
 #[test]
@@ -246,7 +321,7 @@ fn leaf_bytes_round_trip_through_a_byte_store() {
     let want = 1234u64;
     let mut found = None;
     for (fmt, blob) in &store {
-        let leaf = Leaf::<256>::from_parts(*fmt, Arc::from(blob.as_slice())); // re-wrap — proving they're usable as-is
+        let leaf = Leaf::<256, 8>::from_parts(*fmt, Arc::from(blob.as_slice())); // re-wrap — proving they're usable as-is
         if leaf.count() > 0 && leaf.key(0) <= want && leaf.key(leaf.count() - 1) >= want {
             let i = leaf.lower_bound(want);
             if i < leaf.count() && leaf.key(i) == want {
@@ -275,7 +350,7 @@ fn leaf_format_roundtrip() {
         pairs: &[(u64, u64)],
         want: Option<&Want>,
     ) {
-        let leaf = Leaf::<256>::from_pairs(pairs);
+        let leaf = Leaf::<256, 8>::from_pairs(pairs);
         assert_eq!(leaf.count(), pairs.len(), "count for {pairs:?}");
         assert_eq!(leaf.to_pairs(), pairs, "to_pairs for {pairs:?}");
         for (i, &(k, d)) in pairs.iter().enumerate() {
@@ -284,7 +359,7 @@ fn leaf_format_roundtrip() {
         }
         let blob = leaf.bytes();
         assert_eq!(
-            Leaf::<256>::from_parts(leaf.format(), blob).to_pairs(),
+            Leaf::<256, 8>::from_parts(leaf.format(), blob).to_pairs(),
             pairs,
             "bytes round-trip for {pairs:?}"
         );
@@ -617,7 +692,9 @@ fn cow_writer_shares_committed_nodes_then_privatizes_on_write() {
     // node is always shared, so make_mut would copy anyway — see `node::make_private`.)
     use super::node::Node;
     use std::sync::Arc;
-    fn root_rc<const L: usize, const B: usize>(t: &CowBTree<L, B>) -> usize {
+    fn root_rc<const L: usize, const B: usize, const DOC_BYTES: usize>(
+        t: &CowBTree<L, B, DOC_BYTES>
+    ) -> usize {
         match &t.root {
             Node::Branch(b) => Arc::strong_count(b),
             Node::Leaf(_) => panic!("test needs a multi-level tree"),
@@ -678,6 +755,7 @@ fn compact_splice_arms_parity() {
         // doc parity via the cursor, *and* full (key, doc) parity decoded from the leaf bytes
         assert_eq!(tree_range(t, 0, u64::MAX), ref_range(r, 0, u64::MAX));
         assert_eq!(tree_pairs(t), r.iter().copied().collect::<Vec<_>>());
+        assert_first_doc_matches(t, r); // first_doc on Compact leaves
     };
 
     // insert: existing distinct value (no distinct-table change), new doc within width.
@@ -747,7 +825,7 @@ fn no_index_compact_splice_arms() {
     let no_index = |t: &CowBTree| {
         t.leaves()
             .into_iter()
-            .all(|(f, b)| matches!(Leaf::<256>::from_parts(f, b), Leaf::Compact(_)))
+            .all(|(f, b)| matches!(Leaf::<256, 8>::from_parts(f, b), Leaf::Compact(_)))
     };
     assert!(
         no_index(&t),
@@ -756,6 +834,7 @@ fn no_index_compact_splice_arms() {
     let check = |t: &CowBTree, r: &BTreeSet<(u64, u64)>| {
         assert_eq!(t.len(), r.len());
         assert_eq!(tree_pairs(t), r.iter().copied().collect::<Vec<_>>());
+        assert_first_doc_matches(t, r); // first_doc on CompactIndexed leaves
     };
     // new value (fits widths) ⇒ stays no-index.
     t.insert(250, 250);
@@ -810,7 +889,7 @@ fn block_copy_merge_parity() {
     assert!(
         t.leaves()
             .into_iter()
-            .all(|(f, b)| matches!(Leaf::<256>::from_parts(f, b), Leaf::CompactIndexed(_))),
+            .all(|(f, b)| matches!(Leaf::<256, 8>::from_parts(f, b), Leaf::CompactIndexed(_))),
         "setup should be a single indexed leaf"
     );
     // B = 8 (< 200/4), keys all existing distinct (0/1000/2000/3000), docs fit. (2000,102) is a
@@ -838,7 +917,7 @@ fn block_copy_merge_parity() {
     assert!(
         t.leaves()
             .into_iter()
-            .all(|(f, b)| matches!(Leaf::<256>::from_parts(f, b), Leaf::CompactIndexed(_))),
+            .all(|(f, b)| matches!(Leaf::<256, 8>::from_parts(f, b), Leaf::CompactIndexed(_))),
         "block-copy merge must keep the leaf indexed"
     );
     // A *large* all-existing-distinct batch (no size guard now — galloping keeps block-copy ≥ the walk).
@@ -1011,14 +1090,14 @@ fn const_generic_branch_size_parity() {
 /// Walk the whole tree and assert every structural invariant. `min_fill` gates the occupancy check: pass
 /// `true` for trees grown by `insert`/`remove` from empty (splits + rebalance keep non-root pages at least
 /// half full), `false` for a fresh `from_sorted` bulk build (whose last leaf may be short by construction).
-fn check_invariants<const L: usize, const B: usize>(
-    t: &CowBTree<L, B>,
+fn check_invariants<const L: usize, const B: usize, const DOC_BYTES: usize>(
+    t: &CowBTree<L, B, DOC_BYTES>,
     min_fill: bool,
 ) {
     use super::node::Node;
     // Returns (subtree min (key,doc), subtree max (key,doc), depth, entry count).
-    fn walk<const L: usize, const B: usize>(
-        node: &Node<L, B>,
+    fn walk<const L: usize, const B: usize, const DOC_BYTES: usize>(
+        node: &Node<L, B, DOC_BYTES>,
         is_root: bool,
         min_fill: bool,
     ) -> ((u64, u64), (u64, u64), usize, usize) {
@@ -1049,7 +1128,7 @@ fn check_invariants<const L: usize, const B: usize>(
                     "to_pairs disagrees with key/doc accessors"
                 );
                 assert_eq!(
-                    Leaf::<L>::from_pairs(&pairs).to_pairs(),
+                    Leaf::<L, DOC_BYTES>::from_pairs(&pairs).to_pairs(),
                     pairs,
                     "leaf encoder round-trip mismatch"
                 );
@@ -1119,12 +1198,12 @@ fn check_invariants<const L: usize, const B: usize>(
 /// Drive random mixed insert/remove against a `BTreeSet<(key, doc)>` oracle, asserting content parity,
 /// read-path (`range`/`point`) parity, AND every structural invariant after each op — the core integrity
 /// harness, run below at several sizes.
-fn differential<const L: usize, const B: usize>(
+fn differential<const L: usize, const B: usize, const DOC_BYTES: usize>(
     seed: u64,
     ops: usize,
     key_space: u64,
 ) {
-    let mut tree: CowBTree<L, B> = CowBTree::new();
+    let mut tree: CowBTree<L, B, DOC_BYTES> = CowBTree::new();
     let mut oracle: BTreeSet<(u64, u64)> = BTreeSet::new();
     let mut rng = seed;
     for _ in 0..ops {
@@ -1179,19 +1258,29 @@ fn differential<const L: usize, const B: usize>(
 fn integrity_differential_across_sizes() {
     // Tiny capacities make split/merge/borrow/collapse fire on almost every op (at 256 the FIRST split
     // needs 257 inserts, so structural code is otherwise unexercised); the default confirms production width.
-    differential::<4, 4>(0x1111_1111, 3000, 30);
-    differential::<5, 5>(0x2222_2222, 3000, 30);
-    differential::<8, 8>(0x3333_3333, 3000, 50);
-    differential::<8, 32>(0x4444_4444, 3000, 50); // wide branch, narrow leaf
-    differential::<32, 8>(0x5555_5555, 3000, 80); // narrow branch, wide leaf
-    differential::<256, 256>(0x6666_6666, 4000, 800);
+    differential::<4, 4, 8>(0x1111_1111, 3000, 30);
+    differential::<5, 5, 8>(0x2222_2222, 3000, 30);
+    differential::<8, 8, 8>(0x3333_3333, 3000, 50);
+    differential::<8, 32, 8>(0x4444_4444, 3000, 50); // wide branch, narrow leaf
+    differential::<32, 8, 8>(0x5555_5555, 3000, 80); // narrow branch, wide leaf
+    differential::<256, 256, 8>(0x6666_6666, 4000, 800);
+
+    // Same sweep at the narrow (u32) doc width — the 12 B/entry AoS layout the
+    // tensor's EdgeIdStore uses. Docs are `rng % key_space` (well under u32), so
+    // this stresses split/merge/borrow/collapse + leaf round-trip at DOC_BYTES=4.
+    differential::<4, 4, 4>(0x1111_2222, 3000, 30);
+    differential::<5, 5, 4>(0x2222_3333, 3000, 30);
+    differential::<8, 8, 4>(0x3333_4444, 3000, 50);
+    differential::<8, 32, 4>(0x4444_5555, 3000, 50);
+    differential::<32, 8, 4>(0x5555_6666, 3000, 80);
+    differential::<256, 256, 4>(0x6666_7777, 4000, 800);
 }
 
 #[test]
 fn integrity_from_sorted_well_formed_across_sizes() {
     // Bulk build must produce a valid tree at every size + boundary count. `min_fill` off: the last leaf
     // may be short by construction (`chunks(LEAF_MAX)`).
-    fn build<const L: usize, const B: usize>(n: u64) {
+    fn build<const L: usize, const B: usize, const DOC_BYTES: usize>(n: u64) {
         let t = CowBTree::<L, B>::from_sorted(&(0..n).map(|i| (i, i)).collect::<Vec<_>>());
         assert_eq!(t.len() as u64, n, "len != n for n={n}");
         check_invariants(&t, false);
@@ -1199,9 +1288,9 @@ fn integrity_from_sorted_well_formed_across_sizes() {
         // re-encoding its own contents — proving the encoding is deterministic AND the smaller (AoS vs
         // compact) format was chosen.
         for (fmt, bytes) in t.leaves() {
-            let pairs = Leaf::<L>::from_parts(fmt, bytes.clone()).to_pairs();
+            let pairs = Leaf::<L, DOC_BYTES>::from_parts(fmt, bytes.clone()).to_pairs();
             assert_eq!(
-                Leaf::<L>::from_pairs(&pairs).bytes(),
+                Leaf::<L, DOC_BYTES>::from_pairs(&pairs).bytes(),
                 bytes,
                 "from_sorted leaf not byte-identical to its from_pairs re-encode (n={n})"
             );
@@ -1210,10 +1299,10 @@ fn integrity_from_sorted_well_formed_across_sizes() {
     for &n in &[
         0u64, 1, 2, 3, 7, 8, 9, 15, 16, 17, 63, 64, 65, 256, 257, 1000,
     ] {
-        build::<4, 4>(n);
-        build::<8, 8>(n);
-        build::<16, 4>(n);
-        build::<256, 256>(n);
+        build::<4, 4, 8>(n);
+        build::<8, 8, 8>(n);
+        build::<16, 4, 8>(n);
+        build::<256, 256, 8>(n);
     }
 }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1163,6 +1163,61 @@ fn const_generic_branch_size_parity() {
 /// Walk the whole tree and assert every structural invariant. `min_fill` gates the occupancy check: pass
 /// `true` for trees grown by `insert`/`remove` from empty (splits + rebalance keep non-root pages at least
 /// half full), `false` for a fresh `from_sorted` bulk build (whose last leaf may be short by construction).
+#[test]
+fn remove_batch_matches_single_removes_and_stays_valid() {
+    // Small fan-out forces a multi-level tree; a whole multiple of LEAF_MAX means the built tree is
+    // fully min-filled, so the batch removal must keep it that way (`min_fill = true`).
+    let all: Vec<(u64, u64)> = (0..512u64).map(|i| (i, i)).collect();
+    let build = || CowBTree::<8, 4>::from_sorted(&all);
+
+    // (1) Scattered removal (every 3rd key) — must equal looping single removes, tuple for tuple.
+    let removes: Vec<(u64, u64)> = all.iter().copied().filter(|&(k, _)| k % 3 == 0).collect();
+    let mut batched = build();
+    batched.remove_batch(&removes);
+    let mut singly = build();
+    for &(k, d) in &removes {
+        singly.remove(k, d);
+    }
+    let expected: Vec<(u64, u64)> = all.iter().copied().filter(|&(k, _)| k % 3 != 0).collect();
+    assert_eq!(tree_pairs(&batched), expected);
+    assert_eq!(tree_pairs(&batched), tree_pairs(&singly));
+    check_invariants(&batched, true);
+
+    // (2) Empty batch is a no-op.
+    let mut tr = build();
+    tr.remove_batch(&[]);
+    assert_eq!(tree_pairs(&tr), all);
+
+    // (3) Removing absent tuples leaves the tree unchanged.
+    let mut tr = build();
+    let absent: Vec<(u64, u64)> = (1000..1010u64).map(|i| (i, i)).collect();
+    tr.remove_batch(&absent);
+    assert_eq!(tree_pairs(&tr), all);
+    check_invariants(&tr, true);
+
+    // (4) Removing everything drains to an empty tree.
+    let mut tr = build();
+    tr.remove_batch(&all);
+    assert!(tr.is_empty());
+    assert_eq!(tree_pairs(&tr), Vec::<(u64, u64)>::new());
+
+    // (5) A contiguous middle range.
+    let mut tr = build();
+    let mid: Vec<(u64, u64)> = all
+        .iter()
+        .copied()
+        .filter(|&(k, _)| (100..400).contains(&k))
+        .collect();
+    tr.remove_batch(&mid);
+    let expected: Vec<(u64, u64)> = all
+        .iter()
+        .copied()
+        .filter(|&(k, _)| !(100..400).contains(&k))
+        .collect();
+    assert_eq!(tree_pairs(&tr), expected);
+    check_invariants(&tr, true);
+}
+
 fn check_invariants<const L: usize, const B: usize, const DOC_BYTES: usize>(
     t: &CowBTree<L, B, DOC_BYTES>,
     min_fill: bool,
@@ -1407,14 +1462,14 @@ fn integrity_adversarial_ascending_then_cascade_delete() {
     for i in 0..300u64 {
         t.insert(i, i);
         oracle.insert((i, i));
-        check_invariants(&t, true);
+        check_invariants(&t, false);
     }
     for i in 0..300u64 {
         let k = (i * 7) % 300; // gcd(7, 300) == 1 ⇒ a permutation of 0..300
         t.remove(k, k);
         oracle.remove(&(k, k));
         assert_eq!(tree_pairs(&t), oracle.iter().copied().collect::<Vec<_>>());
-        check_invariants(&t, true);
+        check_invariants(&t, false);
     }
     assert!(t.is_empty());
     assert_eq!(t.len(), 0);

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -78,7 +78,9 @@ fn assert_first_doc_matches<const L: usize, const B: usize, const D: usize>(
             t.point(k).next(),
             "first_doc({k}) vs cursor"
         );
-        for kk in [k.wrapping_sub(1), k + 1] {
+        // Both neighbours wrap: `k + 1` panics in debug builds the moment a caller
+        // puts `u64::MAX` in the oracle, which `first_doc_handles_max_key` does.
+        for kk in [k.wrapping_sub(1), k.wrapping_add(1)] {
             if !keys.contains(&kk) {
                 assert_eq!(
                     t.first_doc(kk),
@@ -92,6 +94,40 @@ fn assert_first_doc_matches<const L: usize, const B: usize, const D: usize>(
         t.first_doc(u64::MAX),
         ref_first(u64::MAX),
         "first_doc(u64::MAX)"
+    );
+}
+
+/// `u64::MAX` as a **present** key, not just the absent sentinel every other caller probes. The
+/// maximum key has no upper neighbour, so deriving one has to wrap — this is the case that would
+/// have tripped `assert_first_doc_matches`'s neighbour probe. Covers it both as a lone entry and
+/// sharing its key with a second doc, so the "smallest doc under this key" path runs at the very
+/// top of the tree.
+#[test]
+fn first_doc_handles_max_key() {
+    let mut t = CowBTree::<4, 4, 8>::new();
+    let mut r = BTreeSet::new();
+    for (k, d) in [
+        (0u64, 0u64),
+        (1, 1),
+        (2, 2),
+        (7, 7),
+        (u64::MAX - 1, 5),
+        (u64::MAX, 9),
+        (u64::MAX, 3),
+    ] {
+        assert!(t.insert(k, d), "fresh tuple ({k}, {d}) should be new");
+        r.insert((k, d));
+    }
+    assert!(
+        t.leaves().len() > 1,
+        "test needs a branch root to exercise the descent, not a single leaf"
+    );
+    check_invariants(&t, true);
+    assert_first_doc_matches(&t, &r);
+    assert_eq!(
+        t.first_doc(u64::MAX),
+        Some(3),
+        "smallest doc under the max key"
     );
 }
 
@@ -1331,7 +1367,8 @@ fn integrity_from_sorted_well_formed_across_sizes() {
     // Bulk build must produce a valid tree at every size + boundary count. `min_fill` off: the last leaf
     // may be short by construction (`chunks(LEAF_MAX)`).
     fn build<const L: usize, const B: usize, const DOC_BYTES: usize>(n: u64) {
-        let t = CowBTree::<L, B>::from_sorted(&(0..n).map(|i| (i, i)).collect::<Vec<_>>());
+        let t =
+            CowBTree::<L, B, DOC_BYTES>::from_sorted(&(0..n).map(|i| (i, i)).collect::<Vec<_>>());
         assert_eq!(t.len() as u64, n, "len != n for n={n}");
         check_invariants(&t, false);
         // from_sorted builds every leaf via from_pairs, so each page must be byte-identical to
@@ -1353,6 +1390,11 @@ fn integrity_from_sorted_well_formed_across_sizes() {
         build::<8, 8, 8>(n);
         build::<16, 4, 8>(n);
         build::<256, 256, 8>(n);
+        // The narrow doc width goes through the same bulk build. Keys here are `0..n`, so the docs
+        // (also `0..n`) stay inside 4 bytes for every `n` in the sweep.
+        build::<4, 4, 4>(n);
+        build::<16, 4, 4>(n);
+        build::<256, 256, 4>(n);
     }
 }
 

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1218,6 +1218,73 @@ fn remove_batch_matches_single_removes_and_stays_valid() {
     check_invariants(&tr, true);
 }
 
+/// Emptying a **middle** child outright — the one shape `strip_empty` handles that no other path
+/// reaches. Single-key removal never produces it (an emptied leaf is just maximally under-full, and
+/// `rebalance` merges it into a sibling), and the random differential harness is not guaranteed to
+/// drain one whole child while leaving its neighbours intact.
+///
+/// The question this pins down is which separator survives. Dropping `children[i]` leaves
+/// `seps[i - 1]` — which named the *removed* child's minimum — as the boundary between
+/// `children[i - 1]` and the old `children[i + 1]`. That is deliberately still valid: separators are
+/// **routing boundaries**, `max(left) < sep <= min(right)`, not live minima. `seps[i - 1]` sits above
+/// everything in `children[i - 1]` (unchanged) and strictly below `min(children[i + 1])`, because the
+/// dropped `seps[i]` bracketed them. Rewriting separators to the surviving children's minima would be
+/// extra `min()` walks to restore a property the tree does not maintain anywhere else — a borrow or
+/// merge leaves separators below the right child's current min too (see `check_invariants`).
+#[test]
+fn strip_empty_middle_child_keeps_a_valid_separator() {
+    // 16 keys at LEAF_MAX = 4 pack as [0..3][4..7][8..11][12..15] under one branch root.
+    //
+    // Four children, not three: with only three, *every* single separator left behind happens to be
+    // a valid boundary, so the test could not tell a correct choice from a wrong one. At four, the
+    // surviving separators have to stay aligned with the surviving pairs — keeping the far separator
+    // would leave one that sits below its own left child's max.
+    let all: Vec<(u64, u64)> = (0..16u64).map(|k| (k, k)).collect();
+    let mut t = CowBTree::<4, 4, 8>::from_sorted(&all);
+    assert!(
+        t.root_is_branch(),
+        "test needs a branch root, not a lone leaf"
+    );
+    assert_eq!(
+        t.leaves().len(),
+        4,
+        "test needs four children for the separator choice to be constrained"
+    );
+
+    // Drain the middle child exactly, leaving its neighbours full.
+    let middle: Vec<(u64, u64)> = (4..8u64).map(|k| (k, k)).collect();
+    t.remove_batch(&middle);
+
+    // The separator left behind must still route correctly, and min fill must be restored.
+    check_invariants(&t, true);
+
+    let expected: Vec<(u64, u64)> = (0..4u64).chain(8..16).map(|k| (k, k)).collect();
+    assert_eq!(
+        tree_pairs(&t),
+        expected,
+        "content after draining the middle"
+    );
+
+    // Read across the seam the removed child used to occupy: the keys that bracket the hole, the
+    // hole itself, and a range spanning it.
+    assert_eq!(t.point(3).collect::<Vec<_>>(), vec![3], "left of the hole");
+    assert_eq!(t.point(8).collect::<Vec<_>>(), vec![8], "right of the hole");
+    for k in 4..8u64 {
+        assert_eq!(t.point(k).count(), 0, "removed key {k} still reachable");
+        assert!(!t.contains_key(k), "contains_key({k}) after removal");
+    }
+    assert_eq!(
+        t.range(2, 9).collect::<Vec<_>>(),
+        vec![2, 3, 8, 9],
+        "range spanning the drained child"
+    );
+    // Every surviving key stays reachable through the rewritten branch, including the last child —
+    // the one a mis-aligned separator would strand.
+    for k in (0..4u64).chain(8..16) {
+        assert_eq!(t.point(k).collect::<Vec<_>>(), vec![k], "survivor {k}");
+    }
+}
+
 fn check_invariants<const L: usize, const B: usize, const DOC_BYTES: usize>(
     t: &CowBTree<L, B, DOC_BYTES>,
     min_fill: bool,

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1340,7 +1340,26 @@ fn differential<const L: usize, const B: usize, const DOC_BYTES: usize>(
         rng = splitmix(rng);
         let doc = rng % key_space;
         rng = splitmix(rng);
-        if rng.is_multiple_of(3) && oracle.contains(&(key, doc)) {
+        if rng.is_multiple_of(7) && oracle.len() > 4 {
+            // Batch removal of a scattered subset of *live* tuples. The write path's mass-delete
+            // and mass-update columns go through `remove_batch`, not the single `remove`, and the
+            // two take completely different routes through the tree: one rebuilds each touched
+            // page once, the other descends per tuple. Only exercising the single path left the
+            // batch one covered by a single fixed dataset with no duplicate keys and one doc
+            // width — the two things an index actually produces.
+            let live: Vec<(u64, u64)> = oracle.iter().copied().collect();
+            let mut picks: Vec<(u64, u64)> = Vec::new();
+            for _ in 0..(1 + (rng as usize % 8)).min(live.len()) {
+                rng = splitmix(rng);
+                picks.push(live[rng as usize % live.len()]);
+            }
+            picks.sort_unstable();
+            picks.dedup(); // `remove_batch` requires sorted input; duplicates are meaningless
+            tree.remove_batch(&picks);
+            for p in &picks {
+                oracle.remove(p);
+            }
+        } else if rng.is_multiple_of(3) && oracle.contains(&(key, doc)) {
             tree.remove(key, doc);
             oracle.remove(&(key, doc));
         } else {
@@ -1473,4 +1492,73 @@ fn integrity_adversarial_ascending_then_cascade_delete() {
     }
     assert!(t.is_empty());
     assert_eq!(t.len(), 0);
+}
+
+/// `remove_batch` must handle the maximal tuple `(u64::MAX, u64::MAX)`.
+///
+/// The batch is routed to children by `batch[cursor] < child_upper`, where the last child has no
+/// separator and takes the sentinel `(u64::MAX, u64::MAX)` as its upper bound. A strict `<`
+/// against that sentinel never routes an entry *equal* to it, so the maximal tuple is silently
+/// skipped.
+///
+/// The tree must be deep enough to have a **branch** root — that routing loop only runs on a
+/// branch. A first version of this test used three entries with `LEAF_MAX = 4`, which fits in one
+/// leaf, so it passed without ever reaching the code under test.
+#[test]
+fn remove_batch_handles_the_maximal_tuple() {
+    // 8 filler entries at LEAF_MAX=4 force splits, so the root is a Branch and the maximal tuple
+    // lands in the last child.
+    let mut all: Vec<(u64, u64)> = (0..8u64).map(|i| (i, i)).collect();
+    all.push((u64::MAX, u64::MAX));
+    let build = || CowBTree::<4, 4, 8>::from_sorted(&all);
+
+    let t = build();
+    assert!(
+        t.root_is_branch(),
+        "the test needs a branch root or it does not exercise the routing loop"
+    );
+
+    let mut t = build();
+    t.remove_batch(&[(u64::MAX, u64::MAX)]);
+    assert_eq!(
+        tree_pairs(&t),
+        all[..8].to_vec(),
+        "the maximal tuple must be removable by batch, like any other"
+    );
+    check_invariants(&t, false);
+
+    // And as part of a wider batch, where it is the last entry.
+    let mut t = build();
+    t.remove_batch(&[(3, 3), (u64::MAX, u64::MAX)]);
+    let expected: Vec<(u64, u64)> = all[..8].iter().copied().filter(|&(k, _)| k != 3).collect();
+    assert_eq!(tree_pairs(&t), expected);
+
+    // Parity with the single-remove path, which does not use the sentinel routing.
+    let mut singly = build();
+    singly.remove(u64::MAX, u64::MAX);
+    let mut batched = build();
+    batched.remove_batch(&[(u64::MAX, u64::MAX)]);
+    assert_eq!(tree_pairs(&batched), tree_pairs(&singly));
+}
+
+/// The insert side has the identical sentinel routing, so it needs the identical check: the
+/// maximal tuple must be insertable into a tree whose root is a branch.
+#[test]
+fn insert_batch_handles_the_maximal_tuple() {
+    let base: Vec<(u64, u64)> = (0..8u64).map(|i| (i, i)).collect();
+    let mut t = CowBTree::<4, 4, 8>::from_sorted(&base);
+    assert!(
+        t.root_is_branch(),
+        "need a branch root to exercise the routing"
+    );
+
+    t.insert_batch(&[(u64::MAX, u64::MAX)]);
+    let mut expected = base.clone();
+    expected.push((u64::MAX, u64::MAX));
+    assert_eq!(
+        tree_pairs(&t),
+        expected,
+        "the maximal tuple must be insertable by batch, like any other"
+    );
+    check_invariants(&t, false);
 }

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -95,6 +95,43 @@ fn assert_first_doc_matches<const L: usize, const B: usize, const D: usize>(
     );
 }
 
+/// A branch separator is a *routing* boundary, not a live `min(right child)`. Remove a child's
+/// minimum without underflowing it and the separator keeps naming the removed tuple — so a lookup
+/// that reads a doc straight out of the separator returns an entry that is no longer in the tree.
+///
+/// Two full leaves, separator `(1, 1)`. Removing `(1, 1)` leaves the right leaf with three entries,
+/// which is above `min_fill`, so nothing rebalances and nothing rewrites the separator.
+#[test]
+fn first_doc_does_not_return_a_removed_separator() {
+    let mut t = CowBTree::<4, 4, 8>::from_sorted(&[
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (1, 1),
+        (1, 2),
+        (1, 3),
+        (1, 4),
+    ]);
+    assert_eq!(t.first_doc(1), Some(1));
+
+    t.remove(1, 1);
+    assert_eq!(
+        t.first_doc(1),
+        Some(2),
+        "first_doc must not hand back the doc named by a stale separator"
+    );
+    assert_eq!(t.first_doc(1), t.point(1).next(), "vs the cursor");
+    assert!(t.contains_key(1));
+
+    // And the same key going empty must report absent, not the last separator standing.
+    for doc in [2, 3, 4] {
+        t.remove(1, doc);
+    }
+    assert_eq!(t.first_doc(1), None);
+    assert!(!t.contains_key(1));
+}
+
 #[test]
 fn first_doc_matches_reference_across_configs() {
     // Empty + single-entry edge cases.
@@ -1246,12 +1283,23 @@ fn differential<const L: usize, const B: usize, const DOC_BYTES: usize>(
         let mut pt: Vec<u64> = tree.point(k).collect();
         pt.sort_unstable();
         assert_eq!(pt, ref_range(&oracle, k, k), "point {k} diverged");
+        // `first_doc` takes a *different* path to the same answer — a stackless reference descent
+        // rather than the cursor — so it needs its own parity check under removal. Reusing the
+        // point query's key and oracle makes it free.
+        assert_eq!(
+            tree.first_doc(k),
+            pt.first().copied(),
+            "first_doc {k} diverged"
+        );
     }
     assert_eq!(
         tree_range(&tree, 0, u64::MAX),
         ref_range(&oracle, 0, u64::MAX),
         "range scan diverged"
     );
+    // Every key, its absent neighbours, and the sentinel — after a run of interleaved
+    // inserts and removes, which is the state the per-op sampling may not have landed on.
+    assert_first_doc_matches(&tree, &oracle);
 }
 
 #[test]

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1481,14 +1481,14 @@ fn integrity_adversarial_ascending_then_cascade_delete() {
     for i in 0..300u64 {
         t.insert(i, i);
         oracle.insert((i, i));
-        check_invariants(&t, false);
+        check_invariants(&t, true);
     }
     for i in 0..300u64 {
         let k = (i * 7) % 300; // gcd(7, 300) == 1 ⇒ a permutation of 0..300
         t.remove(k, k);
         oracle.remove(&(k, k));
         assert_eq!(tree_pairs(&t), oracle.iter().copied().collect::<Vec<_>>());
-        check_invariants(&t, false);
+        check_invariants(&t, true);
     }
     assert!(t.is_empty());
     assert_eq!(t.len(), 0);

--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -1313,8 +1313,10 @@ fn integrity_differential_across_sizes() {
     differential::<32, 8, 8>(0x5555_5555, 3000, 80); // narrow branch, wide leaf
     differential::<256, 256, 8>(0x6666_6666, 4000, 800);
 
-    // Same sweep at the narrow (u32) doc width — the 12 B/entry AoS layout the
-    // tensor's EdgeIdStore uses. Docs are `rng % key_space` (well under u32), so
+    // Same sweep at the narrow (u32) doc width — a 12 B/entry AoS layout instead of 16.
+    // No production instantiation narrows today; this keeps the const generic honest so a
+    // future one cannot discover the width is only ever exercised at 8. Docs are
+    // `rng % key_space` (well under u32), so
     // this stresses split/merge/borrow/collapse + leaf round-trip at DOC_BYTES=4.
     differential::<4, 4, 4>(0x1111_2222, 3000, 30);
     differential::<5, 5, 4>(0x2222_3333, 3000, 30);

--- a/graph/src/index/falkordb/data_structures/mod.rs
+++ b/graph/src/index/falkordb/data_structures/mod.rs
@@ -1,4 +1,4 @@
-//! Standalone data structures backing the native (non-RediSearch) index.
+//! Standalone data structures backing the FalkorDB (non-RediSearch) index.
 //!
 //! These are dependency-free building blocks (depend only on `std`); the index layer is wired on top
 //! in later changes.


### PR DESCRIPTION
Closes #2380

## What

Adds six enhancements to the always-compiled CoW B⁺-tree substrate (`graph/src/index/falkordb/data_structures/cow_btree/`), harvested from the tensor-decouple work:

1. **`first_doc(key)` / `contains_key(key)`** — allocation-free reference-descent point lookup. Unlike `point()→RangeIter` it clones no page `Arc`s and allocates no cursor stack, so it's the cheap primitive for equality filters / `EXISTS` / "one representative doc" probes. Handles the child-boundary case (a key whose entries begin at a separator) via a recorded `right_sep`.
2. **`heap_bytes()`** — approximate resident-memory accounting (leaf blob bytes + branch vec sizes), the primitive `GRAPH.MEMORY` needs. `O(pages)`; call off hot paths.
3. **`insert` / `remove` return a `#[must_use]` changed-`bool`** — lets a caller maintain an exact live cardinality in `O(1)` instead of an `O(n)` page walk, and cleanly detects idempotent-insert / absent-remove no-ops. (The change signal is distinct from `remove`'s internal underflow flag.)
4. **`DOC_BYTES` const generic** (`CowBTree<LEAF_MAX, BRANCH_MAX, const DOC_BYTES = 8>`) — narrows the fixed-stride AoS doc field (16→12 B/entry for a 4-byte doc), capturing the per-entry saving the compaction gate forfeits on high-entropy keys. **Defaults to 8** (byte-for-byte identical to today); a narrower width `assert!`s loudly on an over-width doc — no silent truncation. Nothing is instantiated below 8 in this PR.
5. **`Extract` / `TupleExtract` + `range_tuples`** — a zero-cost cursor generalization (`const NEEDS_KEY`) so a scan can also yield the encoded key for covered / index-only reads. The doc-only fast path is unchanged.
6. **`for_each_tuple`** — a bulk full-scan that matches each leaf's format once and runs a tight inner loop (for eager whole-tree consumers: memory/stats/serialize), faster than the lazy cursor.

## Why now / no call sites yet

These enhance the **substrate ahead of its consumers**: the native numeric index that uses `CowBTree` is a separate in-flight PR, and the edge-id store is its own. The methods are `pub` API of the always-compiled `cow_btree` module, so there are intentionally no in-tree callers yet. Landing them here keeps the substrate ready and lets the consumer PRs stay small.

## Compatibility & tests

- **No behavior change for existing code:** `DOC_BYTES` defaults to 8; nothing outside `cow_btree` references the tree today.
- **Correctness gate:** the differential (`BTreeSet` oracle) + fuzz + invariant test suite is kept green and **extended to the 4-byte doc width**, plus a `first_doc`-vs-oracle test across fan-outs and both doc widths. `cargo test -p graph cow_btree`: **27 passed**. `cargo check -p graph` compiles; clippy clean.

Independent of the native-index feature work; targets `main-rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable document storage widths for improved flexibility and memory efficiency.
  * Added tuple-based range iteration and bulk tuple traversal.
  * Added key lookup helpers, first-document retrieval, and heap usage reporting.
  * Insert and remove operations now report whether a tuple was added or removed.

* **Bug Fixes**
  * Improved document encoding and iteration across supported formats and widths.
  * Prevented duplicate structural filters during optimization.
  * Expanded handling of boundary, empty, collision, and deep-tree cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
