### PR TITLE
Batch GRAPH.BULK relation topology construction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,6 +499,27 @@ jobs:
         if: matrix.platform.use_docker && matrix.build_type == 'release'
         run: docker load --input /tmp/falkordb-${{ matrix.platform.suffix }}.tar
 
+      - name: Sanity test base image
+        if: matrix.platform.use_docker && matrix.build_type == 'release'
+        run: |
+          set -euo pipefail
+          docker run -d --name falkordb-sanity -p 6379:6379 -p 3000:3000 falkordb/falkordb-${{ matrix.platform.suffix }}
+          # Wait for redis to accept connections
+          for i in $(seq 1 30); do
+            if docker exec falkordb-sanity redis-cli ping 2>/dev/null | grep -q PONG; then break; fi
+            if [ "$i" -eq 30 ]; then echo "redis did not become ready"; docker logs falkordb-sanity; exit 1; fi
+            sleep 2
+          done
+          # Verify the FalkorDB module is loaded
+          docker exec falkordb-sanity redis-cli MODULE LIST | grep -qi graph
+          # Base image bundles the browser - check it responds on port 3000
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://localhost:3000; then break; fi
+            if [ "$i" -eq 30 ]; then echo "browser did not become ready"; docker logs falkordb-sanity; exit 1; fi
+            sleep 2
+          done
+          docker rm -f falkordb-sanity
+
       - name: Upload base image
         if: matrix.platform.use_docker && matrix.build_type == 'release'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -521,6 +542,21 @@ jobs:
             BASE_IMAGE=localhost:5000/falkordb/falkordb-compiler-${{ matrix.platform.suffix }}
             TARGETPLATFORM=linux/${{ matrix.platform.arch }}
             BROWSER_TAG=${{ env.BROWSER_TAG }}
+
+      - name: Sanity test server image
+        if: matrix.platform.use_docker && steps.dockerfile.outputs.build_server == 'true'
+        run: |
+          set -euo pipefail
+          docker load --input /tmp/falkordb-server-${{ matrix.platform.suffix }}.tar
+          docker run -d --name falkordb-server-sanity -p 6380:6379 falkordb/falkordb-server-${{ matrix.platform.suffix }}
+          # Server image has no browser - only verify redis + module
+          for i in $(seq 1 30); do
+            if docker exec falkordb-server-sanity redis-cli ping 2>/dev/null | grep -q PONG; then break; fi
+            if [ "$i" -eq 30 ]; then echo "redis did not become ready"; docker logs falkordb-server-sanity; exit 1; fi
+            sleep 2
+          done
+          docker exec falkordb-server-sanity redis-cli MODULE LIST | grep -qi graph
+          docker rm -f falkordb-server-sanity
 
       - name: Upload server image
         if: matrix.platform.use_docker && steps.dockerfile.outputs.build_server == 'true'

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           echo "Tag: ${{ env.TAG_NAME }}, version.h: ${FILE_VERSION}"
           if [ "${{ env.TAG_NAME }}" != "${FILE_VERSION}" ]; then

--- a/.github/workflows/release-ramp.yml
+++ b/.github/workflows/release-ramp.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           git fetch origin ${{ env.COMMIT_SHA }} --depth=1
           VERSION_H=$(git show ${{ env.COMMIT_SHA }}:src/version.h)
-          MAJOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MAJOR | awk '{print $3}')
-          MINOR=$(echo "$VERSION_H" | grep FALKOR_VERSION_MINOR | awk '{print $3}')
-          PATCH=$(echo "$VERSION_H" | grep FALKOR_VERSION_PATCH | awk '{print $3}')
+          MAJOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MAJOR ' | awk '{print $3}')
+          MINOR=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_MINOR ' | awk '{print $3}')
+          PATCH=$(echo "$VERSION_H" | grep '^#define FALKOR_VERSION_PATCH ' | awk '{print $3}')
           FILE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
           TAG="${{ steps.set_semver.outputs.TAG_NAME }}"
           echo "Tag: ${TAG}, version.h: ${FILE_VERSION}"

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -35,7 +35,11 @@ RUN ln -s ${FALKORDB_BIN_PATH} /FalkorDB/build/docker && \
     ln -s ${FALKORDB_DATA_PATH} /data
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgomp1 ca-certificates bash && \
+    apt-get install -y --no-install-recommends libgomp1 ca-certificates bash gosu uidmap && \
+    ln -sf "$(command -v gosu)" /usr/local/bin/su-exec && \
+    # Create nextjs user for running the browser (before passwd/login are purged below)
+    groupadd -g 1001 nodejs && \
+    useradd -r -u 1001 -g nodejs nextjs && \
     apt-get dist-upgrade -y && \
     # Remove packages not needed at runtime to reduce CVE surface
     (apt-get purge -y python3.13 python3.13-minimal libpython3.13-minimal libpython3.13-stdlib || true) && \
@@ -65,6 +69,11 @@ COPY --from=compiler /FalkorDB/bin/linux*/falkordb.so ${FALKORDB_BIN_PATH}/falko
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}
 
 COPY --from=browser /usr/local/bin/docker-entrypoint.sh ${FALKORDB_BROWSER_PATH}
+
+# set ownership for the nextjs user
+RUN chown -R 1001:1001 ${FALKORDB_BROWSER_PATH} && \
+    mkdir -p /app/.data && \
+    chown -R 1001:1001 /app/.data
 
 ENV ARCH=${TARGETPLATFORM}
 

--- a/build/docker/Dockerfile.alpine
+++ b/build/docker/Dockerfile.alpine
@@ -27,7 +27,10 @@ ENV FALKORDB_BROWSER_PATH=${FALKORDB_HOME}/browser
 # Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS,
 # ca-certificates for HTTPS in LOAD CSV)
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash libgomp openssl ca-certificates
+    apk add --no-cache bash libgomp openssl ca-certificates su-exec && \
+    # Create nextjs user for running the browser
+    addgroup -g 1001 nodejs && \
+    adduser -S -u 1001 -G nodejs nextjs
 
 WORKDIR ${FALKORDB_HOME}
 
@@ -44,6 +47,11 @@ COPY --from=compiler /FalkorDB/bin/linux*/falkordb.so ${FALKORDB_BIN_PATH}/falko
 COPY --from=browser /app ${FALKORDB_BROWSER_PATH}
 
 COPY --from=browser /usr/local/bin/docker-entrypoint.sh ${FALKORDB_BROWSER_PATH}
+
+# set ownership for the nextjs user
+RUN chown -R 1001:1001 ${FALKORDB_BROWSER_PATH} && \
+    mkdir -p /app/.data && \
+    chown -R 1001:1001 /app/.data
 
 ENV ARCH=${TARGETPLATFORM}
 

--- a/build/docker/Dockerfile.alpine-server
+++ b/build/docker/Dockerfile.alpine-server
@@ -19,7 +19,7 @@ ENV FALKORDB_TLS_PATH=${FALKORDB_HOME}/tls
 # Install only runtime dependencies (openssl for TLS cert generation, libgomp for GraphBLAS,
 # ca-certificates for HTTPS in LOAD CSV)
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash libgomp openssl ca-certificates
+    apk add --no-cache bash libgomp openssl ca-certificates su-exec
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/build/docker/Dockerfile.server
+++ b/build/docker/Dockerfile.server
@@ -26,7 +26,8 @@ RUN ln -s ${FALKORDB_BIN_PATH} /FalkorDB/build/docker && \
     ln -s ${FALKORDB_DATA_PATH} /data
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgomp1 ca-certificates bash && \
+    apt-get install -y --no-install-recommends libgomp1 ca-certificates bash gosu && \
+    ln -sf "$(command -v gosu)" /usr/local/bin/su-exec && \
     apt-get dist-upgrade -y && \
     # Remove packages not needed at runtime to reduce CVE surface
     (apt-get purge -y python3.13 python3.13-minimal libpython3.13-minimal libpython3.13-stdlib || true) && \

