### PR TITLE
feat(index): native numeric index — CoW columns, folded-roots MVCC, read/write paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ strip = false
 
 [features]
 fuzz = []
+# Pass-through for graph's native numeric index. Enables `index::falkordb` in the
+# shipped `.so`; off by default. See graph/Cargo.toml for the full contract.
+index-falkordb = ["graph/index-falkordb"]
 # Drive GraphBLAS at GxB_JIT_ON (full JIT including compile-on-demand) so the
 # JIT cache populates as we exercise the test suite. Consumed by graph's
 # matrix.rs and forwarded by gen_prejit.sh; never enable in shipped builds —

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -18,6 +18,12 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }
 # process env var that could leak into a shipped binary.
 prejit_harvest = []
 
+# Native FalkorDB numeric index (the in-repo replacement for RediSearch). Gates
+# `index::falkordb` — the encoder, the cow_btree-backed index, and its runtime
+# wiring. Off by default: the shipped build is byte-for-byte unchanged until this
+# is switched on. No RediSearch fallback lives under this flag.
+index-falkordb = []
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -21,7 +21,9 @@ prejit_harvest = []
 # Native FalkorDB numeric index (the in-repo replacement for RediSearch). Gates
 # `index::falkordb` — the encoder, the cow_btree-backed index, and its runtime
 # wiring. Off by default: the shipped build is byte-for-byte unchanged until this
-# is switched on. No RediSearch fallback lives under this flag.
+# is switched on. The native index does not yet replace RediSearch: a numeric
+# Equal/Range predicate is served natively and everything else — strings, geo,
+# composite predicates, missing columns — still falls through to RediSearch.
 index-falkordb = []
 
 

