### PR TITLE
test(order-by): cover ordering variable length paths by non-projected length (#303)

### DIFF
--- a/tests/flow/test_order_by.py
+++ b/tests/flow/test_order_by.py
@@ -191,32 +191,37 @@ class testOrderBy(FlowTestsBase):
         # part of the projection.
         g = self.db.select_graph("order_by_path_length")
 
-        g.query("""CREATE (a:City {name: 'A'}), (b:City {name: 'B'}),
-                          (c:City {name: 'C'}), (d:City {name: 'D'}),
-                          (e:City {name: 'E'}), (f:City {name: 'F'}),
-                          (g:City {name: 'G'}),
-                          (a)-[:Road]->(b), (a)-[:Road]->(c), (a)-[:Road]->(d),
-                          (b)-[:Road]->(e), (b)-[:Road]->(d),
-                          (d)-[:Road]->(e), (c)-[:Road]->(f),
-                          (d)-[:Road]->(c), (d)-[:Road]->(f),
-                          (e)-[:Road]->(g), (f)-[:Road]->(g)""")
+        try:
+            g.query("""CREATE (a:City {name: 'A'}), (b:City {name: 'B'}),
+                              (c:City {name: 'C'}), (d:City {name: 'D'}),
+                              (e:City {name: 'E'}), (f:City {name: 'F'}),
+                              (g:City {name: 'G'}),
+                              (a)-[:Road]->(b), (a)-[:Road]->(c), (a)-[:Road]->(d),
+                              (b)-[:Road]->(e), (b)-[:Road]->(d),
+                              (d)-[:Road]->(e), (c)-[:Road]->(f),
+                              (d)-[:Road]->(c), (d)-[:Road]->(f),
+                              (e)-[:Road]->(g), (f)-[:Road]->(g)""")
 
-        # 8 paths lead from A to G, of lengths 3, 3, 3, 3, 4, 4, 4 and 5
-        q = """MATCH p = (:City {name: 'A'})-[*]->(:City {name: 'G'})
-               RETURN [n IN nodes(p) | n.name] AS names
-               ORDER BY length(p)"""
+            # 8 paths lead from A to G, of lengths 3, 3, 3, 3, 4, 4, 4 and 5
+            q = """MATCH p = (:City {name: 'A'})-[*]->(:City {name: 'G'})
+                   RETURN [n IN nodes(p) | n.name] AS names
+                   ORDER BY length(p)"""
 
-        # length(p) is one less than the number of nodes on the path, so the
-        # projected names let us recompute the sort key the server used
-        lengths = [len(row[0]) - 1 for row in g.query(q).result_set]
-        self.env.assertEqual(lengths, [3, 3, 3, 3, 4, 4, 4, 5])
+            # length(p) is one less than the number of nodes on the path, so the
+            # projected names let us recompute the sort key the server used
+            lengths = [len(row[0]) - 1 for row in g.query(q).result_set]
+            self.env.assertEqual(lengths, [3, 3, 3, 3, 4, 4, 4, 5])
 
-        res = g.query(q + " DESC").result_set
-        lengths = [len(row[0]) - 1 for row in res]
-        self.env.assertEqual(lengths, [5, 4, 4, 4, 3, 3, 3, 3])
+            res = g.query(q + " DESC").result_set
+            lengths = [len(row[0]) - 1 for row in res]
+            self.env.assertEqual(lengths, [5, 4, 4, 4, 3, 3, 3, 3])
 
-        # every path must still start at A and end at G
-        for row in res:
-            self.env.assertEqual(row[0][0], 'A')
-            self.env.assertEqual(row[0][-1], 'G')
+            # every path must still start at A and end at G
+            for row in res:
+                self.env.assertEqual(row[0][0], 'A')
+                self.env.assertEqual(row[0][-1], 'G')
+        finally:
+            # the graph is local to this test - drop it so a repeated run does
+            # not accumulate duplicate cities and roads
+            g.delete()
 

--- a/tests/flow/test_order_by.py
+++ b/tests/flow/test_order_by.py
@@ -183,3 +183,40 @@ class testOrderBy(FlowTestsBase):
         except Exception as e:
             self.env.assertContains("failed to map aggregation expression", str(e))
 
+    def test08_order_variable_length_paths_by_length(self):
+        """ordering variable length paths by a non-projected length(p)"""
+
+        # See https://github.com/FalkorDB/FalkorDB/issues/303 - paths were
+        # emitted out of order whenever length(p) was only a sort key and not
+        # part of the projection.
+        g = self.db.select_graph("order_by_path_length")
+
+        g.query("""CREATE (a:City {name: 'A'}), (b:City {name: 'B'}),
+                          (c:City {name: 'C'}), (d:City {name: 'D'}),
+                          (e:City {name: 'E'}), (f:City {name: 'F'}),
+                          (g:City {name: 'G'}),
+                          (a)-[:Road]->(b), (a)-[:Road]->(c), (a)-[:Road]->(d),
+                          (b)-[:Road]->(e), (b)-[:Road]->(d),
+                          (d)-[:Road]->(e), (c)-[:Road]->(f),
+                          (d)-[:Road]->(c), (d)-[:Road]->(f),
+                          (e)-[:Road]->(g), (f)-[:Road]->(g)""")
+
+        # 8 paths lead from A to G, of lengths 3, 3, 3, 3, 4, 4, 4 and 5
+        q = """MATCH p = (:City {name: 'A'})-[*]->(:City {name: 'G'})
+               RETURN [n IN nodes(p) | n.name] AS names
+               ORDER BY length(p)"""
+
+        # length(p) is one less than the number of nodes on the path, so the
+        # projected names let us recompute the sort key the server used
+        lengths = [len(row[0]) - 1 for row in g.query(q).result_set]
+        self.env.assertEqual(lengths, [3, 3, 3, 3, 4, 4, 4, 5])
+
+        res = g.query(q + " DESC").result_set
+        lengths = [len(row[0]) - 1 for row in res]
+        self.env.assertEqual(lengths, [5, 4, 4, 4, 3, 3, 3, 3])
+
+        # every path must still start at A and end at G
+        for row in res:
+            self.env.assertEqual(row[0][0], 'A')
+            self.env.assertEqual(row[0][-1], 'G')
+


### PR DESCRIPTION
Closes #2030
Closes #303

## Summary
Adds regression coverage for #303, where variable length paths came back in
the wrong order from `ORDER BY length(p)` whenever `length(p)` was only a
sort key and not part of the projection.

The behaviour is correct today, but nothing pinned it down. The suite's
closest tests all miss this shape:
- `test_order_by.py::test05_order_by_nonprojected` covers non-projected sort
  keys only for scalars produced by `UNWIND`
- `test_optional_match.py::test15_optional_named_path` and the `length(p)`
  orderings in `test_comprehension_functions.py` all **project** the sort key,
  and use fixed length patterns rather than `[*]`

## Changes
- Add `tests/flow/test_order_by.py::test08_order_variable_length_paths_by_length`
  using the road network from the original report: 8 paths run from `A` to `G`
  with lengths 3, 3, 3, 3, 4, 4, 4 and 5.
- Assert the emitted order is correct both ASC and DESC. The test projects the
  node names and recomputes `length(p)` from them, so it verifies the sort key
  the server actually used without depending on any tie-break order between
  paths of equal length.
- Assert every returned path still runs from `A` to `G`.

Added a new test rather than extending `test05_order_by_nonprojected`: that
test's narrative is scalar variables carried through `WITH`, and folding a
graph pattern into it would have obscured both cases.

## Testing
`TEST="tests/flow/test_order_by" ./flow.sh` → 8/8 pass.
Ran the adjacent suites too (`test_path`, `test_optional_match`,
`test_comprehension_functions`) — no regressions.

Negative check — the test fails on the version the bug was reported against.
On `falkordb/falkordb:v4.0.9` the query does not even execute:

```
$ redis-cli GRAPH.QUERY g303 "MATCH p = (:City {name:'A'})-[*]->(:City {name:'G'}) RETURN [n IN nodes(p) | n.name] ORDER BY length(p)"
_AR_EXP_UpdateEntityIdx: Unable to locate a value with alias p within the record
```

## Memory / Performance Impact
N/A — test-only change.

## Related Issues
References #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for ordering variable-length path query results by path length in ascending and descending order.
  * Verified returned paths consistently begin at the expected origin and end at the expected destination.
  * Confirmed ordering remains reliable across paths with different lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->