--- a/src/bulk_insert/bulk_insert.c
+++ b/src/bulk_insert/bulk_insert.c
@@ -15,6 +15,7 @@
 #include "../util/identifier_limits.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 // the first byte of each property in the binary stream
 // is used to indicate the type of the subsequent SIValue
@@ -388,6 +389,396 @@ static int _BulkInsert_ProcessNodeFile
 	return BULK_OK ;
 }
 
+// Attribute sets move into the edge DataBlock while records are decoded, so
+// each relation partition retains only the topology and stable ID.
+typedef struct {
+	EdgeID id ;
+	NodeID src ;
+	NodeID dest ;
+} BulkEdge ;
+
+typedef struct {
+	RelationID relation ;
+	BulkEdge *edges ;
+} BulkEdgeGroup ;
+
+// The matrix build has a fixed setup cost, so retain the existing delta path
+// for small requests and use it only once it can be amortized by the batch.
+#define BULK_REBUILD_MIN_EDGES 131072U
+
+// Retain the proven per-file path outside the bounded transaction. At larger
+// command sizes retaining every relation partition at once increases peak
+// memory and can make the public bulk-loader path slower.
+#define BULK_TRANSACTION_MAX_EDGES 1048576U
+
+// Locate (or create) the one command-wide record partition for a relation.
+// Multiple descriptor files for the same relation deliberately share it.
+static BulkEdgeGroup *_BulkInsert_GetEdgeGroup
+(
+	BulkEdgeGroup **groups,
+	RelationID relation,
+	uint initial_capacity
+) {
+	ASSERT (groups != NULL) ;
+
+	for (uint i = 0; i < arr_len (*groups); i++) {
+		if ((*groups)[i].relation == relation) {
+			return *groups + i ;
+		}
+	}
+
+	BulkEdgeGroup group = {
+		.relation = relation,
+		.edges = arr_new (BulkEdge, initial_capacity),
+	} ;
+	arr_append (*groups, group) ;
+	return *groups + arr_len (*groups) - 1 ;
+}
+
+// compare bulk edges by endpoint pair
+static int _BulkInsert_BulkEdgeEndpointCmp
+(
+	const void *a,
+	const void *b
+) {
+	const BulkEdge *ea = a ;
+	const BulkEdge *eb = b ;
+
+	if (ea->src != eb->src) {
+		return (ea->src > eb->src) - (ea->src < eb->src) ;
+	}
+
+	return (ea->dest > eb->dest) - (ea->dest < eb->dest) ;
+}
+
+// A matrix can be replaced only when both its forward and transpose state are
+// empty. Existing matrices use the regular delta-matrix insertion path below.
+static bool _BulkInsert_MatrixCanBeRebuilt
+(
+	Delta_Matrix matrix
+) {
+	ASSERT (matrix != NULL) ;
+
+	GrB_Index nvals = 0 ;
+	GrB_OK (Delta_Matrix_nvals (&nvals, matrix)) ;
+	if (nvals != 0 || !Delta_Matrix_Synced (matrix)) {
+		return false ;
+	}
+
+	Delta_Matrix transpose = Delta_Matrix_getTranspose (matrix) ;
+	if (transpose == NULL) {
+		return true ;
+	}
+
+	GrB_OK (Delta_Matrix_nvals (&nvals, transpose)) ;
+	return nvals == 0 && Delta_Matrix_Synced (transpose) ;
+}
+
+// Merge the already-built relation topologies into an empty adjacency matrix,
+// then derive its transpose once. This avoids another command-wide coordinate
+// array while still avoiding per-edge forward and transpose delta mutations.
+static void _BulkInsert_BuildAdjacency
+(
+	Graph *g,
+	Delta_Matrix matrix,
+	const RelationID *relations,
+	uint relation_count,
+	GrB_Index matrix_dim
+) {
+	ASSERT (g != NULL) ;
+	ASSERT (matrix != NULL) ;
+	ASSERT (relations != NULL) ;
+	ASSERT (relation_count > 0) ;
+	ASSERT (_BulkInsert_MatrixCanBeRebuilt (matrix)) ;
+
+	GrB_Matrix adjacency = NULL ;
+	GrB_Matrix transpose = NULL ;
+	GrB_OK (GrB_Matrix_new (&adjacency, GrB_BOOL, matrix_dim, matrix_dim)) ;
+	GrB_OK (GrB_set (adjacency, GxB_SPARSE | GxB_HYPERSPARSE,
+			GxB_SPARSITY_CONTROL)) ;
+
+	for (uint i = 0; i < relation_count; i++) {
+		Tensor relation = Graph_GetRelationMatrix (g, relations[i], false) ;
+		Delta_Matrix relation_transpose = Delta_Matrix_getTranspose (relation) ;
+
+		// Relation transposes are Boolean topology matrices, so their transpose
+		// can be ORed directly into the Boolean all-relation adjacency matrix.
+		GrB_OK (GrB_transpose (adjacency, NULL, GrB_LOR,
+				Delta_Matrix_M (relation_transpose), NULL)) ;
+	}
+
+	GrB_OK (GrB_Matrix_new (&transpose, GrB_BOOL, matrix_dim, matrix_dim)) ;
+	GrB_OK (GrB_set (transpose, GxB_SPARSE | GxB_HYPERSPARSE,
+			GxB_SPARSITY_CONTROL)) ;
+	GrB_OK (GrB_transpose (transpose, NULL, NULL, adjacency, NULL)) ;
+
+	GrB_OK (Delta_Matrix_setM (matrix, &adjacency)) ;
+	GrB_OK (Delta_Matrix_setM (Delta_Matrix_getTranspose (matrix),
+			&transpose)) ;
+}
+
+// Build one empty relation tensor from sorted records. A relation matrix keeps
+// a scalar edge ID for a single endpoint pair and a GraphBLAS vector for a
+// multiedge pair; its transpose stores only topology.
+static void _BulkInsert_BuildRelation
+(
+	Tensor matrix,
+	const BulkEdge *edges,
+	uint edge_count,
+	GrB_Index matrix_dim,
+	GrB_Index *rows,
+	GrB_Index *cols,
+	uint64_t *ids
+) {
+	ASSERT (matrix != NULL) ;
+	ASSERT (edges  != NULL) ;
+	ASSERT (edge_count > 0) ;
+	ASSERT (rows != NULL) ;
+	ASSERT (cols != NULL) ;
+	ASSERT (ids  != NULL) ;
+	ASSERT (_BulkInsert_MatrixCanBeRebuilt (matrix)) ;
+
+	uint tuple_count = 0 ;
+	for (uint i = 0; i < edge_count;) {
+		uint j = i + 1 ;
+		while (j < edge_count && edges[j].src == edges[i].src &&
+				edges[j].dest == edges[i].dest) {
+			j++ ;
+		}
+
+		rows[tuple_count] = edges[i].src ;
+		cols[tuple_count] = edges[i].dest ;
+
+		if (j == i + 1) {
+			ids[tuple_count] = edges[i].id ;
+		} else {
+			GrB_Vector vector = NULL ;
+			GrB_OK (GrB_Vector_new (&vector, GrB_BOOL, GrB_INDEX_MAX)) ;
+
+			for (uint k = i; k < j; k++) {
+				GrB_OK (GrB_Vector_setElement_BOOL (vector, true, edges[k].id)) ;
+			}
+
+			GrB_OK (GrB_wait (vector, GrB_MATERIALIZE)) ;
+			ids[tuple_count] = SET_MSB ((uint64_t)(uintptr_t)vector) ;
+		}
+
+		tuple_count++ ;
+		i = j ;
+	}
+
+	GrB_Matrix relation = NULL ;
+	GrB_Matrix transpose = NULL ;
+	GrB_Descriptor transpose_input = NULL ;
+	GrB_OK (GrB_Matrix_new (&relation, GrB_UINT64, matrix_dim, matrix_dim)) ;
+	GrB_OK (GrB_set (relation, GxB_SPARSE | GxB_HYPERSPARSE,
+			GxB_SPARSITY_CONTROL)) ;
+	GrB_OK (GrB_Matrix_build_UINT64 (relation, rows, cols, ids, tuple_count,
+			GrB_SECOND_UINT64)) ;
+
+	// The relation's scalar may be edge ID zero or a vector pointer. Apply a
+	// constant-one operator while transposing so topology remains true-valued.
+	GrB_OK (GrB_Matrix_new (&transpose, GrB_BOOL, matrix_dim, matrix_dim)) ;
+	GrB_OK (GrB_set (transpose, GxB_SPARSE | GxB_HYPERSPARSE,
+			GxB_SPARSITY_CONTROL)) ;
+	GrB_OK (GrB_Descriptor_new (&transpose_input)) ;
+	GrB_OK (GrB_Descriptor_set (transpose_input, GrB_INP0, GrB_TRAN)) ;
+	GrB_OK (GrB_apply (transpose, NULL, NULL, GxB_ONE_UINT64, relation,
+			transpose_input)) ;
+	GrB_OK (GrB_Descriptor_free (&transpose_input)) ;
+
+	GrB_OK (Delta_Matrix_setM (matrix, &relation)) ;
+	GrB_OK (Delta_Matrix_setM (Delta_Matrix_getTranspose (matrix),
+			&transpose)) ;
+}
+
+// The delta path uses the same Tensor_SetEdges semantics as Graph_CreateEdges.
+// Fixed local batches avoid reintroducing command-wide Edge pointer staging.
+// Batches may split a duplicate group; Tensor_SetEdges extends the vector
+// installed by the preceding batch.
+static void _BulkInsert_SetRelationDelta
+(
+	Tensor matrix,
+	const BulkEdge *bulk_edges,
+	uint edge_count
+) {
+	const uint batch_cap = 4096 ;
+	Edge edges[batch_cap] ;
+	const Edge *edge_ptrs[batch_cap] ;
+
+	for (uint offset = 0; offset < edge_count; offset += batch_cap) {
+		uint batch_size = MIN (batch_cap, edge_count - offset) ;
+		for (uint i = 0; i < batch_size; i++) {
+			const BulkEdge *bulk_edge = bulk_edges + offset + i ;
+			Edge *edge = edges + i ;
+			*edge = (Edge) {
+				.id = bulk_edge->id,
+				.src_id = bulk_edge->src,
+				.dest_id = bulk_edge->dest,
+			} ;
+			edge_ptrs[i] = edge ;
+		}
+		Tensor_SetEdges (matrix, edge_ptrs, batch_size) ;
+	}
+}
+
+// Bulk insertion deliberately has no undo/effect log; preserve only the
+// GraphHub side effect required for schemas with edge indexes.
+static void _BulkInsert_IndexEdges
+(
+	GraphContext *gc,
+	Graph *g,
+	RelationID relation,
+	const BulkEdge *edges,
+	uint edge_count
+) {
+	ASSERT (gc != NULL) ;
+	ASSERT (g != NULL) ;
+	ASSERT (edges != NULL) ;
+
+	Schema *schema = GraphContext_GetSchemaByID (gc, relation, SCHEMA_EDGE) ;
+	ASSERT (schema != NULL) ;
+	if (!Schema_HasIndices (schema)) {
+		return ;
+	}
+
+	for (uint i = 0; i < edge_count; i++) {
+		const BulkEdge *bulk_edge = edges + i ;
+		Edge edge = GE_NEW_LABELED_EDGE (NULL, relation) ;
+		edge.id = bulk_edge->id ;
+		edge.src_id = bulk_edge->src ;
+		edge.dest_id = bulk_edge->dest ;
+		edge.attributes = DataBlock_GetItem (g->edges, edge.id) ;
+		ASSERT (edge.attributes != NULL) ;
+		Schema_AddEdgeToIndex (schema, &edge) ;
+	}
+}
+
+// Install relation-partitioned records. IDs are assigned in wire order while
+// decoding; each partition is endpoint-sorted only after that property is fixed.
+static void _BulkInsert_CommitEdges
+(
+	RedisModuleCtx *ctx,
+	GraphContext *gc,
+	BulkEdgeGroup *groups,
+	uint group_count,
+	uint64_t existing_edge_count,
+	uint total_edge_count
+) {
+	ASSERT (ctx != NULL) ;
+	ASSERT (gc != NULL) ;
+	ASSERT (groups != NULL) ;
+	ASSERT (group_count > 0) ;
+
+	Graph *g = GraphContext_GetGraph (gc) ;
+
+#ifdef RG_DEBUG
+	for (uint i = 0; i < group_count; i++) {
+		for (uint j = 0; j < arr_len (groups[i].edges); j++) {
+			Node node = GE_NEW_NODE () ;
+			ASSERT (Graph_GetNode (g, groups[i].edges[j].src,  &node)) ;
+			ASSERT (Graph_GetNode (g, groups[i].edges[j].dest, &node)) ;
+		}
+	}
+#endif
+
+	// Resize every matrix once while still using the bulk resize policy. Matrix
+	// updates below do not need repeated synchronization or resize checks.
+	ASSERT (Graph_GetMatrixPolicy (g) == SYNC_POLICY_RESIZE) ;
+	Delta_Matrix adjacency = Graph_GetAdjacencyMatrix (g, false) ;
+	RelationID *relations = arr_new (RelationID, group_count) ;
+	uint max_relation_edge_count = 0 ;
+	bool rebuild_adjacency = total_edge_count >= BULK_REBUILD_MIN_EDGES &&
+		existing_edge_count == 0 && _BulkInsert_MatrixCanBeRebuilt (adjacency) ;
+
+	for (uint i = 0; i < group_count; i++) {
+		BulkEdgeGroup *group = groups + i ;
+		uint edge_count = arr_len (group->edges) ;
+		if (edge_count == 0) {
+			continue ;
+		}
+
+		Tensor relation = Graph_GetRelationMatrix (g, group->relation, false) ;
+		arr_append (relations, group->relation) ;
+		max_relation_edge_count = MAX (max_relation_edge_count, edge_count) ;
+		rebuild_adjacency &= _BulkInsert_MatrixCanBeRebuilt (relation) ;
+	}
+
+	ASSERT (max_relation_edge_count > 0) ;
+	MATRIX_POLICY policy = Graph_SetMatrixPolicy (g, SYNC_POLICY_NOP) ;
+	GrB_Index *rows = NULL ;
+	GrB_Index *cols = NULL ;
+	uint64_t *ids = NULL ;
+	if (rebuild_adjacency) {
+		rows = rm_malloc (sizeof (GrB_Index) * max_relation_edge_count) ;
+		cols = rm_malloc (sizeof (GrB_Index) * max_relation_edge_count) ;
+		ids = rm_malloc (sizeof (uint64_t) * max_relation_edge_count) ;
+	}
+	GrB_Index matrix_dim = Graph_RequiredMatrixDim (g) ;
+
+	for (uint i = 0; i < group_count; i++) {
+		BulkEdgeGroup *group = groups + i ;
+		BulkEdge *bulk_edges = group->edges ;
+		uint edge_count = arr_len (bulk_edges) ;
+		if (edge_count == 0) {
+			continue ;
+		}
+
+		qsort (bulk_edges, edge_count, sizeof (BulkEdge),
+				_BulkInsert_BulkEdgeEndpointCmp) ;
+		Tensor relation = Graph_GetRelationMatrix (g, group->relation, false) ;
+
+		if (rebuild_adjacency) {
+			_BulkInsert_BuildRelation (relation, bulk_edges, edge_count,
+					matrix_dim, rows, cols, ids) ;
+		} else {
+			_BulkInsert_SetRelationDelta (relation, bulk_edges, edge_count) ;
+		}
+
+		GraphStatistics_IncEdgeCount (&g->stats, group->relation, edge_count) ;
+
+		if (!rebuild_adjacency) {
+			// Existing graph state uses the regular mutation path. Each distinct
+			// endpoint is set once, preserving pending additions and deletions.
+			for (uint j = 0; j < edge_count;) {
+				GrB_OK (Delta_Matrix_setElement_BOOL (adjacency, bulk_edges[j].src,
+					bulk_edges[j].dest)) ;
+
+				uint k = j + 1 ;
+				while (k < edge_count && bulk_edges[k].src == bulk_edges[j].src &&
+						bulk_edges[k].dest == bulk_edges[j].dest) {
+					k++ ;
+				}
+				j = k ;
+			}
+		}
+
+		_BulkInsert_IndexEdges (gc, g, group->relation, bulk_edges, edge_count) ;
+
+		// A partition has no remaining consumers after its relation, optional
+		// adjacency effects, and index side effects are installed.
+		arr_free (group->edges) ;
+		group->edges = NULL ;
+		RedisModule_Yield (ctx, REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+	}
+
+	if (rows != NULL) {
+		rm_free (ids) ;
+		rm_free (cols) ;
+		rm_free (rows) ;
+	}
+
+	if (rebuild_adjacency) {
+		// Relation matrices now retain every detail needed for adjacency. Their
+		// compact Boolean transposes materialize the all-relation matrix once.
+		_BulkInsert_BuildAdjacency (g, adjacency, relations, arr_len (relations),
+				matrix_dim) ;
+	}
+
+	arr_free (relations) ;
+	Graph_SetMatrixPolicy (g, policy) ;
+}
+
 // process a single edge CSV file
 static int _BulkInsert_ProcessEdgeFile
 (
@@ -522,22 +913,182 @@ static int _BulkInsert_ProcessEdgeFile
 	return BULK_OK ;
 }
 
-static int _BulkInsert_ProcessTokens
+// decode a single edge CSV file into the command-wide transaction buffer
+static int _BulkInsert_ProcessEdgeFileTransaction
+(
+	RedisModuleCtx *ctx,  // redis module context
+	GraphContext *gc,     // graph context
+	const char *data,     // raw data
+	size_t data_len,           // number of bytes in data
+	BulkEdgeGroup **groups,    // relation-partitioned transaction buffers
+	uint partition_capacity    // initial record capacity per relation
+) {
+	size_t   data_idx   = 0 ;
+	uint16_t prop_count = 0 ;
+	uint64_t iterations = 0 ;
+	Graph *g = GraphContext_GetGraph (gc) ;
+
+	//--------------------------------------------------------------------------
+	// parse CSV headers
+	//--------------------------------------------------------------------------
+
+	RelationID *rels = _BulkInsert_ReadHeaderLabels (ctx, gc, SCHEMA_EDGE, data,
+			&data_idx) ;
+	ASSERT (rels != NULL) ;
+
+	uint type_count = arr_len (rels) ;
+
+	// edges must have exactly one type
+	ASSERT (type_count == 1) ;
+	RelationID rel = rels[0] ;
+
+	AttributeID *prop_indices = _BulkInsert_ReadHeaderProperties (ctx, gc,
+			SCHEMA_EDGE, data, &data_idx, &prop_count) ;
+
+	//--------------------------------------------------------------------------
+	// decode edges
+	//--------------------------------------------------------------------------
+
+	SIValue props[prop_count] ;
+	AttributeID prop_attr_ids[prop_count] ;
+	BulkEdgeGroup *group = NULL ;
+
+	while (data_idx < data_len) {
+		BulkEdge edge = {
+			.id = INVALID_ENTITY_ID,
+		} ;
+
+		// read source ID
+		edge.src = *(NodeID*)&data[data_idx] ;
+		data_idx += sizeof (NodeID) ;
+
+		// read destination ID
+		edge.dest = *(NodeID*)&data[data_idx] ;
+		data_idx += sizeof (NodeID) ;
+
+		uint n = 0 ;
+		// read edge properties
+		for (uint i = 0; i < prop_count; i++) {
+			SIValue v = _BulkInsert_ReadProperty (data, &data_idx) ;
+
+			// skip null values
+			if (unlikely (SI_TYPE (v) == T_NULL)) {
+				continue ;
+			}
+
+			// accumulate attributes
+			props[n] = v ;
+			prop_attr_ids[n] = prop_indices[i] ;
+			n++ ;
+		}
+
+		// Allocate in decode order so deleted-slot reuse and edge IDs remain
+		// exactly the same as Graph_CreateEdges without retaining attributes in
+		// the command-wide topology buffer.
+		AttributeSet set = NULL ;
+		AttributeSet_Add (&set, prop_attr_ids, props, n, false) ;
+		AttributeSet *slot = DataBlock_AllocateItem (g->edges, &edge.id) ;
+		*slot = set ;
+
+		if (group == NULL) {
+			group = _BulkInsert_GetEdgeGroup (groups, rel, partition_capacity) ;
+		}
+		arr_append (group->edges, edge) ;
+
+		// yield every 500000 iterations
+		if (iterations++ == 500000) {
+			RedisModule_Yield (ctx, REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+			iterations = 0 ;
+		}
+	}
+
+	arr_free (rels) ;
+	if (prop_indices) {
+		rm_free (prop_indices) ;
+	}
+
+	return BULK_OK ;
+}
+
+// Decode all relation files before committing their topology. This lets one
+// transaction group coordinates across files while retaining parse-time yields.
+static int _BulkInsert_ProcessEdgeTokens
 (
 	RedisModuleCtx *ctx,
 	GraphContext *gc,
 	int token_count,
 	RedisModuleString **argv,
-	SchemaType type
+	uint edge_count
+) {
+	ASSERT (token_count > 0) ;
+
+	// The transaction earns its setup and retained-record cost only in the
+	// direct-build range. Outside that bounded range preserve the established
+	// per-file path, including small and very large append batches.
+	if (edge_count < BULK_REBUILD_MIN_EDGES ||
+			edge_count > BULK_TRANSACTION_MAX_EDGES) {
+		for (int i = 0; i < token_count; i++) {
+			size_t len ;
+			const char *data = RedisModule_StringPtrLen (argv[i], &len) ;
+			if (_BulkInsert_ProcessEdgeFile (ctx, gc, data, len)
+					!= BULK_OK) {
+				return BULK_FAIL ;
+			}
+		}
+		return BULK_OK ;
+	}
+
+	BulkEdgeGroup *groups = arr_new (BulkEdgeGroup, token_count) ;
+	Graph *g = GraphContext_GetGraph (gc) ;
+	uint64_t existing_edge_count = DataBlock_ItemCount (g->edges) ;
+	uint partition_capacity = MAX ((uint)1, edge_count / (uint)token_count) ;
+	int rc = BULK_OK ;
+
+	for (int i = 0; i < token_count; i++) {
+		size_t len ;
+		const char *data = RedisModule_StringPtrLen (argv[i], &len) ;
+		rc = _BulkInsert_ProcessEdgeFileTransaction (ctx, gc, data, len, &groups,
+				partition_capacity) ;
+		if (rc != BULK_OK) {
+			break ;
+		}
+
+		// Match the old per-file commit yield while retaining the transaction.
+		RedisModule_Yield (ctx, REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+	}
+
+	uint total_edge_count = 0 ;
+	for (uint i = 0; i < arr_len (groups); i++) {
+		total_edge_count += arr_len (groups[i].edges) ;
+	}
+
+	if (rc == BULK_OK && total_edge_count > 0) {
+		RedisModule_Yield (ctx, REDISMODULE_YIELD_FLAG_CLIENTS, NULL) ;
+		_BulkInsert_CommitEdges (ctx, gc, groups, arr_len (groups),
+				existing_edge_count, total_edge_count) ;
+	}
+
+	for (uint i = 0; i < arr_len (groups); i++) {
+		arr_free (groups[i].edges) ;
+	}
+	arr_free (groups) ;
+	return rc ;
+}
+
+// Process node tokens. Edge tokens have a separate command-wide transaction
+// path so their topology can be constructed after every relation file is read.
+static int _BulkInsert_ProcessNodeTokens
+(
+	RedisModuleCtx *ctx,
+	GraphContext *gc,
+	int token_count,
+	RedisModuleString **argv
 ) {
 	for (int i = 0; i < token_count; i++) {
 		size_t len ;
 		// retrieve a pointer to the next binary stream and record its length
 		const char *data = RedisModule_StringPtrLen (argv[i], &len) ;
-		int rc = (type == SCHEMA_NODE)
-			? _BulkInsert_ProcessNodeFile (ctx, gc, data, len)
-			: _BulkInsert_ProcessEdgeFile (ctx, gc, data, len) ;
-		if (rc != BULK_OK) {
+		if (_BulkInsert_ProcessNodeFile (ctx, gc, data, len) != BULK_OK) {
 			return BULK_FAIL ;
 		}
 	}
@@ -627,8 +1178,8 @@ int BulkInsert
 	if (node_token_count > 0) {
 		ASSERT (argc >= node_token_count) ;
 
-		if (_BulkInsert_ProcessTokens (ctx, gc, node_token_count, argv,
-					SCHEMA_NODE) != BULK_OK) {
+		if (_BulkInsert_ProcessNodeTokens (ctx, gc, node_token_count, argv)
+				!= BULK_OK) {
 			res = BULK_FAIL ;
 			goto cleanup ;
 		}
@@ -644,8 +1195,8 @@ int BulkInsert
 	if (relation_token_count > 0) {
 		ASSERT (argc >= relation_token_count) ;
 
-		if (_BulkInsert_ProcessTokens (ctx, gc, relation_token_count, argv,
-					SCHEMA_EDGE) != BULK_OK) {
+		if (_BulkInsert_ProcessEdgeTokens (ctx, gc, relation_token_count, argv,
+					edge_count) != BULK_OK) {
 			res = BULK_FAIL ;
 			goto cleanup ;
 		}

--- a/tests/benchmarks/graph_bulk_public_path.py
+++ b/tests/benchmarks/graph_bulk_public_path.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""Measure and validate one Redis-backed GRAPH.BULK public-path shape.
+
+The timed operation is a single GRAPH.BULK request sent over RESP to a fresh
+Redis server. Payload generation and server setup are intentionally outside the
+timer: callers of GRAPH.BULK supply an already materialized binary payload.
+The server CPU delta and VmHWM are sampled for the same request. After timing,
+the driver validates indexed edge lookup, incoming traversal, duplicate pairs,
+arrival-order IDs, and a second append batch.
+
+It has no third-party Python dependencies. Redis is the repository's documented
+flow-test prerequisite and can be selected with REDIS_SERVER or --redis-server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+PROPERTY_INT64 = 4
+
+
+class RedisReplyError(RuntimeError):
+    pass
+
+
+class RESPClient:
+    """Minimal RESP2 client used so binary GRAPH.BULK arguments stay exact."""
+
+    def __init__(self, host: str, port: int) -> None:
+        self._socket = socket.create_connection((host, port), timeout=30)
+        self._socket.settimeout(300)
+        self._reader = self._socket.makefile("rb")
+
+    def close(self) -> None:
+        self._reader.close()
+        self._socket.close()
+
+    def command(self, *arguments: bytes | str | int) -> Any:
+        encoded: list[bytes] = []
+        for argument in arguments:
+            if isinstance(argument, bytes):
+                encoded.append(argument)
+            else:
+                encoded.append(str(argument).encode("utf-8"))
+
+        request = bytearray(f"*{len(encoded)}\r\n".encode("ascii"))
+        for argument in encoded:
+            request.extend(f"${len(argument)}\r\n".encode("ascii"))
+            request.extend(argument)
+            request.extend(b"\r\n")
+
+        self._socket.sendall(request)
+        return self._read_reply()
+
+    def _read_line(self) -> bytes:
+        line = self._reader.readline()
+        if not line.endswith(b"\r\n"):
+            raise RedisReplyError(f"truncated RESP line: {line!r}")
+        return line[:-2]
+
+    def _read_reply(self) -> Any:
+        marker = self._reader.read(1)
+        if not marker:
+            raise RedisReplyError("connection closed while reading RESP reply")
+
+        line = self._read_line()
+        if marker == b"+":
+            return line
+        if marker == b"-":
+            raise RedisReplyError(line.decode("utf-8", "replace"))
+        if marker == b":":
+            return int(line)
+        if marker == b"$":
+            length = int(line)
+            if length == -1:
+                return None
+            value = self._reader.read(length + 2)
+            if len(value) != length + 2 or value[-2:] != b"\r\n":
+                raise RedisReplyError("truncated RESP bulk string")
+            return value[:-2]
+        if marker == b"*":
+            count = int(line)
+            if count == -1:
+                return None
+            return [self._read_reply() for _ in range(count)]
+
+        raise RedisReplyError(f"unsupported RESP marker: {marker!r}")
+
+
+@dataclass(frozen=True)
+class BulkPayload:
+    node_count: int
+    edge_count: int
+    relation_files: tuple[bytes, ...]
+    node_file: bytes
+    duplicate_group_size: int
+    first_pairs: tuple[tuple[int, int], ...]
+    first_ids: tuple[int, ...]
+
+
+def pack_int(value: int) -> bytes:
+    return bytes((PROPERTY_INT64,)) + struct.pack("=q", value)
+
+
+def pair_for_index(pair_index: int, width: int) -> tuple[int, int]:
+    # width * width distinct pairs fit in nodes [0, width]. A nonzero
+    # destination makes the first pair (0, 1), useful for transpose checks.
+    return pair_index % width, 1 + pair_index // width
+
+
+def node_file(node_count: int) -> bytes:
+    stream = bytearray(b"N\0")
+    stream.extend(struct.pack("=I", 1))
+    stream.extend(b"id\0")
+    for node_id in range(node_count):
+        stream.extend(pack_int(node_id))
+    return bytes(stream)
+
+
+def edge_file(name: str, records: Iterable[tuple[int, int, int]]) -> bytes:
+    stream = bytearray(name.encode("ascii"))
+    stream.extend(b"\0")
+    stream.extend(struct.pack("=I", 1))
+    stream.extend(b"p\0")
+    for src, dest, value in records:
+        stream.extend(struct.pack("=QQ", src, dest))
+        stream.extend(pack_int(value))
+    return bytes(stream)
+
+
+def build_payloads(
+    edge_count: int,
+    relation_count: int,
+    duplicate_group_size: int,
+    append_edge_count: int,
+) -> tuple[BulkPayload, BulkPayload]:
+    if edge_count <= 0:
+        raise ValueError("--edges must be positive")
+    if relation_count <= 0:
+        raise ValueError("--relation-files must be positive")
+    if duplicate_group_size <= 0:
+        raise ValueError("--duplicate-group-size must be positive")
+    if edge_count % (relation_count * duplicate_group_size) != 0:
+        raise ValueError(
+            "--edges must divide evenly by --relation-files times "
+            "--duplicate-group-size"
+        )
+    if append_edge_count < 2 * relation_count:
+        raise ValueError("--append-edges must provide at least two records per relation")
+
+    groups_per_relation = edge_count // (relation_count * duplicate_group_size)
+    total_initial_groups = groups_per_relation * relation_count
+    # Append needs one existing pair and at most append_edge_count - relation_count
+    # new pairs. Allocate all nodes up front so the append cannot resize matrices.
+    total_pairs = total_initial_groups + append_edge_count
+    width = math.isqrt(total_pairs - 1) + 1
+    nodes = node_file(width + 1)
+
+    initial_files: list[bytes] = []
+    append_files: list[bytes] = []
+    next_edge_id = 0
+    next_new_pair = total_initial_groups
+    append_value = edge_count
+
+    for relation in range(relation_count):
+        initial_records: list[tuple[int, int, int]] = []
+        for group in range(groups_per_relation):
+            src, dest = pair_for_index(relation * groups_per_relation + group, width)
+            for _ in range(duplicate_group_size):
+                initial_records.append((src, dest, next_edge_id))
+                next_edge_id += 1
+        initial_files.append(edge_file(f"R{relation}", initial_records))
+
+        relation_append_count = append_edge_count // relation_count
+        if relation < append_edge_count % relation_count:
+            relation_append_count += 1
+
+        append_records: list[tuple[int, int, int]] = []
+        # The first append in each relation promotes a scalar to a vector when
+        # duplicate_group_size is one, and extends a vector otherwise.
+        existing_src, existing_dest = pair_for_index(
+            relation * groups_per_relation, width
+        )
+        append_records.append((existing_src, existing_dest, append_value))
+        append_value += 1
+        for _ in range(1, relation_append_count):
+            src, dest = pair_for_index(next_new_pair, width)
+            next_new_pair += 1
+            append_records.append((src, dest, append_value))
+            append_value += 1
+        append_files.append(edge_file(f"R{relation}", append_records))
+
+    first_pairs = tuple(
+        pair_for_index(relation * groups_per_relation, width)
+        for relation in range(relation_count)
+    )
+    first_ids = tuple(
+        relation * groups_per_relation * duplicate_group_size
+        for relation in range(relation_count)
+    )
+    append_first_ids: list[int] = []
+    append_id = edge_count
+    for relation in range(relation_count):
+        append_first_ids.append(append_id)
+        append_id += append_edge_count // relation_count
+        if relation < append_edge_count % relation_count:
+            append_id += 1
+
+    return (
+        BulkPayload(
+            node_count=width + 1,
+            edge_count=edge_count,
+            relation_files=tuple(initial_files),
+            node_file=nodes,
+            duplicate_group_size=duplicate_group_size,
+            first_pairs=first_pairs,
+            first_ids=first_ids,
+        ),
+        BulkPayload(
+            node_count=0,
+            edge_count=append_edge_count,
+            relation_files=tuple(append_files),
+            node_file=b"",
+            duplicate_group_size=duplicate_group_size,
+            first_pairs=first_pairs,
+            first_ids=tuple(append_first_ids),
+        ),
+    )
+
+
+def find_redis_server(argument: str | None) -> str:
+    requested = argument or os.environ.get("REDIS_SERVER") or "redis-server"
+    if os.path.sep in requested:
+        path = Path(requested)
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path.resolve())
+    resolved = shutil.which(requested)
+    if resolved is None:
+        raise RuntimeError(
+            f"Redis server {requested!r} was not found; install Redis 8+ or set "
+            "REDIS_SERVER/--redis-server as documented for the flow tests"
+        )
+    return resolved
+
+
+def unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def start_server(redis_server: str, module: Path, directory: Path) -> tuple[subprocess.Popen[bytes], int]:
+    port = unused_port()
+    log = (directory / "redis.log").open("wb")
+    try:
+        process = subprocess.Popen(
+            [
+                redis_server,
+                "--port",
+                str(port),
+                "--bind",
+                "127.0.0.1",
+                "--save",
+                "",
+                "--appendonly",
+                "no",
+                "--dir",
+                str(directory),
+                "--dbfilename",
+                "graph-bulk.rdb",
+                "--loadmodule",
+                str(module),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    finally:
+        log.close()
+
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            detail = (directory / "redis.log").read_text(errors="replace")
+            raise RuntimeError(f"redis-server exited during startup:\n{detail}")
+        try:
+            client = RESPClient("127.0.0.1", port)
+            try:
+                if client.command("PING") == b"PONG":
+                    return process, port
+            finally:
+                client.close()
+        except OSError:
+            time.sleep(0.02)
+
+    process.terminate()
+    process.wait(timeout=10)
+    detail = (directory / "redis.log").read_text(errors="replace")
+    raise RuntimeError(f"timed out waiting for redis-server:\n{detail}")
+
+
+def stop_server(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=20)
+
+
+def server_cpu_ns(pid: int) -> int:
+    # /proc/<pid>/stat fields 14 and 15 are user and system ticks. The process
+    # name may contain spaces, so split only after its closing parenthesis.
+    stat = Path(f"/proc/{pid}/stat").read_text()
+    trailing = stat.rsplit(")", 1)[1].split()
+    ticks = int(trailing[11]) + int(trailing[12])
+    return ticks * (1_000_000_000 // os.sysconf("SC_CLK_TCK"))
+
+
+def server_rss_bytes(pid: int) -> int:
+    for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+        if line.startswith("VmRSS:"):
+            return int(line.split()[1]) * 1024
+    raise RuntimeError("VmRSS is unavailable in /proc; peak RSS requires Linux")
+
+
+class RSSSampler:
+    """Sample server RSS while one synchronous Redis command is in flight.
+
+    Some Linux procfs configurations omit VmHWM. Sampling VmRSS from a separate
+    client thread preserves a command-scoped peak without changing server work.
+    """
+
+    def __init__(self, pid: int) -> None:
+        self._pid = pid
+        self._peak = server_rss_bytes(pid)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._sample, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> int:
+        self._stop.set()
+        self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            raise RuntimeError("RSS sampler did not stop")
+        self._peak = max(self._peak, server_rss_bytes(self._pid))
+        return self._peak
+
+    def _sample(self) -> None:
+        while not self._stop.wait(0.001):
+            self._peak = max(self._peak, server_rss_bytes(self._pid))
+
+
+def assert_bulk_reply(reply: Any, node_count: int, edge_count: int) -> None:
+    expected = f"{node_count} nodes created, {edge_count} edges created".encode()
+    if reply != expected:
+        raise AssertionError(f"unexpected GRAPH.BULK reply {reply!r}, expected {expected!r}")
+
+
+def graph_bulk(client: RESPClient, graph: str, payload: BulkPayload, include_nodes: bool) -> Any:
+    arguments: list[bytes | str | int] = [
+        "GRAPH.BULK",
+        graph,
+        payload.node_count if include_nodes else 0,
+        payload.edge_count,
+        1 if include_nodes else 0,
+        len(payload.relation_files),
+    ]
+    if include_nodes:
+        arguments.append(payload.node_file)
+    arguments.extend(payload.relation_files)
+    return client.command(*arguments)
+
+
+def graph_result(reply: Any) -> list[Any]:
+    # GRAPH.QUERY uses an outer result-set array, while GRAPH.EXPLAIN returns
+    # its lines directly. Normalize the former without assuming a single row.
+    if isinstance(reply, list) and len(reply) == 1 and isinstance(reply[0], list):
+        return reply[0]
+    if isinstance(reply, list):
+        return reply
+    raise AssertionError(f"unexpected graph query reply: {reply!r}")
+
+
+def rows(reply: Any) -> list[list[Any]]:
+    result = graph_result(reply)
+    if len(result) < 2 or not isinstance(result[1], list):
+        raise AssertionError(f"unexpected graph query reply: {reply!r}")
+    return result[1]
+
+
+def scalar_int(value: Any) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, bytes):
+        return int(value)
+    raise AssertionError(f"expected integer reply, got {value!r}")
+
+
+def query_one_int(client: RESPClient, graph: str, query: str) -> int:
+    result_rows = rows(client.command("GRAPH.QUERY", graph, query))
+    if len(result_rows) != 1 or len(result_rows[0]) != 1:
+        raise AssertionError(f"expected one scalar query result, got {result_rows!r}")
+    return scalar_int(result_rows[0][0])
+
+
+def assert_index_lookup(client: RESPClient, graph: str, relation: str, value: int, expected_id: int) -> None:
+    query = f"MATCH ()-[e:{relation} {{p:{value}}}]->() RETURN ID(e)"
+    explain = client.command("GRAPH.EXPLAIN", graph, query)
+    if not isinstance(explain, list) or not any(
+        isinstance(line, bytes) and b"Edge By Index Scan" in line for line in explain
+    ):
+        raise AssertionError(f"edge property lookup did not use its index: {explain!r}")
+
+    result_rows = rows(client.command("GRAPH.QUERY", graph, query))
+    if len(result_rows) != 1 or scalar_int(result_rows[0][0]) != expected_id:
+        raise AssertionError(
+            f"indexed lookup for property {value} returned {result_rows!r}; "
+            f"expected edge ID {expected_id}"
+        )
+
+
+def validate_graph(
+    client: RESPClient,
+    graph: str,
+    initial: BulkPayload,
+    appended: BulkPayload | None,
+) -> None:
+    append_count = 0 if appended is None else appended.edge_count
+    expected_count = initial.edge_count + append_count
+    total = query_one_int(client, graph, "MATCH ()-[e]->() RETURN count(e)")
+    if total != expected_count:
+        raise AssertionError(f"edge count is {total}, expected {expected_count}")
+
+    # Every relation's first decoded edge checks arrival-order IDs and index
+    # insertion. Incoming traversals read each installed transpose, including
+    # multiedge groups and the append's scalar/vector promotion.
+    expected_incoming = initial.duplicate_group_size + (1 if appended else 0)
+    for relation, first_pair in enumerate(initial.first_pairs):
+        first_id = initial.first_ids[relation]
+        relation_name = f"R{relation}"
+        assert_index_lookup(client, graph, relation_name, first_id, first_id)
+        first_src, first_dest = first_pair
+        incoming = query_one_int(
+            client,
+            graph,
+            "MATCH (target)<-[e:" + relation_name + "]-(source) "
+            f"WHERE ID(target)={first_dest} AND ID(source)={first_src} "
+            "RETURN count(e)",
+        )
+        if incoming != expected_incoming:
+            raise AssertionError(
+                f"incoming {relation_name} multiedge count is {incoming}, "
+                f"expected {expected_incoming}"
+            )
+
+    if appended is not None:
+        # Each append file has one existing pair first. Its value/ID validates
+        # per-file wire-order continuity, vector promotion, and index effects.
+        for relation, append_id in enumerate(appended.first_ids):
+            assert_index_lookup(client, graph, f"R{relation}", append_id, append_id)
+
+
+def create_edge_indices(client: RESPClient, graph: str, relation_count: int) -> None:
+    for relation in range(relation_count):
+        reply = graph_result(client.command(
+            "GRAPH.QUERY",
+            graph,
+            f"CREATE INDEX FOR ()-[e:R{relation}]-() ON (e.p)",
+        ))
+        if not reply or reply[0] != b"Indices created: 1":
+            raise AssertionError(f"failed to create R{relation} edge index: {reply!r}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--module",
+        default="bin/linux-x64-release/falkordb.so",
+        help="built FalkorDB module path (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--redis-server",
+        help="redis-server executable; defaults to REDIS_SERVER or redis-server",
+    )
+    parser.add_argument("--edges", type=int, required=True, help="initial bulk edge count")
+    parser.add_argument(
+        "--relation-files",
+        type=int,
+        required=True,
+        help="number of relation descriptor files",
+    )
+    parser.add_argument(
+        "--duplicate-group-size",
+        type=int,
+        required=True,
+        help="number of parallel edges per initial endpoint pair",
+    )
+    parser.add_argument(
+        "--append-edges",
+        type=int,
+        help="append batch size; defaults to max(64, 2 * relation files)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("fresh", "append"),
+        default="fresh",
+        help="time the initial empty-topology bulk or a subsequent append bulk",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    module = Path(args.module).resolve()
+    if not module.is_file():
+        raise RuntimeError(f"module not found: {module}")
+
+    append_edges = args.append_edges or max(64, 2 * args.relation_files)
+    initial, appended = build_payloads(
+        args.edges,
+        args.relation_files,
+        args.duplicate_group_size,
+        append_edges,
+    )
+    redis_server = find_redis_server(args.redis_server)
+
+    with tempfile.TemporaryDirectory(prefix="falkordb-graph-bulk-") as temporary:
+        # Load a per-run copy from the fresh server directory. Besides avoiding
+        # a server reading a concurrently rebuilt artifact, this makes Linux
+        # module-page residency independent of the baseline/Candidate worktree
+        # path before sampling command-scoped RSS.
+        server_directory = Path(temporary)
+        server_module = server_directory / "falkordb.so"
+        shutil.copy2(module, server_module)
+        process, port = start_server(redis_server, server_module, server_directory)
+        try:
+            client = RESPClient("127.0.0.1", port)
+            try:
+                graph = "graph_bulk_public_path"
+                create_edge_indices(client, graph, args.relation_files)
+
+                if args.mode == "append":
+                    assert_bulk_reply(graph_bulk(client, graph, initial, True), initial.node_count, initial.edge_count)
+                    client.command("PING")
+                    timed_payload = appended
+                    include_nodes = False
+                else:
+                    timed_payload = initial
+                    include_nodes = True
+
+                rss_sampler = RSSSampler(process.pid)
+                rss_sampler.start()
+                cpu_before = server_cpu_ns(process.pid)
+                start = time.perf_counter_ns()
+                reply = graph_bulk(client, graph, timed_payload, include_nodes)
+                wall_ns = time.perf_counter_ns() - start
+                cpu_ns = server_cpu_ns(process.pid) - cpu_before
+                peak_rss_bytes = rss_sampler.stop()
+                assert_bulk_reply(reply, timed_payload.node_count if include_nodes else 0, timed_payload.edge_count)
+
+                if args.mode == "fresh":
+                    assert_bulk_reply(graph_bulk(client, graph, appended, False), 0, appended.edge_count)
+
+                validate_graph(client, graph, initial, appended)
+            finally:
+                client.close()
+        finally:
+            stop_server(process)
+
+    # Perfloop's adapter requires exactly one object per declared metric.
+    print(json.dumps({"metric": "wall_ns", "value": wall_ns}))
+    print(json.dumps({"metric": "server_cpu_ns", "value": cpu_ns}))
+    print(json.dumps({"metric": "server_peak_rss_bytes", "value": peak_rss_bytes}))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"graph_bulk_public_path: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/benchmarks/run_graph_bulk_public_path.sh
+++ b/tests/benchmarks/run_graph_bulk_public_path.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Prepare a pinned Redis server in this worktree and run the public GRAPH.BULK
+# benchmark.  REDIS_SERVER may override the pinned server for local debugging.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly redis_version="8.6.3"
+readonly redis_root="$root/bin/perfloop-redis-$redis_version"
+readonly redis_source="$redis_root/source"
+readonly redis_server="$redis_source/src/redis-server"
+
+log() {
+	echo "$*" >&2
+}
+
+redis_major_version() {
+	local version
+	version="$($1 --version 2>/dev/null || true)"
+	if [[ "$version" =~ v=([0-9]+)\. ]]; then
+		echo "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+require_redis_8() {
+	local major
+	major="$(redis_major_version "$1")" || {
+		log "Unable to determine Redis version for $1"
+		return 1
+	}
+	if (( major < 8 )); then
+		log "GRAPH.BULK requires Redis 8+, but $1 reports Redis $major"
+		return 1
+	fi
+}
+
+build_redis() {
+	if [[ -x "$redis_server" ]]; then
+		require_redis_8 "$redis_server"
+		echo "$redis_server"
+		return 0
+	fi
+
+	local archive jobs downloader
+	archive="$redis_root/redis-$redis_version.tar.gz"
+	jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
+	mkdir -p "$redis_root"
+
+	if [[ ! -f "$archive" ]]; then
+		log "Downloading Redis $redis_version for GRAPH.BULK tests"
+		if command -v curl >/dev/null 2>&1; then
+			downloader=(curl --fail --location --silent --show-error
+				"https://github.com/redis/redis/archive/refs/tags/$redis_version.tar.gz"
+				--output "$archive")
+		elif command -v wget >/dev/null 2>&1; then
+			downloader=(wget --quiet
+				"https://github.com/redis/redis/archive/refs/tags/$redis_version.tar.gz"
+				--output-document "$archive")
+		else
+			log "Neither curl nor wget is available to download Redis $redis_version"
+			return 1
+		fi
+		"${downloader[@]}"
+	fi
+
+	log "Building Redis $redis_version for GRAPH.BULK tests"
+	rm -rf "$redis_source"
+	mkdir -p "$redis_source"
+	tar -xzf "$archive" --strip-components=1 -C "$redis_source"
+	make -C "$redis_source" -j"$jobs" >&2
+	require_redis_8 "$redis_server"
+	echo "$redis_server"
+}
+
+if [[ "${1:-}" == "--prepare" ]]; then
+	if [[ -n "${REDIS_SERVER:-}" ]]; then
+		require_redis_8 "$REDIS_SERVER"
+	else
+		build_redis >/dev/null
+	fi
+	exit 0
+fi
+
+if [[ -n "${REDIS_SERVER:-}" ]]; then
+	require_redis_8 "$REDIS_SERVER"
+	selected_redis="$REDIS_SERVER"
+else
+	selected_redis="$(build_redis)"
+fi
+
+module="${MODULE:-$root/bin/linux-x64-release/falkordb.so}"
+exec python3 "$root/tests/benchmarks/graph_bulk_public_path.py" \
+	--module "$module" --redis-server "$selected_redis" "$@"

--- a/tests/flow/test_vecsim.py
+++ b/tests/flow/test_vecsim.py
@@ -222,3 +222,75 @@ class testVecsim():
         except Exception as e:
             self.env.assertEqual("Vector dimension mismatch, expected 2 but got 3", str(e))
 
+    def test08_reindex_after_update_keeps_node(self):
+        # regression: updating a vector-indexed node must not drop it from the
+        # vector index.
+        #
+        # Every property write re-indexes the node as a RediSearch REPLACE, which
+        # allocates a new docId and appends a new vector while the previous vector
+        # must be removed from the HNSW graph. That removal only runs when the spec
+        # flag Index_HasVecSim is set; it was never set for indexes created through
+        # the low-level C API, so the old vector was never deleted. Stale vectors
+        # accumulated as orphans (docIds no longer resolving to a document) and
+        # shadowed the live entry, so the node became unfindable at small k - e.g.
+        # k=1 returned nothing after any update to the node.
+        g = Graph(self.conn, "vecsim_reindex")
+
+        v = [42.0, 42.0]
+        g.query("CREATE (:RUser {id: 1})")
+        g.create_node_vector_index("RUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_hits(q, k=1):
+            return len(query_node_vector_index(g, "RUser", "emb", k, q).result_set)
+
+        # insert the vector - baseline
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # re-SET the SAME value - node must still be found at k=1
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v)", params={'v': v})
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET an unrelated property (embedding untouched) - still found at k=1
+        g.query("MATCH (u:RUser) SET u.name = 'bob'")
+        self.env.assertEqual(knn_hits(v), 1)
+
+        # SET a different value - found at the new location at k=1
+        v2 = [7.0, 7.0]
+        g.query("MATCH (u:RUser) SET u.emb = vecf32($v2)", params={'v2': v2})
+        self.env.assertEqual(knn_hits(v2), 1)
+
+    def test09_delete_removes_vector_from_index(self):
+        # regression: deleting a vector-indexed node must remove its vector from
+        # the HNSW graph, not leave it as an orphan.
+        #
+        # The low-level delete only dropped the doc-table entry and never removed
+        # the vector from VecSim, so a deleted node's vector lingered and shadowed
+        # a new node inserted at the same coordinates - the new node was
+        # unfindable at k=1.
+        g = Graph(self.conn, "vecsim_delete")
+
+        v = [42.0, 42.0]
+        g.create_node_vector_index("DUser", "emb", dim=2,
+                                   similarity_function="euclidean")
+        wait_for_indices_to_sync(g)
+
+        def knn_tags(q, k=1):
+            res = query_node_vector_index(g, "DUser", "emb", k, q).result_set
+            return [row[0].properties['tag'] for row in res]
+
+        # node A at v
+        g.query("CREATE (:DUser {tag: 'A', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['A'])
+
+        # delete A - nothing at v anymore
+        g.query("MATCH (u:DUser {tag: 'A'}) DELETE u")
+        self.env.assertEqual(knn_tags(v), [])
+
+        # a new node B at the SAME coordinates must be found, not shadowed by
+        # A's leftover vector
+        g.query("CREATE (:DUser {tag: 'B', emb: vecf32($v)})", params={'v': v})
+        self.env.assertEqual(knn_tags(v), ['B'])
+


### PR DESCRIPTION
The change adds a bounded relation-partitioned GRAPH.BULK transaction for declared batches from 131,072 through 1,048,576 edges, while retaining the established path outside that range. It assigns edge IDs and attributes in wire order, builds relation tensors and transposes, rebuilds all-relation adjacency, and preserves the index side effects used by bulk insertion.

Checks and public-path runs completed successfully:
- Release and debug builds passed, as did whole-diff whitespace and benchmark syntax checks.
- On the 1,000,000-edge, four-file, duplicate-size-1 shape, the change measured 5.077 s wall / 5.010 s server CPU / 441 MB peak RSS versus 5.790 s / 5.590 s / 462 MB for the comparison build.
- The 200,000-edge fresh shapes improved for one relation file and for four files with duplicate groups of eight; the 200,000-edge append shape also improved in wall time and CPU while peak RSS stayed effectively level.
- Redis-backed probes preserved counts, arrival-order IDs, indexed lookups, incoming traversal, multiedges, same-relation descriptor-file merging, overlapping relation topology, deletion-slot reuse, no-property edges, and append batches. Save/reload preserved the built topology, and the debug build passed the same multiedge and append probe.
- Boundary probes at and around the transaction threshold, just above its upper bound, and with 16 relation files showed no material regression.

The measured path is a real Redis GRAPH.BULK request and validates parser, transpose, index, append, reply, and command side effects. No material product, measurement, case-scope, or contribution defect was demonstrated.

On workload `GRAPH.BULK fresh: 1000000 edges, 4 relation files, duplicate group size 1`, median metric `wall_ns` changed from 4100849810 to 3794644954; paired median delta 322600758 (at least 19/20 confidence interval 146250097–363254571 from 10 pairs).

On workload `GRAPH.BULK fresh: 1000000 edges, 4 relation files, duplicate group size 1`, median metric `server_cpu_ns` changed from 3845000000 to 3645000000; paired median delta 225000000 (at least 19/20 confidence interval 80000000–250000000 from 10 pairs).

Full evidence: https://app.perfloop.ai/t/oss/case_fptwt283gw