### PR TITLE
ci: require every PR to close an issue

### DIFF
--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -1,0 +1,90 @@
+# Require every PR to close an issue.
+#
+# This check is intended to be REQUIRED in branch protection, which drives two
+# deliberate design choices:
+#
+#   1. No `paths:` filter. A required status check that never reports leaves the
+#      PR blocked forever, so this job must run on every PR to a covered branch.
+#   2. `edited` is in the trigger list. Editing the PR body is how a PR gains (or
+#      loses) a `Closes #N` link, so without it the verdict would go stale.
+#
+# There are no exemptions: bot PRs (dependabot, batch-backport) must also close
+# an issue. That is a deliberate policy choice, not an oversight.
+
+name: PR linked issue
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    # Mirrors rust-pr.yml's branch filter.
+    branches:
+      - "main"
+      - "main-rs"
+      - "[0-9]*.[0-9]*"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-linked-issue-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  linked-issue:
+    name: PR closes an issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the PR closes an issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # closingIssuesReferences is the only source that covers BOTH a
+          # `Closes #N` keyword in the PR body AND an issue attached through the
+          # PR's "Development" sidebar. REST exposes neither.
+          #
+          # The query is single-quoted on purpose: $owner/$repo/$n are GraphQL
+          # variables bound by the -F flags below and must NOT be expanded by the
+          # shell.
+          # shellcheck disable=SC2016
+          COUNT=$(gh api graphql \
+            -f query='
+              query($owner: String!, $repo: String!, $n: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $n) {
+                    closingIssuesReferences(first: 1) { totalCount }
+                  }
+                }
+              }' \
+            -F owner="$OWNER" -F repo="$REPO" -F n="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.totalCount')
+
+          if [ "${COUNT:-0}" -gt 0 ]; then
+            echo "PR #${PR} closes ${COUNT} issue(s)."
+            {
+              echo "### PR closes an issue"
+              echo ""
+              echo "Linked closing issues: **${COUNT}**."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error title=No linked issue::This PR does not close an issue. Add 'Closes #<n>' to the PR body."
+          {
+            echo "### No linked issue"
+            echo ""
+            echo "Every PR must close an issue. Fix it in one of two ways:"
+            echo ""
+            echo "1. **Recommended** — add \`Closes #<n>\` (or \`Fixes #<n>\`) to the PR body."
+            echo "   Editing the body re-runs this check automatically."
+            echo "2. Attach the issue via the PR's **Development** sidebar."
+            echo "   Note: that does *not* emit a \`pull_request\` event, so this check"
+            echo "   will not re-evaluate on its own — re-run it afterwards."
+            echo ""
+            echo "If no issue exists yet, open one describing the change and link it."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -5,11 +5,24 @@
 #
 #   1. No `paths:` filter. A required status check that never reports leaves the
 #      PR blocked forever, so this job must run on every PR to a covered branch.
-#   2. `edited` is in the trigger list. Editing the PR body is how a PR gains (or
-#      loses) a `Closes #N` link, so without it the verdict would go stale.
+#   2. `edited` is in the trigger list, so re-titling/re-describing a PR
+#      re-evaluates the verdict rather than leaving a stale one.
 #
 # There are no exemptions: bot PRs (dependabot, batch-backport) must also close
 # an issue. That is a deliberate policy choice, not an oversight.
+#
+# WHY THE DEVELOPMENT SIDEBAR, NOT `Closes #N` KEYWORDS: GitHub only registers a
+# closing link from a body keyword when the PR targets the repository's DEFAULT
+# branch. Verified on this repo — PR #2245 (base `main-rs`, default `master`)
+# reported 0 closing references with `Closes #2243` as the first line of its
+# body, then reported 1 as soon as the issue was attached through the
+# Development sidebar. Development happens on non-default branches (`main-rs`,
+# `main`, version branches), so the sidebar is the mechanism authors must use and
+# the one the failure message points at. Do not "simplify" that guidance back to
+# keywords.
+#
+# Consequence: a sidebar link emits no `pull_request` event, so this check does
+# not re-evaluate itself after linking — it has to be re-run.
 
 name: PR linked issue
 
@@ -73,17 +86,22 @@ jobs:
             exit 0
           fi
 
-          echo "::error title=No linked issue::This PR does not close an issue. Add 'Closes #<n>' to the PR body."
+          echo "::error title=No linked issue::This PR does not close an issue. Link one via the PR's Development sidebar, then re-run this check."
           {
             echo "### No linked issue"
             echo ""
-            echo "Every PR must close an issue. Fix it in one of two ways:"
+            echo "Every PR must close an issue."
             echo ""
-            echo "1. **Recommended** — add \`Closes #<n>\` (or \`Fixes #<n>\`) to the PR body."
-            echo "   Editing the body re-runs this check automatically."
-            echo "2. Attach the issue via the PR's **Development** sidebar."
-            echo "   Note: that does *not* emit a \`pull_request\` event, so this check"
-            echo "   will not re-evaluate on its own — re-run it afterwards."
+            echo "**Link it via the PR's \`Development\` sidebar** — right-hand panel →"
+            echo "*Development* → pick the issue."
+            echo ""
+            echo "Linking that way emits no \`pull_request\` event, so this check does not"
+            echo "re-evaluate on its own — **re-run it** once the issue is linked."
+            echo ""
+            echo "> A \`Closes #<n>\` keyword in the PR body only registers a closing link when"
+            echo "> the PR targets the repository's **default branch**. On \`main-rs\`, \`main\`"
+            echo "> and version branches it has no effect, so the sidebar is the mechanism that"
+            echo "> works. Writing the keyword anyway is still useful for humans reading the PR."
             echo ""
             echo "If no issue exists yet, open one describing the change and link it."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Re-creation of #2245 against `main`. Same two commits, same single file — see the note at the bottom on why a base change wasn't possible.

Part of #2280.

## What it does

Adds `.github/workflows/pr-linked-issue.yml`, which fails a PR that doesn't close an issue — intended to become a **required status check** in branch protection.

### Detection

Queries GraphQL `closingIssuesReferences`, the only source that covers **both** a `Closes #N` keyword in the PR body **and** an issue attached through the PR's "Development" sidebar. REST exposes neither.

### Design choices worth reviewing

- **No `paths:` filter** — a required check that never reports blocks the PR indefinitely, so it must run on every PR to a covered branch.
- **`edited` in the trigger list** — re-titling or re-describing a PR re-evaluates the verdict instead of leaving a stale one.
- **Branch filter** mirrors `rust-pr.yml`: `main`, `main-rs`, `[0-9]*.[0-9]*`.
- **Read-only permissions** (`contents: read`, `pull-requests: read`).
- **No exemptions** — bot PRs must close an issue too. Deliberate policy; see the consequence below.

## How linking actually works here (verified)

**On a non-default base, the Development sidebar is the only mechanism that works.** GitHub registers a closing link from a body keyword *only* when the PR targets the repository's **default branch**.

Measured on #2245 (base `main-rs`, default `master`):

| state | `closingIssuesReferences` |
| --- | --- |
| `Closes #2243` as the first body line | **0** |
| issue attached via the Development sidebar | **1** |

Corroborated: GitHub search reported that PR as `-linked:issue`, and its timeline held no `CONNECTED_EVENT` / `CROSS_REFERENCED_EVENT`. The link genuinely doesn't exist, so no API can report it.

The failure message therefore points at the sidebar, and notes that a sidebar link emits no `pull_request` event — so the check must be **re-run** after linking. Observed live on #2245: failed at creation, passed on re-run once linked.

> **This resolves itself once `main` is the default branch.** Body keywords will register normally for PRs targeting `main`, and merging will auto-close the linked issue. Until the flip, the sidebar remains the reliable route.

## Before making it a required check

1. Let it report once so the check name exists in branch protection.
2. Be ready for it to block the next Dependabot PR and any `batch-backport` PR — there are no exemptions.

## Why this isn't just a base change on #2245

#2245's branch descends from `main-rs`. The migration commit on `main` (#2279) has a **single parent on `master`'s lineage**, so `main` and `main-rs` share **no common ancestor** — `git merge-base` returns nothing. Retargeting would have made GitHub diff the entire tree rather than this one file.

Since `main`'s tree is byte-identical to `main-rs`'s (`50390330`), the two commits cherry-picked cleanly onto a `main`-based branch. Verified afterwards: one file, 108 insertions, `actionlint` clean.

#2245 is closed in favour of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to ensure pull requests targeting supported branches include at least one linked closing issue.
  * Pull requests without a linked issue now receive clear guidance and cannot pass the required check until updated.
  * Checks automatically re-run when pull request details change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->