### PR TITLE
fix(bulk): index rows appended by GRAPH.BULK into an existing graph

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1492,10 +1492,20 @@ impl Graph {
     }
 
     /// Import pre-resolved relationship attributes directly into the cache.
+    ///
+    /// Marks the imported edges for (re)indexing, exactly as
+    /// [`import_relationship_attrs`](Self::import_relationship_attrs) does; the caller
+    /// publishes them with [`commit_edge_index`](Self::commit_edge_index). Tracking runs
+    /// **before** the import because `import_attrs_resolved` drains `data`.
     pub fn import_relationship_attrs_resolved(
         &mut self,
         data: &mut Vec<(u64, Vec<(u16, Value)>)>,
+        index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
+        self.track_edge_index_updates(
+            data.iter().map(|(id, attrs)| (id, attrs)),
+            index_add_edge_docs,
+        );
         self.relationship_attrs.import_attrs_resolved(data)
     }
 
@@ -1520,9 +1530,9 @@ impl Graph {
     /// Mark every `(type_id, edge_id)` whose changed attributes are
     /// indexed so the next `commit_edge_index` pass rebuilds their
     /// documents. Shared by the import and set paths.
-    fn track_edge_index_updates(
+    fn track_edge_index_updates<'a>(
         &self,
-        attrs: &FxHashMap<u64, Vec<(u16, Value)>>,
+        attrs: impl IntoIterator<Item = (&'a u64, &'a Vec<(u16, Value)>)>,
         index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) {
         if !self.edge_indexer.has_indices() {

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1431,10 +1431,42 @@ impl Graph {
 
     /// Import pre-resolved node attributes directly into the cache.
     /// Used by bulk insert to avoid per-node OrderMap allocations.
+    ///
+    /// Marks the imported nodes for (re)indexing, as
+    /// [`import_node_attrs`](Self::import_node_attrs) does. `label_ids` is the label set the
+    /// caller is applying to every node in `data` — a bulk token carries one label set for
+    /// all its rows, so it is passed once instead of looked up per node.
+    ///
+    /// Keeping the tracking here rather than at the call site matters: the alternative is an
+    /// unwritten rule that attributes must be imported before labels are set, and the natural
+    /// order (the one [`Pending::commit`] uses) is the opposite, so a future refactor would
+    /// silently stop indexing bulk-loaded rows.
+    ///
+    /// Tracking runs **before** the import because `import_attrs_resolved` drains `data`.
     pub fn import_node_attrs_resolved(
         &mut self,
         data: &mut Vec<(u64, Vec<(u16, Value)>)>,
+        label_ids: &[LabelId],
+        index_add_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
+        if self.node_indexer.has_indices() {
+            for (id, attrs) in data.iter() {
+                for label_id in label_ids {
+                    let label = &self.node_labels[label_id.0];
+                    for (attr_id, _) in attrs {
+                        let Some(key) = self.node_attrs.attrs_name.get(*attr_id as usize) else {
+                            continue;
+                        };
+                        if self.node_indexer.has_indexed_attr(label, key) {
+                            index_add_docs
+                                .entry(label_id.0 as u64)
+                                .or_default()
+                                .insert(*id);
+                        }
+                    }
+                }
+            }
+        }
         self.node_attrs.import_attrs_resolved(data)
     }
 
@@ -1500,9 +1532,11 @@ impl Graph {
     pub fn import_relationship_attrs_resolved(
         &mut self,
         data: &mut Vec<(u64, Vec<(u16, Value)>)>,
+        type_id: TypeId,
         index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
-        self.track_edge_index_updates(
+        self.track_edge_index_updates_of_type(
+            type_id,
             data.iter().map(|(id, attrs)| (id, attrs)),
             index_add_edge_docs,
         );
@@ -1530,6 +1564,38 @@ impl Graph {
     /// Mark every `(type_id, edge_id)` whose changed attributes are
     /// indexed so the next `commit_edge_index` pass rebuilds their
     /// documents. Shared by the import and set paths.
+    /// As [`track_edge_index_updates`](Self::track_edge_index_updates), for a caller that
+    /// already knows the type every edge in `attrs` carries — a bulk token has exactly one.
+    ///
+    /// `get_relationship_type_id` iterates `relationship_type_matrix`, and `iter` waits on the
+    /// matrix, forcing a pending-delta merge. Doing that once per edge right after
+    /// `create_relationships_bulk` enqueued a large delta is the per-entity overhead the bulk
+    /// path exists to avoid, so the type is resolved once by the caller instead.
+    fn track_edge_index_updates_of_type<'a>(
+        &self,
+        type_id: TypeId,
+        attrs: impl IntoIterator<Item = (&'a u64, &'a Vec<(u16, Value)>)>,
+        index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
+    ) {
+        if !self.edge_indexer.has_indices() {
+            return;
+        }
+        let type_name = &self.relationship_types[type_id.0];
+        for (id, attrs) in attrs {
+            for (attr_id, _) in attrs {
+                let Some(key) = self.relationship_attrs.attrs_name.get(*attr_id as usize) else {
+                    continue;
+                };
+                if self.edge_indexer.has_indexed_attr(type_name, key) {
+                    index_add_edge_docs
+                        .entry(type_id.0 as u64)
+                        .or_default()
+                        .insert(*id);
+                }
+            }
+        }
+    }
+
     fn track_edge_index_updates<'a>(
         &self,
         attrs: impl IntoIterator<Item = (&'a u64, &'a Vec<(u16, Value)>)>,

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -317,20 +317,21 @@ fn process_node_token(
     g.create_nodes(&nodes_bitmap);
     unsafe { maybe_yield(raw_ctx) };
 
-    // Attributes must land BEFORE the labels. `set_nodes_labels_bulk` decides which nodes
-    // need (re)indexing with `has_attributes(id)`; running it first meant that test was
-    // always false here, so `index_add_docs` came back empty and rows bulk-loaded into a
-    // graph that already had an index were never indexed.
-    if !resolved_attrs.is_empty() {
-        g.import_node_attrs_resolved(&mut resolved_attrs);
-        unsafe { maybe_yield(raw_ctx) };
-    }
-
-    // Collect into the insert-wide accumulator; `BulkIndexDocs::publish` flushes it once
-    // every token has succeeded. Nothing else on this path would: GRAPH.BULK does not run
-    // the post-load `populate_indexes_sync` rebuild (that is the RDB / replica path).
     g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut docs.nodes);
     unsafe { maybe_yield(raw_ctx) };
+
+    // `import_node_attrs_resolved` marks these nodes for indexing, collecting into the
+    // insert-wide accumulator that `BulkIndexDocs::publish` flushes once every token has
+    // succeeded. Nothing else on this path would: GRAPH.BULK does not run the post-load
+    // `populate_indexes_sync` rebuild (that is the RDB / replica path).
+    //
+    // `set_nodes_labels_bulk` above also collects, but only for nodes that already have
+    // attributes — none do at this point — so it contributes nothing here and the two do
+    // not double up.
+    if !resolved_attrs.is_empty() {
+        g.import_node_attrs_resolved(&mut resolved_attrs, &label_ids, &mut docs.nodes);
+        unsafe { maybe_yield(raw_ctx) };
+    }
 
     Ok(())
 }
@@ -353,7 +354,7 @@ fn process_edge_token(
         ));
     }
     let type_name = Arc::new(type_names[0].clone());
-    g.get_type_id_mut(&type_name);
+    let type_id = g.get_type_id_mut(&type_name);
 
     let attr_ids: Vec<u16> = prop_names
         .iter()
@@ -403,7 +404,7 @@ fn process_edge_token(
 
     if !resolved_rel_attrs.is_empty() {
         // Same as the node path: collect now, publish once the whole insert has succeeded.
-        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs, &mut docs.edges);
+        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs, type_id, &mut docs.edges);
         unsafe { maybe_yield(raw_ctx) };
     }
 

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -642,6 +642,19 @@ pub fn graph_bulk_insert(
                     session.with_graph(|tg| tg.graph.rollback());
                     break 'phase Err(format!("ERR bulk insert failed: {e}"));
                 }
+                // Every token succeeded, so the index documents are safe to publish —
+                // and this must happen while still in phase 1, GIL-free. A bulk load
+                // can carry millions of documents, and phase 2 below holds the GIL, so
+                // publishing there would stall the whole server for the duration.
+                // `commit_index` takes the indexer's own write lock, so it needs no
+                // help from L1.
+                //
+                // The only failure left after this point is `upgrade_to_write`
+                // reporting that the graph was deleted or replaced — in which case the
+                // indexer these documents went into departs with it, so they are
+                // unreachable rather than stale.
+                docs.publish(&mut g_arc.borrow_mut());
+
                 // Phase 2: commit + replicate as a writer, so the commit Arc-swap
                 // happens under the GIL and stays fork-safe (#452). Escalation takes
                 // the global lock before the write lock, never the reverse (#726).
@@ -652,8 +665,6 @@ pub fn graph_bulk_insert(
                     session.with_graph(|tg| tg.graph.rollback());
                     break 'phase Err(e);
                 }
-                // Success path only — see the note on the synchronous branch.
-                docs.publish(&mut g_arc.borrow_mut());
                 session
                     .with_graph_mut(|tg| tg.graph.commit(g_arc))
                     .expect("writer mode after upgrade_to_write");

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -642,19 +642,6 @@ pub fn graph_bulk_insert(
                     session.with_graph(|tg| tg.graph.rollback());
                     break 'phase Err(format!("ERR bulk insert failed: {e}"));
                 }
-                // Every token succeeded, so the index documents are safe to publish —
-                // and this must happen while still in phase 1, GIL-free. A bulk load
-                // can carry millions of documents, and phase 2 below holds the GIL, so
-                // publishing there would stall the whole server for the duration.
-                // `commit_index` takes the indexer's own write lock, so it needs no
-                // help from L1.
-                //
-                // The only failure left after this point is `upgrade_to_write`
-                // reporting that the graph was deleted or replaced — in which case the
-                // indexer these documents went into departs with it, so they are
-                // unreachable rather than stale.
-                docs.publish(&mut g_arc.borrow_mut());
-
                 // Phase 2: commit + replicate as a writer, so the commit Arc-swap
                 // happens under the GIL and stays fork-safe (#452). Escalation takes
                 // the global lock before the write lock, never the reverse (#726).
@@ -665,6 +652,18 @@ pub fn graph_bulk_insert(
                     session.with_graph(|tg| tg.graph.rollback());
                     break 'phase Err(e);
                 }
+                // Publish the index documents inside the writer scope, matching
+                // `CommitOp`: the index is not MVCC, so readers must be excluded while
+                // it is mutated, and a read query holds L1-read for its whole session.
+                // Published in phase 1 instead, a concurrent reader could see documents
+                // for entities that exist only in this uncommitted fork and get ids it
+                // cannot resolve against its own snapshot.
+                //
+                // Every token has succeeded by now, so nothing reaches the index for an
+                // insert that later rolls back. The cost is a GIL hold proportional to
+                // the number of indexed rows — paid only when the graph actually has an
+                // index, since `docs` is otherwise empty.
+                docs.publish(&mut g_arc.borrow_mut());
                 session
                     .with_graph_mut(|tg| tg.graph.commit(g_arc))
                     .expect("writer mode after upgrade_to_write");

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -286,12 +286,24 @@ fn process_node_token(
     g.create_nodes(&nodes_bitmap);
     unsafe { maybe_yield(raw_ctx) };
 
+    // Attributes must land BEFORE the labels. `set_nodes_labels_bulk` decides which nodes
+    // need (re)indexing with `has_attributes(id)`; running it first meant that test was
+    // always false here, so `index_add_docs` came back empty and rows bulk-loaded into a
+    // graph that already had an index were never indexed.
+    if !resolved_attrs.is_empty() {
+        g.import_node_attrs_resolved(&mut resolved_attrs);
+        unsafe { maybe_yield(raw_ctx) };
+    }
+
     let mut index_add_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
     g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut index_add_docs);
     unsafe { maybe_yield(raw_ctx) };
 
-    if !resolved_attrs.is_empty() {
-        g.import_node_attrs_resolved(&mut resolved_attrs);
+    // Publish what `set_nodes_labels_bulk` collected. Nothing else on this path flushes it:
+    // GRAPH.BULK does not run the post-load `populate_indexes_sync` rebuild (that is the
+    // RDB / replica path), so without this the documents are simply dropped.
+    if !index_add_docs.is_empty() {
+        g.commit_index(&mut index_add_docs, &mut FxHashMap::default());
         unsafe { maybe_yield(raw_ctx) };
     }
 
@@ -364,8 +376,15 @@ fn process_edge_token(
     unsafe { maybe_yield(raw_ctx) };
 
     if !resolved_rel_attrs.is_empty() {
-        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs);
+        let mut index_add_edge_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
+        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs, &mut index_add_edge_docs);
         unsafe { maybe_yield(raw_ctx) };
+
+        // Same as the node path: nothing else flushes these on a bulk load.
+        if !index_add_edge_docs.is_empty() {
+            g.commit_edge_index(&mut index_add_edge_docs, &mut FxHashMap::default());
+            unsafe { maybe_yield(raw_ctx) };
+        }
     }
 
     Ok(())

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -226,12 +226,43 @@ unsafe fn maybe_yield(raw_ctx: *mut raw::RedisModuleCtx) {
     }
 }
 
+/// Index documents collected while processing bulk tokens.
+///
+/// RediSearch is not versioned, so anything published into it cannot be undone by the
+/// MVCC rollback that a later failing token triggers. Accumulate across the whole insert
+/// and publish once, on the success path only — otherwise a batch that fails midway
+/// leaves documents behind for entities that were never committed (and whose ids may be
+/// handed to different entities later).
+#[derive(Default)]
+struct BulkIndexDocs {
+    nodes: FxHashMap<u64, RoaringTreemap>,
+    edges: FxHashMap<u64, RoaringTreemap>,
+}
+
+impl BulkIndexDocs {
+    /// Publish into the indexes. Call only once every token has succeeded, and while
+    /// `g` is still the un-published fork — a committed version may be borrowed by
+    /// concurrent readers.
+    fn publish(
+        &mut self,
+        g: &mut Graph,
+    ) {
+        if !self.nodes.is_empty() {
+            g.commit_index(&mut self.nodes, &mut FxHashMap::default());
+        }
+        if !self.edges.is_empty() {
+            g.commit_edge_index(&mut self.edges, &mut FxHashMap::default());
+        }
+    }
+}
+
 fn process_node_token(
     g: &mut Graph,
     data: &[u8],
     node_ids: &[NodeId],
     node_id_cursor: &mut usize,
     raw_ctx: *mut raw::RedisModuleCtx,
+    docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
     let mut idx = 0;
     let (labels, prop_names) = parse_header(data, &mut idx, "Label name")?;
@@ -295,17 +326,11 @@ fn process_node_token(
         unsafe { maybe_yield(raw_ctx) };
     }
 
-    let mut index_add_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
-    g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut index_add_docs);
+    // Collect into the insert-wide accumulator; `BulkIndexDocs::publish` flushes it once
+    // every token has succeeded. Nothing else on this path would: GRAPH.BULK does not run
+    // the post-load `populate_indexes_sync` rebuild (that is the RDB / replica path).
+    g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut docs.nodes);
     unsafe { maybe_yield(raw_ctx) };
-
-    // Publish what `set_nodes_labels_bulk` collected. Nothing else on this path flushes it:
-    // GRAPH.BULK does not run the post-load `populate_indexes_sync` rebuild (that is the
-    // RDB / replica path), so without this the documents are simply dropped.
-    if !index_add_docs.is_empty() {
-        g.commit_index(&mut index_add_docs, &mut FxHashMap::default());
-        unsafe { maybe_yield(raw_ctx) };
-    }
 
     Ok(())
 }
