### PR TITLE
test(rdb): cover RESTORE of a graph dump under a different key (#2048)

### DIFF
--- a/tests/flow/test_rdb_load.py
+++ b/tests/flow/test_rdb_load.py
@@ -118,5 +118,19 @@ class testRdbLoad():
 
         self.env.assertEqual(src.query(q).result_set, [[1, 2, 3]])
         self.env.assertEqual(dst.query(q).result_set, [[1, 2, 3]])
+
+        # each graph kept its own write, and only its own
+        self.env.assertEqual(src.query(count % "ONLY_IN_SRC").result_set, [[1]])
+        self.env.assertEqual(dst.query(count % "ONLY_IN_DST").result_set, [[1]])
         self.env.assertEqual(src.query(count % "ONLY_IN_DST").result_set, [[0]])
         self.env.assertEqual(dst.query(count % "ONLY_IN_SRC").result_set, [[0]])
+
+        # a write issued after the reload must still not leak across keys: a
+        # decoder that re-created the alias would only show up on mutation
+        dst.query("CREATE (:AFTER_RELOAD_DST)")
+        src.query("CREATE (:AFTER_RELOAD_SRC)")
+
+        self.env.assertEqual(src.query(count % "AFTER_RELOAD_SRC").result_set, [[1]])
+        self.env.assertEqual(dst.query(count % "AFTER_RELOAD_DST").result_set, [[1]])
+        self.env.assertEqual(src.query(count % "AFTER_RELOAD_DST").result_set, [[0]])
+        self.env.assertEqual(dst.query(count % "AFTER_RELOAD_SRC").result_set, [[0]])

--- a/tests/flow/test_rdb_load.py
+++ b/tests/flow/test_rdb_load.py
@@ -3,7 +3,8 @@ from common import *
 
 class testRdbLoad():
     def __init__(self):
-        self.env, self.db = Env(moduleArgs='VKEY_MAX_ENTITY_COUNT 10')
+        self.env, self.db = Env(moduleArgs='VKEY_MAX_ENTITY_COUNT 10',
+                                enableDebugCommand=True)
         self.conn = self.env.getConnection()
 
     # assert that |keyspace| == `n`
@@ -76,3 +77,46 @@ class testRdbLoad():
 
         # Verify save works after load
         self.conn.save()
+
+    def test_restore_under_a_different_key(self):
+        # Restoring a graph DUMP under a key name other than the one it was
+        # dumped from used to alias the two keys: only the original showed up
+        # in GRAPH.LIST, writes to the restored key mutated the original, and
+        # the server segfaulted while loading the resulting RDB.
+        # See https://github.com/FalkorDB/FalkorDB/issues/2048
+        self.conn.flushall()
+
+        src = self.db.select_graph("src")
+        src.query("CREATE (:A {v: 1})-[:R {w: 2}]->(:B {v: 3})")
+
+        self.conn.restore("dst", 0, self.conn.dump("src"))
+
+        # both graphs are listed, and both hold the same data
+        graphs = [g.decode() if isinstance(g, bytes) else g
+                  for g in self.conn.execute_command("GRAPH.LIST")]
+        self.env.assertIn("src", graphs)
+        self.env.assertIn("dst", graphs)
+
+        dst = self.db.select_graph("dst")
+        q = "MATCH (a:A)-[e:R]->(b:B) RETURN a.v, e.w, b.v"
+        self.env.assertEqual(src.query(q).result_set, [[1, 2, 3]])
+        self.env.assertEqual(dst.query(q).result_set, [[1, 2, 3]])
+
+        # the two graphs are independent: a write to one is not visible in the
+        # other, in either direction
+        dst.query("CREATE (:ONLY_IN_DST)")
+        src.query("CREATE (:ONLY_IN_SRC)")
+
+        count = "MATCH (n:%s) RETURN count(n)"
+        self.env.assertEqual(src.query(count % "ONLY_IN_DST").result_set, [[0]])
+        self.env.assertEqual(dst.query(count % "ONLY_IN_SRC").result_set, [[0]])
+        self.env.assertEqual(src.query(count % "ONLY_IN_SRC").result_set, [[1]])
+        self.env.assertEqual(dst.query(count % "ONLY_IN_DST").result_set, [[1]])
+
+        # the restored graph must survive an RDB round trip
+        self.conn.execute_command("DEBUG", "RELOAD")
+
+        self.env.assertEqual(src.query(q).result_set, [[1, 2, 3]])
+        self.env.assertEqual(dst.query(q).result_set, [[1, 2, 3]])
+        self.env.assertEqual(src.query(count % "ONLY_IN_DST").result_set, [[0]])
+        self.env.assertEqual(dst.query(count % "ONLY_IN_SRC").result_set, [[0]])


### PR DESCRIPTION
Closes #170
Closes #2048

## Summary
Adds regression coverage for #2048, where restoring a graph `DUMP` under a
key name other than the one it was dumped from aliased the two keys.

## Changes
- Add `tests/flow/test_rdb_load.py::test_restore_under_a_different_key`:
  dump `src`, `RESTORE` it as `dst`, then assert
  - both keys appear in `GRAPH.LIST`
  - both hold the same data
  - the two graphs are independent — a write to one is not visible through
    the other, checked in **both** directions
  - both survive an RDB round trip (`DEBUG RELOAD`)
- Pass `enableDebugCommand=True` to this class's `Env` so the round trip can
  be exercised, matching `test_graph_copy` and `test_encode_decode`.

Added to `test_rdb_load.py` because that file already owns the graph
`DUMP`/`RESTORE` narrative. Its existing `test_rdb_load` only restores back
to the *same* key name, and `test_graph_copy.py` exercises the `GRAPH.COPY`
command rather than `DUMP`/`RESTORE`, so no existing test covered this.

## Testing
`TEST="tests/flow/test_rdb_load" ./flow.sh` → 2/2 pass.
Also ran `test_encode_decode`, `test_graph_copy` and `test_persistency`
alongside the touched files (88 tests) — no regressions.

Negative check — the test fails on the version the bug was reported against.
On `falkordb/falkordb:v4.20.1` the `RESTORE` decodes into the **source**
graph and then hangs the server:

```
1:M ... * <module> Graph 'src' processing virtual key: 1/1
1:M ... * <module> Graph 'src' processed 4/2 nodes
1:M ... * <module> Graph 'src' processed 2/1 edges
```

Note the graph name is `src` even though the restore target was `dst`, and
the node count has doubled (`4/2`) because the dump was decoded on top of
the existing graph. The connection never returns and a subsequent `PING`
times out.

## Memory / Performance Impact
N/A — test-only change. The added test builds a two-node graph.

## Related Issues
References #2048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for restoring graph data under alternate keys.
  * Verified restored graphs appear correctly, initially retain equivalent data, and remain independently writable.
  * Confirmed write isolation is preserved before and after reload operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->