--- a/graph/src/entity_type.rs
+++ b/graph/src/entity_type.rs
@@ -14,7 +14,7 @@
 //! scan selection), and the graph storage layer (index maintenance).
 
 /// Entity type that can be indexed.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum EntityType {
     /// Index on node properties
     Node,

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1451,16 +1451,24 @@ impl Graph {
             let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
                 HashMap::new();
             let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            let mut labels: Vec<u64> = Vec::new();
             for (id, m) in attrs {
+                // Once per node — see `node_label_ids_into`. The old-value read is hoisted out of
+                // the label loop for the same reason: it does not vary with the label.
+                self.node_label_ids_into(*id, &mut labels);
                 for (attr_id, new_value) in m.iter() {
                     // main now passes pre-resolved u16 attr ids; the index keys columns by name.
                     let Some(attr) = self.node_attr_name(*attr_id) else {
                         continue;
                     };
-                    if let Some(old) = self.get_node_attribute_by_idx(NodeId(*id), *attr_id) {
-                        self.stage_index_node(*id, &attr, &old, &mut removes);
+                    let old = self.get_node_attribute_by_idx(NodeId(*id), *attr_id);
+                    for &label_id in &labels {
+                        let label = &self.node_labels[label_id as usize];
+                        if let Some(old) = &old {
+                            self.stage_index_column(label, &attr, old, *id, &mut removes);
+                        }
+                        self.stage_index_column(label, &attr, new_value, *id, &mut adds);
                     }
-                    self.stage_index_node(*id, &attr, new_value, &mut adds);
                 }
             }
             (removes, adds)
@@ -1510,9 +1518,20 @@ impl Graph {
         if !self.falkordb_index.is_empty() {
             let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
             for (id, m) in attrs {
+                // Labels come from `new_labels`, never from the matrix — that is the whole reason
+                // this function takes them. The index staging used to reach for
+                // `node_labels_matrix.iter` once per (node, attribute), reintroducing exactly the
+                // `wait`-forced delta merge the doc comment above says this path avoids.
+                let Some(label_ids) = new_labels.get(id) else {
+                    continue; // no labels this transaction — nothing routes to a column
+                };
                 for (attr_id, value) in m.iter() {
-                    if let Some(attr) = self.node_attr_name(*attr_id) {
-                        self.stage_index_node(*id, &attr, value, &mut adds);
+                    let Some(attr) = self.node_attr_name(*attr_id) else {
+                        continue;
+                    };
+                    for &label_id in label_ids {
+                        let label = &self.node_labels[label_id as usize];
+                        self.stage_index_column(label, &attr, value, *id, &mut adds);
                     }
                 }
             }
@@ -1849,9 +1868,14 @@ impl Graph {
         if !self.falkordb_index.is_empty() {
             let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
                 HashMap::new();
+            let mut labels: Vec<u64> = Vec::new();
             for id in deleted_nodes {
+                self.node_label_ids_into(id, &mut labels); // once per node, not per attribute
                 for (attr, value) in self.get_node_all_attrs(NodeId(id)) {
-                    self.stage_index_node(id, &attr, &value, &mut removes);
+                    for &label_id in &labels {
+                        let label = &self.node_labels[label_id as usize];
+                        self.stage_index_column(label, &attr, &value, id, &mut removes);
+                    }
                 }
             }
             self.falkordb_index
@@ -3286,24 +3310,40 @@ impl Graph {
     /// Stage `(value, id)` into every index column `(label, attr)` the node `id` belongs to (a node
     /// may carry several labels). Shared-borrow only — the caller applies the staged columns after.
     #[cfg(feature = "index-falkordb")]
-    fn stage_index_node(
+    fn stage_index_column(
         &self,
-        id: u64,
+        label: &Arc<String>,
         attr: &Arc<String>,
         value: &Value,
+        id: u64,
         out: &mut HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>>,
     ) {
-        for (_, label_id) in self.node_labels_matrix.iter(id, id) {
-            let label = &self.node_labels[label_id as usize];
-            if self
-                .falkordb_index
-                .has_column(EntityType::Node, label, attr)
-            {
-                out.entry((label.clone(), attr.clone()))
-                    .or_default()
-                    .push((value.clone(), id));
-            }
+        if self
+            .falkordb_index
+            .has_column(EntityType::Node, label, attr)
+        {
+            out.entry((label.clone(), attr.clone()))
+                .or_default()
+                .push((value.clone(), id));
         }
+    }
+
+    /// The node's label ids, reusing `out`'s allocation across nodes.
+    ///
+    /// Exists so callers resolve labels **once per node**. `node_labels_matrix.iter` carries a
+    /// `wait` that forces a pending-delta merge — O(accumulated delta) — and a node's label set
+    /// does not depend on which attribute is being written, so folding this into a per-attribute
+    /// helper multiplied that cost for nothing. Same defect, and same fix, as the edge path in
+    /// #2344. A caller that already knows the labels (`import_node_attrs` has them in
+    /// `new_labels`) must not call this at all.
+    #[cfg(feature = "index-falkordb")]
+    fn node_label_ids_into(
+        &self,
+        id: u64,
+        out: &mut Vec<u64>,
+    ) {
+        out.clear();
+        out.extend(self.node_labels_matrix.iter(id, id).map(|(_, l)| l));
     }
 
     /// Stage every indexed `(value, id)` the node `id` carries **under the single label `label_id`** —

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3169,6 +3169,14 @@ impl Graph {
 
     /// Create an index and populate it synchronously (for RDB load).
     /// Unlike `create_index`, this doesn't spawn async tasks.
+    ///
+    /// **The caller must reach `populate_indexes_sync` before publishing this version.** This
+    /// leaves the native column created but *empty*, and an empty column is indistinguishable
+    /// from one that legitimately matches nothing — a query reaching it would return no rows
+    /// rather than falling back. Every caller pairs the two inside one unpublished fork today
+    /// (`rebuild_indexes` + `populate_indexes_sync` in the decoder, and the `has_index_ops` arm
+    /// of `apply_effects`), so no reader can observe the gap; a new caller that skips the
+    /// populate would silently serve empty results.
     pub fn create_index_sync(
         &mut self,
         index_type: &IndexType,
@@ -3225,12 +3233,6 @@ impl Graph {
         Ok(())
     }
 
-    /// Bulk-build the index for each of `attrs` on `label` from
-    /// the current live nodes, on the write thread. The folded index lives on
-    /// this graph version, so it MUST be filled here (with `&mut Graph`) and
-    /// never via the async RediSearch populate, which reads through the
-    /// `Indexer -> Graph` back-pointer this design rejects. A `(label, attr)`
-    /// with no live nodes or no numeric values yields an empty column.
     /// Collect the `(value, node_id)` entries for one node index column `(label, attr)` from the
     /// current live nodes — shared-borrow only (label matrix + attribute store are `&self`).
     #[cfg(feature = "index-falkordb")]
@@ -3254,6 +3256,12 @@ impl Graph {
         pairs
     }
 
+    /// Bulk-build the index for each of `attrs` on `label` from
+    /// the current live nodes, on the write thread. The folded index lives on
+    /// this graph version, so it MUST be filled here (with `&mut Graph`) and
+    /// never via the async RediSearch populate, which reads through the
+    /// `Indexer -> Graph` back-pointer this design rejects. A `(label, attr)`
+    /// with no live nodes or no numeric values yields an empty column.
     #[cfg(feature = "index-falkordb")]
     fn populate_index_node(
         &mut self,
@@ -3333,12 +3341,8 @@ impl Graph {
     // edges; a mutation that bypasses these hooks would leak a stale tuple that surfaces once the
     // edge_id is reused. Add the stage/apply hook to any new indexed-edge-attr write path.
 
-    /// Bulk-build the edge index for each of `attrs` on `type_name` from the type's
-    /// live edges, on the write thread. Mirrors [`populate_index_node`] for edges.
-    #[cfg(feature = "index-falkordb")]
     /// Collect the `(value, edge_id)` entries for one edge index column `(type, attr)` from the
-    /// type's live edges — shared-borrow only. Reused by the synchronous populate and the background
-    /// build.
+    /// type's live edges — shared-borrow only.
     #[cfg(feature = "index-falkordb")]
     fn collect_edge_index_entries(
         &self,
@@ -3363,6 +3367,8 @@ impl Graph {
             .collect()
     }
 
+    /// Bulk-build the edge index for each of `attrs` on `type_name` from the type's
+    /// live edges, on the write thread. Mirrors [`populate_index_node`] for edges.
     #[cfg(feature = "index-falkordb")]
     fn populate_index_edge(
         &mut self,
@@ -3759,23 +3765,6 @@ impl Graph {
             }
         }
 
-        // Index: drop the column(s) in O(1) (releases the tree Arc). P4b (node) / #51 (edge).
-        #[cfg(feature = "index-falkordb")]
-        if *index_type == IndexType::Range {
-            for attr in &effective_attrs {
-                match entity_type {
-                    EntityType::Node => {
-                        self.falkordb_index
-                            .drop_column(EntityType::Node, label, attr)
-                    }
-                    EntityType::Relationship => {
-                        self.falkordb_index
-                            .drop_column(EntityType::Relationship, label, attr)
-                    }
-                }
-            }
-        }
-
         let (indexer, total, kind) = match entity_type {
             EntityType::Node => {
                 let total = self.get_label_matrix(label).map_or(
@@ -3799,6 +3788,16 @@ impl Graph {
 
         match reindex {
             Some((dropped, remaining)) if dropped > 0 => {
+                // Drop the native column(s) only now, after the indexer confirmed the drop.
+                // Doing it earlier meant the `no such index` arm below could leave RediSearch
+                // holding the index while the native columns were already gone — DROP INDEX
+                // reports failure but half the state is destroyed. O(1) each: releases the tree Arc.
+                #[cfg(feature = "index-falkordb")]
+                if *index_type == IndexType::Range {
+                    for attr in &effective_attrs {
+                        self.falkordb_index.drop_column(*entity_type, label, attr);
+                    }
+                }
                 if remaining > 0 {
                     indexer.recreate_index(label)?;
                     populate_index(kind, label.clone(), indexer.clone());
@@ -3871,13 +3870,24 @@ impl Graph {
         let iter =
             self.falkordb_index()
                 .query_numeric(EntityType::Relationship, type_name, query)?;
-        let resolved: Vec<(NodeId, NodeId, RelationshipId)> = iter
-            .filter_map(|eid| {
-                self.endpoints_for_edge(eid)
-                    .map(|(src, dst)| (NodeId(src), NodeId(dst), RelationshipId(eid)))
-            })
-            .collect();
-        Some(resolved.into_iter())
+        // Own the reverse index rather than borrowing `self`, so the iterator stays lazy: the
+        // signature is `+ use<>` (captures no lifetime), which is why this used to `collect()`
+        // into a Vec. `edge_endpoints` is an `Arc`, so cloning is a refcount bump and the decode
+        // is the same shift/mask `endpoints_for_edge` does. Laziness matters here — a range scan
+        // under a LIMIT should stop at the limit, not materialize every match first.
+        let endpoints = Arc::clone(&self.edge_endpoints);
+        Some(iter.filter_map(move |eid| {
+            endpoints
+                .get(eid as usize)
+                .filter(|&&key| key != EDGE_NO_ENDPOINT)
+                .map(|&key| {
+                    (
+                        NodeId(key >> 32),
+                        NodeId(key & 0xFFFF_FFFF),
+                        RelationshipId(eid),
+                    )
+                })
+        }))
     }
 
     #[must_use]

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1585,6 +1585,32 @@ impl Graph {
         label_ids: &[LabelId],
         index_add_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
+        // Native index: bulk-loaded rows are pure adds, exactly as in
+        // `import_node_attrs`. This has to be here and not only in the RediSearch block below —
+        // they are two separate indexes, and a row missing from the native one does not error, it
+        // just fails to come back: `test13_bulk_append_into_indexed_graph` returned 0 rows instead
+        // of 100 with the flag on while passing with it off.
+        //
+        // Labels come from `label_ids`, the set the bulk token applies to every row, so this never
+        // touches `node_labels_matrix` — same reason as `import_node_attrs`.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, attrs) in data.iter() {
+                for (attr_id, value) in attrs {
+                    let Some(attr) = self.node_attr_name(*attr_id) else {
+                        continue;
+                    };
+                    for label_id in label_ids {
+                        let label = &self.node_labels[label_id.0];
+                        self.stage_index_column(label, &attr, value, *id, &mut adds);
+                    }
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Node, adds, HashMap::new());
+        }
+
         if self.node_indexer.has_indices() {
             for (id, attrs) in data.iter() {
                 for label_id in label_ids {
@@ -1662,6 +1688,24 @@ impl Graph {
         type_id: TypeId,
         index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
+        // Native index: the edge half of the same gap the node path had. Bulk-loaded edges are
+        // pure adds; without this they are absent from the native edge column and an indexed
+        // edge query silently under-returns.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let type_name = self.relationship_types[type_id.0].clone();
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, attrs) in data.iter() {
+                for (attr_id, value) in attrs {
+                    if let Some(attr) = self.rel_attr_name(*attr_id) {
+                        self.stage_index_edge_of_type(&type_name, *id, &attr, value, &mut adds);
+                    }
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Relationship, adds, HashMap::new());
+        }
+
         self.track_edge_index_updates_of_type(
             type_id,
             data.iter().map(|(id, attrs)| (id, attrs)),
@@ -3451,6 +3495,30 @@ impl Graph {
     ) {
         let type_id = self.get_relationship_type_id(RelationshipId(id));
         let type_name = &self.relationship_types[type_id.0];
+        if self
+            .falkordb_index
+            .has_column(EntityType::Relationship, type_name, attr)
+        {
+            out.entry((type_name.clone(), attr.clone()))
+                .or_default()
+                .push((value.clone(), id));
+        }
+    }
+
+    /// [`stage_index_edge`](Self::stage_index_edge) for a caller that already knows the type.
+    ///
+    /// A bulk token carries exactly one type for all its rows, so re-deriving it per edge would
+    /// pay `get_relationship_type_id`'s `relationship_type_matrix` scan — and that `iter`'s wait
+    /// on the pending delta — once per row. Same hoist as `track_edge_index_updates_of_type`.
+    #[cfg(feature = "index-falkordb")]
+    fn stage_index_edge_of_type(
+        &self,
+        type_name: &Arc<String>,
+        id: u64,
+        attr: &Arc<String>,
+        value: &Value,
+        out: &mut HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>>,
+    ) {
         if self
             .falkordb_index
             .has_column(EntityType::Relationship, type_name, attr)

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -105,6 +105,23 @@ use crate::{
     threadpool::spawn,
 };
 
+/// Measurement gate: `true` when `FALKORDB_INDEX_ONLY=1`, meaning the index
+/// numeric index should be the sole maintainer of node Range indexes and the
+/// redundant RediSearch feed is skipped on the write path. Read once and cached.
+///
+/// This exists only to benchmark the index-only write cost against RediSearch
+/// without the dark-launch double-write; it is not a shipping mode (it disables
+/// the string/geo fallback). P7 replaces it with a per-index coverage guard.
+#[cfg(feature = "index-falkordb")]
+fn index_only_writes() -> bool {
+    use std::sync::OnceLock;
+    static INDEX_ONLY: OnceLock<bool> = OnceLock::new();
+    *INDEX_ONLY.get_or_init(|| {
+        std::env::var("FALKORDB_INDEX_ONLY")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
 /// Result of query parsing and planning.
 ///
 /// Contains the execution plan along with metadata about parsing performance.
@@ -326,6 +343,12 @@ pub struct Graph {
     pub version: u64,
     /// Schema version (incremented only on schema changes: new labels, relationship types, or attributes)
     pub schema_version: u64,
+    /// FalkorDB numeric indexes, folded into the graph version: `new_version`
+    /// forks them copy-on-write and the committed-version swap publishes graph +
+    /// index atomically (PR2 · P3). Strictly gated — absent when the feature is
+    /// off.
+    #[cfg(feature = "index-falkordb")]
+    falkordb_index: crate::index::falkordb::falkordb_index::FalkorDbIndex,
 }
 
 /// Wrapper for plan trees to implement Send+Sync.
@@ -720,6 +743,8 @@ impl Graph {
             constraints: Vec::new(),
             version,
             schema_version: 0,
+            #[cfg(feature = "index-falkordb")]
+            falkordb_index: crate::index::falkordb::falkordb_index::FalkorDbIndex::new(),
         }
     }
 
@@ -798,6 +823,11 @@ impl Graph {
             constraints: Vec::new(),
             version: 0,
             schema_version,
+            // P3: an empty set on restore. RDB (de)serialization of the pages is
+            // a later, separately-versioned step (P-SER); until then a restored
+            // graph's index is rebuilt by the populate path.
+            #[cfg(feature = "index-falkordb")]
+            falkordb_index: crate::index::falkordb::falkordb_index::FalkorDbIndex::new(),
         }
     }
 
@@ -895,7 +925,25 @@ impl Graph {
             constraints: self.constraints.clone(),
             version: self.version + 1,
             schema_version: self.schema_version,
+            #[cfg(feature = "index-falkordb")]
+            falkordb_index: self.falkordb_index.clone(),
         }
+    }
+
+    /// Shared read access to this version's FalkorDB indexes.
+    #[cfg(feature = "index-falkordb")]
+    #[must_use]
+    pub fn falkordb_index(&self) -> &crate::index::falkordb::falkordb_index::FalkorDbIndex {
+        &self.falkordb_index
+    }
+
+    /// Mutable access to this version's FalkorDB indexes, for the write path to
+    /// maintain them within the already-CoW-forked version.
+    #[cfg(feature = "index-falkordb")]
+    pub fn falkordb_index_mut(
+        &mut self
+    ) -> &mut crate::index::falkordb::falkordb_index::FalkorDbIndex {
+        &mut self.falkordb_index
     }
 
     #[must_use]
@@ -1391,7 +1439,38 @@ impl Graph {
         attrs: &FxHashMap<u64, Vec<(u16, Value)>>,
         index_add_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> Result<(usize, usize), String> {
+        // Index: collect maintenance BEFORE the overwrite, so the OLD value is still readable
+        // (that is the value-precise removal the tuple-keyed B-tree needs). Multi-SET in one txn is
+        // already collapsed by pending to `(first_old, final_new)`, so this sees exactly that pair.
+        // Fast path: with no native index columns, skip all staging (the per-attr Arc clone +
+        // old-value read the RediSearch path also avoids via `has_indices()`).
+        #[cfg(feature = "index-falkordb")]
+        let (index_removes, index_adds) = if self.falkordb_index.is_empty() {
+            (HashMap::new(), HashMap::new())
+        } else {
+            let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                HashMap::new();
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, m) in attrs {
+                for (attr_id, new_value) in m.iter() {
+                    // main now passes pre-resolved u16 attr ids; the index keys columns by name.
+                    let Some(attr) = self.node_attr_name(*attr_id) else {
+                        continue;
+                    };
+                    if let Some(old) = self.get_node_attribute_by_idx(NodeId(*id), *attr_id) {
+                        self.stage_index_node(*id, &attr, &old, &mut removes);
+                    }
+                    self.stage_index_node(*id, &attr, new_value, &mut adds);
+                }
+            }
+            (removes, adds)
+        };
         let (nremoved, nset) = self.node_attrs.insert_attrs(attrs)?;
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            self.falkordb_index
+                .merge(EntityType::Node, index_adds, index_removes);
+        }
 
         if self.node_indexer.has_indices() {
             for (id, attrs) in attrs {
@@ -1425,6 +1504,21 @@ impl Graph {
         index_add_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
         let nset = self.node_attrs.import_attrs(attrs);
+
+        // Index: new nodes are pure adds (no prior value). Fast path: skip staging with no columns.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, m) in attrs {
+                for (attr_id, value) in m.iter() {
+                    if let Some(attr) = self.node_attr_name(*attr_id) {
+                        self.stage_index_node(*id, &attr, value, &mut adds);
+                    }
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Node, adds, HashMap::new());
+        }
 
         if self.node_indexer.has_indices() {
             for (id, attrs) in attrs {
@@ -1461,6 +1555,11 @@ impl Graph {
     /// silently stop indexing bulk-loaded rows.
     ///
     /// Tracking runs **before** the import because `import_attrs_resolved` drains `data`.
+    ///
+    /// The native index is deliberately NOT maintained here yet: this stages only the
+    /// RediSearch documents. Bulk-loading into a graph with a native column therefore
+    /// leaves it stale, which is why the native read path is still gated behind
+    /// `index-falkordb`. Porting this hook to the native side is tracked separately.
     pub fn import_node_attrs_resolved(
         &mut self,
         data: &mut Vec<(u64, Vec<(u16, Value)>)>,
@@ -1566,6 +1665,22 @@ impl Graph {
         index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> usize {
         let nset = self.relationship_attrs.import_attrs(attrs);
+
+        // Edge index: new edges are pure adds (no prior value). #51. Fast path: skip with no columns.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, m) in attrs {
+                for (attr_id, value) in m.iter() {
+                    if let Some(attr) = self.rel_attr_name(*attr_id) {
+                        self.stage_index_edge(*id, &attr, value, &mut adds);
+                    }
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Relationship, adds, HashMap::new());
+        }
+
         self.track_edge_index_updates(attrs, index_add_edge_docs);
         nset
     }
@@ -1645,6 +1760,19 @@ impl Graph {
     ) {
         self.resize();
 
+        // Index: a node gaining a label indexes its current attrs under that label. (A fresh
+        // node has no attrs here — imported later — so this only fires for an existing node gaining a
+        // label; new nodes are handled by `import_node_attrs`.)
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (&id, &label_id) in label_rows.iter().zip(label_cols.iter()) {
+                self.stage_index_node_for_label(id, label_id, &mut adds);
+            }
+            self.falkordb_index
+                .merge(EntityType::Node, adds, HashMap::new());
+        }
+
         // Collect entries grouped by label for per-label matrices
         let num_labels = self.labels_matices.len();
         let mut by_label: Vec<Vec<u64>> = vec![Vec::new(); num_labels];
@@ -1685,6 +1813,20 @@ impl Graph {
     ) {
         self.resize();
 
+        // Index: a node losing a label drops its indexed attrs from that label's column,
+        // staged BEFORE the labels come off (attrs still present). Without this the tuples orphan and
+        // later resurrect on id reuse (review finding #2).
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                HashMap::new();
+            for (&id, &label_id) in label_rows.iter().zip(label_cols.iter()) {
+                self.stage_index_node_for_label(id, label_id, &mut removes);
+            }
+            self.falkordb_index
+                .merge(EntityType::Node, HashMap::new(), removes);
+        }
+
         for (&id, &label_id) in label_rows.iter().zip(label_cols.iter()) {
             self.node_labels_matrix.remove(id, label_id);
             self.labels_matices[label_id as usize].remove(id, id);
@@ -1700,6 +1842,21 @@ impl Graph {
         deleted_nodes: &RoaringTreemap,
         remove_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> Result<(), String> {
+        // Index: remove each deleted node's indexed values while its attrs are still present
+        // (the graph tears them down below). Batched per column — the mass-delete path.
+        // Fast path: skip the per-node attr scan entirely with no native columns.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                HashMap::new();
+            for id in deleted_nodes {
+                for (attr, value) in self.get_node_all_attrs(NodeId(id)) {
+                    self.stage_index_node(id, &attr, &value, &mut removes);
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Node, HashMap::new(), removes);
+        }
         self.deleted_nodes |= deleted_nodes;
         self.node_count -= deleted_nodes.len();
 
@@ -2209,7 +2366,38 @@ impl Graph {
         attrs: &FxHashMap<u64, Vec<(u16, Value)>>,
         index_add_edge_docs: &mut FxHashMap<u64, RoaringTreemap>,
     ) -> Result<(usize, usize), String> {
+        // Edge index: collect maintenance BEFORE the overwrite so the OLD value is still
+        // readable (value-precise removal the tuple-keyed B-tree needs). Mirrors
+        // `set_nodes_attributes`. #51.
+        // Fast path: skip staging (old-value read + Arc clone) with no native columns.
+        #[cfg(feature = "index-falkordb")]
+        let (index_removes, index_adds) = if self.falkordb_index.is_empty() {
+            (HashMap::new(), HashMap::new())
+        } else {
+            let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                HashMap::new();
+            let mut adds: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> = HashMap::new();
+            for (id, m) in attrs {
+                for (attr_id, new_value) in m.iter() {
+                    let Some(attr) = self.rel_attr_name(*attr_id) else {
+                        continue;
+                    };
+                    if let Some(old) =
+                        self.get_relationship_attribute_by_idx(RelationshipId(*id), *attr_id)
+                    {
+                        self.stage_index_edge(*id, &attr, &old, &mut removes);
+                    }
+                    self.stage_index_edge(*id, &attr, new_value, &mut adds);
+                }
+            }
+            (removes, adds)
+        };
         let (nremoved, nset) = self.relationship_attrs.insert_attrs(attrs)?;
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            self.falkordb_index
+                .merge(EntityType::Relationship, index_adds, index_removes);
+        }
         self.track_edge_index_updates(attrs, index_add_edge_docs);
         Ok((nremoved, nset))
     }
@@ -2298,6 +2486,22 @@ impl Graph {
                     resolved.insert(edge_id);
                 }
             }
+        }
+
+        // Edge index: remove each resolved edge's indexed values while its attrs and type are
+        // still present (torn down below). Batched per column — the mass-delete path. #51.
+        // Fast path: skip the per-edge attr scan entirely with no native columns.
+        #[cfg(feature = "index-falkordb")]
+        if !self.falkordb_index.is_empty() {
+            let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                HashMap::new();
+            for id in &resolved {
+                for (attr, value) in self.get_relationship_all_attrs(RelationshipId(id)) {
+                    self.stage_index_edge(id, &attr, &value, &mut removes);
+                }
+            }
+            self.falkordb_index
+                .merge(EntityType::Relationship, HashMap::new(), removes);
         }
 
         // --- Phase 2: mutate state for the actually-resolved edges only ---
@@ -2454,6 +2658,21 @@ impl Graph {
                         .or_default()
                         .insert(edge_id, (src, dst));
                 }
+            }
+            // Edge index: remove this type's cascade-deleted edges before their attrs and type
+            // mapping are torn down below. Mirrors `delete_relationships`. #51.
+            // Fast path: skip the per-edge attr scan entirely with no native columns.
+            #[cfg(feature = "index-falkordb")]
+            if !self.falkordb_index.is_empty() {
+                let mut removes: HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>> =
+                    HashMap::new();
+                for &(edge_id, _, _) in &rels {
+                    for (attr, value) in self.get_relationship_all_attrs(RelationshipId(edge_id)) {
+                        self.stage_index_edge(edge_id, &attr, &value, &mut removes);
+                    }
+                }
+                self.falkordb_index
+                    .merge(EntityType::Relationship, HashMap::new(), removes);
             }
             self.relationship_type_matrix.remove_mask(&type_mask);
             self.relationship_attrs.remove_all(&del_keys);
@@ -2917,6 +3136,14 @@ impl Graph {
                     self.add_node_attribute_name(attr);
                 }
                 populate_index(IndexKind::Node, label.clone(), self.node_indexer.clone());
+                // Dark-launch the index alongside RediSearch. The column is built
+                // synchronously here, on the write thread, so CREATE INDEX returns with a
+                // column that already serves reads. A background build (which lets CREATE
+                // INDEX return before the pre-existing snapshot is in) is a separate change.
+                #[cfg(feature = "index-falkordb")]
+                if *index_type == IndexType::Range {
+                    self.populate_index_node(label, attrs);
+                }
             }
             EntityType::Relationship => {
                 // get-or-create the relationship type so that
@@ -2929,6 +3156,12 @@ impl Graph {
                     self.add_rel_attribute_name(attr);
                 }
                 populate_index(IndexKind::Edge, label.clone(), self.edge_indexer.clone());
+                // Dark-launch the edge index (#51): built synchronously here, same as the
+                // node branch above (docs are edge_ids).
+                #[cfg(feature = "index-falkordb")]
+                if *index_type == IndexType::Range {
+                    self.populate_index_edge(label, attrs);
+                }
             }
         }
         Ok(())
@@ -2957,6 +3190,15 @@ impl Graph {
                 for attr in attrs {
                     self.add_node_attribute_name(attr);
                 }
+                // Create the index column now (empty); populate_indexes_sync
+                // fills it once all nodes are loaded (RDB/replica path). P4a.
+                #[cfg(feature = "index-falkordb")]
+                if *index_type == IndexType::Range {
+                    for attr in attrs {
+                        self.falkordb_index
+                            .create_numeric(EntityType::Node, label, attr);
+                    }
+                }
                 // Don't spawn async — caller will populate via populate_index_sync
             }
             EntityType::Relationship => {
@@ -2969,18 +3211,232 @@ impl Graph {
                 for attr in attrs {
                     self.add_rel_attribute_name(attr);
                 }
+                // Create the index edge column now (empty); populate_indexes_sync fills it once
+                // all edges are loaded (RDB/replica path). #51, mirrors the node branch above.
+                #[cfg(feature = "index-falkordb")]
+                if *index_type == IndexType::Range {
+                    for attr in attrs {
+                        self.falkordb_index
+                            .create_numeric(EntityType::Relationship, label, attr);
+                    }
+                }
             }
         }
         Ok(())
+    }
+
+    /// Bulk-build the index for each of `attrs` on `label` from
+    /// the current live nodes, on the write thread. The folded index lives on
+    /// this graph version, so it MUST be filled here (with `&mut Graph`) and
+    /// never via the async RediSearch populate, which reads through the
+    /// `Indexer -> Graph` back-pointer this design rejects. A `(label, attr)`
+    /// with no live nodes or no numeric values yields an empty column.
+    /// Collect the `(value, node_id)` entries for one node index column `(label, attr)` from the
+    /// current live nodes — shared-borrow only (label matrix + attribute store are `&self`).
+    #[cfg(feature = "index-falkordb")]
+    fn collect_node_index_entries(
+        &self,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> Vec<(Value, u64)> {
+        let mut pairs = Vec::new();
+        if let (Some(lm), Some(idx)) = (
+            self.get_label_matrix(label),
+            self.get_node_attribute_id(attr),
+        ) {
+            let idx = idx as u16;
+            for (n, _) in lm.iter(0, u64::MAX) {
+                if let Some(value) = self.get_node_attribute_by_idx(NodeId(n), idx) {
+                    pairs.push((value, n));
+                }
+            }
+        }
+        pairs
+    }
+
+    #[cfg(feature = "index-falkordb")]
+    fn populate_index_node(
+        &mut self,
+        label: &Arc<String>,
+        attrs: &[Arc<String>],
+    ) {
+        // Phase 1 — collect per attr (shared borrows only). Phase 2 — bulk-build the CoW columns.
+        let built: Vec<(Arc<String>, Vec<(Value, u64)>)> = attrs
+            .iter()
+            .map(|attr| (attr.clone(), self.collect_node_index_entries(label, attr)))
+            .collect();
+        for (attr, pairs) in built {
+            self.falkordb_index.build_numeric(
+                EntityType::Node,
+                label,
+                &attr,
+                pairs.iter().map(|(v, id)| (v, *id)),
+            );
+        }
+    }
+
+    /// Stage `(value, id)` into every index column `(label, attr)` the node `id` belongs to (a node
+    /// may carry several labels). Shared-borrow only — the caller applies the staged columns after.
+    #[cfg(feature = "index-falkordb")]
+    fn stage_index_node(
+        &self,
+        id: u64,
+        attr: &Arc<String>,
+        value: &Value,
+        out: &mut HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>>,
+    ) {
+        for (_, label_id) in self.node_labels_matrix.iter(id, id) {
+            let label = &self.node_labels[label_id as usize];
+            if self
+                .falkordb_index
+                .has_column(EntityType::Node, label, attr)
+            {
+                out.entry((label.clone(), attr.clone()))
+                    .or_default()
+                    .push((value.clone(), id));
+            }
+        }
+    }
+
+    /// Stage every indexed `(value, id)` the node `id` carries **under the single label `label_id`** —
+    /// for label add/remove, where only that one column changes. Reads the node's current attrs, so a
+    /// node with no attrs yet (a fresh node whose props import later) stages nothing.
+    #[cfg(feature = "index-falkordb")]
+    fn stage_index_node_for_label(
+        &self,
+        id: u64,
+        label_id: u64,
+        out: &mut HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>>,
+    ) {
+        let label = &self.node_labels[label_id as usize];
+        for (attr, value) in self.get_node_all_attrs(NodeId(id)) {
+            if self
+                .falkordb_index
+                .has_column(EntityType::Node, label, &attr)
+            {
+                out.entry((label.clone(), attr.clone()))
+                    .or_default()
+                    .push((value, id));
+            }
+        }
+    }
+
+    // ---- Edge (relationship) index maintenance (#51) ----
+    // The edge column stores `(value, edge_id)`; `(src, dst)` are recovered on read from the graph's
+    // own `edge_id → (src, dst)` reverse index (`endpoints_for_edge`), so nothing about endpoints is
+    // maintained here. An edge has exactly ONE type (immutable after create), so — unlike a node's
+    // many mutable labels — routing is a single `(type, attr)` lookup and there is no label-change churn.
+    //
+    // INVARIANT: every path that mutates an indexed edge attribute MUST route through these hooks
+    // (import_relationship_attrs / set_relationships_attributes / delete_relationships /
+    // delete_implicit_edges). The endpoint-liveness filter on read only hides *deleted-and-not-reused*
+    // edges; a mutation that bypasses these hooks would leak a stale tuple that surfaces once the
+    // edge_id is reused. Add the stage/apply hook to any new indexed-edge-attr write path.
+
+    /// Bulk-build the edge index for each of `attrs` on `type_name` from the type's
+    /// live edges, on the write thread. Mirrors [`populate_index_node`] for edges.
+    #[cfg(feature = "index-falkordb")]
+    /// Collect the `(value, edge_id)` entries for one edge index column `(type, attr)` from the
+    /// type's live edges — shared-borrow only. Reused by the synchronous populate and the background
+    /// build.
+    #[cfg(feature = "index-falkordb")]
+    fn collect_edge_index_entries(
+        &self,
+        type_name: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> Vec<(Value, u64)> {
+        let Some(idx) = self.get_relationship_attribute_id(attr) else {
+            return Vec::new();
+        };
+        let idx = idx as u16;
+        let edge_ids: Vec<u64> = self
+            .get_relationship_matrix(type_name)
+            .map_or_else(Vec::new, |t| {
+                t.iter(0, u64::MAX, false).map(|(_, _, eid)| eid).collect()
+            });
+        edge_ids
+            .into_iter()
+            .filter_map(|eid| {
+                self.get_relationship_attribute_by_idx(RelationshipId(eid), idx)
+                    .map(|value| (value, eid))
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "index-falkordb")]
+    fn populate_index_edge(
+        &mut self,
+        type_name: &Arc<String>,
+        attrs: &[Arc<String>],
+    ) {
+        let built: Vec<(Arc<String>, Vec<(Value, u64)>)> = attrs
+            .iter()
+            .map(|attr| {
+                (
+                    attr.clone(),
+                    self.collect_edge_index_entries(type_name, attr),
+                )
+            })
+            .collect();
+        for (attr, pairs) in built {
+            self.falkordb_index.build_numeric(
+                EntityType::Relationship,
+                type_name,
+                &attr,
+                pairs.iter().map(|(v, id)| (v, *id)),
+            );
+        }
+    }
+
+    /// Stage `(value, edge_id)` into the index column `(type, attr)` for the edge `id`'s single type,
+    /// if such a column exists. Shared-borrow only — the caller applies the staged columns after.
+    ///
+    /// Relies on `get_relationship_type_id` (which `.expect`s the edge is in the type matrix). Every
+    /// caller upholds this: create/SET touch a live edge, and both delete hooks stage removes BEFORE
+    /// they tear the type matrix down. The panic is a loud tripwire if a future caller violates it —
+    /// preferable to silently skipping maintenance and leaking a stale tuple.
+    #[cfg(feature = "index-falkordb")]
+    fn stage_index_edge(
+        &self,
+        id: u64,
+        attr: &Arc<String>,
+        value: &Value,
+        out: &mut HashMap<(Arc<String>, Arc<String>), Vec<(Value, u64)>>,
+    ) {
+        let type_id = self.get_relationship_type_id(RelationshipId(id));
+        let type_name = &self.relationship_types[type_id.0];
+        if self
+            .falkordb_index
+            .has_column(EntityType::Relationship, type_name, attr)
+        {
+            out.entry((type_name.clone(), attr.clone()))
+                .or_default()
+                .push((value.clone(), id));
+        }
     }
 
     /// Synchronously populate all pending indexes.
     /// Used after RDB load when the graph is fully constructed.
     pub fn populate_indexes_sync(&mut self) {
         let node_snapshots = self.node_indexer.acquire_population_snapshots();
+        // Index numeric columns to (re)build after the RediSearch pass — collect
+        // just the names here, build after the loop to keep borrows simple. P4a.
+        #[cfg(feature = "index-falkordb")]
+        let mut index_todo: Vec<(Arc<String>, Vec<Arc<String>>)> = Vec::new();
         for snapshot in node_snapshots {
             let label = snapshot.ticket.label().clone();
             let attrs = snapshot.fields;
+            #[cfg(feature = "index-falkordb")]
+            {
+                let range_attrs: Vec<Arc<String>> = attrs
+                    .iter()
+                    .filter(|(_, fields)| fields.iter().any(|f| f.ty == IndexType::Range))
+                    .map(|(a, _)| a.clone())
+                    .collect();
+                if !range_attrs.is_empty() {
+                    index_todo.push((label.clone(), range_attrs));
+                }
+            }
             if let Some(lm) = self.get_label_matrix(&label) {
                 // Pre-resolve attribute indices to avoid string lookups per node
                 let resolved_attrs: Vec<(u16, Vec<_>)> = attrs
@@ -3019,6 +3475,11 @@ impl Graph {
                 .release_population_ticket(&snapshot.ticket);
         }
 
+        #[cfg(feature = "index-falkordb")]
+        for (label, attrs) in index_todo {
+            self.populate_index_node(&label, &attrs);
+        }
+
         // Edge indexes: symmetric to the node path, but walk the
         // relationship tensor and emit `Document::new_edge(src, dst, eid)`
         // so RediSearch keys stay the 24-byte `[src, dst, edge_id]`
@@ -3027,9 +3488,23 @@ impl Graph {
         // `(src, dst, eid)` triple for large relationship types on
         // RDB load.
         let edge_snapshots = self.edge_indexer.acquire_population_snapshots();
+        // Edge index numeric columns to (re)build after the RediSearch pass. #51.
+        #[cfg(feature = "index-falkordb")]
+        let mut edge_index_todo: Vec<(Arc<String>, Vec<Arc<String>>)> = Vec::new();
         for snapshot in edge_snapshots {
             let type_name = snapshot.ticket.label().clone();
             let attrs = snapshot.fields;
+            #[cfg(feature = "index-falkordb")]
+            {
+                let range_attrs: Vec<Arc<String>> = attrs
+                    .iter()
+                    .filter(|(_, fields)| fields.iter().any(|f| f.ty == IndexType::Range))
+                    .map(|(a, _)| a.clone())
+                    .collect();
+                if !range_attrs.is_empty() {
+                    edge_index_todo.push((type_name.clone(), range_attrs));
+                }
+            }
             if let Some(tensor) = self.get_relationship_matrix(&type_name) {
                 let mut batch = Vec::new();
                 for (src, dst, eid) in tensor.iter(0, u64::MAX, false) {
@@ -3058,6 +3533,11 @@ impl Graph {
             }
             self.edge_indexer
                 .release_population_ticket(&snapshot.ticket);
+        }
+
+        #[cfg(feature = "index-falkordb")]
+        for (type_name, attrs) in edge_index_todo {
+            self.populate_index_edge(&type_name, &attrs);
         }
     }
 
@@ -3199,6 +3679,21 @@ impl Graph {
             return;
         }
 
+        // MEASUREMENT GATE (not a shipping mode): with the index active,
+        // `FALKORDB_INDEX_ONLY=1` skips RediSearch node maintenance so the write path is
+        // index-only — isolating the index-vs-RediSearch write cost without the dark-launch
+        // double-write. The index column has already been maintained inline in the mutation
+        // hooks, so the tuples are safe; only the redundant RediSearch feed is
+        // dropped. This breaks string/geo reads on a Range index (they still expect RediSearch), so
+        // it is a benchmark instrument for all-numeric workloads. P7 productionizes the same skip
+        // behind a per-label "fully index-covered" guard + the xfail ledger.
+        #[cfg(feature = "index-falkordb")]
+        if matches!(kind, IndexKind::Node) && index_only_writes() {
+            index_add_docs.clear();
+            remove_docs.clear();
+            return;
+        }
+
         let (indexer, names, attr_store) = match kind {
             IndexKind::Node => (&self.node_indexer, &self.node_labels, &self.node_attrs),
             IndexKind::Edge => unreachable!("use commit_edge_index for edges"),
@@ -3264,6 +3759,23 @@ impl Graph {
             }
         }
 
+        // Index: drop the column(s) in O(1) (releases the tree Arc). P4b (node) / #51 (edge).
+        #[cfg(feature = "index-falkordb")]
+        if *index_type == IndexType::Range {
+            for attr in &effective_attrs {
+                match entity_type {
+                    EntityType::Node => {
+                        self.falkordb_index
+                            .drop_column(EntityType::Node, label, attr)
+                    }
+                    EntityType::Relationship => {
+                        self.falkordb_index
+                            .drop_column(EntityType::Relationship, label, attr)
+                    }
+                }
+            }
+        }
+
         let (indexer, total, kind) = match entity_type {
             EntityType::Node => {
                 let total = self.get_label_matrix(label).map_or(
@@ -3326,6 +3838,46 @@ impl Graph {
         query: IndexQuery<Value>,
     ) -> impl Iterator<Item = NodeId> + use<> {
         self.node_indexer.query(label, query).map(NodeId)
+    }
+
+    /// Node ids for `query` from the index numeric column, or `None` to fall through to RediSearch
+    /// (non-numeric / composite / missing column). Wraps
+    /// [`FalkorDbIndex::query_numeric`], mapping raw ids to `NodeId` (whose constructor is
+    /// module-private). `use<>` keeps the returned iterator free of the `&self` borrow — it owns its
+    /// tree snapshot, so it outlives this borrow.
+    #[cfg(feature = "index-falkordb")]
+    pub fn query_index_numeric_nodes(
+        &self,
+        label: &Arc<String>,
+        query: &IndexQuery<Value>,
+    ) -> Option<impl Iterator<Item = NodeId> + use<>> {
+        self.falkordb_index()
+            .query_numeric(EntityType::Node, label, query)
+            .map(|iter| iter.map(NodeId))
+    }
+
+    /// Answer an EDGE numeric `Equal`/`Range` from the index column for `type_name`, yielding
+    /// `(src, dst, edge_id)` — endpoints recovered from the graph's `edge_id → (src, dst)` reverse
+    /// index (`endpoints_for_edge`), like RediSearch's edge read (which instead reads them from its
+    /// 24-byte key). Endpoints are resolved eagerly into an owned iterator because the edge scan op
+    /// only holds a temporary graph borrow, so the result must not borrow `self`. `None` (fall back to
+    /// RediSearch) for non-numeric/composite predicates or a missing column. #51.
+    #[cfg(feature = "index-falkordb")]
+    pub fn query_index_numeric_edges(
+        &self,
+        type_name: &Arc<String>,
+        query: &IndexQuery<Value>,
+    ) -> Option<impl Iterator<Item = (NodeId, NodeId, RelationshipId)> + use<>> {
+        let iter =
+            self.falkordb_index()
+                .query_numeric(EntityType::Relationship, type_name, query)?;
+        let resolved: Vec<(NodeId, NodeId, RelationshipId)> = iter
+            .filter_map(|eid| {
+                self.endpoints_for_edge(eid)
+                    .map(|(src, dst)| (NodeId(src), NodeId(dst), RelationshipId(eid)))
+            })
+            .collect();
+        Some(resolved.into_iter())
     }
 
     #[must_use]
@@ -4283,5 +4835,299 @@ mod attr_id_space_tests {
                 "RDB position {id} disagrees with the live id for {name}"
             );
         }
+    }
+}
+
+#[cfg(all(test, feature = "index-falkordb"))]
+mod falkordb_index_mvcc_tests {
+    use super::Graph;
+    use crate::entity_type::EntityType;
+    use crate::runtime::value::Value;
+    use roaring::RoaringTreemap;
+    use rustc_hash::FxHashMap;
+    use std::sync::Arc;
+
+    /// `Graph::new` builds GraphBLAS matrices, which need GraphBLAS initialized
+    /// first (done at Redis module-load in production, never from a bare unit
+    /// test).
+    ///
+    /// This MUST go through the crate-wide guard rather than its own `Once`:
+    /// GraphBLAS may be initialized exactly once per process, so a second `Once`
+    /// gets `GrB_INVALID_VALUE`, and when the loser is
+    /// `graphblas::test_init::ensure_init` its `unwrap` panics inside `call_once`,
+    /// poisoning that `Once` for every later GraphBLAS test.
+    fn ensure_graphblas() {
+        crate::graph::graphblas::test_init::ensure_init();
+    }
+
+    /// Folded-roots MVCC: `new_version` forks the FalkorDB index copy-on-write,
+    /// so mutating the writer's version leaves the committed version — the
+    /// snapshot a reader may still hold — untouched, riding one version bump.
+    #[test]
+    fn new_version_isolates_the_falkordb_index() {
+        ensure_graphblas();
+        let label = Arc::new("Person".to_string());
+        let attr = Arc::new("age".to_string());
+
+        let mut committed = Graph::new(64, 64, 10, 1, "t");
+        committed
+            .falkordb_index_mut()
+            .create_numeric(EntityType::Node, &label, &attr);
+        committed
+            .falkordb_index_mut()
+            .numeric_mut(EntityType::Node, &label, &attr)
+            .unwrap()
+            .add(&Value::Int(30), 1);
+
+        // A writer forks the next version and indexes another node.
+        let mut writer = committed.new_version();
+        writer
+            .falkordb_index_mut()
+            .numeric_mut(EntityType::Node, &label, &attr)
+            .unwrap()
+            .add(&Value::Int(40), 2);
+
+        let all = |g: &Graph| -> Vec<u64> {
+            g.falkordb_index()
+                .numeric(EntityType::Node, &label, &attr)
+                .unwrap()
+                .range(None, None, true, true)
+                .collect()
+        };
+        assert_eq!(all(&committed), vec![1], "committed snapshot is untouched");
+        assert_eq!(all(&writer), vec![1, 2], "writer sees its own write");
+        assert_eq!(writer.version, committed.version + 1);
+    }
+
+    /// `populate_index_node` bulk-builds the column from real graph state:
+    /// three `:Person {age}` nodes, then a range scan returns the right ids in
+    /// `(value, id)` order. Drives the populate reads (`get_label_matrix` →
+    /// `get_node_attribute_by_idx`) directly, bypassing `create_index`'s
+    /// RediSearch FFI (uninitialised in a unit test).
+    #[test]
+    fn populate_index_node_indexes_live_nodes() {
+        ensure_graphblas();
+        let mut g = Graph::new(64, 64, 10, 1, "t");
+        let label = Arc::new("Person".to_string());
+        let attr = Arc::new("age".to_string());
+
+        // Register the label and activate three nodes (ids 0,1,2 on a fresh graph).
+        let lid = g.get_label_id_mut("Person");
+        let ids: Vec<u64> = g.reserve_nodes(3).unwrap().iter().map(|n| n.0).collect();
+        let mut set = RoaringTreemap::new();
+        for &id in &ids {
+            set.insert(id);
+        }
+        g.create_nodes(&set);
+
+        // Assign the :Person label to all three.
+        let label_cols: Vec<u64> = vec![lid.0 as u64; ids.len()];
+        g.set_nodes_labels_bulk(&ids, &label_cols, &mut FxHashMap::default(), false);
+
+        // age = 10, 20, 30.
+        let aid = g.get_or_create_node_attr_id(&attr);
+        let mut attrs: FxHashMap<u64, Vec<(u16, Value)>> = FxHashMap::default();
+        for (i, &id) in ids.iter().enumerate() {
+            attrs.insert(id, vec![(aid, Value::Int(((i + 1) * 10) as i64))]);
+        }
+        g.set_nodes_attributes(&attrs, &mut FxHashMap::default())
+            .unwrap();
+
+        // Build the index numeric column from the live nodes.
+        g.populate_index_node(&label, std::slice::from_ref(&attr));
+
+        let scan = |lo: Option<i64>, hi: Option<i64>| -> Vec<u64> {
+            let lo = lo.map(Value::Int);
+            let hi = hi.map(Value::Int);
+            g.falkordb_index()
+                .numeric(EntityType::Node, &label, &attr)
+                .unwrap()
+                .range(lo.as_ref(), hi.as_ref(), true, true)
+                .collect()
+        };
+        // [15, 35] → age 20 (id 1), age 30 (id 2), in (value, id) order.
+        assert_eq!(scan(Some(15), Some(35)), vec![ids[1], ids[2]]);
+        // Unbounded → all three, value-ordered.
+        assert_eq!(scan(None, None), vec![ids[0], ids[1], ids[2]]);
+    }
+
+    // --- P4b write-path maintenance (the adversarial scenarios) ---
+
+    /// A graph with a index on `(:Person, v)` and `n` labeled Person nodes
+    /// (ids `0..n`), no attrs yet.
+    fn graph_with_index(n: usize) -> (Graph, Arc<String>, Arc<String>, Vec<u64>) {
+        ensure_graphblas();
+        let mut g = Graph::new(64, 64, 10, 1, "t");
+        let label = Arc::new("Person".to_string());
+        let attr = Arc::new("v".to_string());
+        g.falkordb_index_mut()
+            .create_numeric(EntityType::Node, &label, &attr);
+        let lid = g.get_label_id_mut("Person");
+        let ids: Vec<u64> = g.reserve_nodes(n).unwrap().iter().map(|x| x.0).collect();
+        let mut set = RoaringTreemap::new();
+        for &id in &ids {
+            set.insert(id);
+        }
+        g.create_nodes(&set);
+        let cols = vec![lid.0 as u64; ids.len()];
+        g.set_nodes_labels_bulk(&ids, &cols, &mut FxHashMap::default(), false);
+        (g, label, attr, ids)
+    }
+
+    /// Drive the existing-node SET path with one `(id, attr) = value`.
+    fn set_attr(
+        g: &mut Graph,
+        id: u64,
+        attr: &Arc<String>,
+        value: Value,
+    ) {
+        let aid = g.get_or_create_node_attr_id(attr);
+        let mut attrs = FxHashMap::default();
+        attrs.insert(id, vec![(aid, value)]);
+        g.set_nodes_attributes(&attrs, &mut FxHashMap::default())
+            .unwrap();
+    }
+
+    fn range_scan(
+        g: &Graph,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        lo: i64,
+        hi: i64,
+    ) -> Vec<u64> {
+        g.falkordb_index()
+            .numeric(EntityType::Node, label, attr)
+            .unwrap()
+            .range(Some(&Value::Int(lo)), Some(&Value::Int(hi)), true, true)
+            .collect()
+    }
+
+    /// UPDATE must remove the old tuple — the reviewer's FAILURE 1.
+    #[test]
+    fn update_removes_the_old_tuple() {
+        let (mut g, label, attr, ids) = graph_with_index(1);
+        set_attr(&mut g, ids[0], &attr, Value::Int(5));
+        assert_eq!(range_scan(&g, &label, &attr, 4, 6), vec![ids[0]]);
+        set_attr(&mut g, ids[0], &attr, Value::Int(9)); // 5 -> 9
+        assert!(
+            range_scan(&g, &label, &attr, 4, 6).is_empty(),
+            "the stale value 5 must not surface after the update"
+        );
+        assert_eq!(range_scan(&g, &label, &attr, 8, 10), vec![ids[0]]);
+    }
+
+    /// SET x = null drops the entry (remove old, add nothing).
+    #[test]
+    fn set_null_removes_from_index() {
+        let (mut g, label, attr, ids) = graph_with_index(1);
+        set_attr(&mut g, ids[0], &attr, Value::Int(5));
+        set_attr(&mut g, ids[0], &attr, Value::Null);
+        assert!(range_scan(&g, &label, &attr, 0, 100).is_empty());
+    }
+
+    /// DELETE removes the node's tuple, leaving the others.
+    #[test]
+    fn delete_removes_from_index() {
+        let (mut g, label, attr, ids) = graph_with_index(2);
+        set_attr(&mut g, ids[0], &attr, Value::Int(5));
+        set_attr(&mut g, ids[1], &attr, Value::Int(6));
+        let mut del = RoaringTreemap::new();
+        del.insert(ids[0]);
+        g.delete_nodes(&del, &mut FxHashMap::default()).unwrap();
+        assert_eq!(range_scan(&g, &label, &attr, 0, 100), vec![ids[1]]);
+    }
+
+    /// Eager removal at delete means a reused id (same value) has no stale duplicate — the id-reuse
+    /// correctness the delete model relies on.
+    #[test]
+    fn delete_then_reuse_id_and_value_stays_correct() {
+        let (mut g, label, attr, ids) = graph_with_index(1);
+        set_attr(&mut g, ids[0], &attr, Value::Int(5));
+        let mut del = RoaringTreemap::new();
+        del.insert(ids[0]);
+        g.delete_nodes(&del, &mut FxHashMap::default()).unwrap();
+        assert!(range_scan(&g, &label, &attr, 4, 6).is_empty());
+
+        // Reclaim the freed id for a fresh node with the same value.
+        let reused: Vec<u64> = g.reserve_nodes(1).unwrap().iter().map(|x| x.0).collect();
+        assert_eq!(reused[0], ids[0], "the deleted id should be reclaimed");
+        let mut set = RoaringTreemap::new();
+        set.insert(reused[0]);
+        g.create_nodes(&set);
+        let lid = g.get_label_id_mut("Person");
+        g.set_nodes_labels_bulk(&reused, &[lid.0 as u64], &mut FxHashMap::default(), false);
+        set_attr(&mut g, reused[0], &attr, Value::Int(5));
+
+        // Exactly one entry — the reused node — no resurrected duplicate.
+        assert_eq!(range_scan(&g, &label, &attr, 4, 6), vec![reused[0]]);
+    }
+
+    /// A graph with the `(:Person, v)` index and one node that is NOT labeled `:Person`.
+    fn unlabeled_graph_with_index() -> (Graph, Arc<String>, Arc<String>, u64) {
+        ensure_graphblas();
+        let mut g = Graph::new(64, 64, 10, 1, "t");
+        let label = Arc::new("Person".to_string());
+        let attr = Arc::new("v".to_string());
+        g.falkordb_index_mut()
+            .create_numeric(EntityType::Node, &label, &attr);
+        let _lid = g.get_label_id_mut("Person"); // register the label matrix
+        let ids: Vec<u64> = g.reserve_nodes(1).unwrap().iter().map(|x| x.0).collect();
+        let mut set = RoaringTreemap::new();
+        set.insert(ids[0]);
+        g.create_nodes(&set);
+        (g, label, attr, ids[0])
+    }
+
+    /// SET :Label indexes the node's already-present attrs — review finding #1.
+    #[test]
+    fn set_label_indexes_existing_attrs() {
+        let (mut g, label, attr, id) = unlabeled_graph_with_index();
+        set_attr(&mut g, id, &attr, Value::Int(5));
+        assert!(
+            range_scan(&g, &label, &attr, 4, 6).is_empty(),
+            "no :Person label yet ⇒ not indexed"
+        );
+        let lid = g.get_label_id_mut("Person");
+        g.set_nodes_labels_bulk(&[id], &[lid.0 as u64], &mut FxHashMap::default(), false);
+        assert_eq!(
+            range_scan(&g, &label, &attr, 4, 6),
+            vec![id],
+            "SET :Person must index the existing attr"
+        );
+    }
+
+    /// REMOVE :Label drops the tuple, and no phantom resurrects when the id is reused with a
+    /// different value — review finding #2 (the worst case).
+    #[test]
+    fn remove_label_drops_tuple_and_no_resurrect_on_reuse() {
+        let (mut g, label, attr, ids) = graph_with_index(1);
+        set_attr(&mut g, ids[0], &attr, Value::Int(5));
+        assert_eq!(range_scan(&g, &label, &attr, 4, 6), vec![ids[0]]);
+
+        // REMOVE n:Person — the (:Person, v) tuple must be gone (without this hook it orphans).
+        let lid = g.get_label_id_mut("Person");
+        g.remove_nodes_labels(&[ids[0]], &[lid.0 as u64], &mut FxHashMap::default());
+        assert!(
+            range_scan(&g, &label, &attr, 4, 6).is_empty(),
+            "REMOVE :Person must drop the tuple"
+        );
+
+        // Delete the node and reuse its id for a fresh :Person with a DIFFERENT value.
+        let mut del = RoaringTreemap::new();
+        del.insert(ids[0]);
+        g.delete_nodes(&del, &mut FxHashMap::default()).unwrap();
+        let reused: Vec<u64> = g.reserve_nodes(1).unwrap().iter().map(|x| x.0).collect();
+        assert_eq!(reused[0], ids[0]);
+        let mut set = RoaringTreemap::new();
+        set.insert(reused[0]);
+        g.create_nodes(&set);
+        g.set_nodes_labels_bulk(&reused, &[lid.0 as u64], &mut FxHashMap::default(), false);
+        set_attr(&mut g, reused[0], &attr, Value::Int(99));
+
+        assert!(
+            range_scan(&g, &label, &attr, 4, 6).is_empty(),
+            "the old value 5 must not resurrect through the reused id"
+        );
+        assert_eq!(range_scan(&g, &label, &attr, 98, 100), vec![reused[0]]);
     }
 }

--- a/graph/src/index/falkordb/encode.rs
+++ b/graph/src/index/falkordb/encode.rs
@@ -135,6 +135,150 @@ mod tests {
         );
     }
 
+    /// The encoded order must agree with the evaluator's own `compare_value`, because the index
+    /// answers `Equal` / `Range` with **no post-filter** — a pair the encoder orders differently
+    /// from the evaluator is a wrong row, not a slow one.
+    ///
+    /// This is the contract that makes the `f64` coercion sound rather than merely convenient.
+    /// `compare_value` promotes for *mixed* numerics — `(Int(i), Float(f)) => compare_floats(i as
+    /// f64, f)` — which is exactly what `encode_numeric` does, so the two agree by construction and
+    /// a `Float` bound against `Int` data needs no precision guard.
+    ///
+    /// The one pair deliberately excluded is **Int vs Int past 2^53**: there `compare_value` is
+    /// exact (`a.cmp(b)`) while the encoder rounds both through `f64`, so they genuinely disagree.
+    /// That gap is closed upstream — `can_utilize_index` rejects such a query via
+    /// `Index::int_loses_f64_precision` and routes it to a label scan. If this test is ever
+    /// extended to cover that pair, the guard is what has to change with it.
+    #[test]
+    fn encoded_order_matches_value_comparison() {
+        use crate::index::Index;
+        use crate::runtime::value::CompareValue;
+        use std::cmp::Ordering;
+
+        const P: i64 = 1 << 53; // first integer f64 cannot represent exactly alongside its successor
+
+        // Int and Float only. `Bool` is deliberately absent: the evaluator treats it as a type
+        // disjoint from the numerics, while the encoder folds it into the same key space — see
+        // `bool_shares_a_numeric_key_but_not_an_equality` for that divergence.
+        let vals = [
+            Value::Int(i64::MIN),
+            Value::Int(-P - 1),
+            Value::Int(-P),
+            Value::Int(-5),
+            Value::Int(0),
+            Value::Float(-0.0),
+            Value::Int(1),
+            Value::Float(1.5),
+            Value::Int(P),
+            Value::Int(P + 1),
+            Value::Float(P as f64),
+            Value::Int(i64::MAX),
+            Value::Float(f64::INFINITY),
+            Value::Float(f64::NEG_INFINITY),
+        ];
+
+        // Int-vs-Int is the only pair the evaluator compares exactly, so it is the only pair the
+        // encoder can disagree with — and only once a magnitude stops fitting in f64's mantissa.
+        let exempt = |a: &Value, b: &Value| match (a, b) {
+            (Value::Int(x), Value::Int(y)) => {
+                Index::int_loses_f64_precision(*x) || Index::int_loses_f64_precision(*y)
+            }
+            _ => false,
+        };
+
+        let mut checked = 0;
+        for a in &vals {
+            for b in &vals {
+                if exempt(a, b) {
+                    continue;
+                }
+                let (ka, kb) = (
+                    encode_numeric(a).expect("all sweep values are numeric"),
+                    encode_numeric(b).expect("all sweep values are numeric"),
+                );
+                let encoded = ka.cmp(&kb);
+                let evaluated = a.compare_value(b).0;
+                assert_eq!(
+                    encoded, evaluated,
+                    "encoder and evaluator disagree on {a:?} vs {b:?}: \
+                     encoded {encoded:?} (keys {ka} vs {kb}), evaluator {evaluated:?}"
+                );
+                checked += 1;
+            }
+        }
+        // Guard against the sweep silently collapsing (an over-broad exemption, or a `vals` edit
+        // that drops the interesting cases). Most of the n² pairs should survive the exemption.
+        assert!(
+            checked > vals.len() * vals.len() / 2,
+            "sweep collapsed to {checked} pairs out of {}",
+            vals.len() * vals.len()
+        );
+
+        // And the exempted pair really does disagree — otherwise the guard, and this exemption,
+        // would be dead weight nobody would notice removing.
+        // `2^53` is the last integer f64 holds exactly with its successor unrepresentable: `P + 1`
+        // rounds back to `P`, while `P + 2` is exact again. So `P` and `P + 1` are the collision.
+        let (big, bigger) = (Value::Int(P), Value::Int(P + 1));
+        assert_eq!(big.compare_value(&bigger).0, Ordering::Less, "exact i64");
+        assert_eq!(
+            encode_numeric(&big),
+            encode_numeric(&bigger),
+            "f64 rounding should collapse these to one key"
+        );
+        assert!(
+            Index::int_loses_f64_precision(P),
+            "the upstream guard must reject the values this test exempts"
+        );
+    }
+
+    /// **Inherited divergence, pinned deliberately — do not "fix" this here.**
+    ///
+    /// `encode_numeric` folds `Bool` into the numeric key space (`false`/`true` → `0.0`/`1.0`), so a
+    /// bool and a number share a key. The evaluator disagrees: `compare_value` has no `(Int, Bool)`
+    /// arm, so the pair falls to `self.order().cmp(&b.order())` with `DisjointOrNull::Disjoint` —
+    /// different types never compare equal.
+    ///
+    /// That is **not** this index's invention. The RediSearch path does the same thing: bools go
+    /// into the NUMERIC field as `f64::from(b)` on write (`index/mod.rs`, `DocumentAddFieldNumber`)
+    /// and are queried as a numeric node with the same bounds. Measured on `MATCH (n:F) WHERE
+    /// n.flag = 1` over one `flag: true` node and one `flag: 1` node, with an index on `F.flag`:
+    ///
+    /// | engine | unindexed | indexed |
+    /// |---|---|---|
+    /// | C (`:edge-c`) | `int_one` | both |
+    /// | Rust + RediSearch | `int_one` | both |
+    /// | Rust + native index | — | both |
+    ///
+    /// Every engine is correct without an index and wrong with one, because `Node By Index Scan`
+    /// drops the `Filter` for `Equal`. So the defect is the missing post-filter, engine-wide, not
+    /// the encoding — and making the native index alone disagree would mean the same query
+    /// returning different rows depending on a build flag.
+    ///
+    /// Pinned so the behaviour is visible, and so a real fix has a failing assertion to flip.
+    #[test]
+    fn bool_shares_a_numeric_key_but_not_an_equality() {
+        use crate::runtime::value::CompareValue;
+        use std::cmp::Ordering;
+
+        for (b, n) in [
+            (Value::Bool(true), Value::Int(1)),
+            (Value::Bool(false), Value::Int(0)),
+            (Value::Bool(true), Value::Float(1.0)),
+        ] {
+            assert_eq!(
+                encode_numeric(&b),
+                encode_numeric(&n),
+                "the index gives {b:?} and {n:?} one key"
+            );
+            assert_ne!(
+                b.compare_value(&n).0,
+                Ordering::Equal,
+                "but the evaluator does not consider {b:?} equal to {n:?}"
+            );
+            assert!(b != n, "so `Value::eq` disagrees with the index for {b:?}");
+        }
+    }
+
     /// `decode_f64` inverts `encode_f64` across the sweep.
     #[test]
     fn roundtrip() {

--- a/graph/src/index/falkordb/encode.rs
+++ b/graph/src/index/falkordb/encode.rs
@@ -1,0 +1,155 @@
+//! Order-preserving key encoding for the index (PR2 · P1).
+//!
+//! The numeric index stores `(key, doc)` tuples in a
+//! [`CowBTree`](super::data_structures::cow_btree), sorted by `(key, doc)`:
+//! `key` is the *encoded* numeric value, `doc` the entity id. For range scans to
+//! be correct the encoding must be **monotone** — for any two non-NaN numeric
+//! values `a`, `b`:
+//!
+//! ```text
+//!     a < b   (as numbers)   <=>   encode(a) < encode(b)   (as u64)
+//! ```
+//!
+//! Every value is coerced to `f64` first, matching the RediSearch NUMERIC field
+//! this replaces, so a mixed Int/Float column shares a single order. That
+//! coercion inherits RediSearch's precision limit for integer magnitudes
+//! `>= 2^53`; it is documented here and a wider key is a future refinement.
+
+use crate::runtime::value::Value;
+
+/// IEEE-754 sign bit of an `f64`.
+const SIGN: u64 = 0x8000_0000_0000_0000;
+
+/// Encode a numeric [`Value`] into the monotone `u64` key half of a
+/// `(key, doc)` index tuple.
+///
+/// Returns `None` for non-numeric values and for `NaN`, which has no position
+/// in a sorted index.
+#[must_use]
+pub fn encode_numeric(value: &Value) -> Option<u64> {
+    let x = match value {
+        Value::Int(i) => *i as f64,
+        Value::Float(f) => *f,
+        Value::Bool(b) => f64::from(*b),
+        Value::Datetime(t) | Value::Date(t) | Value::Time(t) | Value::Duration(t) => *t as f64,
+        _ => return None,
+    };
+    (!x.is_nan()).then(|| encode_f64(x))
+}
+
+/// Monotone total order over non-`NaN` `f64`, as a `u64`: for non-`NaN` `a`, `b`,
+/// `a < b`  ⇔  `encode_f64(a) < encode_f64(b)`.
+///
+/// Non-negatives get the sign bit set (sorting them above every negative);
+/// negatives are bit-inverted so more-negative sorts lower. `-0.0` collapses
+/// into `+0.0` so the two numerically-equal zeros share a key.
+#[must_use]
+pub fn encode_f64(x: f64) -> u64 {
+    // Collapse -0.0 into +0.0 so `n.x = 0` matches both signs of zero.
+    let x = if x == 0.0 { 0.0 } else { x };
+    let bits = x.to_bits();
+    if bits & SIGN == 0 { bits | SIGN } else { !bits }
+}
+
+/// Inverse of [`encode_f64`], for tests and debugging. Note `-0.0` does not
+/// round-trip: it was normalized to `+0.0` on encode.
+#[cfg(test)]
+#[must_use]
+fn decode_f64(key: u64) -> f64 {
+    let bits = if key & SIGN != 0 { key & !SIGN } else { !key };
+    f64::from_bits(bits)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Strictly increasing keys across a representative sweep of the f64 domain
+    /// (a single zero — the two-zero collision is checked separately).
+    #[test]
+    fn strictly_monotone_across_the_domain() {
+        let vals = [
+            f64::NEG_INFINITY,
+            -1e308,
+            -1.0,
+            -f64::MIN_POSITIVE,
+            0.0,
+            f64::MIN_POSITIVE,
+            1.0,
+            1e308,
+            f64::INFINITY,
+        ];
+        let mut prev = encode_f64(vals[0]);
+        for &v in &vals[1..] {
+            let k = encode_f64(v);
+            assert!(
+                k > prev,
+                "encode not strictly monotone at {v}: {k} <= {prev}"
+            );
+            prev = k;
+        }
+    }
+
+    /// Both zeros — and the integer/bool zeros — map to one key.
+    #[test]
+    fn zeros_collide() {
+        let z = encode_f64(0.0);
+        assert_eq!(encode_f64(-0.0), z);
+        assert_eq!(encode_numeric(&Value::Int(0)), Some(z));
+        assert_eq!(encode_numeric(&Value::Float(-0.0)), Some(z));
+        assert_eq!(encode_numeric(&Value::Bool(false)), Some(z));
+    }
+
+    /// Int and Float values interleave in a single order.
+    #[test]
+    fn int_float_interleave() {
+        let three = encode_numeric(&Value::Int(3)).unwrap();
+        let three_five = encode_numeric(&Value::Float(3.5)).unwrap();
+        let four = encode_numeric(&Value::Int(4)).unwrap();
+        assert!(three < three_five && three_five < four);
+
+        // Negatives order by numeric value, not magnitude.
+        let neg5 = encode_numeric(&Value::Int(-5)).unwrap();
+        let neg4 = encode_numeric(&Value::Int(-4)).unwrap();
+        assert!(neg5 < neg4 && neg4 < three);
+    }
+
+    /// Bool and temporal values coerce like their f64 equivalents (parity).
+    #[test]
+    fn bool_and_temporal_parity() {
+        assert_eq!(encode_numeric(&Value::Bool(true)), Some(encode_f64(1.0)));
+        assert_eq!(
+            encode_numeric(&Value::Datetime(1000)),
+            Some(encode_f64(1000.0))
+        );
+        assert_eq!(encode_numeric(&Value::Duration(-7)), Some(encode_f64(-7.0)));
+    }
+
+    /// NaN and non-numeric values are not indexable.
+    #[test]
+    fn nan_and_non_numeric_reject() {
+        assert_eq!(encode_numeric(&Value::Float(f64::NAN)), None);
+        assert_eq!(
+            encode_numeric(&Value::String(std::sync::Arc::new("x".to_string()))),
+            None
+        );
+    }
+
+    /// `decode_f64` inverts `encode_f64` across the sweep.
+    #[test]
+    fn roundtrip() {
+        for &v in &[
+            f64::NEG_INFINITY,
+            -1e308,
+            -42.5,
+            -1.0,
+            0.0,
+            1.0,
+            42.5,
+            1e308,
+            f64::INFINITY,
+        ] {
+            assert_eq!(decode_f64(encode_f64(v)), v, "roundtrip failed for {v}");
+        }
+    }
+}

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -1,0 +1,492 @@
+//! Folded-roots MVCC holder (PR2 · P3/P4a): the FalkorDB index state that lives
+//! on [`Graph`](crate::graph::Graph) as its own copy-on-write field, so
+//! `Graph::new_version()` forks it in `O(1)` per column and the committed-version
+//! `Arc<AtomicRefCell<Graph>>` swap publishes graph + index together — one atomic
+//! step, no torn read.
+//!
+//! Deliberately **pure data — no reference back to `Graph`**. The RediSearch
+//! `Indexer` holds an `Arc<Mutex<Option<Arc<AtomicRefCell<Graph>>>>>` pointing
+//! back at the graph for background population; that cycle is exactly what this
+//! avoids. The write path mutates a version's own copy instead.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::entity_type::EntityType;
+use crate::index::IndexQuery;
+use crate::runtime::value::Value;
+
+use super::encode::encode_numeric;
+use super::numeric::{DocIter, NumericIndex};
+
+/// Identifies one index column: `(label, attribute)`.
+///
+/// Placeholder key shape for P4 — a later step may switch to interned numeric
+/// ids for compactness once the write/read wiring already resolves names.
+pub type IndexKey = (Arc<String>, Arc<String>);
+
+/// A staged batch of maintenance for one commit: `(label, attr) → [(value, id)]`,
+/// applied per column by [`FalkorDbIndex::merge`].
+pub type StagedColumns = HashMap<IndexKey, Vec<(Value, u64)>>;
+
+/// One index column, of a specific kind.
+///
+/// Index kinds are a **closed set we own**, so this is a static enum — no
+/// `Box<dyn>`, no boxed iterators, and exhaustive matching forces every kind to
+/// be handled (an unimplemented kind fails loudly, never silently). Kind-specific
+/// queries (numeric range/point vs a future vector ANN) are reached by matching
+/// the variant; the uniform lifecycle ([`add`](Self::add)/[`remove`](Self::remove))
+/// is delegated here. More variants (Text, Vector, Geo) land with their kinds.
+#[derive(Clone)]
+pub enum IndexColumn {
+    Numeric(NumericIndex),
+}
+
+impl IndexColumn {
+    /// Index `id` under `value` — the new value on create/update. Each kind
+    /// interprets the `Value` (numeric encodes it; a future text kind tokenizes).
+    pub fn add(
+        &mut self,
+        value: &Value,
+        id: u64,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.add(value, id),
+        }
+    }
+
+    /// Remove `id` under `value` — the old value on delete/update.
+    pub fn remove(
+        &mut self,
+        value: &Value,
+        id: u64,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.remove(value, id),
+        }
+    }
+
+    /// Add a batch of `(value, id)` entries — the columnar write path's add column.
+    pub fn add_batch(
+        &mut self,
+        entries: impl IntoIterator<Item = (Value, u64)>,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.add_batch(entries),
+        }
+    }
+
+    /// Remove a batch of `(value, id)` entries — the columnar write path's remove column.
+    pub fn remove_batch(
+        &mut self,
+        entries: impl IntoIterator<Item = (Value, u64)>,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.remove_batch(entries),
+        }
+    }
+
+    /// Whether this column holds no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Numeric(idx) => idx.is_empty(),
+        }
+    }
+}
+
+/// One column's index.
+#[derive(Clone)]
+struct ColumnEntry {
+    column: IndexColumn,
+}
+
+impl ColumnEntry {
+    /// A column that already holds all its data and serves reads immediately —
+    /// the synchronous populate path.
+    fn ready(column: IndexColumn) -> Self {
+        Self { column }
+    }
+}
+
+/// The graph's FalkorDB indexes: one CoW column per indexed `(label, attr)`.
+///
+/// Node and edge (relationship) columns live in separate maps — a node label and
+/// a relationship type can share a name, so one keyspace would collide. Callers
+/// select the map with an [`EntityType`], mirroring the `node_indexer` /
+/// `edge_indexer` split on [`Graph`](crate::graph::Graph). An edge column's docs
+/// are `edge_id`s; the read path recovers `(src, dst)` from the graph's own
+/// `edge_id → (src, dst)` reverse index, so no endpoints are stored here.
+///
+/// Cloning is `O(1)` per column (each index is a root-`Arc` bump), so it rides
+/// `Graph::new_version()` cheaply and shares pages with the prior version until a
+/// writer mutates that particular column.
+#[derive(Clone, Default)]
+pub struct FalkorDbIndex {
+    node_columns: HashMap<IndexKey, ColumnEntry>,
+    edge_columns: HashMap<IndexKey, ColumnEntry>,
+}
+
+impl FalkorDbIndex {
+    /// An empty set of indexes.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether no index column (node or edge) has been created.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.node_columns.is_empty() && self.edge_columns.is_empty()
+    }
+
+    /// Number of index columns (node + edge).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.node_columns.len() + self.edge_columns.len()
+    }
+
+    /// The column map for `entity` — node labels and relationship types keep
+    /// separate keyspaces (a label and a type may share a name).
+    fn columns(
+        &self,
+        entity: EntityType,
+    ) -> &HashMap<IndexKey, ColumnEntry> {
+        match entity {
+            EntityType::Node => &self.node_columns,
+            EntityType::Relationship => &self.edge_columns,
+        }
+    }
+
+    fn columns_mut(
+        &mut self,
+        entity: EntityType,
+    ) -> &mut HashMap<IndexKey, ColumnEntry> {
+        match entity {
+            EntityType::Node => &mut self.node_columns,
+            EntityType::Relationship => &mut self.edge_columns,
+        }
+    }
+
+    /// Create an empty numeric column for `(entity, label, attr)` in the `Ready`
+    /// state, replacing any existing one. Used by the synchronous paths (RDB load /
+    /// replica), where the caller fills it via [`build_numeric`](Self::build_numeric)
+    /// before any read is served. An edge column's docs are `edge_id`s.
+    pub fn create_numeric(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) {
+        self.columns_mut(entity).insert(
+            (label.clone(), attr.clone()),
+            ColumnEntry::ready(IndexColumn::Numeric(NumericIndex::new())),
+        );
+    }
+
+    /// Build (or rebuild) the numeric column for `(entity, label, attr)` from
+    /// `entries` (any order) in the `Ready` state, replacing any existing one — the
+    /// bulk populate path. `NumericIndex::from_entries` bottom-up-loads the sorted
+    /// pairs (cheaper than looping incremental adds). Non-numeric / `NaN` values are
+    /// skipped by the encoder, so a Range attr holding mixed types indexes only its
+    /// numeric values — mirroring the NUMERIC half of the RediSearch Range field.
+    pub fn build_numeric<'a>(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        entries: impl IntoIterator<Item = (&'a Value, u64)>,
+    ) {
+        self.columns_mut(entity).insert(
+            (label.clone(), attr.clone()),
+            ColumnEntry::ready(IndexColumn::Numeric(NumericIndex::from_entries(entries))),
+        );
+    }
+
+    /// Drop the column for `(entity, label, attr)` in `O(1)` — releases the tree `Arc`. DROP INDEX.
+    pub fn drop_column(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) {
+        self.columns_mut(entity)
+            .remove(&(label.clone(), attr.clone()));
+    }
+
+    /// The numeric column for `(entity, label, attr)`, if one exists and is numeric.
+    /// Used by the
+    /// populate path and tests, not the read path (which gates on state).
+    #[must_use]
+    pub fn numeric(
+        &self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> Option<&NumericIndex> {
+        match self.columns(entity).get(&(label.clone(), attr.clone())) {
+            Some(ColumnEntry {
+                column: IndexColumn::Numeric(idx),
+                ..
+            }) => Some(idx),
+            None => None,
+        }
+    }
+
+    /// Mutable numeric column for `(entity, label, attr)`, if one exists and is numeric.
+    pub fn numeric_mut(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> Option<&mut NumericIndex> {
+        match self
+            .columns_mut(entity)
+            .get_mut(&(label.clone(), attr.clone()))
+        {
+            Some(ColumnEntry {
+                column: IndexColumn::Numeric(idx),
+                ..
+            }) => Some(idx),
+            None => None,
+        }
+    }
+
+    /// Whether a column exists for `(entity, label, attr)` — the write path's staging gate.
+    #[must_use]
+    pub fn has_column(
+        &self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> bool {
+        self.columns(entity)
+            .contains_key(&(label.clone(), attr.clone()))
+    }
+
+    /// Apply one commit's batched maintenance for `entity`: **remove** the old-value
+    /// tuples, then **add** the new-value tuples, one batched tree op per touched
+    /// column. This is the single merge primitive — the caller only stages
+    /// `(value, id)` from graph state; the per-column batching lives here, and both
+    /// the steady-state write path and the background-build install go through it.
+    ///
+    /// Removes precede adds so a `(value, id)` removed and re-added in the same commit
+    /// nets to present. Each side is a batched op, so on disk this is one page-flush
+    /// pass per column — the merge is storage-agnostic (only the medium behind the
+    /// page store changes).
+    pub fn merge(
+        &mut self,
+        entity: EntityType,
+        adds: StagedColumns,
+        removes: StagedColumns,
+    ) {
+        let columns = self.columns_mut(entity);
+        for (key, entries) in removes {
+            if let Some(entry) = columns.get_mut(&key) {
+                entry.column.remove_batch(entries);
+            }
+        }
+        for (key, entries) in adds {
+            if let Some(entry) = columns.get_mut(&key) {
+                entry.column.add_batch(entries);
+            }
+        }
+    }
+
+    /// Answer an index query for `(entity, label)` from the numeric column — but ONLY a **numeric**
+    /// `Equal`/`Range` leaf. A Range index also holds strings and geo (served by
+    /// RediSearch), so a non-numeric or composite predicate returns `None` to fall through, as does a
+    /// missing column (the read
+    /// falls back to a scan — today's `UNDER CONSTRUCTION` behavior). Yields docs — node ids for a node
+    /// column, `edge_id`s for an edge column. The read path routes here and falls back on `None`.
+    #[must_use]
+    pub fn query_numeric(
+        &self,
+        entity: EntityType,
+        label: &Arc<String>,
+        query: &IndexQuery<Value>,
+    ) -> Option<DocIter> {
+        let (key, numeric) = match query {
+            IndexQuery::Equal { key, value } => (key, encode_numeric(value).is_some()),
+            IndexQuery::Range { key, min, max, .. } => (
+                key,
+                min.as_ref().is_none_or(|v| encode_numeric(v).is_some())
+                    && max.as_ref().is_none_or(|v| encode_numeric(v).is_some()),
+            ),
+            // And / Or / Point (geo) / InList / ArrayContains → not a numeric leaf.
+            _ => return None,
+        };
+        if !numeric {
+            return None; // string / geo on a Range index — RediSearch owns those entries
+        }
+        let entry = self.columns(entity).get(&(label.clone(), key.clone()))?;
+        match &entry.column {
+            IndexColumn::Numeric(idx) => idx.query(query),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity_type::EntityType::{Node, Relationship};
+
+    fn arc(s: &str) -> Arc<String> {
+        Arc::new(s.to_string())
+    }
+
+    #[test]
+    fn new_version_is_copy_on_write() {
+        let (label, attr) = (arc("Person"), arc("age"));
+
+        let mut v1 = FalkorDbIndex::new();
+        v1.create_numeric(Node, &label, &attr);
+        v1.numeric_mut(Node, &label, &attr)
+            .unwrap()
+            .add(&Value::Int(30), 1);
+
+        let mut v2 = v1.clone(); // the O(1) fork
+        v2.numeric_mut(Node, &label, &attr)
+            .unwrap()
+            .add(&Value::Int(40), 2);
+
+        let all = |v: &FalkorDbIndex| -> Vec<u64> {
+            v.numeric(Node, &label, &attr)
+                .unwrap()
+                .range(None, None, true, true)
+                .collect()
+        };
+        assert_eq!(all(&v1), vec![1]); // committed version unchanged
+        assert_eq!(all(&v2), vec![1, 2]); // new version sees the write
+    }
+
+    /// `create_numeric` installs a column; before it, the key is absent.
+    #[test]
+    fn create_then_lookup() {
+        let (label, attr) = (arc("Person"), arc("age"));
+        let mut idx = FalkorDbIndex::new();
+        assert!(idx.is_empty());
+        assert!(idx.numeric(Node, &label, &attr).is_none());
+
+        idx.create_numeric(Node, &label, &attr);
+        assert_eq!(idx.len(), 1);
+        assert!(idx.numeric(Node, &label, &attr).is_some());
+        assert!(idx.numeric(Node, &label, &attr).unwrap().is_empty());
+    }
+
+    /// `merge` batches adds+removes into the right columns (removes before adds).
+    #[test]
+    fn merge_batches_into_columns() {
+        let (label, attr) = (arc("Person"), arc("age"));
+        let mut idx = FalkorDbIndex::new();
+        idx.create_numeric(Node, &label, &attr);
+
+        let staged = |vals: &[(i64, u64)]| -> StagedColumns {
+            let mut m: StagedColumns = HashMap::new();
+            m.insert(
+                (label.clone(), attr.clone()),
+                vals.iter().map(|&(v, id)| (Value::Int(v), id)).collect(),
+            );
+            m
+        };
+        idx.merge(Node, staged(&[(7, 1), (9, 2)]), StagedColumns::new());
+        idx.merge(Node, StagedColumns::new(), staged(&[(7, 1)]));
+
+        let ids: Vec<u64> = idx
+            .numeric(Node, &label, &attr)
+            .unwrap()
+            .range(None, None, true, true)
+            .collect();
+        assert_eq!(ids, vec![2]);
+    }
+
+    /// A node label and a relationship type can share a name; their columns must be independent
+    /// (separate keyspaces), or edge writes would corrupt node reads and vice-versa. #51.
+    #[test]
+    fn node_and_edge_columns_do_not_collide() {
+        let (name, attr) = (arc("Rated"), arc("score")); // same name as a node label AND a rel type
+        let mut idx = FalkorDbIndex::new();
+        idx.create_numeric(Node, &name, &attr);
+        idx.create_numeric(Relationship, &name, &attr);
+        assert_eq!(idx.len(), 2, "one node column + one edge column");
+
+        idx.numeric_mut(Node, &name, &attr)
+            .unwrap()
+            .add(&Value::Int(1), 10);
+        idx.numeric_mut(Relationship, &name, &attr)
+            .unwrap()
+            .add(&Value::Int(1), 20);
+
+        let ids = |e| -> Vec<u64> {
+            idx.numeric(e, &name, &attr)
+                .unwrap()
+                .range(None, None, true, true)
+                .collect()
+        };
+        assert_eq!(ids(Node), vec![10], "node column sees only the node doc");
+        assert_eq!(
+            ids(Relationship),
+            vec![20],
+            "edge column sees only the edge doc"
+        );
+
+        // Dropping the edge column leaves the node column intact.
+        idx.drop_column(Relationship, &name, &attr);
+        assert!(idx.numeric(Relationship, &name, &attr).is_none());
+        assert!(idx.numeric(Node, &name, &attr).is_some());
+    }
+
+    /// Reads route only numeric `Equal`/`Range` leaves to the numeric column, for either entity.
+    /// A node query on a shared name must not see the edge column, and vice-versa.
+    #[test]
+    fn query_numeric_routes_only_numeric_leaves_per_entity() {
+        let (label, attr) = (arc("Person"), arc("age"));
+        let mut idx = FalkorDbIndex::new();
+        idx.create_numeric(Node, &label, &attr);
+        idx.numeric_mut(Node, &label, &attr)
+            .unwrap()
+            .add(&Value::Int(30), 1);
+        let key = attr.clone();
+
+        // Numeric Equal / Range → routed to the node column, correct ids.
+        let eq = IndexQuery::Equal {
+            key: key.clone(),
+            value: Value::Int(30),
+        };
+        let hit: Vec<u64> = idx.query_numeric(Node, &label, &eq).unwrap().collect();
+        assert_eq!(hit, vec![1]);
+        let rg = IndexQuery::Range {
+            key: key.clone(),
+            min: Some(Value::Int(10)),
+            max: None,
+            include_min: true,
+            include_max: true,
+        };
+        assert!(idx.query_numeric(Node, &label, &rg).is_some());
+
+        // A string on the same Range index must fall through (RediSearch owns the TAG entries).
+        let str_eq = IndexQuery::Equal {
+            key: key.clone(),
+            value: Value::String(Arc::new("x".to_string())),
+        };
+        assert!(idx.query_numeric(Node, &label, &str_eq).is_none());
+        // Composite, missing-column, and the wrong entity all fall through.
+        let eq2 = IndexQuery::Equal {
+            key: key.clone(),
+            value: Value::Int(30),
+        };
+        assert!(
+            idx.query_numeric(Node, &label, &IndexQuery::And(vec![eq2]))
+                .is_none()
+        );
+        let other = IndexQuery::Equal {
+            key: arc("height"),
+            value: Value::Int(5),
+        };
+        assert!(idx.query_numeric(Node, &label, &other).is_none());
+        assert!(
+            idx.query_numeric(Relationship, &label, &eq).is_none(),
+            "no edge column of this name"
+        );
+    }
+}

--- a/graph/src/index/falkordb/mod.rs
+++ b/graph/src/index/falkordb/mod.rs
@@ -1,6 +1,17 @@
-//! The native FalkorDB index (the in-repo replacement for RediSearch).
+//! The FalkorDB index (the in-repo replacement for RediSearch).
 //!
-//! Currently this holds only the standalone [`data_structures`]; the index trait, encoders, and
-//! runtime wiring land in subsequent changes.
+//! [`data_structures`] is the always-compiled substrate (the CoW B⁺-tree). The
+//! index proper — the numeric key [`encode`]r, the tree-backed index, and its
+//! runtime wiring — lives behind the `index-falkordb` feature and lands across
+//! PR2.
 
 pub mod data_structures;
+
+#[cfg(feature = "index-falkordb")]
+pub mod encode;
+
+#[cfg(feature = "index-falkordb")]
+pub mod falkordb_index;
+
+#[cfg(feature = "index-falkordb")]
+pub mod numeric;

--- a/graph/src/index/falkordb/mod.rs
+++ b/graph/src/index/falkordb/mod.rs
@@ -2,8 +2,7 @@
 //!
 //! [`data_structures`] is the always-compiled substrate (the CoW B⁺-tree). The
 //! index proper — the numeric key [`encode`]r, the tree-backed index, and its
-//! runtime wiring — lives behind the `index-falkordb` feature and lands across
-//! PR2.
+//! runtime wiring — lives behind the `index-falkordb` feature, off by default.
 
 pub mod data_structures;
 

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -1,0 +1,403 @@
+//! The index (PR2 · P2): a CoW B⁺-tree of `(key, entity_id)`
+//! tuples, where `key` is the [`encode_numeric`] image of the indexed value.
+//!
+//! Concrete-first — no trait yet. The generic `Index` trait is extracted at P4,
+//! when there is an actual dispatch caller (the indexer). MVCC is intrinsic: a
+//! query snapshots the tree in `O(1)` (root-`Arc` clone) and writes are
+//! copy-on-write, so readers never see a torn write. Folding the root into the
+//! graph's committed version is P3.
+
+use super::data_structures::cow_btree::{CowBTree, RangeIter};
+use super::encode::encode_numeric;
+use crate::index::IndexQuery;
+use crate::runtime::value::Value;
+
+/// Tree fan-out. Fixed at the tuned default for now; a future step can make the
+/// index generic over these if a workload wants a different page size.
+const LEAF_MAX: usize = 256;
+const BRANCH_MAX: usize = 256;
+/// Full-width doc ids. The tree can store them narrower (fewer bytes per entry, so more entries
+/// per page), but that caps the representable id and the index must hold any node or edge id the
+/// graph can mint. Narrowing is a memory optimization to make deliberately, once there is a bound
+/// to justify it — not a default to inherit.
+const DOC_BYTES: usize = 8;
+
+type Tree = CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
+
+/// Lazy iterator of matching entity ids, yielded in `(value, id)` order.
+pub type DocIter = RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
+
+/// A numeric property index over one `(label, attribute)`: entity ids keyed by
+/// the order-preserving encoding of their value, so `n.x <predicate> v` is a
+/// tree range scan. Non-numeric and `NaN` values are not indexed (parity with
+/// the RediSearch NUMERIC field it replaces).
+///
+/// `Clone` is `O(1)` — the underlying `CowBTree` clone is a root-`Arc` bump — so
+/// a graph version can fork its index snapshot cheaply (see
+/// [`FalkorDbIndex`](super::falkordb_index::FalkorDbIndex)).
+#[derive(Clone, Default)]
+pub struct NumericIndex {
+    tree: Tree,
+}
+
+impl NumericIndex {
+    /// An empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bulk-build from `(value, id)` pairs in any order. Non-numeric / `NaN`
+    /// values are dropped. Far cheaper than repeated [`add`](Self::add) for
+    /// initial population — one sort + bottom-up page build, no per-item
+    /// traversal.
+    #[must_use]
+    pub fn from_entries<'a>(entries: impl IntoIterator<Item = (&'a Value, u64)>) -> Self {
+        let mut pairs: Vec<(u64, u64)> = entries
+            .into_iter()
+            .filter_map(|(v, id)| encode_numeric(v).map(|k| (k, id)))
+            .collect();
+        pairs.sort_unstable();
+        pairs.dedup();
+        Self {
+            tree: Tree::from_sorted(&pairs),
+        }
+    }
+
+    /// Index `id` under `value`. A no-op for non-numeric / `NaN` values and
+    /// idempotent for an already-present `(value, id)`.
+    pub fn add(
+        &mut self,
+        value: &Value,
+        id: u64,
+    ) {
+        if let Some(k) = encode_numeric(value) {
+            // The bool reports whether the tuple was newly inserted — for callers keeping an
+            // exact live count. This index derives its counts from the tree, so it is discarded
+            // deliberately rather than ignored.
+            let _newly_inserted = self.tree.insert(k, id);
+        }
+    }
+
+    /// Remove `id` from under `value`. A no-op if it was never indexed.
+    pub fn remove(
+        &mut self,
+        value: &Value,
+        id: u64,
+    ) {
+        if let Some(k) = encode_numeric(value) {
+            let _was_present = self.tree.remove(k, id);
+        }
+    }
+
+    /// Add a batch of `(value, id)` entries, consuming any iterator (the runtime's columnar batch).
+    /// Non-numeric / `NaN` are dropped. Collects + sorts internally — the tree's `insert_batch` needs
+    /// a sorted slice — so callers never have to pre-materialize; cheaper than repeated
+    /// [`add`](Self::add).
+    pub fn add_batch(
+        &mut self,
+        entries: impl IntoIterator<Item = (Value, u64)>,
+    ) {
+        let mut pairs = Self::encode_pairs(entries);
+        pairs.sort_unstable();
+        self.tree.insert_batch(&pairs);
+    }
+
+    /// Remove a batch of `(value, id)` entries, consuming any iterator. Non-numeric / `NaN` dropped;
+    /// collect + sort internally — for the write path's mass-delete / mass-update column.
+    pub fn remove_batch(
+        &mut self,
+        entries: impl IntoIterator<Item = (Value, u64)>,
+    ) {
+        let mut pairs = Self::encode_pairs(entries);
+        pairs.sort_unstable();
+        self.tree.remove_batch(&pairs);
+    }
+
+    /// Encode `(value, id)` entries to `(key, id)` tree tuples, dropping non-numeric / `NaN` values.
+    fn encode_pairs(entries: impl IntoIterator<Item = (Value, u64)>) -> Vec<(u64, u64)> {
+        entries
+            .into_iter()
+            .filter_map(|(v, id)| encode_numeric(&v).map(|k| (k, id)))
+            .collect()
+    }
+
+    /// Whether the index holds no tuples.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tree.is_empty()
+    }
+
+    /// Entity ids whose value equals `value`. Empty for a non-numeric value.
+    #[must_use]
+    pub fn point(
+        &self,
+        value: &Value,
+    ) -> DocIter {
+        match encode_numeric(value) {
+            Some(k) => self.tree.point(k),
+            None => self.empty(),
+        }
+    }
+
+    /// Entity ids whose value lies in the (optionally half-open) numeric range.
+    /// A `None` bound is unbounded on that side; a non-numeric bound yields no
+    /// matches. Results are in `(value, id)` order.
+    #[must_use]
+    pub fn range(
+        &self,
+        min: Option<&Value>,
+        max: Option<&Value>,
+        include_min: bool,
+        include_max: bool,
+    ) -> DocIter {
+        // Map value bounds to inclusive key bounds. Exclusive bounds step one key
+        // inward: encodings of distinct f64 are adjacent u64, so `k+1` / `k-1` is
+        // exactly the next / previous representable value. The `checked_*` guards
+        // catch the ±∞ edges (`x > +inf`, `x < -inf`) as empty.
+        let lo = match min {
+            None => 0,
+            Some(v) => {
+                let Some(k) = encode_numeric(v) else {
+                    return self.empty();
+                };
+                if include_min {
+                    k
+                } else {
+                    match k.checked_add(1) {
+                        Some(k1) => k1,
+                        None => return self.empty(),
+                    }
+                }
+            }
+        };
+        let hi = match max {
+            None => u64::MAX,
+            Some(v) => {
+                let Some(k) = encode_numeric(v) else {
+                    return self.empty();
+                };
+                if include_max {
+                    k
+                } else {
+                    match k.checked_sub(1) {
+                        Some(k1) => k1,
+                        None => return self.empty(),
+                    }
+                }
+            }
+        };
+        if lo > hi {
+            return self.empty();
+        }
+        self.tree.range(lo, hi)
+    }
+
+    /// Dispatch the numeric *leaf* predicates. `Equal` → [`point`](Self::point),
+    /// `Range` → [`range`](Self::range). Composite (`And`/`Or`) and non-numeric
+    /// variants return `None` — the query router composes or rejects those (P5).
+    #[must_use]
+    pub fn query(
+        &self,
+        q: &IndexQuery<Value>,
+    ) -> Option<DocIter> {
+        match q {
+            IndexQuery::Equal { value, .. } => Some(self.point(value)),
+            IndexQuery::Range {
+                min,
+                max,
+                include_min,
+                include_max,
+                ..
+            } => Some(self.range(min.as_ref(), max.as_ref(), *include_min, *include_max)),
+            _ => None,
+        }
+    }
+
+    /// An iterator over no entries (`lo > hi` yields nothing).
+    fn empty(&self) -> DocIter {
+        self.tree.range(1, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn ids(it: DocIter) -> Vec<u64> {
+        it.collect()
+    }
+
+    /// Values: 10→{1,2}, 20→{3}, -5→{4}, 3.5→{5}.
+    fn sample() -> NumericIndex {
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(10), 1);
+        idx.add(&Value::Int(10), 2);
+        idx.add(&Value::Int(20), 3);
+        idx.add(&Value::Int(-5), 4);
+        idx.add(&Value::Float(3.5), 5);
+        idx
+    }
+
+    #[test]
+    fn point_matches_all_ids_for_a_value() {
+        let idx = sample();
+        assert_eq!(ids(idx.point(&Value::Int(10))), vec![1, 2]); // doc-ascending
+        assert_eq!(ids(idx.point(&Value::Int(20))), vec![3]);
+        assert_eq!(ids(idx.point(&Value::Float(10.0))), vec![1, 2]); // 10 == 10.0
+        assert!(ids(idx.point(&Value::Int(99))).is_empty());
+    }
+
+    #[test]
+    fn range_inclusive_exclusive_unbounded() {
+        let idx = sample();
+        let i = |x| Value::Int(x);
+        // inclusive [-5, 20] → ordered by (value, id): -5,3.5,10,10,20
+        assert_eq!(
+            ids(idx.range(Some(&i(-5)), Some(&i(20)), true, true)),
+            vec![4, 5, 1, 2, 3]
+        );
+        // (10, 20] — exclusive min drops value 10
+        assert_eq!(
+            ids(idx.range(Some(&i(10)), Some(&i(20)), false, true)),
+            vec![3]
+        );
+        // [10, 20) — exclusive max drops value 20
+        assert_eq!(
+            ids(idx.range(Some(&i(10)), Some(&i(20)), true, false)),
+            vec![1, 2]
+        );
+        // unbounded below, <= 3.5
+        assert_eq!(
+            ids(idx.range(None, Some(&Value::Float(3.5)), true, true)),
+            vec![4, 5]
+        );
+        // >= 10, unbounded above
+        assert_eq!(
+            ids(idx.range(Some(&i(10)), None, true, true)),
+            vec![1, 2, 3]
+        );
+        // fully unbounded → everything, in order
+        assert_eq!(ids(idx.range(None, None, true, true)), vec![4, 5, 1, 2, 3]);
+    }
+
+    #[test]
+    fn empty_and_degenerate_ranges() {
+        let idx = sample();
+        let i = |x| Value::Int(x);
+        // min > max
+        assert!(ids(idx.range(Some(&i(20)), Some(&i(10)), true, true)).is_empty());
+        // (10, 10) — exclusive both sides of one value
+        assert!(ids(idx.range(Some(&i(10)), Some(&i(10)), false, false)).is_empty());
+    }
+
+    #[test]
+    fn remove_deletes_one_tuple() {
+        let mut idx = sample();
+        idx.remove(&Value::Int(10), 1);
+        assert_eq!(ids(idx.point(&Value::Int(10))), vec![2]);
+        idx.remove(&Value::Int(10), 2);
+        assert!(ids(idx.point(&Value::Int(10))).is_empty());
+        // the rest are untouched
+        assert_eq!(ids(idx.point(&Value::Int(20))), vec![3]);
+    }
+
+    #[test]
+    fn non_numeric_and_nan_are_not_indexed() {
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::String(Arc::new("hi".to_string())), 1); // skipped
+        idx.add(&Value::Float(f64::NAN), 2); // skipped
+        idx.add(&Value::Int(7), 3);
+        assert!(!idx.is_empty());
+        assert_eq!(ids(idx.point(&Value::Int(7))), vec![3]);
+        // a non-numeric bound yields no matches
+        assert!(
+            ids(idx.range(
+                Some(&Value::String(Arc::new("a".to_string()))),
+                None,
+                true,
+                true
+            ))
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn bulk_build_matches_incremental() {
+        let entries = [
+            (Value::Int(10), 1),
+            (Value::Int(10), 2),
+            (Value::Int(20), 3),
+            (Value::Int(-5), 4),
+            (Value::Float(3.5), 5),
+        ];
+        let bulk = NumericIndex::from_entries(entries.iter().map(|(v, id)| (v, *id)));
+        let inc = sample();
+        let all = |ix: &NumericIndex| ids(ix.range(None, None, true, true));
+        assert_eq!(all(&bulk), all(&inc));
+    }
+
+    #[test]
+    fn duplicate_insert_is_idempotent() {
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(5), 1);
+        idx.add(&Value::Int(5), 1);
+        assert_eq!(ids(idx.point(&Value::Int(5))), vec![1]);
+    }
+
+    #[test]
+    fn query_dispatches_leaf_predicates() {
+        let idx = sample();
+        let key = Arc::new("x".to_string());
+        let eq = IndexQuery::Equal {
+            key: key.clone(),
+            value: Value::Int(20),
+        };
+        assert_eq!(ids(idx.query(&eq).unwrap()), vec![3]);
+        let rg = IndexQuery::Range {
+            key: key.clone(),
+            min: Some(Value::Int(10)),
+            max: None,
+            include_min: true,
+            include_max: true,
+        };
+        assert_eq!(ids(idx.query(&rg).unwrap()), vec![1, 2, 3]);
+        // composite predicates are the router's job, not a single index's
+        assert!(idx.query(&IndexQuery::And(vec![eq])).is_none());
+    }
+
+    #[test]
+    fn batch_ops_match_single_ops() {
+        let entries = vec![
+            (Value::Int(30), 1),
+            (Value::Int(10), 2),
+            (Value::Int(20), 3),
+            (Value::Float(15.5), 4),
+            (Value::Int(10), 5),
+            (Value::String(Arc::new("skip".to_string())), 6), // non-numeric → dropped
+        ];
+        let all = |ix: &NumericIndex| ids(ix.range(None, None, true, true));
+
+        // add_batch == repeated add
+        let mut batched = NumericIndex::new();
+        batched.add_batch(entries.iter().cloned());
+        let mut singly = NumericIndex::new();
+        for (v, id) in &entries {
+            singly.add(v, *id);
+        }
+        assert_eq!(all(&batched), all(&singly));
+
+        // remove_batch == repeated remove (incl. an absent entry, which is a no-op)
+        let removes = vec![
+            (Value::Int(10), 2),
+            (Value::Int(30), 1),
+            (Value::Int(99), 7),
+        ];
+        batched.remove_batch(removes.iter().cloned());
+        for (v, id) in &removes {
+            singly.remove(v, *id);
+        }
+        assert_eq!(all(&batched), all(&singly));
+    }
+}

--- a/graph/src/runtime/ops/edge_by_index_scan.rs
+++ b/graph/src/runtime/ops/edge_by_index_scan.rs
@@ -321,7 +321,24 @@ impl<'a> Iterator for EdgeByIndexScanOp<'a> {
                 // so we don't rebuild the full-type Vec per row.
                 let base: Box<dyn Iterator<Item = (NodeId, NodeId, RelationshipId)>> =
                     if Self::can_utilize_index(&q) {
-                        Box::new(self.runtime.g.borrow().get_indexed_edges(label, q))
+                        let g = self.runtime.g.borrow();
+                        // Edge index: a numeric Equal/Range on a column we own is served
+                        // by the CoW B-tree (endpoints recovered from the graph's reverse index);
+                        // string/geo/composite or a missing column falls through to RediSearch during
+                        // the dark-launch. #51, mirrors `NodeByIndexScanOp`.
+                        #[cfg(feature = "index-falkordb")]
+                        let it: Box<
+                            dyn Iterator<Item = (NodeId, NodeId, RelationshipId)>,
+                        > = if let Some(hit) = g.query_index_numeric_edges(label, &q) {
+                            Box::new(hit)
+                        } else {
+                            Box::new(g.get_indexed_edges(label, q))
+                        };
+                        #[cfg(not(feature = "index-falkordb"))]
+                        let it: Box<
+                            dyn Iterator<Item = (NodeId, NodeId, RelationshipId)>,
+                        > = Box::new(g.get_indexed_edges(label, q));
+                        it
                     } else {
                         let cached = {
                             let mut cache = self.all_edges_cache.borrow_mut();

--- a/graph/src/runtime/ops/node_by_index_scan.rs
+++ b/graph/src/runtime/ops/node_by_index_scan.rs
@@ -289,7 +289,21 @@ impl<'a> Iterator for NodeByIndexScanOp<'a> {
                 // (e.g. non-indexable value types), fall back to a
                 // label scan.
                 let base: Box<dyn Iterator<Item = NodeId>> = if Self::can_utilize_index(&q) {
-                    Box::new(self.runtime.g.borrow().get_indexed_nodes(self.index, q))
+                    let g = self.runtime.g.borrow();
+                    // Index: a numeric Equal/Range on a column we own is served by the
+                    // CoW B-tree; everything else (string/geo on the same Range index, composite, or a
+                    // missing column) falls through to RediSearch during the dark-launch.
+                    #[cfg(feature = "index-falkordb")]
+                    let it: Box<dyn Iterator<Item = NodeId>> =
+                        if let Some(hit) = g.query_index_numeric_nodes(self.index, &q) {
+                            Box::new(hit)
+                        } else {
+                            Box::new(g.get_indexed_nodes(self.index, q))
+                        };
+                    #[cfg(not(feature = "index-falkordb"))]
+                    let it: Box<dyn Iterator<Item = NodeId>> =
+                        Box::new(g.get_indexed_nodes(self.index, q));
+                    it
                 } else {
                     Box::new(
                         self.runtime


### PR DESCRIPTION
Closes #2354

Brings the native numeric index into the engine. Everything is
behind the `index-falkordb` feature, **off by default** — with the flag off the graph crate's
tests are unchanged (109 pass); with it on, 137.

## What this adds

A numeric index column per indexed `(label, attr)`, built on the CoW B-tree, with the read and
write paths wired to it.

- **Folded-roots MVCC.** The index is a `Graph` field, so `new_version()` CoW-clones it and
  publishing an index change *is* publishing a version — no separate index versioning. Cloning
  is O(1) per column (a root-`Arc` bump), so a fork shares pages with the prior version until a
  writer touches that particular column.
- **Node and edge columns are separate maps.** A node label and a relationship type can share a
  name, so one keyspace would collide. Edge columns store `edge_id`s; the read path recovers
  `(src, dst)` from the graph's own reverse index, so no endpoints are duplicated.
- **`CREATE INDEX` builds synchronously**, on the write thread, so the create returns with a
  column that already serves reads. (Making it a background build is #PR2 — that is the entire
  content of the next PR.)
- **Write maintenance** stages `(value, id)` per column during a commit and applies it in one
  batched pass, removes before adds so a tuple removed and re-added in the same commit nets to
  present. The delete hooks stage their removes *before* the type matrix is torn down, so an
  edge's type is still resolvable when its removal is recorded.
- **Reads** route a numeric `Equal`/`Range` predicate to the native column and fall through to
  RediSearch for anything else — a Range index also holds strings and geo, which RediSearch
  still owns.

## Also fixes a latent test-harness bug

`graph.rs`'s test module had its own `Once` calling `GrB_init`, alongside
`graphblas::test_init`'s `Once` calling `GxB_init`. GraphBLAS permits exactly one init per
process, so whichever lost got `GrB_INVALID_VALUE` — and because the loser's `unwrap` runs
*inside* `call_once`, it poisoned that `Once` and every later test touching GraphBLAS died.
Test names in `graph::graph::` sort before `graph::graphblas::`, so the tensor tests were the
casualties. The helper's own comment already flagged this as a TODO; it now routes through the
shared guard.

This was live on `main`'s test suite whenever ordering happened to expose it, and it is why the
suite here is verified with `--test-threads=1` rather than trusting a parallel green.

## Verification

| | flag off | flag on |
|---|---|---|
| `cargo test -p graph` | 109 pass | 137 pass |

Both single-threaded (deterministic order). `cargo fmt --all --check` clean; root crate builds
with the flag on and off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional FalkorDB numeric indexes for node and relationship properties.
  * Supports equality and range queries across numeric, boolean, and temporal values.
  * Added efficient index creation, bulk population, updates, removals, and copy-on-write behavior.
  * Numeric indexes remain consistent as properties, labels, relationships, or entities change.

* **Bug Fixes**
  * Improved indexed node and relationship scans with numeric-index lookups and reliable fallback behavior.
  * Ensured index data remains isolated and correct across graph versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