@@ -316,6 +341,7 @@ fn process_edge_token(
     rel_ids: &[RelationshipId],
     rel_id_cursor: &mut usize,
     raw_ctx: *mut raw::RedisModuleCtx,
+    docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
     let mut idx = 0;
     let (type_names, prop_names) = parse_header(data, &mut idx, "Relationship type")?;
@@ -376,15 +402,9 @@ fn process_edge_token(
     unsafe { maybe_yield(raw_ctx) };
 
     if !resolved_rel_attrs.is_empty() {
-        let mut index_add_edge_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
-        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs, &mut index_add_edge_docs);
+        // Same as the node path: collect now, publish once the whole insert has succeeded.
+        g.import_relationship_attrs_resolved(&mut resolved_rel_attrs, &mut docs.edges);
         unsafe { maybe_yield(raw_ctx) };
-
-        // Same as the node path: nothing else flushes these on a bulk load.
-        if !index_add_edge_docs.is_empty() {
-            g.commit_edge_index(&mut index_add_edge_docs, &mut FxHashMap::default());
-            unsafe { maybe_yield(raw_ctx) };
-        }
     }
 
     Ok(())
@@ -398,6 +418,7 @@ fn bulk_insert_sync(
     edge_count: usize,
     node_token_count: usize,
     rel_token_count: usize,
+    docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
     let node_ids = g.reserve_nodes(node_count);
     let rel_ids = g.reserve_relationships(edge_count);
@@ -406,11 +427,11 @@ fn bulk_insert_sync(
 
     let null_ctx = std::ptr::null_mut();
     for token in tokens.iter().take(node_token_count) {
-        process_node_token(g, token, &node_ids, &mut node_id_cursor, null_ctx)?;
+        process_node_token(g, token, &node_ids, &mut node_id_cursor, null_ctx, docs)?;
     }
 
     for token in tokens.iter().skip(node_token_count).take(rel_token_count) {
-        process_edge_token(g, token, &rel_ids, &mut rel_id_cursor, null_ctx)?;
+        process_edge_token(g, token, &rel_ids, &mut rel_id_cursor, null_ctx, docs)?;
     }
 
     // Flush delta-plus into base to prevent large dp from slowing subsequent commands
@@ -427,6 +448,7 @@ fn bulk_insert_sync_yield(
     node_token_count: usize,
     rel_token_count: usize,
     raw_ctx: *mut raw::RedisModuleCtx,
+    docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
     let node_ids = g.reserve_nodes(node_count);
     let rel_ids = g.reserve_relationships(edge_count);
@@ -434,13 +456,13 @@ fn bulk_insert_sync_yield(
     let mut rel_id_cursor = 0usize;
 
     for token in tokens.iter().take(node_token_count) {
-        process_node_token(g, token, &node_ids, &mut node_id_cursor, raw_ctx)?;
+        process_node_token(g, token, &node_ids, &mut node_id_cursor, raw_ctx, docs)?;
         // Yield to let Redis process PING from other clients
         unsafe { maybe_yield(raw_ctx) };
     }
 
     for token in tokens.iter().skip(node_token_count).take(rel_token_count) {
-        process_edge_token(g, token, &rel_ids, &mut rel_id_cursor, raw_ctx)?;
+        process_edge_token(g, token, &rel_ids, &mut rel_id_cursor, raw_ctx, docs)?;
         unsafe { maybe_yield(raw_ctx) };
     }
 
@@ -536,6 +558,7 @@ pub fn graph_bulk_insert(
                 "ERR another write is in progress, retry the query".to_string(),
             ));
         };
+        let mut docs = BulkIndexDocs::default();
         let result = {
             let mut g = g_arc.borrow_mut();
             bulk_insert_sync_yield(
@@ -546,10 +569,16 @@ pub fn graph_bulk_insert(
                 node_token_count,
                 rel_token_count,
                 ctx.ctx,
+                &mut docs,
             )
         };
         return match result {
             Ok(()) => {
+                // Every token succeeded, so the index documents are safe to publish. Do it
+                // while `g_arc` is still the un-published fork: after the swap it may be
+                // borrowed by concurrent readers, and on the error arm below it is thrown
+                // away — which is precisely what must happen to the documents too.
+                docs.publish(&mut g_arc.borrow_mut());
                 tg.graph.commit(g_arc);
                 ctx.replicate_verbatim();
                 let reply = format!("{node_count} nodes created, {edge_count} relations created");
@@ -594,6 +623,7 @@ pub fn graph_bulk_insert(
                         "ERR another write is in progress, retry the query".to_string()
                     );
                 };
+                let mut docs = BulkIndexDocs::default();
                 let inserted = {
                     let mut g = g_arc.borrow_mut();
                     let tokens: Vec<&[u8]> =
@@ -605,6 +635,7 @@ pub fn graph_bulk_insert(
                         edge_count,
                         node_token_count,
                         rel_token_count,
+                        &mut docs,
                     )
                 };
                 if let Err(e) = inserted {
@@ -621,6 +652,8 @@ pub fn graph_bulk_insert(
                     session.with_graph(|tg| tg.graph.rollback());
                     break 'phase Err(e);
                 }
+                // Success path only — see the note on the synchronous branch.
+                docs.publish(&mut g_arc.borrow_mut());
                 session
                     .with_graph_mut(|tg| tg.graph.commit(g_arc))
                     .expect("writer mode after upgrade_to_write");

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -835,3 +835,64 @@ class testGraphBulkInsertFlow(FlowTestsBase):
         for edge_csv in edge_csvs:
             os.remove(edge_csv)
 
+    # Rows appended by GRAPH.BULK into a graph that ALREADY has an index must be indexed.
+    #
+    # GRAPH.BULK only creates a graph when the batch carries a BEGIN token; a batch
+    # without it appends to the existing graph. The official loader always begins on a
+    # fresh graph and adds its indexes afterwards, so it never exercises the append path
+    # against a live index — this test does, by reusing the loader's own serialization
+    # with the BEGIN token suppressed.
+    #
+    # Regression: the bulk path collected index documents *before* importing the
+    # attributes, so `has_attributes(id)` was always false and it collected none — then
+    # dropped the map without committing it. Nothing repaired it afterwards, because
+    # GRAPH.BULK does not run the post-load `populate_indexes_sync` rebuild.
+    def test13_bulk_append_into_indexed_graph(self):
+        from falkordb_bulk_loader.bulk_insert import parse_schemas, process_entities
+        from falkordb_bulk_loader.query_buffer import QueryBuffer
+        from falkordb_bulk_loader.config import Config
+        from falkordb_bulk_loader.label import Label
+        from falkordb_bulk_loader.relation_type import RelationType
+
+        graphname = "bulk_append_indexed"
+        graph = self.db.select_graph(graphname)
+
+        # Creates the graph AND the indexes, before any bulk data exists.
+        graph.query("CREATE INDEX FOR (n:N) ON (n.v)")
+        graph.query("CREATE INDEX FOR ()-[r:R]->() ON (r.w)")
+
+        node_csv, rel_csv = '/tmp/bulk_append_nodes.tmp', '/tmp/bulk_append_rels.tmp'
+        with open(node_csv, mode='w') as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["v"])
+            for i in range(100):
+                out.writerow([i])
+        with open(rel_csv, mode='w') as csv_file:
+            out = csv.writer(csv_file)
+            out.writerow(["src", "dest", "w"])
+            for i in range(99):
+                out.writerow([i, i + 1, i])
+
+        # Append (no BEGIN) — the path the loader CLI cannot produce.
+        config = Config(store_node_identifiers=True)
+        buf = QueryBuffer(graphname, self.db.connection, config)
+        buf.initial_query = False
+        entities = parse_schemas(Label, buf, [], [('N', node_csv)], config)
+        entities += parse_schemas(RelationType, buf, [], [('R', rel_csv)], config)
+        process_entities(entities)
+        buf.send_buffer()
+        buf.wait_pool()
+
+        # An index-served count must equal the full-scan count; `+ 0` defeats index selection.
+        idx_n = graph.query("MATCH (n:N) WHERE n.v >= 0 RETURN count(n)").result_set[0][0]
+        scan_n = graph.query("MATCH (n:N) WHERE n.v + 0 >= 0 RETURN count(n)").result_set[0][0]
+        self.env.assertEqual(scan_n, 100)
+        self.env.assertEqual(idx_n, scan_n)
+
+        idx_e = graph.query("MATCH ()-[r:R]->() WHERE r.w >= 0 RETURN count(r)").result_set[0][0]
+        scan_e = graph.query("MATCH ()-[r:R]->() WHERE r.w + 0 >= 0 RETURN count(r)").result_set[0][0]
+        self.env.assertEqual(scan_e, 99)
+        self.env.assertEqual(idx_e, scan_e)
+
+        os.remove(node_csv)
+        os.remove(rel_csv)

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -884,13 +884,30 @@ class testGraphBulkInsertFlow(FlowTestsBase):
         buf.wait_pool()
 
         # An index-served count must equal the full-scan count; `+ 0` defeats index selection.
-        idx_n = graph.query("MATCH (n:N) WHERE n.v >= 0 RETURN count(n)").result_set[0][0]
-        scan_n = graph.query("MATCH (n:N) WHERE n.v + 0 >= 0 RETURN count(n)").result_set[0][0]
+        # Compare an index-served count against a full-scan count of the same rows: the
+        # `+ 0` defeats index selection, so the two agree only if the bulk-loaded rows
+        # actually reached the index.
+        #
+        # Pin that premise first. Without these two assertions the comparison silently
+        # degrades to scan-vs-scan the day the planner stops picking the index here, and
+        # the test would then pass with the fix reverted.
+        idx_n_query = "MATCH (n:N) WHERE n.v >= 0 RETURN count(n)"
+        scan_n_query = "MATCH (n:N) WHERE n.v + 0 >= 0 RETURN count(n)"
+        self.env.assertContains('Node By Index Scan', str(graph.explain(idx_n_query)))
+        self.env.assertNotContains('Node By Index Scan', str(graph.explain(scan_n_query)))
+
+        idx_n = graph.query(idx_n_query).result_set[0][0]
+        scan_n = graph.query(scan_n_query).result_set[0][0]
         self.env.assertEqual(scan_n, 100)
         self.env.assertEqual(idx_n, scan_n)
 
-        idx_e = graph.query("MATCH ()-[r:R]->() WHERE r.w >= 0 RETURN count(r)").result_set[0][0]
-        scan_e = graph.query("MATCH ()-[r:R]->() WHERE r.w + 0 >= 0 RETURN count(r)").result_set[0][0]
+        idx_e_query = "MATCH ()-[r:R]->() WHERE r.w >= 0 RETURN count(r)"
+        scan_e_query = "MATCH ()-[r:R]->() WHERE r.w + 0 >= 0 RETURN count(r)"
+        self.env.assertContains('Edge By Index Scan', str(graph.explain(idx_e_query)))
+        self.env.assertNotContains('Edge By Index Scan', str(graph.explain(scan_e_query)))
+
+        idx_e = graph.query(idx_e_query).result_set[0][0]
+        scan_e = graph.query(scan_e_query).result_set[0][0]
         self.env.assertEqual(scan_e, 99)
         self.env.assertEqual(idx_e, scan_e)
 


### PR DESCRIPTION
Closes #2294.

## The bug

`GRAPH.BULK` creates a graph only when the batch carries a `BEGIN` token; a batch without one appends to the existing graph. On that append path the loaded rows were never indexed.

It is not a partial miss — the index returns **zero** rows for data that is plainly there, so any index-served query on that graph silently returns nothing:

| | index count | scan count |
|---|---|---|
| before | **0** | 100 |
| after | 100 | 100 |

## Root cause

Two separate causes, one per entity type.

**Nodes — right logic, wrong order.** `set_nodes_labels_bulk` already decides which nodes need (re)indexing:

```rust
if self.node_indexer.has_index(label) && self.node_attrs.has_attributes(id) {
    index_add_docs.entry(label_id).or_default().insert(id);
}
```

but it ran *before* `import_node_attrs_resolved`, so `has_attributes(id)` was always false and it collected nothing. The map it filled was then dropped without ever being committed. Fixed by importing the attributes first, then collecting, then publishing with `commit_index`.

**Edges — no maintenance at all.** `import_relationship_attrs_resolved` did none, unlike its `import_relationship_attrs` sibling. It now tracks the imported edges, and the caller publishes them with `commit_edge_index`. Tracking runs *before* the import because `import_attrs_resolved` drains its input. `track_edge_index_updates` now takes an iterator so both the map-shaped and `Vec`-shaped callers can use it.

Nothing repaired this afterwards: `GRAPH.BULK` does not run the post-load `populate_indexes_sync` rebuild — that belongs to the RDB and replica load paths.

## Reachability

The official `falkordb-bulk-loader` **cannot** trigger this. It always sends `BEGIN` against a fresh graph, and creates its own `-i` indexes *after* the load ("Add in Graph Indices after graph creation"), so no index can pre-exist. That is presumably why this went unnoticed.

It is reachable by any client issuing `GRAPH.BULK <key> <counts> …` without `BEGIN` against a graph that already has an index — a supported, unguarded append (e.g. incremental bulk loading from a custom client).

Issue #2294's original repro used the CLI and does not reproduce; I have corrected it there.

## Test

`test13_bulk_append_into_indexed_graph` drives the append path directly, since the CLI cannot. It reuses the loader's own serialization with the `BEGIN` token suppressed (`QueryBuffer.initial_query = False`), so there is no hand-rolled wire format.

Verified **red before the fix, green after** — 0/100 nodes and 0/99 edges indexed without it, correct with it. Full `testGraphBulkInsertFlow` class: 13/13 passing.

One caveat worth flagging for review: the test couples to `falkordb-bulk-loader` internals (`QueryBuffer`, `initial_query`, `parse_schemas`). That package is already pinned in `tests/requirements.txt`, but a loader restructure would break the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bulk data insertion so node labels and relationship attributes are correctly reflected in indexes.
  - Ensured index updates are committed during bulk loading, improving indexed query accuracy.
  - Fixed appending bulk data to already indexed graphs, including workflows without an explicit transaction start.
  - Prevented failed bulk insertions from publishing incomplete index updates.

- **Tests**
  - Added coverage verifying indexed counts match full graph scans after bulk insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->