### PR TITLE
ci: publish the Rust image to the rolling :edge channel

### DIFF
--- a/.github/workflows/rust-push.yml
+++ b/.github/workflows/rust-push.yml
@@ -4,14 +4,14 @@ on:
   push:
     # Mirror rust-pr.yml's filter so post-merge CI on version branches works
     # the same as on a trunk. Channel-pointer promotion (toolchain :latest,
-    # edge-rs) is still gated to a TRUNK further down — see the `if:` on those
+    # :edge) is still gated to a TRUNK further down — see the `if:` on those
     # jobs. The version glob is `[0-9]*.[0-9]*` (glob, not regex; `*` is
     # multi-char).
     #
     # TRUNK = `main` (this repo) or `main-rs` (the interim Rust branch in
     # FalkorDB/FalkorDB, which carries this tree while the C engine keeps
     # `master`). Both promote the same channels, so the migration doesn't
-    # silently stop publishing `edge-rs`. Gates below spell this as
+    # silently stop publishing the rolling image. Gates below spell this as
     # contains(fromJSON('["refs/heads/main","refs/heads/main-rs"]'), github.ref).
     branches:
       - "main"
@@ -56,7 +56,7 @@ jobs:
           fi
   # Look up the merging PR once and share the number with the promote-* jobs.
   # Same SHA→PR API call used by release-image.yml's release-event flow.
-  # Trunk-only: version branches don't promote toolchain or edge-rs.
+  # Trunk-only: version branches don't promote toolchain or :edge.
   #
   # A commit with no PR *in this repo* is not an error — it just means no
   # rc-pr-<N> image was ever built for it, so there is nothing to promote. The
@@ -93,7 +93,7 @@ jobs:
             #   - someone pushes (or force-pushes) straight to a trunk.
             # Emit an empty pr_n; the promote-* jobs below skip on it. Downside
             # accepted: a direct push to a trunk now skips promotion quietly
-            # instead of erroring, so watch for this notice if edge-rs stops
+            # instead of erroring, so watch for this notice if :edge stops
             # advancing.
             echo "::notice::commit ${SHA} has no merged PR in ${REPO}; skipping channel promotion (no rc-pr-<N> image to retag)"
             echo "n=" >> "$GITHUB_OUTPUT"
@@ -132,12 +132,15 @@ jobs:
             -t ghcr.io/falkordb/falkordb-build:latest \
             "ghcr.io/falkordb/falkordb-build:pr-${PR_NUM}"
 
-  # Promote the merging PR's runtime RC images (rc-pr-<N>) to the edge-rs
-  # channel on every trunk merge — same byte-identical retag, no rebuild.
-  # `edge-rs` distinguishes the Rust port from the C port's `:edge` on the
-  # shared falkordb/falkordb repos, so publishing to BOTH registries cannot
-  # clobber the C channel. Bare `:latest` is untouched (that pointer only moves
-  # at 6.0 GA, via release-image.yml).
+  # Promote the merging PR's runtime RC images (rc-pr-<N>) to the rolling
+  # `:edge` channel on every trunk merge — same byte-identical retag, no
+  # rebuild.
+  #
+  # `:edge` serves the Rust engine now that this tree is the default branch.
+  # The C engine's rolling images moved to the `edge-c` family on `master`, and
+  # C never published to GHCR, so there is no contention on either registry.
+  # `:edge-rs` stays as a deprecated alias. Bare `:latest` is untouched — that
+  # pointer only moves at 6.0 GA, via release-image.yml. See issue #2290.
   promote-edge:
     needs: find-pr
     if: ${{ needs.find-pr.outputs.pr_n != '' && contains(fromJSON('["refs/heads/main","refs/heads/main-rs"]'), github.ref) }}
@@ -165,7 +168,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Promote rc-pr-${{ needs.find-pr.outputs.pr_n }} → edge-rs (${{ matrix.repo }})
+      - name: Promote rc-pr-${{ needs.find-pr.outputs.pr_n }} → :edge (${{ matrix.repo }})
         env:
           PR_NUM: ${{ needs.find-pr.outputs.pr_n }}
           REPO:   ${{ matrix.repo }}
