### PR TITLE
ci: move C's rolling images to the edge-c channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -918,16 +918,29 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Dispatch release-image.yml for the edge channel
+      - name: Dispatch release-image.yml for the edge-c channel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          # `edge-c`, not `edge`: now that `main` (Rust engine) is the default
+          # branch, the plain `:edge` channel serves the Rust image, published by
+          # rust-push.yml on `main`. This is the C engine's own rolling channel.
+          #
+          # release-image.yml derives EVERY tag it pushes from TAG_NAME, so this
+          # one value renames the whole family in step:
+          #   edge-c, edge-c-x64, edge-c-arm64v8, edge-c-alpine{,-x64,-arm64v8},
+          #   edge-c-rhel8-x64, edge-c-rhel9-x64, edge-c-amazonlinux2023-x64
+          # and the falkordb-server equivalents.
+          #
+          # Renaming rather than deleting keeps a rolling image for testing
+          # `master` before a 5.x release, and makes reverting the channel swap a
+          # one-line change. See issue #2290.
           gh workflow run release-image.yml --ref master \
-            -f tag=edge \
+            -f tag=edge-c \
             -f commit_sha="$SHA" \
             -f run_falkordb_cloud_update=false \
             -f run_testflight_workflow=false
-          echo "dispatched release-image.yml for edge at ${SHA}"
+          echo "dispatched release-image.yml for edge-c at ${SHA}"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -69,9 +69,15 @@ jobs:
             TAG_NAME=${{ github.event.inputs.tag }}
           fi
 
-          # If the event is a workflow_run, and branch is master, set to "edge"
+          # If the event is a workflow_run, and branch is master, set to "edge-c"
+          #
+          # Currently UNREACHABLE: the workflow_run trigger was removed above, so
+          # build.yml's publish-edge job dispatches this workflow instead. Kept in
+          # step with that dispatch (`edge-c`, not `edge`) so that re-adding the
+          # trigger cannot resurrect a C-side publisher for the plain `:edge`
+          # channel, which now serves the Rust image from `main`. See #2290.
           if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" == "master" ]; then
-            TAG_NAME="edge"
+            TAG_NAME="edge-c"
           fi
 
           # If the event is a workflow_run, and branch is not master, set to the branch name


### PR DESCRIPTION
**Step 1 of 2** for #2290. This one must merge **first** — see Ordering.

`main` (Rust engine) is now the default branch, so the plain `:edge` channel should serve the Rust image. This gives the C engine its own rolling channel rather than taking it away.

## Change

`build.yml`'s `publish-edge` job dispatches `release-image.yml` with `-f tag=edge` → **`-f tag=edge-c`**.

Because `release-image.yml` derives **every** tag it pushes from `env.TAG_NAME`, that single value renames the whole family:

```
edge-c            edge-c-x64            edge-c-arm64v8
edge-c-alpine     edge-c-alpine-x64     edge-c-alpine-arm64v8
edge-c-rhel8-x64  edge-c-rhel9-x64      edge-c-amazonlinux2023-x64
```
…plus the `falkordb-server` equivalents — 15 tags in total, all still rolling for C.

Also renames the **unreachable** `TAG_NAME="edge"` in `release-image.yml`'s `workflow_run` arm (that trigger was removed when `publish-edge` took over the hand-off). Keeping it in step means re-adding the trigger can't resurrect a C-side publisher for the plain `:edge` channel and race the Rust one.

## Why rename rather than delete

- C is maintained through 5.x and benefits from a rolling image for testing `master` before a release.
- Reverting the whole channel swap becomes a **one-line change**.
- Nothing is deleted, so no consumer loses an image outright — they just move to an explicitly-named channel.

## Ordering — this PR first

The two halves live on **different branches** and cannot be atomic. If the Rust side starts publishing `:edge` while C still does, `:edge` **flip-flops per push** depending on which branch was touched last — worse than either steady state.

Merging this first leaves `:edge` frozen-but-stable during the gap, then step 2 (on `main`) picks it up.

## Behaviour

No change beyond the tag names. The `Verify tag matches version.h` step is gated on `startsWith(env.TAG_NAME, 'v')`, which is false for `edge-c` exactly as it was for `edge`, so it still skips. `actionlint`: **28 findings before and after**.

## Resulting tag landscape (after both steps)

| tag | engine |
| --- | --- |
| `falkordb/falkordb:edge`, `-server:edge` | **Rust** (rolling, from `main`) |
| `…:edge-rs` | Rust — alias, deprecated later |
| `ghcr.io/falkordb/…:edge` | **Rust** (new; C never published to GHCR) |
| `…:edge-c*` (15 tags) | **C** (rolling, from `master`) |
| `…:latest` | C 4.21.x — untouched; that's the separate 6.0 GA decision |

## Follow-up not in this PR

Once this merges, the pre-existing `edge-alpine` / `edge-rhel8-x64` / `edge-rhel9-x64` / `edge-amazonlinux2023-x64` / `edge-x64` / `edge-arm64v8` tags (and `-server` equivalents) stop being written and sit frozen on Docker Hub — so `:edge` would be rolling Rust while `:edge-alpine` is a stale C build under the same channel name. Recommend deleting them; tracked in #2290.