@@ -175,7 +178,17 @@ jobs:
           # registries — still a retag, never a rebuild, so the bytes PR CI
           # validated are the bytes that ship. Same pattern release-image.yml
           # uses for semver tags.
+          # `:edge` is the primary rolling channel now that this tree is the
+          # default branch. `:edge-rs` is kept as an alias so anything already
+          # pinned to it keeps working — same manifest, so the extra tags cost
+          # nothing. It is deprecated and will be dropped once consumers move.
+          #
+          # No contention with the C engine: its rolling images moved to the
+          # `edge-c` family on `master`, and C never published to GHCR at all.
+          # See issue #2290.
           docker buildx imagetools create \
+            -t "ghcr.io/falkordb/${REPO}:edge" \
+            -t "docker.io/falkordb/${REPO}:edge" \
             -t "ghcr.io/falkordb/${REPO}:edge-rs" \
             -t "docker.io/falkordb/${REPO}:edge-rs" \
             "ghcr.io/falkordb/${REPO}:rc-pr-${PR_NUM}"


### PR DESCRIPTION
**Step 2 of 2** for #2290. ⚠️ **Merge #2291 first** — see Ordering.

This tree is now the default branch, so the rolling `:edge` channel should serve the Rust engine.

## Change

`promote-edge` already retags the PR's validated `rc-pr-<N>` manifest. This adds `:edge` to the same `imagetools create` call on both registries, **keeping `:edge-rs`** as an alias:

```
-t ghcr.io/falkordb/${REPO}:edge          ← new
-t docker.io/falkordb/${REPO}:edge        ← new
-t ghcr.io/falkordb/${REPO}:edge-rs       ← kept (deprecated alias)
-t docker.io/falkordb/${REPO}:edge-rs     ← kept (deprecated alias)
```

Applies to both `falkordb` and `falkordb-server` via the existing matrix. It remains a **retag, never a rebuild** — the bytes PR CI validated are the bytes that ship.

Keeping `edge-rs` costs nothing: all four tags point at the same manifest, so there's no extra build. Anything already pinned to `edge-rs` keeps working; it gets dropped once consumers have moved.

## ⚠️ Ordering — #2291 must merge first

The two halves live on **different branches** and cannot be atomic. If this merges while `master` still publishes `:edge`, the tag **flip-flops per push** depending on which branch was touched last — worse than either steady state.

#2291 moves C's rolling images to the `edge-c` family. Once that's in, there is no contention on either registry:

- **Docker Hub** — C now writes `edge-c*`, this writes `edge` / `edge-rs`
- **GHCR** — C never published there at all

## Also in this PR: comment corrections

Several comments asserted the *inverse* of the new arrangement — most directly:

> `edge-rs` distinguishes the Rust port from the C port's `:edge` … so publishing to BOTH registries cannot clobber the C channel

That was true when C owned `:edge`; it now reads backwards. The trigger header, the `find-pr` notice, the `promote-edge` block header and the step name are updated to match. Stale comments that state the opposite of the code are worse than none.

## Resulting tag landscape

| tag | engine |
| --- | --- |
| `falkordb/falkordb:edge`, `-server:edge` | **Rust** (rolling, from `main`) |
| `ghcr.io/falkordb/…:edge` | **Rust** (new — C never published to GHCR) |
| `…:edge-rs` | Rust — alias, deprecated |
| `…:edge-c*` (15 tags) | C (rolling, from `master`, via #2291) |
| `…:latest` | C 4.21.x — untouched; separate 6.0 GA decision |

After this, `:edge` and `:latest` deliberately serve different engines — coherent ("edge is the future"), but it needs saying in the Docker Hub description. Tracked in #2290.

## Verification

`actionlint` reports **14 findings before and after** — none introduced. Runtime effect is observable on the first merge to `main` after this lands: `:edge` and `:edge-rs` should resolve to the same digest on both registries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime release-candidate images are now promoted to the primary `:edge` channel.
  - The `:edge-rs` channel remains available as a deprecated alias.

- **Bug Fixes**
  - Promotion behavior now consistently uses updated `edge` terminology.
  - Toolchain and channel promotions remain limited to the appropriate main branches.
  - Promotions are safely skipped with a notice when merged pull requests are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->