### PR TITLE
feat(index): online (background) index build — BASE/DELTA/TOMB

### DIFF
--- a/docs/design/online-index-build.md
+++ b/docs/design/online-index-build.md
@@ -1,0 +1,377 @@
+# Online (background) index build — design
+
+**Status:** proposed. **Revision 2**, after four independent adversarial reviews
+(correctness proof / scan-vs-hook divergence / assumption fact-check / concurrency).
+Supersedes the prototype on `rs/native-numeric-index`, which **must not ship** (§11).
+**Scope:** native FalkorDB index (`index-falkordb`), numeric column kind, node + edge.
+**Base:** `FalkorDB/FalkorDB@main` (post-#726 two-phase write path).
+
+> **What changed in r2.** The mechanism is unchanged and survived attack. The *specification*
+> did not: K-SOUND was false as written (§5), DELTA's defining property was never stated (§5),
+> the locking section was wrong in both its premise and its conclusion (§7), and the TOMB-vs-`dirty`
+> change was mis-sold as a pure win (§11). Two hard-failure bugs were found in the prototype and
+> two live correctness bugs in `main` (§13).
+
+---
+
+## 1. Problem
+
+`CREATE INDEX ON :L(a)` on a graph that already holds data must scan every matching entity,
+read its attribute, and build the index — O(|L|) reads + sort + bulk load. Hundreds of ms per
+million rows for numeric; far worse for vector, where embedding is CPU-bound.
+
+1. `CREATE INDEX` returns promptly; it does not block writes for the scan's duration.
+2. Concurrent writes are neither lost nor left stale.
+3. No query may observe a partially-built index.
+4. No deadlock, and no use of L1 (§7).
+
+---
+
+## 2. Model
+
+Committed versions `V0, V1, …` are immutable; a write forks the current version, mutates the
+fork, publishes it. **The index is folded into the version** (`falkordb_index` is a `Graph`
+field, CoW-cloned by `new_version()`), so publishing an index change means publishing a version.
+
+A **column** `c = (entity-type, label/type L, attr a)`. For version `V`, entity `x`:
+
+- `match_V(x)` — live, carries `L`, has `a`, and the value is indexable.
+- `tuples_V(x)` — the **encoded** tuples `x` contributes: `{(encode(value), x)}`. A set, so
+  array kinds generalize — but see I-W8 and §13(B) for what that requires.
+- `T[V]` — tuples physically stored in column `c` at `V`.
+
+**EXACT(V)** ⟺ `T[V] == ⋃ₓ tuples_V(x)`.
+
+> **Caveat on EXACT.** It is defined over *encoded* tuples, so it is satisfied by an index that
+> answers queries wrongly whenever the encoder is many-to-one — which it is today (§13 B).
+> EXACT is the right target for *this* design; it is not a complete correctness statement for
+> the index as a whole.
+
+---
+
+## 3. Three artifacts
+
+| Artifact | Lives in | Size | Written by |
+|---|---|---|---|
+| **BASE** | the build job's private memory — unreachable from any version | O(N) | the scan |
+| **DELTA** | the column's own tree, inside the version | O(writes during build) | client writes |
+| **TOMB** | a second tree in `Building` state, inside the version | O(writes during build) | client writes |
+
+BASE is deliberately stale; TOMB + DELTA are the catch-up log that makes installing a stale
+artifact safe.
+
+**Writers write directly into the column** — DELTA *is* the column's tree during a build; there
+is no parallel write path. The sole exception is a *remove* whose target row lives in BASE,
+which no version can name yet; that remove is deferred into TOMB.
+
+```
+ColumnState::Building { tomb, epoch: u64 }   // tomb: same CoW tuple tree as the column
+ColumnState::Ready
+```
+
+**TOMB stores encoded `(key, doc)` tuples**, not raw `Value`s — its dedup must use the same
+equivalence relation as the column, or §13(B)'s collisions turn into wrong removals.
+
+---
+
+## 4. Flows
+
+### 4.1 CREATE INDEX (client path)
+One ordinary write commit: column ← `Building { tomb: empty, epoch: fresh }`; record `N` = the
+version produced; return. `create_index_sync` (RDB load, replica effect) stays synchronous → `Ready`.
+
+### 4.2 Scan — no locks
+```
+snapshot := Arc to version N        (lock-free clone; immutable)
+BASE     := scan(snapshot)          (minutes are fine; parallelisable; chunk for bounded memory)
+```
+Writes committing as N+1, N+2, … are invisible to the scan by construction.
+
+### 4.3 Client write while Building
+```
+fork current version                 (CoW: index roots bump, O(1))
+stage rem/add from live graph state  (existing hooks)
+  add    → column tree (DELTA)
+  remove → column tree (usually a no-op) AND append to TOMB
+commit
+```
+
+### 4.4 Install — one commit
+```
+try-acquire writer slot             (NON-blocking; on failure back off and retry — §7)
+  fork the current committed version V_M
+  read DELTA and TOMB *from this fork*   (never from a value captured earlier)
+  new := BASE
+  new.remove_batch(TOMB)            (removes strictly first)
+  new.merge(DELTA)                  (then adds)
+  column := Ready { tree: new }     (TOMB dropped)
+  acquire GIL
+  commit V_M+1                      (Arc swap under the GIL — #452 fork-safety)
+release GIL, release slot
+```
+
+### 4.5 Read
+`Building` → must not use the column → fall back. `Ready` → exact for that snapshot → use it.
+A query holding a `Building` snapshot keeps falling back for its whole life; no mid-query switch.
+
+---
+
+## 5. Invariants
+
+**Reads**
+- **I-R1** A query consults `c` only if its snapshot says `Ready`. Obligation at every read site.
+- **I-R2** Index and graph resolve from the same snapshot. (Free: folded roots.)
+- **I-R3** EXACT holds wherever `c` is `Ready`.
+- **I-R4** A `Building` column has a correct fallback at plan/run time.
+
+**Writes**
+- **I-W1** One writer at a time; **fork and commit inside the same exclusive window**.
+- **I-W3** Every mutation changing whether/how an entity is indexed goes through the hooks.
+- **I-W4** While Building: new tuples → DELTA, destroyed tuples → TOMB.
+- **I-W4′** `DELTA == ⋃ tuples_V_M(x)` over touched `x` — DELTA holds each touched entity's
+  **final** state, not an append-only add-log. *Requires removes to hit the column tree, not
+  only TOMB.* Without this, `v0→v1→v2` installs two rows.
+- **I-W5** Writes never wait for the scan; only for the single install commit.
+- **I-W6** A **pure-add hook** may be used only where `tuples_before(x) ⊆ tuples_after(x)`.
+  Three hooks stage no removes — `import_node_attrs`, `import_relationship_attrs`,
+  `set_nodes_labels_bulk` — and every new hook must be audited against this.
+- **I-W7** Each hook recomputes the entity's tuples from **live state at its own point in the
+  commit order**, never from a value captured earlier. (`pending::commit` fixes an intra-commit
+  order: labels → label-removes → imports → sets → deletes; correctness of combinations such as
+  `REMOVE n:L SET n.a=9` depends on it.)
+- **I-W8** Hooks stage **encoded tuples**, never raw values. Any diffing (arrays) happens
+  post-encode — see §13(B).
+
+**Build**
+- **I-B1** `BASE == ⋃ₓ tuples_V_N(x)`.
+- **I-B2** BASE is unreachable from any committed version until install; the scan holds no locks.
+- **I-B3** Install is one commit; reads DELTA/TOMB from the version it forks; **removes strictly
+  before adds**; publishes `Ready` atomically with the merged tree.
+- **I-B4** Epoch: install/finish are no-ops unless the column's epoch matches. In-flight
+  bookkeeping is epoch-keyed.
+- **I-B5** **Liveness:** every `Building` column is eventually dispatched, by a mechanism that
+  does not depend on a subsequent client write (§8).
+- **I-B6** The scan **materialises the snapshot under the Rust mutex** (`Matrix::wait`) before
+  iterating, so that no later `GxB_rowIterator_attach` — the scan's or a concurrent query's —
+  triggers materialisation outside that mutex. See §10.5.
+
+**Resources**
+- **I-X1** Every per-build artifact carried in the version forks in **O(1)**. (`RoaringTreemap`
+  does not — see §11.)
+- **I-X2** The writer slot is released on **every** exit path including unwind — RAII, not a
+  convention. See §13(C).
+
+**Locking** — §7.
+
+**Derived**
+- **K-SOUND′** For every `t ∈ tuples_V_N(x) ∖ tuples_V_M(x)`, `t ∈ TOMB`.
+  *Holds because* every tuple-**destroying** hook recomputes the destroyed tuple from live state
+  when it runs, and the first such recomputation for `x` yields its snapshot-era tuple.
+  *(The r1 formulation — "the first remove staged enters TOMB" — was **false**: pure-add hooks
+  mean no remove need be staged at all. Counterexample: `SET n:L` on a node already carrying `:L`.)*
+- **K-SAFE** Any tuple in TOMB still valid at `V_M` is also in DELTA — by I-W4′. Hence removes
+  must precede adds.
+
+---
+
+## 6. Correctness argument
+
+**Claim.** I-B1 ∧ I-W3 ∧ I-W4′ ∧ I-W6 ∧ I-B3 ⇒ EXACT(V_M+1).
+
+| Case | BASE | TOMB | DELTA | Result |
+|---|---|---|---|---|
+| untouched, matched at N | row | — | — | correct ✓ |
+| untouched, unmatched at N | — | — | — | absent ✓ |
+| updated v0→v1→v2 | (v0,x) | (v0,x),(v1,x) | (v2,x) | (v2,x) ✓ |
+| updated v0→v1→v0 | (v0,x) | (v0,x),(v1,x) | (v0,x) | (v0,x) ✓ *order-critical* |
+| deleted | (v0,x) | (v0,x) | — | absent ✓ |
+| created after N | — | — | (v1,x) | (v1,x) ✓ |
+| created and deleted after N | — | no-op | — | absent ✓ |
+| id reused, same value | (v,x) | (v,x) | (v,x) | (v,x) ✓ *order-critical* |
+| id reused repeatedly (n cycles) | (v0,x) | all intermediates | final | final ✓ — TOMB is subtracted from BASE **only**, never from DELTA |
+| label added during build | — | — | (v,x) | (v,x) ✓ |
+| label removed during build | (v0,x) | (v0,x) | — | absent ✓ |
+| **no-op label re-add** (`SET n:L`, already `:L`) | (v,x) | **—** (pure-add hook) | (v,x) | (v,x) ✓ — correct by *set collapse*, not by K-SOUND |
+| numeric → non-numeric | (v0,x) | (v0,x) | — (encoder drops) | absent ✓ |
+| **attribute deleted** (`SET a=NULL` / `REMOVE`) | (v0,x) | (v0,x) | — (`Null` dropped by encoder) | absent ✓ — relies on every kind rejecting `Null` |
+| **multi-label node** | per-label row | per-label | per-label | ✓ — `stage_index_node` fans one attr write to **every** label column; the whole argument is per-column |
+| **cascade edge delete** | (v0,e) | (v0,e) | — | ✓ — `delete_implicit_edges` is a *second, independent* remove path, correct only because it stages before `relationship_attrs.remove_all` |
+| **`GRAPH.BULK` row** | maybe | — | — | ✗ **BROKEN** — §13(A) |
+
+Untouched entities follow from the contrapositive of I-W3; touched entities from K-SOUND′ and
+induction on I-W4′.
+
+**Scan-vs-write races do not exist.** The scan reads a frozen snapshot, so whether a write
+touches an entity the scan has passed or not yet reached is irrelevant. Carol deleted before the
+scan reaches her: the scan still emits her row; TOMB removes it at install.
+
+**Remove-before-add is necessary and sufficient.** Install starts *from* BASE, so all
+snapshot-era tuples are present; the only ordering is TOMB-vs-DELTA. Applying DELTA first would
+delete exactly `TOMB ∩ DELTA` — every tuple destroyed and later recreated. By I-W4′ no DELTA
+tuple is invalid at `V_M`, so TOMB never needs to fire after DELTA. No case requires the opposite.
+
+---
+
+## 7. Locking — rewritten in r2
+
+Both the premise and the conclusion of r1 were wrong.
+
+**Premise (wrong in r1).** r1 said "L1 is the de-facto writer lock; the CAS slot is a backstop."
+False: the main client writer CASes the slot while holding L1-**read** (`graph_core.rs:592`,
+`Mode::Reader`; the comment there says so). **The writer slot is already the real exclusion
+primitive.** L1 exists only to serialize the non-MVCC RediSearch index.
+
+**Conclusion (wrong in r1, and again in the first r2 draft).** r1 required the slot to become
+*blocking*. That creates a cycle: the client path holds the slot and *then* acquires the GIL during
+escalation, so a blocking slot deadlocks the moment the main thread parks on it — and **dropping L1
+does not help**, because the main thread's GIL hold is implicit and non-releasable. **The
+blocking-slot requirement is withdrawn.**
+
+The first r2 draft then said the installer takes "writer-slot → GIL, never L1". **That is also
+wrong**, for a blunt reason found during implementation: `MvccGraph::commit` takes **`&mut self`**
+(`read`/`write`/`rollback` take `&self`, only `commit` does not). Publishing a version therefore
+requires exclusive access to the `ThreadedGraph`, i.e. **L1-write is unavoidable**. "The native
+index is MVCC so it needs no L1" is true of the *index*, false of the *commit*.
+
+**Actual orders in the code:**
+
+```
+inline main-thread cmd   GIL (implicit) → L1 → try-slot (None ⇒ retryable error)
+pooled client write      L1-read → try-slot (None ⇒ error) → [escalate: drop L1-read, GIL, L1-write]
+installer                GIL → L1-write → try-slot → install → commit
+```
+
+**Why this is cycle-free:**
+
+- **I-L1 (load-bearing)** The **main thread must never block on the writer slot** — try-acquire
+  plus a retryable error. It cannot release its implicit GIL, so any main-thread park is a global
+  stall.
+- **I-L2** The installer acquires **GIL → L1-write → try-slot**, the same GIL-before-L1 order every
+  other writer uses. The slot is *try*-acquired: a client can hold the slot while waiting for the
+  GIL during escalation, so blocking on it would deadlock. On contention the installer releases
+  everything and is re-dispatched by the sweep (§8) — a background job can retry; a client cannot.
+- **I-L3** Never block (channel send, slot park, GIL acquire) while holding L1.
+- **I-L4** Slot release survives an unwind (I-X2): `MvccGraph::write` latches a flag cleared only by
+  `commit`/`rollback`, so a panic between them wedges *every* subsequent write in the process. The
+  installer catches around `install` and rolls back.
+
+The escalating client holds the slot but no L1 while it waits for the GIL, so the installer's
+`GIL → L1-write` never waits on a thread that is waiting for the GIL.
+
+The GIL covers only the Arc swap (#452 BGSAVE fork-exclusion). **It is not free:
+`MvccGraph::commit` calls `trim_attr_stores()`, an O(attribute-store) walk. That is a pre-existing
+cost on every commit; it is an argument for one install commit rather than N/1024 of them.**
+
+---
+
+## 8. Liveness
+
+Dispatch on "a client write committed" is insufficient — it is wired into **one of five** write
+paths, and it leaks its bookkeeping. A single **periodic sweep** over the graph registry running
+`dispatch(collect_pending_builds(g))` subsumes all of it: MULTI/EXEC and replica `CREATE INDEX`,
+a dropped `spawn`, a panicked job, a fork-contention bail, and "CREATE INDEX was the last write".
+Dispatch is idempotent under the in-flight set, so the sweep is cheap and needs no per-path wiring.
+
+**The in-flight marker must be inserted by the job, not the dispatcher** (or handed to the job so
+it is released if `spawn` drops it) — otherwise a dropped job leaks the key and suppresses every
+future re-spawn of that column.
+
+---
+
+## 9. Cost
+
+| Phase | Cost | Locks |
+|---|---|---|
+| scan + BASE build | O(N) reads + sort + bulk load | **none** |
+| client write during build | one batched insert into DELTA + one into TOMB | ordinary write locks |
+| install | O(1) adopt BASE + O(\|TOMB\|·log N) + O(\|DELTA\|·log N) | slot + GIL, briefly |
+
+The O(N) work never runs under a lock, and nothing is quadratic — provided I-X1 holds.
+
+---
+
+## 10. Verified assumptions
+
+| # | Assumption | Verdict |
+|---|---|---|
+| 1 | Read gating enforced at every read site | **TRUE** — two sites, both funnel through `query_numeric`, which cannot return a `Building` column. *But* `numeric()`/`numeric_mut()` are `pub` state-agnostic hatches, and the fallback goes to **RediSearch, not a scan** — a hole at P7 |
+| 2 | Aborted writes discard index mutations with the fork | **TRUE** — `rollback()` never touches the graph; the fork drops. *This is why TOMB must be versioned, not a shared log* |
+| 3 | `new_version()` is O(1) per column | **PARTIAL** — trees are Arc-rooted ✓, but `dirty: RoaringTreemap` deep-clones ⇒ O(W²) per build. Fixed by TOMB (§11) |
+| 4 | L1 guarantees the writer wins the CAS | **FALSE** — see §7 |
+| 5 | Off-thread snapshot scan is safe | **SETTLED — safe, with a required mitigation.** `Iter::new` does not call `Matrix::wait`; it calls `GxB_rowIterator_attach`, and SuiteSparse finishes pending work on attach (corroborated by the comment at `graph.rs:1478`). So the scan **does** mutate the snapshot's matrix, and that materialization happens inside GraphBLAS, *not* under the Rust `self.lock`. **This is identical to what concurrent read queries already do** — two `MATCH`es on the same committed snapshot both attach — so the scan adds no new hazard class. **Mitigation (adopted, I-B6):** the scan calls `Matrix::wait()` on the snapshot first, which materializes once *under* the Rust mutex (correct double-checked lock: Acquire fast path → mutex → re-check → `GrB_MATERIALIZE` → Release). Afterwards `has_pending` is false and every later attach, scan's or query's, is a pure read — the scan warms the snapshot instead of racing on it. Residual: the pre-existing attach-materialises-outside-the-mutex race for *first* readers deserves its own investigation, but it does not block this design |
+
+---
+
+## 11. Difference from the prototype — with the honest trade
+
+| Prototype | This design | Note |
+|---|---|---|
+| Chunked install: N/1024 commits | One install commit; BASE adopted wholesale | chunking multiplies the O(N) `trim_attr_stores` per commit |
+| `dirty` RoaringTreemap of ids | TOMB tuple tree | **not a pure win — see below** |
+| `dirty` deep-clones per fork (O(W²)) | TOMB forks O(1) | strict improvement |
+| L1 → slot → GIL (**inverted** ⇒ deadlock) | slot → GIL, never L1 | strict improvement |
+| Dispatch on client write only | Periodic sweep (§8) | strict improvement |
+| Slot leaked on panic | RAII guard (I-X2) | strict improvement |
+
+> **The TOMB trade-off, stated plainly.** `dirty` is *touch*-keyed: any touch of an id suppresses
+> **all** of that id's BASE rows, so it is immune to a hook computing the wrong value. TOMB is
+> *remove*-keyed: a stale row survives unless the hook stages the exact matching encoded tuple.
+> This is a **narrowing of the safety property**, bought in exchange for O(1) BASE adoption.
+> It is acceptable because the steady-state (`Ready`) path *already* depends on exact value
+> precision — a hook staging a wrong old value corrupts the index today, build or no build — so
+> TOMB extends an existing dependency rather than creating a new class. But it makes **I-W6 an
+> audit obligation**, not a note.
+
+---
+
+## 12. Edge cases
+
+| # | Case | Resolution |
+|---|---|---|
+| C1 | DROP during build | Epoch ⇒ install no-ops; needs a cancel signal for liveness |
+| C2 | DROP + re-CREATE during build | New epoch ⇒ stale install inert; in-flight key must include the epoch |
+| C3 | Graph deleted during build | Job holds an Arc (no UAF); install no-ops on teardown |
+| C4 | Crash / restart mid-build | Index not serialised; RDB load rebuilds synchronously ⇒ `Ready` |
+| C5 | BGSAVE fork mid-build | BASE unpublished ⇒ child sees no partial index; commit under GIL |
+| C6 | Replica | Effect → `create_index_sync`. **Open:** a long sync build stalls the replica link |
+| C7 | Build panics / OOMs | Sweep (§8) re-dispatches; RAII (I-X2) prevents a wedged slot |
+| C8 | Many columns building at once | Independent epochs; needs a concurrency cap |
+| C9 | **`GRAPH.BULK` during build** | **Unsound — §13(A)** |
+| C10 | Long build, write-heavy | \|DELTA\|,\|TOMB\| = O(writes) ⇒ install cost grows; needs a cap for vector scale |
+| C11 | Aborted write | Fork discarded ⇒ DELTA/TOMB entries vanish — the reason TOMB is versioned |
+| C12 | Id reuse after an unhooked delete | `deleted_*` is a **free list**, cleared on reuse, so the backstop is defeated; TOMB is the *only* real defence, and it depends on hook completeness — which §13(A) breaks |
+
+---
+
+## 13. Defects found in review that are **not** this design's to fix
+
+**(A) `GRAPH.BULK` bypasses the index hooks — live on `main`.**
+`import_node_attrs_resolved` / `import_relationship_attrs_resolved` have no hook at all;
+`bulk_insert.rs:294` / `:367` call them. The comment's stated mitigation is fictional —
+`populate_indexes_sync` is never called from `bulk_insert.rs`. Bulk-loading into an indexed graph
+leaves rows permanently unindexed; `bulk_insert.rs:290` runs the one hooked call *before* the
+attributes exist, so it no-ops. **During a build it is worse than a hole:** those ids are never
+recorded, so install writes the *snapshot* value for a row the bulk has overwritten.
+*This design cannot be sound until (A) is fixed or `GRAPH.BULK` is excluded by precondition.*
+
+**(B) The encoder is many-to-one across types — live on `main`.**
+```rust
+Value::Int(i)  => *i as f64,        // lossy at >= 2^53
+Value::Bool(b) => f64::from(*b),    // true -> 1.0
+Value::Datetime(t) | Date(t) | Time(t) | Duration(t) => *t as f64,
+```
+No type tag, so `WHERE n.a = 1` matches a node with `a = true`, `a = duration(1)`, or
+`a = datetime(epoch 1)`; and `Int >= 2^53` is coerced (`9007199254740993` → `…992`). EXACT can
+hold while answers are wrong. Fix: widen the key with the `Value` discriminant, or re-check the
+raw attribute on the read path. Also the reason arrays must diff post-encode (I-W8).
+
+**(C) The writer slot has no RAII release — latent on `main`, reachable via the prototype.**
+Released only by `commit`/`rollback`; unwinding never releases it. Every other slot-taker pairs
+with a rollback *by convention*. A panic in a slot-holder wedges **all** writes for the life of
+the process.
+
+**(D) `delete_relationships` drops removes for unresolvable edges**, leaving orphan tuples that
+resurface on edge-id reuse.
+
+**(E) Latent coupling:** the scan reads `labels_matices`; the hooks read `node_labels_matrix`.
+They agree today only because three sites update both.

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3497,64 +3497,61 @@ impl Graph {
         self.falkordb_index.building_columns()
     }
 
-    /// Read the `(value, doc)` entries for one building column from *this snapshot* — the base the
-    /// background job builds off-thread, then installs in batch-size chunks.
+    /// Build BASE for one building column from *this snapshot*, already encoded — everything the
+    /// install needs, computed off the write thread. Shared-borrow only and lock-free: the snapshot
+    /// is immutable, so writes committing after it are invisible to the scan by construction and
+    /// there is no scan-vs-write race to reason about.
+    ///
+    /// `None` if the column no longer exists (dropped mid-build).
     #[cfg(feature = "index-falkordb")]
     #[must_use]
-    pub fn collect_index_entries(
+    pub fn collect_index_base_encoded(
         &self,
         entity: EntityType,
         label: &Arc<String>,
         attr: &Arc<String>,
-    ) -> Vec<(Value, u64)> {
-        match entity {
+    ) -> Option<Vec<(u64, u64)>> {
+        let entries = match entity {
             EntityType::Node => self.collect_node_index_entries(label, attr),
             EntityType::Relationship => self.collect_edge_index_entries(label, attr),
-        }
+        };
+        self.falkordb_index
+            .encode_for_column(entity, label, attr, entries)
     }
 
-    /// Install one batch-size chunk of the background-built base (dropping ids already written since
-    /// `CREATE INDEX`). Called by the controller under the write serialization via `commit_index_build`.
+    /// Install a background-built BASE and flip the column to `Ready` — **one commit**.
+    /// Returns whether it installed; `false` means the column is gone, already `Ready`, or on a
+    /// different epoch (dropped and re-created since the job started), and the caller should not
+    /// commit.
+    ///
+    /// `base` arrives already encoded, from [`collect_index_base_encoded`](Self::collect_index_base_encoded)
+    /// running off the write thread — the commit pays only the tree build and the TOMB/DELTA merge.
+    ///
+    /// The `deleted_*` filter here is a cheap backstop, not the real defence: those bitmaps are a
+    /// free list and are cleared when an id is reused, so an id recycled during the build is no
+    /// longer marked. TOMB is what actually makes the stale BASE safe; this just drops the easy
+    /// cases before the tree build.
     #[cfg(feature = "index-falkordb")]
-    pub fn install_index_base_chunk(
+    pub fn install_index_base(
         &mut self,
         entity: EntityType,
         label: &Arc<String>,
         attr: &Arc<String>,
         epoch: u64,
-        chunk: Vec<(Value, u64)>,
-    ) {
-        // Authoritative delete backstop (O(1)/entry): drop base entries for entities deleted since
-        // the snapshot, via the graph's correctly-versioned `deleted_nodes`/`deleted_relationships`
-        // bitmaps (the writer's fork sees every committed delete). `install_base_chunk` then drops the
-        // per-column `dirty` ids (updated/created since create — the live delta holds their current
-        // state). Both are cheap bitmap checks, so the write-guarded window stays short — no re-scan,
-        // no GraphBLAS extract, no attribute reads.
-        let survivors: Vec<(Value, u64)> = match entity {
-            EntityType::Node => chunk
+        base: Vec<(u64, u64)>,
+    ) -> bool {
+        let survivors: Vec<(u64, u64)> = match entity {
+            EntityType::Node => base
                 .into_iter()
                 .filter(|(_, id)| !self.is_node_deleted(NodeId(*id)))
                 .collect(),
-            EntityType::Relationship => chunk
+            EntityType::Relationship => base
                 .into_iter()
                 .filter(|(_, id)| !self.is_relationship_deleted(RelationshipId(*id)))
                 .collect(),
         };
         self.falkordb_index
-            .install_base_chunk(entity, label, attr, epoch, survivors);
-    }
-
-    /// Flip a building column to `Ready` after its last chunk installs (only if `epoch` still matches
-    /// — a drop + re-create since the build started makes this a no-op; the fresh column is built anew).
-    #[cfg(feature = "index-falkordb")]
-    pub fn finish_index_build(
-        &mut self,
-        entity: EntityType,
-        label: &Arc<String>,
-        attr: &Arc<String>,
-        epoch: u64,
-    ) {
-        self.falkordb_index.finish_build(entity, label, attr, epoch);
+            .install_base(entity, label, attr, epoch, survivors)
     }
 
     /// Stage `(value, edge_id)` into the index column `(type, attr)` for the edge `id`'s single type,
@@ -5086,7 +5083,9 @@ mod falkordb_index_mvcc_tests {
         let epoch = g
             .falkordb_index_mut()
             .create_building(EntityType::Node, &label, &attr);
-        let base = g.collect_index_entries(EntityType::Node, &label, &attr);
+        let base = g
+            .collect_index_base_encoded(EntityType::Node, &label, &attr)
+            .expect("column exists");
         assert_eq!(base.len(), 6);
 
         // Writes that land DURING the build (before the base installs): delete id1(20) & id3(40),
@@ -5097,9 +5096,9 @@ mod falkordb_index_mvcc_tests {
         g.delete_nodes(&del, &mut FxHashMap::default()).unwrap();
         set_attr(&mut g, ids[4], &attr, Value::Int(55));
 
-        // Install the (now-stale) base, then finish. Validate-at-install drops the dead entries.
-        g.install_index_base_chunk(EntityType::Node, &label, &attr, epoch, base);
-        g.finish_index_build(EntityType::Node, &label, &attr, epoch);
+        // One install commit. TOMB (the removes staged by the hooks above) is subtracted from the
+        // stale base before DELTA is replayed, so the dead entries never reach the column.
+        assert!(g.install_index_base(EntityType::Node, &label, &attr, epoch, base));
 
         // Survivors, value-ordered: id0(10), id2(30), id4(55), id5(60).
         let all: Vec<u64> = g
@@ -5163,7 +5162,9 @@ mod falkordb_index_mvcc_tests {
         let epoch = g
             .falkordb_index_mut()
             .create_building(EntityType::Relationship, &ty, &attr);
-        let base = g.collect_index_entries(EntityType::Relationship, &ty, &attr);
+        let base = g
+            .collect_index_base_encoded(EntityType::Relationship, &ty, &attr)
+            .expect("column exists");
         assert_eq!(base.len(), 6);
 
         // Writes that land DURING the build (before the base installs): delete id1(20) & id3(40),
@@ -5180,8 +5181,7 @@ mod falkordb_index_mvcc_tests {
             .unwrap();
 
         // Install the (now-stale) base, then finish. Reconciliation drops the dead/updated entries.
-        g.install_index_base_chunk(EntityType::Relationship, &ty, &attr, epoch, base);
-        g.finish_index_build(EntityType::Relationship, &ty, &attr, epoch);
+        assert!(g.install_index_base(EntityType::Relationship, &ty, &attr, epoch, base));
 
         // Survivors, value-ordered: id0(10), id2(30), id4(55), id5(60).
         let all: Vec<u64> = g

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3204,13 +3204,18 @@ impl Graph {
                     self.add_node_attribute_name(attr);
                 }
                 populate_index(IndexKind::Node, label.clone(), self.node_indexer.clone());
-                // Dark-launch the index alongside RediSearch. The column is built
-                // synchronously here, on the write thread, so CREATE INDEX returns with a
-                // column that already serves reads. A background build (which lets CREATE
-                // INDEX return before the pre-existing snapshot is in) is a separate change.
+                // Dark-launch the index alongside RediSearch. CREATE INDEX returns
+                // immediately: the column is marked `Building` and the pre-existing
+                // snapshot is built off the write thread by the graph_core controller
+                // (which installs it via `commit_index_build`), flipping it `Ready`.
+                // Live writes maintain it meanwhile; reads scan-fall-back until ready.
+                // (`create_index_sync` — the RDB/replica path — stays synchronous.)
                 #[cfg(feature = "index-falkordb")]
                 if *index_type == IndexType::Range {
-                    self.populate_index_node(label, attrs);
+                    for attr in attrs {
+                        self.falkordb_index
+                            .create_building(EntityType::Node, label, attr);
+                    }
                 }
             }
             EntityType::Relationship => {
@@ -3224,11 +3229,14 @@ impl Graph {
                     self.add_rel_attribute_name(attr);
                 }
                 populate_index(IndexKind::Edge, label.clone(), self.edge_indexer.clone());
-                // Dark-launch the edge index (#51): built synchronously here, same as the
-                // node branch above (docs are edge_ids).
+                // Dark-launch the edge index (#51): mark `Building`, background-build
+                // off the write thread (docs are edge_ids). Same online-build path as nodes.
                 #[cfg(feature = "index-falkordb")]
                 if *index_type == IndexType::Range {
-                    self.populate_index_edge(label, attrs);
+                    for attr in attrs {
+                        self.falkordb_index
+                            .create_building(EntityType::Relationship, label, attr);
+                    }
                 }
             }
         }
@@ -3302,7 +3310,8 @@ impl Graph {
     }
 
     /// Collect the `(value, node_id)` entries for one node index column `(label, attr)` from the
-    /// current live nodes — shared-borrow only (label matrix + attribute store are `&self`).
+    /// current live nodes — shared-borrow only (label matrix + attribute store are `&self`). Reused
+    /// by the synchronous populate and by the background build (which reads a snapshot).
     #[cfg(feature = "index-falkordb")]
     fn collect_node_index_entries(
         &self,
@@ -3476,6 +3485,76 @@ impl Graph {
                 pairs.iter().map(|(v, id)| (v, *id)),
             );
         }
+    }
+
+    // ---- Background (online) index build — the pub seam the graph_core controller drives (#online). ----
+
+    /// Every `(entity, label, attr)` column currently building — the controller's work list,
+    /// read from a committed snapshot right after a `CREATE INDEX`.
+    #[cfg(feature = "index-falkordb")]
+    #[must_use]
+    pub fn building_index_columns(&self) -> Vec<(EntityType, Arc<String>, Arc<String>, u64)> {
+        self.falkordb_index.building_columns()
+    }
+
+    /// Read the `(value, doc)` entries for one building column from *this snapshot* — the base the
+    /// background job builds off-thread, then installs in batch-size chunks.
+    #[cfg(feature = "index-falkordb")]
+    #[must_use]
+    pub fn collect_index_entries(
+        &self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> Vec<(Value, u64)> {
+        match entity {
+            EntityType::Node => self.collect_node_index_entries(label, attr),
+            EntityType::Relationship => self.collect_edge_index_entries(label, attr),
+        }
+    }
+
+    /// Install one batch-size chunk of the background-built base (dropping ids already written since
+    /// `CREATE INDEX`). Called by the controller under the write serialization via `commit_index_build`.
+    #[cfg(feature = "index-falkordb")]
+    pub fn install_index_base_chunk(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        epoch: u64,
+        chunk: Vec<(Value, u64)>,
+    ) {
+        // Authoritative delete backstop (O(1)/entry): drop base entries for entities deleted since
+        // the snapshot, via the graph's correctly-versioned `deleted_nodes`/`deleted_relationships`
+        // bitmaps (the writer's fork sees every committed delete). `install_base_chunk` then drops the
+        // per-column `dirty` ids (updated/created since create — the live delta holds their current
+        // state). Both are cheap bitmap checks, so the write-guarded window stays short — no re-scan,
+        // no GraphBLAS extract, no attribute reads.
+        let survivors: Vec<(Value, u64)> = match entity {
+            EntityType::Node => chunk
+                .into_iter()
+                .filter(|(_, id)| !self.is_node_deleted(NodeId(*id)))
+                .collect(),
+            EntityType::Relationship => chunk
+                .into_iter()
+                .filter(|(_, id)| !self.is_relationship_deleted(RelationshipId(*id)))
+                .collect(),
+        };
+        self.falkordb_index
+            .install_base_chunk(entity, label, attr, epoch, survivors);
+    }
+
+    /// Flip a building column to `Ready` after its last chunk installs (only if `epoch` still matches
+    /// — a drop + re-create since the build started makes this a no-op; the fresh column is built anew).
+    #[cfg(feature = "index-falkordb")]
+    pub fn finish_index_build(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        epoch: u64,
+    ) {
+        self.falkordb_index.finish_build(entity, label, attr, epoch);
     }
 
     /// Stage `(value, edge_id)` into the index column `(type, attr)` for the edge `id`'s single type,
@@ -4976,6 +5055,157 @@ mod falkordb_index_mvcc_tests {
     /// poisoning that `Once` for every later GraphBLAS test.
     fn ensure_graphblas() {
         crate::graph::graphblas::test_init::ensure_init();
+    }
+
+    /// Online-build reconciliation (the scale-bug regression test): `CREATE INDEX` snapshots the
+    /// base, then a DELETE and a SET land while the build is pending, then the base installs. The
+    /// **validate-at-install** guard must drop the stale base entries for the deleted and re-valued
+    /// nodes — no resurrection — while the steady-state delta carries the new value. Deterministic,
+    /// exercises the real `delete_nodes` + `set_nodes_attributes` + `install_index_base_chunk` paths.
+    #[test]
+    fn online_build_install_validates_against_concurrent_writes() {
+        ensure_graphblas();
+        let mut g = Graph::new(64, 64, 10, 1, "t");
+        let label = Arc::new("Person".to_string());
+        let attr = Arc::new("v".to_string());
+        let lid = g.get_label_id_mut("Person");
+        let ids: Vec<u64> = g.reserve_nodes(6).unwrap().iter().map(|x| x.0).collect();
+        let mut set = RoaringTreemap::new();
+        for &id in &ids {
+            set.insert(id);
+        }
+        g.create_nodes(&set);
+        let cols = vec![lid.0 as u64; ids.len()];
+        g.set_nodes_labels_bulk(&ids, &cols, &mut FxHashMap::default(), false);
+        // values 10,20,30,40,50,60 — set BEFORE the index exists (no incremental maintenance yet).
+        for (i, &id) in ids.iter().enumerate() {
+            set_attr(&mut g, id, &attr, Value::Int(((i as i64) + 1) * 10));
+        }
+
+        // Begin an online build: mark Building + snapshot the base (all 6 pre-existing entries).
+        let epoch = g
+            .falkordb_index_mut()
+            .create_building(EntityType::Node, &label, &attr);
+        let base = g.collect_index_entries(EntityType::Node, &label, &attr);
+        assert_eq!(base.len(), 6);
+
+        // Writes that land DURING the build (before the base installs): delete id1(20) & id3(40),
+        // update id4 50 -> 55. These go to the live delta via the real write hooks.
+        let mut del = RoaringTreemap::new();
+        del.insert(ids[1]);
+        del.insert(ids[3]);
+        g.delete_nodes(&del, &mut FxHashMap::default()).unwrap();
+        set_attr(&mut g, ids[4], &attr, Value::Int(55));
+
+        // Install the (now-stale) base, then finish. Validate-at-install drops the dead entries.
+        g.install_index_base_chunk(EntityType::Node, &label, &attr, epoch, base);
+        g.finish_index_build(EntityType::Node, &label, &attr, epoch);
+
+        // Survivors, value-ordered: id0(10), id2(30), id4(55), id5(60).
+        let all: Vec<u64> = g
+            .falkordb_index()
+            .numeric(EntityType::Node, &label, &attr)
+            .unwrap()
+            .range(None, None, true, true)
+            .collect();
+        assert_eq!(all, vec![ids[0], ids[2], ids[4], ids[5]]);
+        assert!(
+            range_scan(&g, &label, &attr, 20, 20).is_empty(),
+            "deleted id1 must not resurrect"
+        );
+        assert!(
+            range_scan(&g, &label, &attr, 40, 40).is_empty(),
+            "deleted id3 must not resurrect"
+        );
+        assert!(
+            range_scan(&g, &label, &attr, 50, 50).is_empty(),
+            "updated-away value 50 must not resurrect"
+        );
+        assert_eq!(
+            range_scan(&g, &label, &attr, 55, 55),
+            vec![ids[4]],
+            "id4 has its new value"
+        );
+    }
+    /// Online-build reconciliation on the EDGE path — the #51 mirror of the node regression above.
+    /// `CREATE INDEX FOR ()-[r:R]->()` snapshots the base, then a `DELETE` and a `SET` on edges land
+    /// while the build is pending, then the base installs. Install-time reconciliation must drop the
+    /// stale base entries for the deleted and re-valued edges (via the authoritative
+    /// `deleted_relationships` backstop + the per-column `dirty` set) — no resurrection — while the
+    /// steady-state delta carries the new value. Exercises the real `delete_relationships` +
+    /// `set_relationships_attributes` + `install_index_base_chunk` edge paths end-to-end.
+    #[test]
+    fn online_build_edge_install_validates_against_concurrent_writes() {
+        ensure_graphblas();
+        let mut g = Graph::new(64, 64, 10, 1, "t");
+        let ty = Arc::new("R".to_string());
+        let attr = Arc::new("w".to_string());
+        let aid = g.get_or_create_rel_attr_id(&attr);
+
+        // 6 edges 0->1 with ids 0..6 and weights 10,20,30,40,50,60 — set BEFORE the index exists
+        // (no incremental maintenance yet), so `collect_index_entries` is the sole base source.
+        let ids: Vec<u64> = g
+            .reserve_relationships(6)
+            .unwrap()
+            .iter()
+            .map(|r| r.0)
+            .collect();
+        let srcs = vec![0u64; 6];
+        let dsts = vec![1u64; 6];
+        g.create_relationships_bulk(&ty, &srcs, &dsts, &ids);
+        let mut attrs: FxHashMap<u64, Vec<(u16, Value)>> = FxHashMap::default();
+        for (i, &id) in ids.iter().enumerate() {
+            attrs.insert(id, vec![(aid, Value::Int(((i as i64) + 1) * 10))]);
+        }
+        g.import_relationship_attrs(&attrs, &mut FxHashMap::default());
+
+        // Begin an online build: mark Building + snapshot the base (all 6 pre-existing entries).
+        let epoch = g
+            .falkordb_index_mut()
+            .create_building(EntityType::Relationship, &ty, &attr);
+        let base = g.collect_index_entries(EntityType::Relationship, &ty, &attr);
+        assert_eq!(base.len(), 6);
+
+        // Writes that land DURING the build (before the base installs): delete id1(20) & id3(40),
+        // update id4 50 -> 55. These go to the live delta via the real edge write hooks, which also
+        // record the touched ids in the column's `dirty` set and (for deletes) `deleted_relationships`.
+        let mut del = RoaringTreemap::new();
+        del.insert(ids[1]);
+        del.insert(ids[3]);
+        g.delete_relationships(&del, &mut FxHashMap::default())
+            .unwrap();
+        let mut upd: FxHashMap<u64, Vec<(u16, Value)>> = FxHashMap::default();
+        upd.insert(ids[4], vec![(aid, Value::Int(55))]);
+        g.set_relationships_attributes(&upd, &mut FxHashMap::default())
+            .unwrap();
+
+        // Install the (now-stale) base, then finish. Reconciliation drops the dead/updated entries.
+        g.install_index_base_chunk(EntityType::Relationship, &ty, &attr, epoch, base);
+        g.finish_index_build(EntityType::Relationship, &ty, &attr, epoch);
+
+        // Survivors, value-ordered: id0(10), id2(30), id4(55), id5(60).
+        let all: Vec<u64> = g
+            .falkordb_index()
+            .numeric(EntityType::Relationship, &ty, &attr)
+            .unwrap()
+            .range(None, None, true, true)
+            .collect();
+        assert_eq!(all, vec![ids[0], ids[2], ids[4], ids[5]]);
+
+        let point = |v: i64| -> Vec<u64> {
+            g.falkordb_index()
+                .numeric(EntityType::Relationship, &ty, &attr)
+                .unwrap()
+                .range(Some(&Value::Int(v)), Some(&Value::Int(v)), true, true)
+                .collect()
+        };
+        assert!(point(20).is_empty(), "deleted edge id1 must not resurrect");
+        assert!(point(40).is_empty(), "deleted edge id3 must not resurrect");
+        assert!(
+            point(50).is_empty(),
+            "updated-away value 50 must not resurrect"
+        );
+        assert_eq!(point(55), vec![ids[4]], "edge id4 has its new value");
     }
 
     /// Folded-roots MVCC: `new_version` forks the FalkorDB index copy-on-write,

--- a/graph/src/index/falkordb/build_registry.rs
+++ b/graph/src/index/falkordb/build_registry.rs
@@ -1,0 +1,242 @@
+//! Bookkeeping for background (online) index builds: which columns have a job in flight, and when
+//! a column whose last attempt failed may be tried again.
+//!
+//! The sweep thread and the thread pool that drive these builds live in the module crate, next to
+//! the graph registry. This half lives here because the module crate installs Redis's allocator and
+//! therefore cannot run a unit test at all — and the rule this encodes (do not re-run a full BASE
+//! scan on every sweep for a column that keeps losing the version slot) is worth testing.
+//!
+//! Every method takes `now` rather than reading the clock, so the backoff schedule can be asserted
+//! without sleeping.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+
+use crate::entity_type::EntityType;
+
+/// One in-flight build, identified by graph name + column + build epoch.
+///
+/// The **epoch** is part of the identity on purpose: a column dropped and re-created mid-build gets
+/// a fresh epoch, so the new build is not suppressed by the old job's marker, and the old job
+/// cannot publish into the new column.
+pub type BuildKey = (String, EntityType, String, String, u64);
+
+/// What the registry remembers about one column's build.
+#[derive(Debug)]
+enum BuildSlot {
+    /// A job is dispatched or running; whoever dispatched it owns the entry until it exits.
+    Running { attempts: u32 },
+    /// The last attempt did not install — it lost the version slot, the graph was tearing down, or
+    /// the epoch was stale. Re-dispatch is suppressed until `until`.
+    Backoff { until: Instant, attempts: u32 },
+}
+
+/// Ceiling on the backoff doublings, so a permanently-contended column settles at
+/// `interval << 5` (16s at a 500ms sweep) rather than drifting towards never.
+const MAX_DOUBLINGS: u32 = 5;
+
+/// Which columns are being built, and which are waiting out a retry backoff.
+pub struct BuildRegistry {
+    slots: Mutex<HashMap<BuildKey, BuildSlot>>,
+    /// The dispatch cadence the backoff is expressed in multiples of — one doubling per failure.
+    interval: Duration,
+}
+
+impl BuildRegistry {
+    #[must_use]
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            slots: Mutex::new(HashMap::new()),
+            interval,
+        }
+    }
+
+    /// Claim the keys that should be dispatched now, marking each `Running`. Returns the subset to
+    /// spawn: a key already running, or still inside its backoff window, is left out.
+    ///
+    /// The attempt count carries across a claim, so a column that keeps failing keeps widening its
+    /// interval instead of restarting at one sweep.
+    pub fn claim(
+        &self,
+        builds: Vec<BuildKey>,
+        now: Instant,
+    ) -> Vec<BuildKey> {
+        let mut slots = self.slots.lock();
+        builds
+            .into_iter()
+            .filter(|key| {
+                let attempts = match slots.get(key) {
+                    Some(BuildSlot::Running { .. }) => return false,
+                    Some(BuildSlot::Backoff { until, .. }) if *until > now => return false,
+                    Some(BuildSlot::Backoff { attempts, .. }) => *attempts,
+                    None => 0,
+                };
+                slots.insert(key.clone(), BuildSlot::Running { attempts });
+                true
+            })
+            .collect()
+    }
+
+    /// Give a key back when its job exits.
+    ///
+    /// `installed == true` means the base landed and the column is `Ready`; it will never be in the
+    /// work list again, so the entry goes. Anything else — bail, stale epoch, lost version slot,
+    /// panic, or a job the pool dropped without running — arms the backoff, because the sweep will
+    /// otherwise re-dispatch the same full BASE scan on its very next pass.
+    pub fn release(
+        &self,
+        key: &BuildKey,
+        installed: bool,
+        now: Instant,
+    ) {
+        let mut slots = self.slots.lock();
+        if installed {
+            slots.remove(key);
+            return;
+        }
+        let attempts = match slots.get(key) {
+            Some(BuildSlot::Running { attempts }) => attempts.saturating_add(1),
+            _ => 1,
+        };
+        let until = now + self.interval * 2u32.pow(attempts.min(MAX_DOUBLINGS));
+        slots.insert(key.clone(), BuildSlot::Backoff { until, attempts });
+    }
+
+    /// Forget the backoff of columns nobody is `Building` any more — a dropped index, a finished
+    /// build, or an epoch superseded by a fresh one.
+    ///
+    /// `Running` entries are never pruned: their job owns the key and rewrites the entry when it
+    /// exits. Without this the map keeps one entry per (column, epoch) that ever failed to install,
+    /// for the life of the process. Call it from whoever can see *all* pending builds at once —
+    /// pruning against one graph's work list would drop every other graph's entries.
+    pub fn prune(
+        &self,
+        pending: &HashSet<BuildKey>,
+    ) {
+        self.slots
+            .lock()
+            .retain(|key, slot| matches!(slot, BuildSlot::Running { .. }) || pending.contains(key));
+    }
+
+    /// Number of tracked keys, running and backing off. Diagnostics and tests.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots.lock().len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(epoch: u64) -> BuildKey {
+        (
+            "g".to_string(),
+            EntityType::Node,
+            "L".to_string(),
+            "a".to_string(),
+            epoch,
+        )
+    }
+
+    const INTERVAL: Duration = Duration::from_millis(500);
+
+    #[test]
+    fn claims_once_then_suppresses_while_running() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let now = Instant::now();
+        assert_eq!(reg.claim(vec![key(1)], now), vec![key(1)]);
+        assert!(
+            reg.claim(vec![key(1)], now).is_empty(),
+            "a running build must not be dispatched twice"
+        );
+    }
+
+    #[test]
+    fn a_fresh_epoch_is_not_suppressed_by_the_old_job() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let now = Instant::now();
+        reg.claim(vec![key(1)], now);
+        assert_eq!(
+            reg.claim(vec![key(2)], now),
+            vec![key(2)],
+            "dropping and re-creating the column must build again"
+        );
+    }
+
+    /// The point of the backoff: a build that cannot take the version slot under sustained write
+    /// load would otherwise re-run its whole BASE scan and encode every single sweep.
+    #[test]
+    fn failure_defers_the_retry_and_the_delay_doubles() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let t0 = Instant::now();
+        reg.claim(vec![key(1)], t0);
+        reg.release(&key(1), false, t0);
+
+        assert!(
+            reg.claim(vec![key(1)], t0 + INTERVAL).is_empty(),
+            "one sweep later is still inside the first backoff"
+        );
+        // First failure waits 2 intervals.
+        assert_eq!(reg.claim(vec![key(1)], t0 + INTERVAL * 2), vec![key(1)]);
+
+        // Second failure waits 4 — the count carried across the re-claim.
+        let t1 = t0 + INTERVAL * 2;
+        reg.release(&key(1), false, t1);
+        assert!(reg.claim(vec![key(1)], t1 + INTERVAL * 3).is_empty());
+        assert_eq!(reg.claim(vec![key(1)], t1 + INTERVAL * 4), vec![key(1)]);
+    }
+
+    #[test]
+    fn backoff_is_capped() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let mut t = Instant::now();
+        // Well past MAX_DOUBLINGS.
+        for _ in 0..12 {
+            reg.claim(vec![key(1)], t);
+            reg.release(&key(1), false, t);
+            t += INTERVAL * (1 << MAX_DOUBLINGS);
+        }
+        assert_eq!(
+            reg.claim(vec![key(1)], t + INTERVAL * (1 << MAX_DOUBLINGS)),
+            vec![key(1)],
+            "a permanently contended column must keep retrying at the capped interval"
+        );
+    }
+
+    #[test]
+    fn success_releases_the_key_outright() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let now = Instant::now();
+        reg.claim(vec![key(1)], now);
+        reg.release(&key(1), true, now);
+        assert!(reg.is_empty(), "a Ready column leaves nothing behind");
+    }
+
+    #[test]
+    fn prune_reclaims_backoff_but_never_a_running_build() {
+        let reg = BuildRegistry::new(INTERVAL);
+        let now = Instant::now();
+        reg.claim(vec![key(1), key(2)], now);
+        reg.release(&key(1), false, now); // key(1) backing off, key(2) still running
+
+        let pending: HashSet<BuildKey> = [key(1)].into_iter().collect();
+        reg.prune(&pending);
+        assert_eq!(reg.len(), 2, "still pending, and still running: both kept");
+
+        // The index was dropped: neither is pending any more.
+        reg.prune(&HashSet::new());
+        assert_eq!(
+            reg.len(),
+            1,
+            "the backoff entry is reclaimed; the running job still owns its key"
+        );
+    }
+}

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -12,8 +12,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use roaring::RoaringTreemap;
-
 use crate::entity_type::EntityType;
 use crate::index::IndexQuery;
 use crate::runtime::value::Value;
@@ -88,6 +86,62 @@ impl IndexColumn {
         }
     }
 
+    /// Encode `(value, id)` entries under *this* column's kind, dropping whatever the kind
+    /// does not index (numeric drops non-numeric and `NaN`). Lets the background job encode
+    /// BASE off-thread, so the install commit pays only the tree build.
+    #[must_use]
+    pub fn encode_entries(
+        &self,
+        entries: Vec<(Value, u64)>,
+    ) -> Vec<(u64, u64)> {
+        match self {
+            Self::Numeric(_) => NumericIndex::encode_entries(entries),
+        }
+    }
+
+    /// A new column of *this* column's kind, built from already-encoded tuples — how the
+    /// install adopts BASE without hard-coding a kind at the call site.
+    #[must_use]
+    pub fn new_like_from_encoded(
+        &self,
+        pairs: Vec<(u64, u64)>,
+    ) -> Self {
+        match self {
+            Self::Numeric(_) => Self::Numeric(NumericIndex::from_encoded(pairs)),
+        }
+    }
+
+    /// Every `(key, doc)` tuple this column holds, encoded — the install's DELTA/TOMB
+    /// enumeration. Encoded, not `Value`s: TOMB must use the same equivalence relation as
+    /// the column it will be subtracted from, and decoding to re-encode would be a second
+    /// trip through a many-to-one map.
+    #[must_use]
+    pub fn encoded_tuples(&self) -> Vec<(u64, u64)> {
+        match self {
+            Self::Numeric(idx) => idx.encoded_tuples(),
+        }
+    }
+
+    /// Add already-encoded tuples (install: replay DELTA onto BASE).
+    pub fn add_encoded(
+        &mut self,
+        pairs: &mut Vec<(u64, u64)>,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.add_encoded(pairs),
+        }
+    }
+
+    /// Remove already-encoded tuples (install: subtract TOMB from BASE).
+    pub fn remove_encoded(
+        &mut self,
+        pairs: &mut Vec<(u64, u64)>,
+    ) {
+        match self {
+            Self::Numeric(idx) => idx.remove_encoded(pairs),
+        }
+    }
+
     /// Whether this column holds no entries.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -115,13 +169,22 @@ impl IndexColumn {
 ///   correctly versioned core state, so deletes are dropped even if `dirty` ever missed one.
 #[derive(Clone)]
 pub enum ColumnState {
-    /// Base not yet fully installed — reads scan-fall-back. `dirty` = ids written since create.
+    /// Base not yet installed — reads scan-fall-back.
+    ///
+    /// `tomb` is the catch-up log of tuples *destroyed* since `CREATE INDEX`. It is the same CoW
+    /// tuple tree as the column, for two reasons: it forks in `O(1)` with the version (a
+    /// `RoaringTreemap` deep-clones, which is `O(writes²)` across a build), and it dedups under
+    /// the column's own equivalence relation, which a set of raw values would not.
+    ///
+    /// Adds are *not* recorded here — they go straight into the column tree, which is the DELTA.
+    /// Only removes are deferred, because a remove may target a row that still lives only in the
+    /// not-yet-installed BASE, where no version can name it yet.
     ///
     /// `epoch` is the build's identity: a monotonic token assigned at `create_building` and carried
-    /// by the background job. `install_base_chunk` / `finish_build` no-op unless the column's current
-    /// epoch matches the job's — so if the column is dropped and re-created mid-build, the stale job
-    /// installs nothing into the new column (which has a fresh epoch) and a new job builds it instead.
-    Building { dirty: RoaringTreemap, epoch: u64 },
+    /// by the background job. `install_base` no-ops unless the column's current epoch matches the
+    /// job's — so if the column is dropped and re-created mid-build, the stale job installs nothing
+    /// into the new column (which has a fresh epoch) and a new job builds it instead.
+    Building { tomb: IndexColumn, epoch: u64 },
     /// Base installed (or the graph was empty at create) — the column serves reads.
     Ready,
 }
@@ -143,13 +206,15 @@ impl ColumnEntry {
         }
     }
 
-    /// Record the ids in `entries` as written-since-create, but only while `Building`.
-    fn note_dirty(
+    /// Defer these *destroyed* tuples into TOMB, so the install can subtract them from a BASE
+    /// that was scanned before they died. A no-op once `Ready` — after install there is no stale
+    /// BASE left to correct.
+    fn note_tomb(
         &mut self,
-        entries: &[(Value, u64)],
+        removed: &[(Value, u64)],
     ) {
-        if let ColumnState::Building { dirty, .. } = &mut self.state {
-            dirty.extend(entries.iter().map(|(_, id)| *id));
+        if let ColumnState::Building { tomb, .. } = &mut self.state {
+            tomb.add_batch(removed.iter().cloned());
         }
     }
 }
@@ -253,7 +318,7 @@ impl FalkorDbIndex {
             ColumnEntry {
                 column: IndexColumn::Numeric(NumericIndex::new()),
                 state: ColumnState::Building {
-                    dirty: RoaringTreemap::new(),
+                    tomb: IndexColumn::Numeric(NumericIndex::new()),
                     epoch,
                 },
             },
@@ -360,71 +425,84 @@ impl FalkorDbIndex {
         let columns = self.columns_mut(entity);
         for (key, entries) in removes {
             if let Some(entry) = columns.get_mut(&key) {
-                entry.note_dirty(&entries);
+                // TOMB for the install's BASE subtraction, *and* the column tree itself: I-W4'
+                // requires DELTA to hold each touched entity's final state, not an append-only
+                // add-log. Skipping the tree here would install two rows for `v0 -> v1 -> v2`.
+                entry.note_tomb(&entries);
                 entry.column.remove_batch(entries);
             }
         }
         for (key, entries) in adds {
             if let Some(entry) = columns.get_mut(&key) {
-                entry.note_dirty(&entries);
                 entry.column.add_batch(entries);
             }
         }
     }
 
-    /// Add one chunk of the background-built base to a `Building` column, skipping any entry whose
-    /// id was written since `CREATE INDEX` (`dirty`) — that entity's current state is already in the
-    /// live delta (or it's deleted). The caller ([`Graph::install_index_base_chunk`](crate::graph::Graph))
-    /// has already applied the authoritative `deleted_nodes`/`deleted_relationships` backstop, so both
-    /// filters are cheap `O(1)`-per-entry bitmap checks. No-op if the column is missing or already
-    /// `Ready`; `finish_build` flips to `Ready` after the last chunk.
-    pub fn install_base_chunk(
+    /// Install a background-built BASE and flip the column to `Ready` — **one commit**, per
+    /// I-B3. No-op (returning `false`) if the column is gone, already `Ready`, or carries a
+    /// different epoch, which is how a drop-and-recreate mid-build makes the stale job inert.
+    ///
+    /// ```text
+    /// new := BASE                 (adopted wholesale — the job already built the tree)
+    /// new.remove(TOMB)            (removes strictly first)
+    /// new.add(DELTA)              (then adds)
+    /// column := new, state := Ready
+    /// ```
+    ///
+    /// **Order is load-bearing.** Install starts *from* BASE, so every snapshot-era tuple is
+    /// present and the only question is TOMB-vs-DELTA. Applying DELTA first would then delete
+    /// exactly `TOMB ∩ DELTA` — every tuple destroyed and recreated during the build, e.g.
+    /// `v0 -> v1 -> v0` or an id reused with the same value. By I-W4' no DELTA tuple is invalid
+    /// at the version being installed into, so TOMB never needs to fire after DELTA.
+    ///
+    /// Chunking this would be wrong as well as slow: a partially-subtracted BASE is not a valid
+    /// index at any version, and `MvccGraph::commit` pays an `O(attribute-store)`
+    /// `trim_attr_stores()` per commit, so N/1024 commits multiply a cost the single install pays
+    /// once.
+    pub fn install_base(
         &mut self,
         entity: EntityType,
         label: &Arc<String>,
         attr: &Arc<String>,
         epoch: u64,
-        chunk: impl IntoIterator<Item = (Value, u64)>,
-    ) {
+        base: Vec<(u64, u64)>,
+    ) -> bool {
         let Some(entry) = self
             .columns_mut(entity)
             .get_mut(&(label.clone(), attr.clone()))
         else {
-            return;
+            return false;
         };
-        // No-op unless this is still the same build: a mismatched epoch means the column was dropped
-        // and re-created since the job started, so this chunk is stale (the fresh column is built by
-        // a new job). A `Ready` column also falls through here.
-        let ColumnState::Building { dirty, epoch: e } = &entry.state else {
-            return;
+        let ColumnState::Building { tomb, epoch: e } = &entry.state else {
+            return false; // already Ready — nothing to install into
         };
         if *e != epoch {
-            return;
+            return false; // stale job: the column was dropped and re-created since it started
         }
-        let survivors: Vec<(Value, u64)> = chunk
-            .into_iter()
-            .filter(|(_, id)| !dirty.contains(*id))
-            .collect();
-        entry.column.add_batch(survivors);
+        let mut new = entry.column.new_like_from_encoded(base);
+        let mut tomb_tuples = tomb.encoded_tuples();
+        new.remove_encoded(&mut tomb_tuples);
+        let mut delta = entry.column.encoded_tuples();
+        new.add_encoded(&mut delta);
+        entry.column = new;
+        entry.state = ColumnState::Ready;
+        true
     }
 
-    /// Flip a `Building` column to `Ready` (base fully installed) — but only if `epoch` still matches
-    /// (the same drop/re-create guard as [`install_base_chunk`](Self::install_base_chunk)), so a stale
-    /// job can never publish a freshly re-created column. After this, the read path serves the column.
-    pub fn finish_build(
-        &mut self,
+    /// Encode `entries` under the kind of the column `(entity, label, attr)`, if it exists.
+    /// `None` when there is no such column — the build was for a column since dropped.
+    #[must_use]
+    pub fn encode_for_column(
+        &self,
         entity: EntityType,
         label: &Arc<String>,
         attr: &Arc<String>,
-        epoch: u64,
-    ) {
-        if let Some(entry) = self
-            .columns_mut(entity)
-            .get_mut(&(label.clone(), attr.clone()))
-            && matches!(&entry.state, ColumnState::Building { epoch: e, .. } if *e == epoch)
-        {
-            entry.state = ColumnState::Ready;
-        }
+        entries: Vec<(Value, u64)>,
+    ) -> Option<Vec<(u64, u64)>> {
+        self.columns(entity)
+            .get(&(label.clone(), attr.clone()))
+            .map(|entry| entry.column.encode_entries(entries))
     }
 
     /// Every `(entity, label, attr, epoch)` column currently in the `Building` state —
@@ -484,6 +562,7 @@ impl FalkorDbIndex {
 
 #[cfg(test)]
 mod tests {
+    use super::super::encode::encode_numeric;
     use super::*;
     use crate::entity_type::EntityType::{Node, Relationship};
 
@@ -491,12 +570,9 @@ mod tests {
         Arc::new(s.to_string())
     }
 
-    /// Stage a single-column `(value, id)` batch (the shape the write path passes to `merge`).
-    /// Online-build state machine at the column level: a `Building` column gates reads (returns
-    /// `None` → scan fallback) even after chunks are installed, until `finish_build` flips it `Ready`;
-    /// then it serves. (Reconciliation of concurrent writes is validated at the graph level, where
-    /// `Graph::install_index_base_chunk` re-checks each entry against live state — see
-    /// `falkordb_index_mvcc_tests`.)
+    /// The online-build state machine at the column level: a `Building` column gates reads
+    /// (returns `None`, so the caller scan-falls-back), a stale epoch cannot publish, and the
+    /// single install commit subtracts TOMB from the stale BASE before replaying DELTA.
     #[test]
     fn building_column_gates_reads_until_finished() {
         let (label, attr) = (arc("Person"), arc("age"));
@@ -504,56 +580,58 @@ mod tests {
             key: attr.clone(),
             value: Value::Int(v),
         };
+        let staged = |v: i64, id: u64| {
+            let mut m: StagedColumns = HashMap::default();
+            m.insert((label.clone(), attr.clone()), vec![(Value::Int(v), id)]);
+            m
+        };
+        let key = |v: i64| encode_numeric(&Value::Int(v)).unwrap();
+        let hits = |idx: &FalkorDbIndex, v: i64| -> Vec<u64> {
+            idx.query_numeric(Node, &label, &eq(v))
+                .map_or_else(Vec::new, Iterator::collect)
+        };
 
         let mut idx = FalkorDbIndex::new();
         let epoch = idx.create_building(Node, &label, &attr);
-        assert!(
-            idx.query_numeric(Node, &label, &eq(10)).is_none(),
-            "empty Building → None"
-        );
+        assert!(hits(&idx, 10).is_empty(), "empty Building → None");
 
-        // Install a (pre-validated) base chunk — reads still gated while Building.
-        idx.install_base_chunk(
-            Node,
-            &label,
-            &attr,
-            epoch,
-            [(Value::Int(10), 0u64), (Value::Int(20), 1)],
-        );
+        // Writes landing during the build. 30 is created (DELTA); 20 is destroyed, which goes to
+        // TOMB *and* to the column tree — the pair that stops the stale base resurrecting it.
+        idx.merge(Node, staged(30, 2), HashMap::default());
+        idx.merge(Node, HashMap::default(), staged(20, 1));
         assert!(
-            idx.query_numeric(Node, &label, &eq(10)).is_none(),
-            "installed but Building → None"
+            hits(&idx, 30).is_empty(),
+            "still Building → None even with a live delta"
         );
         assert_eq!(idx.building_columns().len(), 1);
 
-        // A stale epoch (as if the column had been dropped + re-created) installs nothing and
-        // must NOT flip the column `Ready` — the drop/re-create guard.
-        idx.install_base_chunk(Node, &label, &attr, epoch + 1, [(Value::Int(99), 9u64)]);
-        idx.finish_build(Node, &label, &attr, epoch + 1);
+        // A stale epoch — as if the column had been dropped and re-created — installs nothing and
+        // must not flip the column `Ready`.
         assert!(
-            idx.query_numeric(Node, &label, &eq(10)).is_none(),
-            "stale epoch cannot publish"
+            !idx.install_base(Node, &label, &attr, epoch + 1, vec![(key(99), 9)]),
+            "stale epoch cannot install"
         );
+        assert!(hits(&idx, 99).is_empty(), "stale epoch cannot publish");
         assert_eq!(
             idx.building_columns().len(),
             1,
-            "still Building after stale finish"
+            "still Building after a stale install"
         );
 
-        // Finish with the right epoch → serves; the stale value never landed.
-        idx.finish_build(Node, &label, &attr, epoch);
-        assert_eq!(
-            idx.query_numeric(Node, &label, &eq(10))
-                .map_or_else(Vec::new, |it| it.collect()),
-            vec![0],
-        );
-        assert!(
-            idx.query_numeric(Node, &label, &eq(99))
-                .map_or_else(Vec::new, |it| it.collect())
-                .is_empty(),
-            "stale entry absent"
-        );
+        // The real install, one commit: BASE holds the snapshot-era rows 10 and 20.
+        assert!(idx.install_base(Node, &label, &attr, epoch, vec![(key(10), 0), (key(20), 1)]));
         assert!(idx.building_columns().is_empty(), "no longer building");
+        assert_eq!(hits(&idx, 10), vec![0], "untouched base row survives");
+        assert!(
+            hits(&idx, 20).is_empty(),
+            "TOMB must stop the deleted row resurrecting from the stale base"
+        );
+        assert_eq!(
+            hits(&idx, 30),
+            vec![2],
+            "DELTA row preserved by the install"
+        );
+        assert!(hits(&idx, 99).is_empty(), "stale-epoch value never landed");
     }
 
     /// Forking a new version (what `Graph::new_version` does) and mutating it
@@ -583,7 +661,6 @@ mod tests {
         assert_eq!(all(&v2), vec![1, 2]); // new version sees the write
     }
 
-    /// `create_numeric` installs a column; before it, the key is absent.
     #[test]
     fn create_then_lookup() {
         let (label, attr) = (arc("Person"), arc("age"));

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -154,19 +154,17 @@ impl IndexColumn {
 /// Build state of a column, for online (background) index build.
 ///
 /// `CREATE INDEX` on existing data returns immediately with the column in
-/// [`Building`](Self::Building); a background job builds the pre-existing snapshot
-/// off-thread and the writer installs it in chunks, flipping to [`Ready`](Self::Ready).
+/// [`Building`](Self::Building); a background job scans the pre-existing snapshot (BASE)
+/// off-thread and one install commit adopts it, flipping to [`Ready`](Self::Ready).
 /// While `Building` the read path returns `None` (falls back to a scan). Live writes
-/// maintain the column normally (the "delta" for post-snapshot creates/updates).
+/// maintain the column normally — the column's own tree *is* the DELTA.
 ///
-/// **Reconciliation** (so a concurrently deleted/updated entity's stale snapshot entry
-/// never resurrects) is by cheap `O(1)` bitmap checks at install, not a re-scan:
-/// - `dirty` — ids written (created / updated / deleted) since `CREATE INDEX`, recorded
-///   by the write path. A base entry for a dirty id is skipped: the live delta already
-///   holds that entity's current state (or it's gone).
-/// - **plus** the graph's authoritative `deleted_nodes` / `deleted_relationships` bitmaps
-///   as the delete backstop ([`Graph::install_index_base_chunk`](crate::graph::Graph)) —
-///   correctly versioned core state, so deletes are dropped even if `dirty` ever missed one.
+/// **Reconciliation**, so a concurrently deleted or updated entity's stale snapshot entry
+/// never resurrects, is by TOMB: the tuples destroyed since `CREATE INDEX`, subtracted from
+/// BASE before DELTA is replayed. The graph's `deleted_nodes` / `deleted_relationships`
+/// bitmaps are applied first as a cheap backstop
+/// ([`Graph::install_index_base`](crate::graph::Graph)), but they are only that — the
+/// bitmaps are a free list and are cleared on id reuse, so TOMB is the real defence.
 #[derive(Clone)]
 pub enum ColumnState {
     /// Base not yet installed — reads scan-fall-back.
@@ -299,12 +297,12 @@ impl FalkorDbIndex {
         );
     }
 
-    /// Create an empty numeric column in the `Building` state — the online-build
-    /// path. Returns immediately; live writes maintain it (recording `touched`) and
-    /// reads fall back to a scan until [`install_base_chunk`](Self::install_base_chunk)
-    /// / [`finish_build`](Self::finish_build) install the pre-existing snapshot and
-    /// flip it to `Ready`. Returns the build **epoch** the background job must carry
-    /// (see [`ColumnState::Building`]); replaces any existing column with a fresh epoch.
+    /// Create an empty numeric column in the `Building` state — the online-build path.
+    /// Returns immediately; live writes maintain the column (adds into it, removes also into
+    /// TOMB) and reads fall back to a scan until [`install_base`](Self::install_base) adopts
+    /// the pre-existing snapshot and flips it `Ready`. Returns the build **epoch** the
+    /// background job must carry (see [`ColumnState::Building`]); replaces any existing column
+    /// with a fresh epoch.
     pub fn create_building(
         &mut self,
         entity: EntityType,

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -12,6 +12,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use roaring::RoaringTreemap;
+
 use crate::entity_type::EntityType;
 use crate::index::IndexQuery;
 use crate::runtime::value::Value;
@@ -95,17 +97,60 @@ impl IndexColumn {
     }
 }
 
-/// One column's index.
+/// Build state of a column, for online (background) index build.
+///
+/// `CREATE INDEX` on existing data returns immediately with the column in
+/// [`Building`](Self::Building); a background job builds the pre-existing snapshot
+/// off-thread and the writer installs it in chunks, flipping to [`Ready`](Self::Ready).
+/// While `Building` the read path returns `None` (falls back to a scan). Live writes
+/// maintain the column normally (the "delta" for post-snapshot creates/updates).
+///
+/// **Reconciliation** (so a concurrently deleted/updated entity's stale snapshot entry
+/// never resurrects) is by cheap `O(1)` bitmap checks at install, not a re-scan:
+/// - `dirty` — ids written (created / updated / deleted) since `CREATE INDEX`, recorded
+///   by the write path. A base entry for a dirty id is skipped: the live delta already
+///   holds that entity's current state (or it's gone).
+/// - **plus** the graph's authoritative `deleted_nodes` / `deleted_relationships` bitmaps
+///   as the delete backstop ([`Graph::install_index_base_chunk`](crate::graph::Graph)) —
+///   correctly versioned core state, so deletes are dropped even if `dirty` ever missed one.
+#[derive(Clone)]
+pub enum ColumnState {
+    /// Base not yet fully installed — reads scan-fall-back. `dirty` = ids written since create.
+    ///
+    /// `epoch` is the build's identity: a monotonic token assigned at `create_building` and carried
+    /// by the background job. `install_base_chunk` / `finish_build` no-op unless the column's current
+    /// epoch matches the job's — so if the column is dropped and re-created mid-build, the stale job
+    /// installs nothing into the new column (which has a fresh epoch) and a new job builds it instead.
+    Building { dirty: RoaringTreemap, epoch: u64 },
+    /// Base installed (or the graph was empty at create) — the column serves reads.
+    Ready,
+}
+
+/// One column's index plus its build state.
 #[derive(Clone)]
 struct ColumnEntry {
     column: IndexColumn,
+    state: ColumnState,
 }
 
 impl ColumnEntry {
     /// A column that already holds all its data and serves reads immediately —
-    /// the synchronous populate path.
+    /// the synchronous populate / bulk-build path.
     fn ready(column: IndexColumn) -> Self {
-        Self { column }
+        Self {
+            column,
+            state: ColumnState::Ready,
+        }
+    }
+
+    /// Record the ids in `entries` as written-since-create, but only while `Building`.
+    fn note_dirty(
+        &mut self,
+        entries: &[(Value, u64)],
+    ) {
+        if let ColumnState::Building { dirty, .. } = &mut self.state {
+            dirty.extend(entries.iter().map(|(_, id)| *id));
+        }
     }
 }
 
@@ -125,6 +170,11 @@ impl ColumnEntry {
 pub struct FalkorDbIndex {
     node_columns: HashMap<IndexKey, ColumnEntry>,
     edge_columns: HashMap<IndexKey, ColumnEntry>,
+    /// Monotonic build-epoch source (see [`ColumnState::Building`]). Bumped by `create_building`,
+    /// which only runs under the serialized write path (forked from the latest committed version),
+    /// so it increases monotonically across the committed lineage — every online build gets a
+    /// process-unique id. `0` is never a live building epoch (the counter pre-increments).
+    next_build_epoch: u64,
 }
 
 impl FalkorDbIndex {
@@ -184,6 +234,33 @@ impl FalkorDbIndex {
         );
     }
 
+    /// Create an empty numeric column in the `Building` state — the online-build
+    /// path. Returns immediately; live writes maintain it (recording `touched`) and
+    /// reads fall back to a scan until [`install_base_chunk`](Self::install_base_chunk)
+    /// / [`finish_build`](Self::finish_build) install the pre-existing snapshot and
+    /// flip it to `Ready`. Returns the build **epoch** the background job must carry
+    /// (see [`ColumnState::Building`]); replaces any existing column with a fresh epoch.
+    pub fn create_building(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+    ) -> u64 {
+        self.next_build_epoch += 1;
+        let epoch = self.next_build_epoch;
+        self.columns_mut(entity).insert(
+            (label.clone(), attr.clone()),
+            ColumnEntry {
+                column: IndexColumn::Numeric(NumericIndex::new()),
+                state: ColumnState::Building {
+                    dirty: RoaringTreemap::new(),
+                    epoch,
+                },
+            },
+        );
+        epoch
+    }
+
     /// Build (or rebuild) the numeric column for `(entity, label, attr)` from
     /// `entries` (any order) in the `Ready` state, replacing any existing one — the
     /// bulk populate path. `NumericIndex::from_entries` bottom-up-loads the sorted
@@ -215,7 +292,7 @@ impl FalkorDbIndex {
     }
 
     /// The numeric column for `(entity, label, attr)`, if one exists and is numeric.
-    /// Used by the
+    /// State-agnostic (inspects a `Building` or `Ready` column alike) — used by the
     /// populate path and tests, not the read path (which gates on state).
     #[must_use]
     pub fn numeric(
@@ -283,20 +360,96 @@ impl FalkorDbIndex {
         let columns = self.columns_mut(entity);
         for (key, entries) in removes {
             if let Some(entry) = columns.get_mut(&key) {
+                entry.note_dirty(&entries);
                 entry.column.remove_batch(entries);
             }
         }
         for (key, entries) in adds {
             if let Some(entry) = columns.get_mut(&key) {
+                entry.note_dirty(&entries);
                 entry.column.add_batch(entries);
             }
         }
     }
 
+    /// Add one chunk of the background-built base to a `Building` column, skipping any entry whose
+    /// id was written since `CREATE INDEX` (`dirty`) — that entity's current state is already in the
+    /// live delta (or it's deleted). The caller ([`Graph::install_index_base_chunk`](crate::graph::Graph))
+    /// has already applied the authoritative `deleted_nodes`/`deleted_relationships` backstop, so both
+    /// filters are cheap `O(1)`-per-entry bitmap checks. No-op if the column is missing or already
+    /// `Ready`; `finish_build` flips to `Ready` after the last chunk.
+    pub fn install_base_chunk(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        epoch: u64,
+        chunk: impl IntoIterator<Item = (Value, u64)>,
+    ) {
+        let Some(entry) = self
+            .columns_mut(entity)
+            .get_mut(&(label.clone(), attr.clone()))
+        else {
+            return;
+        };
+        // No-op unless this is still the same build: a mismatched epoch means the column was dropped
+        // and re-created since the job started, so this chunk is stale (the fresh column is built by
+        // a new job). A `Ready` column also falls through here.
+        let ColumnState::Building { dirty, epoch: e } = &entry.state else {
+            return;
+        };
+        if *e != epoch {
+            return;
+        }
+        let survivors: Vec<(Value, u64)> = chunk
+            .into_iter()
+            .filter(|(_, id)| !dirty.contains(*id))
+            .collect();
+        entry.column.add_batch(survivors);
+    }
+
+    /// Flip a `Building` column to `Ready` (base fully installed) — but only if `epoch` still matches
+    /// (the same drop/re-create guard as [`install_base_chunk`](Self::install_base_chunk)), so a stale
+    /// job can never publish a freshly re-created column. After this, the read path serves the column.
+    pub fn finish_build(
+        &mut self,
+        entity: EntityType,
+        label: &Arc<String>,
+        attr: &Arc<String>,
+        epoch: u64,
+    ) {
+        if let Some(entry) = self
+            .columns_mut(entity)
+            .get_mut(&(label.clone(), attr.clone()))
+            && matches!(&entry.state, ColumnState::Building { epoch: e, .. } if *e == epoch)
+        {
+            entry.state = ColumnState::Ready;
+        }
+    }
+
+    /// Every `(entity, label, attr, epoch)` column currently in the `Building` state —
+    /// the work list the background-build controller spawns jobs for. The epoch identifies
+    /// the build so a stale job can't publish a re-created column.
+    #[must_use]
+    pub fn building_columns(&self) -> Vec<(EntityType, Arc<String>, Arc<String>, u64)> {
+        let mut out = Vec::new();
+        for (entity, columns) in [
+            (EntityType::Node, &self.node_columns),
+            (EntityType::Relationship, &self.edge_columns),
+        ] {
+            for ((label, attr), entry) in columns {
+                if let ColumnState::Building { epoch, .. } = &entry.state {
+                    out.push((entity, label.clone(), attr.clone(), *epoch));
+                }
+            }
+        }
+        out
+    }
+
     /// Answer an index query for `(entity, label)` from the numeric column — but ONLY a **numeric**
-    /// `Equal`/`Range` leaf. A Range index also holds strings and geo (served by
-    /// RediSearch), so a non-numeric or composite predicate returns `None` to fall through, as does a
-    /// missing column (the read
+    /// `Equal`/`Range` leaf on a `Ready` column. A Range index also holds strings and geo (served by
+    /// RediSearch), so a non-numeric or composite predicate returns `None` to fall through; so does a
+    /// missing column, and so does a `Building` column (its base isn't installed yet, so the read
     /// falls back to a scan — today's `UNDER CONSTRUCTION` behavior). Yields docs — node ids for a node
     /// column, `edge_id`s for an edge column. The read path routes here and falls back on `None`.
     #[must_use]
@@ -320,6 +473,9 @@ impl FalkorDbIndex {
             return None; // string / geo on a Range index — RediSearch owns those entries
         }
         let entry = self.columns(entity).get(&(label.clone(), key.clone()))?;
+        if !matches!(entry.state, ColumnState::Ready) {
+            return None; // Building — base not installed yet, fall back to a scan
+        }
         match &entry.column {
             IndexColumn::Numeric(idx) => idx.query(query),
         }
@@ -335,6 +491,73 @@ mod tests {
         Arc::new(s.to_string())
     }
 
+    /// Stage a single-column `(value, id)` batch (the shape the write path passes to `merge`).
+    /// Online-build state machine at the column level: a `Building` column gates reads (returns
+    /// `None` → scan fallback) even after chunks are installed, until `finish_build` flips it `Ready`;
+    /// then it serves. (Reconciliation of concurrent writes is validated at the graph level, where
+    /// `Graph::install_index_base_chunk` re-checks each entry against live state — see
+    /// `falkordb_index_mvcc_tests`.)
+    #[test]
+    fn building_column_gates_reads_until_finished() {
+        let (label, attr) = (arc("Person"), arc("age"));
+        let eq = |v: i64| IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+
+        let mut idx = FalkorDbIndex::new();
+        let epoch = idx.create_building(Node, &label, &attr);
+        assert!(
+            idx.query_numeric(Node, &label, &eq(10)).is_none(),
+            "empty Building → None"
+        );
+
+        // Install a (pre-validated) base chunk — reads still gated while Building.
+        idx.install_base_chunk(
+            Node,
+            &label,
+            &attr,
+            epoch,
+            [(Value::Int(10), 0u64), (Value::Int(20), 1)],
+        );
+        assert!(
+            idx.query_numeric(Node, &label, &eq(10)).is_none(),
+            "installed but Building → None"
+        );
+        assert_eq!(idx.building_columns().len(), 1);
+
+        // A stale epoch (as if the column had been dropped + re-created) installs nothing and
+        // must NOT flip the column `Ready` — the drop/re-create guard.
+        idx.install_base_chunk(Node, &label, &attr, epoch + 1, [(Value::Int(99), 9u64)]);
+        idx.finish_build(Node, &label, &attr, epoch + 1);
+        assert!(
+            idx.query_numeric(Node, &label, &eq(10)).is_none(),
+            "stale epoch cannot publish"
+        );
+        assert_eq!(
+            idx.building_columns().len(),
+            1,
+            "still Building after stale finish"
+        );
+
+        // Finish with the right epoch → serves; the stale value never landed.
+        idx.finish_build(Node, &label, &attr, epoch);
+        assert_eq!(
+            idx.query_numeric(Node, &label, &eq(10))
+                .map_or_else(Vec::new, |it| it.collect()),
+            vec![0],
+        );
+        assert!(
+            idx.query_numeric(Node, &label, &eq(99))
+                .map_or_else(Vec::new, |it| it.collect())
+                .is_empty(),
+            "stale entry absent"
+        );
+        assert!(idx.building_columns().is_empty(), "no longer building");
+    }
+
+    /// Forking a new version (what `Graph::new_version` does) and mutating it
+    /// leaves the prior version — the snapshot a reader may still hold — untouched.
     #[test]
     fn new_version_is_copy_on_write() {
         let (label, attr) = (arc("Person"), arc("age"));

--- a/graph/src/index/falkordb/mod.rs
+++ b/graph/src/index/falkordb/mod.rs
@@ -7,6 +7,9 @@
 pub mod data_structures;
 
 #[cfg(feature = "index-falkordb")]
+pub mod build_registry;
+
+#[cfg(feature = "index-falkordb")]
 pub mod encode;
 
 #[cfg(feature = "index-falkordb")]

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -122,6 +122,51 @@ impl NumericIndex {
             .collect()
     }
 
+    /// Build directly from already-encoded `(key, doc)` tuples, in any order — how the
+    /// install adopts a background-built BASE without re-encoding or re-sorting it per row.
+    #[must_use]
+    pub fn from_encoded(mut pairs: Vec<(u64, u64)>) -> Self {
+        pairs.sort_unstable();
+        pairs.dedup();
+        Self {
+            tree: Tree::from_sorted(&pairs),
+        }
+    }
+
+    /// Encode `(value, id)` entries to tree tuples, dropping non-numeric / `NaN`.
+    /// Public so a background build can encode BASE off the write thread.
+    #[must_use]
+    pub fn encode_entries(entries: Vec<(Value, u64)>) -> Vec<(u64, u64)> {
+        Self::encode_pairs(entries)
+    }
+
+    /// Every `(key, doc)` tuple, in key order — the install's DELTA/TOMB enumeration.
+    /// `O(n)`; intended for build-sized artifacts, not a populated column.
+    #[must_use]
+    pub fn encoded_tuples(&self) -> Vec<(u64, u64)> {
+        self.tree.range_tuples(0, u64::MAX).collect()
+    }
+
+    /// Add already-encoded tuples. Used by the install to replay DELTA onto BASE, where the
+    /// tuples come straight out of another tree and must not be re-encoded — re-encoding a
+    /// decoded key would be a second trip through a many-to-one map.
+    pub fn add_encoded(
+        &mut self,
+        pairs: &mut Vec<(u64, u64)>,
+    ) {
+        pairs.sort_unstable();
+        self.tree.insert_batch(pairs);
+    }
+
+    /// Remove already-encoded tuples — the install subtracting TOMB from BASE.
+    pub fn remove_encoded(
+        &mut self,
+        pairs: &mut Vec<(u64, u64)>,
+    ) {
+        pairs.sort_unstable();
+        self.tree.remove_batch(pairs);
+    }
+
     /// Whether the index holds no tuples.
     #[must_use]
     pub fn is_empty(&self) -> bool {

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -1398,21 +1398,20 @@ pub(crate) fn commit_and_replicate(
 // ---- Background (online) FalkorDB index build controller (feature: index-falkordb) ----
 //
 // `CREATE INDEX` on existing data leaves the native column `Building` and returns immediately; the
-// pre-existing snapshot is built off the write thread and installed here in batch-size chunks through
-// the one audited committer (`commit_index_build`). Reads on a `Building` column scan-fall-back until
-// it flips `Ready`.
+// pre-existing snapshot (BASE) is scanned and encoded off the write thread, then installed in ONE
+// commit through the single audited committer (`commit_index_build`), which subtracts TOMB and
+// replays DELTA before flipping the column `Ready`. Reads on a `Building` column scan-fall-back
+// until that flip.
 
-/// Batch size for the chunked base install — mirrors the runtime batch-emitter grain. Small chunks keep
-/// each write-guard hold short so client writes interleave with the build.
-#[cfg(feature = "index-falkordb")]
 /// One in-flight background build, identified by graph name + column + build epoch.
 #[cfg(feature = "index-falkordb")]
 type BuildKey = (String, graph::entity_type::EntityType, String, String, u64);
 
 /// Columns whose background build is already spawned — dedups re-spawn across subsequent writes.
 /// Keyed including the build **epoch**, so a dropped-and-re-created column (fresh epoch) spawns a new
-/// job rather than being suppressed by the old job's lingering marker. Removed when the job ends
-/// (finish / bail / panic — via the job's RAII cleanup), never under the graph write lock.
+/// job rather than being suppressed by the old job's lingering marker. Cleared by the
+/// [`BuildCleanup`] guard the dispatcher hands to the job — on completion, panic, or the job being
+/// dropped undispatched — never under the graph write lock.
 #[cfg(feature = "index-falkordb")]
 static INDEX_BUILDS_IN_FLIGHT: std::sync::LazyLock<
     parking_lot::Mutex<std::collections::HashSet<BuildKey>>,
@@ -1459,24 +1458,75 @@ const INDEX_BUILD_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::fro
 /// Dispatch is idempotent under the in-flight set, so a sweep that finds nothing new costs one
 /// registry lock plus one snapshot read per graph.
 #[cfg(feature = "index-falkordb")]
-pub fn spawn_index_build_sweep() {
-    std::thread::Builder::new()
-        .name("falkordb-index-sweep".into())
-        .spawn(|| {
-            loop {
-                std::thread::sleep(INDEX_BUILD_SWEEP_INTERVAL);
-                // Clone the Arcs out under the registry lock, then release it before dispatching:
-                // `spawn` blocks on a full pool queue, and blocking while holding the registry
-                // would stall every other registry user.
-                let graphs: Vec<Arc<RwLock<ThreadedGraph>>> =
-                    GRAPH_REGISTRY.lock().values().map(Arc::clone).collect();
-                for tg in graphs {
-                    dispatch_index_builds(&tg, collect_pending_index_builds(&tg));
-                }
-            }
-        })
-        .expect("spawn index-build sweep thread");
+static INDEX_SWEEP_STARTED: std::sync::Once = std::sync::Once::new();
+
+#[cfg(feature = "index-falkordb")]
+static INDEX_SWEEP_STOP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Ask the sweep to exit. Called from the shutdown handler *before* `threadpool::shutdown()`, so
+/// the sweep cannot keep handing jobs to a pool that is dropping them (and logging each one) while
+/// GraphBLAS is being torn down underneath it.
+#[cfg(feature = "index-falkordb")]
+pub fn stop_index_build_sweep() {
+    INDEX_SWEEP_STOP.store(true, Ordering::Relaxed);
 }
+
+#[cfg(feature = "index-falkordb")]
+pub fn spawn_index_build_sweep() {
+    // Idempotent: module init can run more than once in-process (tests, repeated load), and each
+    // extra call would otherwise add another unstoppable sweep thread duplicating dispatch work.
+    INDEX_SWEEP_STARTED.call_once(|| {
+        std::thread::Builder::new()
+            .name("falkordb-index-sweep".into())
+            .spawn(|| {
+                loop {
+                    // Sleep in slices so shutdown is observed promptly rather than up to a full
+                    // interval later.
+                    let mut slept = std::time::Duration::ZERO;
+                    while slept < INDEX_BUILD_SWEEP_INTERVAL {
+                        if INDEX_SWEEP_STOP.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        let slice = std::time::Duration::from_millis(50);
+                        std::thread::sleep(slice);
+                        slept += slice;
+                    }
+                    if INDEX_SWEEP_STOP.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    // Clone the Arcs out under the registry lock, then release it before dispatching:
+                    // `spawn` blocks on a full pool queue, and blocking while holding the registry
+                    // would stall every other registry user.
+                    let graphs: Vec<Arc<RwLock<ThreadedGraph>>> =
+                        GRAPH_REGISTRY.lock().values().map(Arc::clone).collect();
+                    for tg in graphs {
+                        dispatch_index_builds(&tg, collect_pending_index_builds(&tg));
+                    }
+                }
+            })
+            .expect("spawn index-build sweep thread");
+    });
+}
+/// Clears a column's in-flight marker on drop — including when the job is never run.
+///
+/// This is *moved into the spawned closure* rather than constructed inside the job, because
+/// `threadpool::spawn` drops the job outright when the pool is shutting down. With the guard
+/// living inside the job, a dropped job left the key claimed forever and suppressed every future
+/// re-dispatch of that column. Owning it from the closure means the key is released whether the
+/// job runs to completion, panics (the pool wraps jobs in `catch_unwind`), or is dropped
+/// undispatched.
+#[cfg(feature = "index-falkordb")]
+struct BuildCleanup {
+    key: BuildKey,
+}
+
+#[cfg(feature = "index-falkordb")]
+impl Drop for BuildCleanup {
+    fn drop(&mut self) {
+        INDEX_BUILDS_IN_FLIGHT.lock().remove(&self.key);
+    }
+}
+
 /// Spawn a background build for each column not already being built. **MUST be called with NO graph
 /// write lock held**: `spawn` does a blocking send on the bounded thread-pool queue, and holding the
 /// write lock across a full-queue block deadlocks the server (workers park on the read lock this
@@ -1497,47 +1547,37 @@ fn dispatch_index_builds(
             .filter(|key| in_flight.insert(key.clone()))
             .collect()
     };
-    for (name, entity, label, attr, epoch) in to_spawn {
+    for key in to_spawn {
+        let (_name, entity, label, attr, epoch) = key.clone();
+        // The guard rides *with* the job. If `spawn` drops it (pool shutting down), dropping the
+        // closure drops the guard and releases the key; otherwise it lives until the job ends.
+        let cleanup = BuildCleanup { key };
         let tg = Arc::clone(tg);
         spawn(
-            move || run_index_build(tg, name, entity, Arc::new(label), Arc::new(attr), epoch),
+            move || {
+                let _cleanup = cleanup;
+                run_index_build(tg, entity, Arc::new(label), Arc::new(attr), epoch);
+            },
             None,
         );
     }
 }
 
 /// Background build job (thread pool): read the base from a committed snapshot off the write thread,
-/// install it in batch-size chunks via `commit_index_build` under the matching `epoch`, flip the column
+/// install it in one commit via `commit_index_build` under the matching `epoch`, flipping the column
 /// `Ready`. Holds an `Arc` to the graph, so a graph deleted mid-build stays alive until this returns
 /// (no use-after-free); if a fork can't be taken the job bails and the column stays `Building` (a later
-/// write re-spawns it). A [`BuildCleanup`] guard frees the detached context and clears the in-flight
-/// marker on EVERY exit — normal, bail, or panic (the pool wraps jobs in `catch_unwind`) — so a panic
-/// can never leak the context or wedge the column `Building` forever.
+/// write re-spawns it). The in-flight marker is cleared by the [`BuildCleanup`] guard the dispatcher
+/// moves into this job, so it is released on every exit — normal, bail, panic (the pool wraps jobs in
+/// `catch_unwind`), or the job never running at all.
 #[cfg(feature = "index-falkordb")]
 fn run_index_build(
     tg: Arc<RwLock<ThreadedGraph>>,
-    name: String,
     entity: graph::entity_type::EntityType,
     label: Arc<String>,
     attr: Arc<String>,
     epoch: u64,
 ) {
-    /// Clears the in-flight marker on drop (incl. unwind), so a panic can never wedge the column
-    /// `Building` forever. (The GIL context is owned per-commit by `hold_gil`, not by this job.)
-    struct BuildCleanup {
-        key: BuildKey,
-    }
-    impl Drop for BuildCleanup {
-        fn drop(&mut self) {
-            INDEX_BUILDS_IN_FLIGHT.lock().remove(&self.key);
-        }
-    }
-    // Arm cleanup BEFORE any fallible work: the in-flight marker was inserted by the dispatcher, so it
-    // must be cleared even if the scan below panics.
-    let _cleanup = BuildCleanup {
-        key: (name, entity, label.to_string(), attr.to_string(), epoch),
-    };
-
     // 1. Scan BASE off-thread from a committed snapshot, already encoded. No locks are held for the
     //    scan's duration beyond the snapshot Arc: the version is immutable, so writes committing
     //    after it are invisible by construction and there is no scan-vs-write race. Encoding here
@@ -1562,7 +1602,7 @@ fn run_index_build(
     //    re-dispatches. A background job can retry — a client cannot, which is why the slot is
     //    try-acquired rather than blocked on.
     commit_index_build(&tg, |g| {
-        g.install_index_base(entity, &label, &attr, epoch, base);
+        g.install_index_base(entity, &label, &attr, epoch, base)
     });
     // `_cleanup` drops here (or on unwind): clears the in-flight marker.
 }
@@ -1576,7 +1616,7 @@ fn run_index_build(
 #[cfg(feature = "index-falkordb")]
 fn commit_index_build(
     tg: &Arc<RwLock<ThreadedGraph>>,
-    install: impl FnOnce(&mut Graph),
+    install: impl FnOnce(&mut Graph) -> bool,
 ) -> bool {
     // GIL BEFORE the write lock. Every other writer takes them in that order —
     // `QuerySession::begin_writer` and `escalate` both `Gil::acquire()` then `write_arc`, and an
@@ -1601,11 +1641,20 @@ fn commit_index_build(
     // fail with "another write is in progress". The pool's own `catch_unwind` would hide that, so
     // catch here and roll back explicitly.
     let installed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        install(&mut fork.borrow_mut());
+        install(&mut fork.borrow_mut())
     }));
-    if installed.is_err() {
+    let Ok(changed) = installed else {
         g.graph.rollback();
         eprintln!("index build: install panicked; version slot released, build abandoned");
+        return false;
+    };
+
+    // Roll back rather than commit when the install was a no-op — the column was dropped, is
+    // already `Ready`, or carries a different epoch. Committing anyway would publish a version
+    // identical to its parent and still pay `MvccGraph::commit`'s O(attribute-store)
+    // `trim_attr_stores()`, which is exactly the cost the single-commit install exists to avoid.
+    if !changed {
+        g.graph.rollback();
         return false;
     }
 

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -1434,7 +1434,13 @@ fn collect_pending_index_builds(tg: &Arc<RwLock<ThreadedGraph>>) -> Vec<BuildKey
     g.building_index_columns()
         .into_iter()
         .map(|(entity, label, attr, epoch)| {
-            (name.clone(), entity, label.to_string(), attr.to_string(), epoch)
+            (
+                name.clone(),
+                entity,
+                label.to_string(),
+                attr.to_string(),
+                epoch,
+            )
         })
         .collect()
 }

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -1405,8 +1405,6 @@ pub(crate) fn commit_and_replicate(
 /// Batch size for the chunked base install — mirrors the runtime batch-emitter grain. Small chunks keep
 /// each write-guard hold short so client writes interleave with the build.
 #[cfg(feature = "index-falkordb")]
-const INDEX_BUILD_BATCH: usize = 1024;
-
 /// One in-flight background build, identified by graph name + column + build epoch.
 #[cfg(feature = "index-falkordb")]
 type BuildKey = (String, graph::entity_type::EntityType, String, String, u64);
@@ -1445,6 +1443,40 @@ fn collect_pending_index_builds(tg: &Arc<RwLock<ThreadedGraph>>) -> Vec<BuildKey
         .collect()
 }
 
+/// How often the sweep looks for `Building` columns that nobody is building.
+#[cfg(feature = "index-falkordb")]
+const INDEX_BUILD_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Periodically dispatch every `Building` column across the registry.
+///
+/// Dispatching only when a client write commits is not enough: that hook sits on **one** of the
+/// write paths, so a `CREATE INDEX` arriving through MULTI/EXEC or a replica effect — or simply
+/// being the last write the server sees — leaves the column `Building` with nothing to finish it.
+/// It also cannot recover a build that a shutting-down pool dropped, that panicked, or that bailed
+/// on fork contention. One sweep over the registry subsumes all of those and needs no per-path
+/// wiring.
+///
+/// Dispatch is idempotent under the in-flight set, so a sweep that finds nothing new costs one
+/// registry lock plus one snapshot read per graph.
+#[cfg(feature = "index-falkordb")]
+pub fn spawn_index_build_sweep() {
+    std::thread::Builder::new()
+        .name("falkordb-index-sweep".into())
+        .spawn(|| {
+            loop {
+                std::thread::sleep(INDEX_BUILD_SWEEP_INTERVAL);
+                // Clone the Arcs out under the registry lock, then release it before dispatching:
+                // `spawn` blocks on a full pool queue, and blocking while holding the registry
+                // would stall every other registry user.
+                let graphs: Vec<Arc<RwLock<ThreadedGraph>>> =
+                    GRAPH_REGISTRY.lock().values().map(Arc::clone).collect();
+                for tg in graphs {
+                    dispatch_index_builds(&tg, collect_pending_index_builds(&tg));
+                }
+            }
+        })
+        .expect("spawn index-build sweep thread");
+}
 /// Spawn a background build for each column not already being built. **MUST be called with NO graph
 /// write lock held**: `spawn` does a blocking send on the bounded thread-pool queue, and holding the
 /// write lock across a full-queue block deadlocks the server (workers park on the read lock this
@@ -1501,35 +1533,37 @@ fn run_index_build(
         }
     }
     // Arm cleanup BEFORE any fallible work: the in-flight marker was inserted by the dispatcher, so it
-    // must be cleared even if `collect_index_entries` below panics.
+    // must be cleared even if the scan below panics.
     let _cleanup = BuildCleanup {
         key: (name, entity, label.to_string(), attr.to_string(), epoch),
     };
 
-    // 1. Build the base off-thread from a committed snapshot (shared read, no write contention).
-    let base = {
+    // 1. Scan BASE off-thread from a committed snapshot, already encoded. No locks are held for the
+    //    scan's duration beyond the snapshot Arc: the version is immutable, so writes committing
+    //    after it are invisible by construction and there is no scan-vs-write race. Encoding here
+    //    rather than at install keeps that cost off the write thread too.
+    let Some(base) = ({
         let arc = tg.read().graph.read();
-        let entries = arc.borrow().collect_index_entries(entity, &label, &attr);
-        entries
+        let b = arc
+            .borrow()
+            .collect_index_base_encoded(entity, &label, &attr);
+        b
+    }) else {
+        return; // column dropped while we were dispatched — nothing to build
     };
 
-    // 2. Install in batch-size chunks; each chunk is one short write-guarded, GIL-protected commit
-    //    (`commit_index_build` takes the module GIL via `hold_gil`). The `epoch` makes each
-    //    install/finish a no-op if the column was dropped + re-created since this job started, so a
-    //    stale job can never publish into the fresh column.
-    let mut alive = true;
-    for chunk in base.chunks(INDEX_BUILD_BATCH) {
-        let chunk = chunk.to_vec();
-        alive = commit_index_build(&tg, |g| {
-            g.install_index_base_chunk(entity, &label, &attr, epoch, chunk);
-        });
-        if !alive {
-            break;
-        }
-    }
-    if alive {
-        commit_index_build(&tg, |g| g.finish_index_build(entity, &label, &attr, epoch));
-    }
+    // 2. Install in ONE commit. Chunking would be wrong as well as slow: a partially-subtracted
+    //    BASE is not a valid index at any version, and `MvccGraph::commit` pays an
+    //    O(attribute-store) `trim_attr_stores()` every time, so N/1024 commits multiply a cost the
+    //    single install pays once. The `epoch` makes the install a no-op if the column was dropped
+    //    and re-created since this job started, so a stale job cannot publish into the fresh one.
+    //
+    //    On fork contention `commit_index_build` returns false without installing; the sweep
+    //    re-dispatches. A background job can retry — a client cannot, which is why the slot is
+    //    try-acquired rather than blocked on.
+    commit_index_build(&tg, |g| {
+        g.install_index_base(entity, &label, &attr, epoch, base);
+    });
     // `_cleanup` drops here (or on unwind): clears the in-flight marker.
 }
 

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -43,6 +43,8 @@ use crossfire::{
     MTx, Rx,
     mpsc::{Array, bounded_blocking},
 };
+#[cfg(feature = "index-falkordb")]
+use graph::index::falkordb::build_registry::{BuildKey, BuildRegistry};
 use graph::{
     graph::{
         graph::{Graph, Plan},
@@ -1403,19 +1405,16 @@ pub(crate) fn commit_and_replicate(
 // replays DELTA before flipping the column `Ready`. Reads on a `Building` column scan-fall-back
 // until that flip.
 
-/// One in-flight background build, identified by graph name + column + build epoch.
+/// Columns whose background build is already spawned — dedups re-spawn across subsequent writes —
+/// plus the retry backoff of those that failed to install.
+///
+/// Maintained by the [`BuildCleanup`] guard the dispatcher hands to the job — on completion, panic,
+/// or the job being dropped undispatched — never under the graph write lock. The bookkeeping itself
+/// lives in `graph` so it can be unit-tested; this crate installs Redis's allocator and its test
+/// binary aborts before `main`.
 #[cfg(feature = "index-falkordb")]
-type BuildKey = (String, graph::entity_type::EntityType, String, String, u64);
-
-/// Columns whose background build is already spawned — dedups re-spawn across subsequent writes.
-/// Keyed including the build **epoch**, so a dropped-and-re-created column (fresh epoch) spawns a new
-/// job rather than being suppressed by the old job's lingering marker. Cleared by the
-/// [`BuildCleanup`] guard the dispatcher hands to the job — on completion, panic, or the job being
-/// dropped undispatched — never under the graph write lock.
-#[cfg(feature = "index-falkordb")]
-static INDEX_BUILDS_IN_FLIGHT: std::sync::LazyLock<
-    parking_lot::Mutex<std::collections::HashSet<BuildKey>>,
-> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashSet::new()));
+static INDEX_BUILDS_IN_FLIGHT: std::sync::LazyLock<BuildRegistry> =
+    std::sync::LazyLock::new(|| BuildRegistry::new(INDEX_BUILD_SWEEP_INTERVAL));
 
 /// The `Building` columns of the just-committed graph — the online-build work list. Pure read
 /// (reads the committed version via `MvccGraph::read`, an `Arc` clone, no RwLock), so it is safe to
@@ -1457,25 +1456,51 @@ const INDEX_BUILD_SWEEP_INTERVAL: std::time::Duration = std::time::Duration::fro
 ///
 /// Dispatch is idempotent under the in-flight set, so a sweep that finds nothing new costs one
 /// registry lock plus one snapshot read per graph.
+/// The running sweep thread, so [`stop_index_build_sweep`] can join it and
+/// [`spawn_index_build_sweep`] can tell "already running" from "never started".
 #[cfg(feature = "index-falkordb")]
-static INDEX_SWEEP_STARTED: std::sync::Once = std::sync::Once::new();
+static INDEX_SWEEP: std::sync::LazyLock<parking_lot::Mutex<Option<std::thread::JoinHandle<()>>>> =
+    std::sync::LazyLock::new(|| parking_lot::Mutex::new(None));
 
 #[cfg(feature = "index-falkordb")]
 static INDEX_SWEEP_STOP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-/// Ask the sweep to exit. Called from the shutdown handler *before* `threadpool::shutdown()`, so
-/// the sweep cannot keep handing jobs to a pool that is dropping them (and logging each one) while
-/// GraphBLAS is being torn down underneath it.
+/// Stop the sweep and wait for it to exit. Called from the shutdown handler *before*
+/// `threadpool::shutdown()`, so the sweep cannot keep handing jobs to a pool that is dropping them
+/// (and logging each one) while GraphBLAS is being torn down underneath it.
+///
+/// The **join** is the point, not just the flag. `on_shutdown` tears down the threadpool, GraphBLAS
+/// and RediSearch as soon as this returns, and the sweep can be inside `collect_pending_index_builds`
+/// touching a `Graph` at that moment. Signalling without joining leaves that window open — the same
+/// class of bug `telemetry::shutdown_flusher_thread` joins to prevent.
 #[cfg(feature = "index-falkordb")]
 pub fn stop_index_build_sweep() {
     INDEX_SWEEP_STOP.store(true, Ordering::Relaxed);
+    // Take the handle out before joining: holding the lock across the join would make a concurrent
+    // `spawn_index_build_sweep` wait on a thread that is only exiting because we asked it to.
+    let handle = INDEX_SWEEP.lock().take();
+    if let Some(handle) = handle {
+        // The sweep polls the stop flag every 50ms, so this waits at most that plus one dispatch
+        // pass. A panicked sweep gives `Err` here, which is nothing to act on during shutdown.
+        drop(handle.join());
+    }
 }
 
 #[cfg(feature = "index-falkordb")]
 pub fn spawn_index_build_sweep() {
+    let mut slot = INDEX_SWEEP.lock();
     // Idempotent: module init can run more than once in-process (tests, repeated load), and each
-    // extra call would otherwise add another unstoppable sweep thread duplicating dispatch work.
-    INDEX_SWEEP_STARTED.call_once(|| {
+    // extra call would otherwise add another sweep thread duplicating dispatch work.
+    if slot.is_some() {
+        return;
+    }
+    // Clear the stop flag HERE rather than at shutdown. `stop_index_build_sweep` latches it, and
+    // init can follow a shutdown in the same process; a latched flag meant the reloaded module ran
+    // with no sweep at all, so every later `CREATE INDEX` sat `Building` forever and every indexed
+    // read silently degraded to a scan. Clearing under the same lock that owns the handle keeps
+    // "flag says run" and "thread exists" from disagreeing.
+    INDEX_SWEEP_STOP.store(false, Ordering::Relaxed);
+    *slot = Some(
         std::thread::Builder::new()
             .name("falkordb-index-sweep".into())
             .spawn(|| {
@@ -1499,13 +1524,19 @@ pub fn spawn_index_build_sweep() {
                     // would stall every other registry user.
                     let graphs: Vec<Arc<RwLock<ThreadedGraph>>> =
                         GRAPH_REGISTRY.lock().values().map(Arc::clone).collect();
+                    let mut pending = std::collections::HashSet::new();
                     for tg in graphs {
-                        dispatch_index_builds(&tg, collect_pending_index_builds(&tg));
+                        let builds = collect_pending_index_builds(&tg);
+                        pending.extend(builds.iter().cloned());
+                        dispatch_index_builds(&tg, builds);
                     }
+                    // The sweep is the only place that sees every graph at once, so it is where
+                    // stale backoff entries are reclaimed.
+                    INDEX_BUILDS_IN_FLIGHT.prune(&pending);
                 }
             })
-            .expect("spawn index-build sweep thread");
-    });
+            .expect("spawn index-build sweep thread"),
+    );
 }
 /// Clears a column's in-flight marker on drop — including when the job is never run.
 ///
@@ -1518,12 +1549,16 @@ pub fn spawn_index_build_sweep() {
 #[cfg(feature = "index-falkordb")]
 struct BuildCleanup {
     key: BuildKey,
+    /// Set by the job only when the base actually landed. Every other exit — bail, stale epoch,
+    /// lost version slot, panic, or the job never running — leaves it `false`, which is what arms
+    /// the retry backoff.
+    installed: bool,
 }
 
 #[cfg(feature = "index-falkordb")]
 impl Drop for BuildCleanup {
     fn drop(&mut self) {
-        INDEX_BUILDS_IN_FLIGHT.lock().remove(&self.key);
+        INDEX_BUILDS_IN_FLIGHT.release(&self.key, self.installed, std::time::Instant::now());
     }
 }
 
@@ -1539,24 +1574,23 @@ fn dispatch_index_builds(
     if builds.is_empty() {
         return;
     }
-    // Claim the not-yet-building keys under the in-flight lock, then release it before spawning.
-    let to_spawn: Vec<BuildKey> = {
-        let mut in_flight = INDEX_BUILDS_IN_FLIGHT.lock();
-        builds
-            .into_iter()
-            .filter(|key| in_flight.insert(key.clone()))
-            .collect()
-    };
+    // Claim the not-yet-building keys, then spawn with the registry lock released — `spawn` blocks
+    // on a full queue. A key still inside its retry backoff is not claimed.
+    let to_spawn = INDEX_BUILDS_IN_FLIGHT.claim(builds, std::time::Instant::now());
     for key in to_spawn {
         let (_name, entity, label, attr, epoch) = key.clone();
         // The guard rides *with* the job. If `spawn` drops it (pool shutting down), dropping the
         // closure drops the guard and releases the key; otherwise it lives until the job ends.
-        let cleanup = BuildCleanup { key };
+        let mut cleanup = BuildCleanup {
+            key,
+            installed: false,
+        };
         let tg = Arc::clone(tg);
         spawn(
             move || {
-                let _cleanup = cleanup;
-                run_index_build(tg, entity, Arc::new(label), Arc::new(attr), epoch);
+                cleanup.installed =
+                    run_index_build(tg, entity, Arc::new(label), Arc::new(attr), epoch);
+                drop(cleanup);
             },
             None,
         );
@@ -1577,7 +1611,7 @@ fn run_index_build(
     label: Arc<String>,
     attr: Arc<String>,
     epoch: u64,
-) {
+) -> bool {
     // 1. Scan BASE off-thread from a committed snapshot, already encoded. No locks are held for the
     //    scan's duration beyond the snapshot Arc: the version is immutable, so writes committing
     //    after it are invisible by construction and there is no scan-vs-write race. Encoding here
@@ -1589,7 +1623,7 @@ fn run_index_build(
             .collect_index_base_encoded(entity, &label, &attr);
         b
     }) else {
-        return; // column dropped while we were dispatched — nothing to build
+        return false; // column dropped while we were dispatched — nothing to build
     };
 
     // 2. Install in ONE commit. Chunking would be wrong as well as slow: a partially-subtracted
@@ -1599,12 +1633,12 @@ fn run_index_build(
     //    and re-created since this job started, so a stale job cannot publish into the fresh one.
     //
     //    On fork contention `commit_index_build` returns false without installing; the sweep
-    //    re-dispatches. A background job can retry — a client cannot, which is why the slot is
-    //    try-acquired rather than blocked on.
+    //    re-dispatches, after the caller's backoff. A background job can retry — a client cannot,
+    //    which is why the slot is try-acquired rather than blocked on.
     commit_index_build(&tg, |g| {
         g.install_index_base(entity, &label, &attr, epoch, base)
-    });
-    // `_cleanup` drops here (or on unwind): clears the in-flight marker.
+    })
+    // The caller's `BuildCleanup` reads this: installed → release the key, otherwise → back off.
 }
 
 /// The one audited committer for a background install step: take the writer's exclusion (RwLock write

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -1395,6 +1395,185 @@ pub(crate) fn commit_and_replicate(
     }
 }
 
+// ---- Background (online) FalkorDB index build controller (feature: index-falkordb) ----
+//
+// `CREATE INDEX` on existing data leaves the native column `Building` and returns immediately; the
+// pre-existing snapshot is built off the write thread and installed here in batch-size chunks through
+// the one audited committer (`commit_index_build`). Reads on a `Building` column scan-fall-back until
+// it flips `Ready`.
+
+/// Batch size for the chunked base install — mirrors the runtime batch-emitter grain. Small chunks keep
+/// each write-guard hold short so client writes interleave with the build.
+#[cfg(feature = "index-falkordb")]
+const INDEX_BUILD_BATCH: usize = 1024;
+
+/// One in-flight background build, identified by graph name + column + build epoch.
+#[cfg(feature = "index-falkordb")]
+type BuildKey = (String, graph::entity_type::EntityType, String, String, u64);
+
+/// Columns whose background build is already spawned — dedups re-spawn across subsequent writes.
+/// Keyed including the build **epoch**, so a dropped-and-re-created column (fresh epoch) spawns a new
+/// job rather than being suppressed by the old job's lingering marker. Removed when the job ends
+/// (finish / bail / panic — via the job's RAII cleanup), never under the graph write lock.
+#[cfg(feature = "index-falkordb")]
+static INDEX_BUILDS_IN_FLIGHT: std::sync::LazyLock<
+    parking_lot::Mutex<std::collections::HashSet<BuildKey>>,
+> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashSet::new()));
+
+/// The `Building` columns of the just-committed graph — the online-build work list. Pure read
+/// (reads the committed version via `MvccGraph::read`, an `Arc` clone, no RwLock), so it is safe to
+/// call under the writer's held write guard (`committed` is that guard's `ThreadedGraph`). It does
+/// NOT spawn — dispatch is deliberately split out (see [`dispatch_index_builds`]) so the blocking
+/// `spawn` never runs while the write lock is held.
+#[cfg(feature = "index-falkordb")]
+fn collect_pending_index_builds(tg: &Arc<RwLock<ThreadedGraph>>) -> Vec<BuildKey> {
+    let bind = tg.read();
+    let arc = bind.graph.read();
+    let g = arc.borrow();
+    let name = g.name().to_string();
+    g.building_index_columns()
+        .into_iter()
+        .map(|(entity, label, attr, epoch)| {
+            (name.clone(), entity, label.to_string(), attr.to_string(), epoch)
+        })
+        .collect()
+}
+
+/// Spawn a background build for each column not already being built. **MUST be called with NO graph
+/// write lock held**: `spawn` does a blocking send on the bounded thread-pool queue, and holding the
+/// write lock across a full-queue block deadlocks the server (workers park on the read lock this
+/// writer holds, so the queue never drains). The in-flight lock is likewise released before spawning.
+#[cfg(feature = "index-falkordb")]
+fn dispatch_index_builds(
+    tg: &Arc<RwLock<ThreadedGraph>>,
+    builds: Vec<BuildKey>,
+) {
+    if builds.is_empty() {
+        return;
+    }
+    // Claim the not-yet-building keys under the in-flight lock, then release it before spawning.
+    let to_spawn: Vec<BuildKey> = {
+        let mut in_flight = INDEX_BUILDS_IN_FLIGHT.lock();
+        builds
+            .into_iter()
+            .filter(|key| in_flight.insert(key.clone()))
+            .collect()
+    };
+    for (name, entity, label, attr, epoch) in to_spawn {
+        let tg = Arc::clone(tg);
+        spawn(
+            move || run_index_build(tg, name, entity, Arc::new(label), Arc::new(attr), epoch),
+            None,
+        );
+    }
+}
+
+/// Background build job (thread pool): read the base from a committed snapshot off the write thread,
+/// install it in batch-size chunks via `commit_index_build` under the matching `epoch`, flip the column
+/// `Ready`. Holds an `Arc` to the graph, so a graph deleted mid-build stays alive until this returns
+/// (no use-after-free); if a fork can't be taken the job bails and the column stays `Building` (a later
+/// write re-spawns it). A [`BuildCleanup`] guard frees the detached context and clears the in-flight
+/// marker on EVERY exit — normal, bail, or panic (the pool wraps jobs in `catch_unwind`) — so a panic
+/// can never leak the context or wedge the column `Building` forever.
+#[cfg(feature = "index-falkordb")]
+fn run_index_build(
+    tg: Arc<RwLock<ThreadedGraph>>,
+    name: String,
+    entity: graph::entity_type::EntityType,
+    label: Arc<String>,
+    attr: Arc<String>,
+    epoch: u64,
+) {
+    /// Clears the in-flight marker on drop (incl. unwind), so a panic can never wedge the column
+    /// `Building` forever. (The GIL context is owned per-commit by `hold_gil`, not by this job.)
+    struct BuildCleanup {
+        key: BuildKey,
+    }
+    impl Drop for BuildCleanup {
+        fn drop(&mut self) {
+            INDEX_BUILDS_IN_FLIGHT.lock().remove(&self.key);
+        }
+    }
+    // Arm cleanup BEFORE any fallible work: the in-flight marker was inserted by the dispatcher, so it
+    // must be cleared even if `collect_index_entries` below panics.
+    let _cleanup = BuildCleanup {
+        key: (name, entity, label.to_string(), attr.to_string(), epoch),
+    };
+
+    // 1. Build the base off-thread from a committed snapshot (shared read, no write contention).
+    let base = {
+        let arc = tg.read().graph.read();
+        let entries = arc.borrow().collect_index_entries(entity, &label, &attr);
+        entries
+    };
+
+    // 2. Install in batch-size chunks; each chunk is one short write-guarded, GIL-protected commit
+    //    (`commit_index_build` takes the module GIL via `hold_gil`). The `epoch` makes each
+    //    install/finish a no-op if the column was dropped + re-created since this job started, so a
+    //    stale job can never publish into the fresh column.
+    let mut alive = true;
+    for chunk in base.chunks(INDEX_BUILD_BATCH) {
+        let chunk = chunk.to_vec();
+        alive = commit_index_build(&tg, |g| {
+            g.install_index_base_chunk(entity, &label, &attr, epoch, chunk);
+        });
+        if !alive {
+            break;
+        }
+    }
+    if alive {
+        commit_index_build(&tg, |g| g.finish_index_build(entity, &label, &attr, epoch));
+    }
+    // `_cleanup` drops here (or on unwind): clears the in-flight marker.
+}
+
+/// The one audited committer for a background install step: take the writer's exclusion (RwLock write
+/// guard), fork the CURRENT committed version (so it sees the latest writes — `dirty` reconciles the
+/// stale base), run `install` on the fork, then swap it in under the GIL (BGSAVE fork-safety, #452).
+/// This is the **same lock discipline as the client write path** (RwLock-write → GIL → commit → release
+/// — see `process_write_queued_query`), reused deliberately; it does not introduce a new lock-order
+/// edge. Returns false if no version could be forked (graph tearing down) — the caller bails.
+#[cfg(feature = "index-falkordb")]
+fn commit_index_build(
+    tg: &Arc<RwLock<ThreadedGraph>>,
+    install: impl FnOnce(&mut Graph),
+) -> bool {
+    // GIL BEFORE the write lock. Every other writer takes them in that order —
+    // `QuerySession::begin_writer` and `escalate` both `Gil::acquire()` then `write_arc`, and an
+    // inline command already holds the GIL when it reaches `graph.write()`. Taking the write lock
+    // first (as this function used to) inverts against them: this thread would hold L1 waiting for
+    // the GIL while the main thread holds the GIL waiting for L1, wedging the server.
+    //
+    // L1-write is unavoidable here despite the native index being MVCC: `MvccGraph::commit` takes
+    // `&mut self`, so publishing a version needs exclusive access to the `ThreadedGraph`.
+    let _gil = crate::query_session::hold_gil();
+    let mut g = tg.write();
+
+    // TRY-acquire the version slot, never block on it. A client can hold the slot while waiting for
+    // the GIL during escalation, so blocking here would deadlock; a background build can simply back
+    // off and be re-dispatched later.
+    let Some(fork) = g.graph.write() else {
+        return false;
+    };
+
+    // `MvccGraph::write` latches a flag that only `commit` or `rollback` clears — an unwind past
+    // this point would leave it latched forever and every subsequent write in the process would
+    // fail with "another write is in progress". The pool's own `catch_unwind` would hide that, so
+    // catch here and roll back explicitly.
+    let installed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        install(&mut fork.borrow_mut());
+    }));
+    if installed.is_err() {
+        g.graph.rollback();
+        eprintln!("index build: install panicked; version slot released, build abandoned");
+        return false;
+    }
+
+    g.graph.commit(fork);
+    true
+    // Drop order is the reverse of acquisition: `g` (L1) then `_gil`.
+}
+
 pub fn process_write_queued_query(graph: &Arc<RwLock<ThreadedGraph>>) {
     if graph
         .read()
@@ -1488,6 +1667,12 @@ pub fn process_write_queued_query(graph: &Arc<RwLock<ThreadedGraph>>) {
         match res {
             Ok((params_offset, exec_ms)) => {
                 unsafe { ffi::free_thread_safe_context(ctx.ctx) };
+                // If this write left native index columns `Building`, spawn their background builds
+                // now. No write lock is held here (the query session released it before returning),
+                // so the blocking spawn is safe — the C1 deadlock only arises when spawning under the
+                // write guard, which this path no longer does.
+                #[cfg(feature = "index-falkordb")]
+                dispatch_index_builds(graph, collect_pending_index_builds(graph));
                 let query_text = &query[params_offset..];
                 let params_text = &query[..params_offset];
                 let report_ms = (write_wall_ms - exec_ms).max(0.0);

--- a/src/module_init.rs
+++ b/src/module_init.rs
@@ -485,6 +485,10 @@ unsafe extern "C" fn on_shutdown(
     // thread-safe context, which races with Redis tearing down server state
     // and produces a SIGSEGV under ASAN if left running.
     telemetry::shutdown_flusher_thread();
+    // Stop the index-build sweep before the pool: otherwise it keeps handing jobs to a pool that
+    // is dropping (and logging) each one, while GraphBLAS is torn down under it.
+    #[cfg(feature = "index-falkordb")]
+    crate::graph_core::stop_index_build_sweep();
     threadpool::shutdown();
     graph::graph::graphblas::matrix::shutdown();
     unsafe { RediSearch_CleanupModule() };

--- a/src/module_init.rs
+++ b/src/module_init.rs
@@ -453,6 +453,12 @@ pub fn graph_init(
         }
     }
 
+    // Liveness for online index builds. Dispatch-on-client-write covers only one of the write
+    // paths, so a `CREATE INDEX` through MULTI/EXEC or a replica effect — or one that is simply the
+    // last write the server sees — would otherwise leave its column `Building` forever.
+    #[cfg(feature = "index-falkordb")]
+    crate::graph_core::spawn_index_build_sweep();
+
     Status::Ok
 }
 


### PR DESCRIPTION
Closes #2355

**Based on #2350** — review that one first; the diff shown here is
only this layer.

Turns the synchronous `CREATE INDEX` from #2350 into a background build, implementing
`docs/design/online-index-build.md` (included here; it was written and reviewed alongside an
earlier prototype but never implemented).

## The model

Three artifacts. **BASE** is scanned off-thread from an immutable snapshot and lives in the
job's private memory. **DELTA** is the column's own tree — writers write directly into it during
a build, there is no parallel write path. **TOMB** is a second tree holding the tuples
*destroyed* since `CREATE INDEX`. BASE is deliberately stale; TOMB and DELTA are the catch-up
log that makes installing a stale artifact safe.

`CREATE INDEX` marks the column `Building` and returns. Reads on a `Building` column return
`None` and fall back to a scan; live writes maintain it normally. One install commit adopts
BASE, subtracts TOMB, replays DELTA, and flips to `Ready`.

## Why TOMB rather than a set of touched ids

The earlier prototype reconciled with a `RoaringTreemap` of ids written since create. Two
problems: it deep-clones on every version fork, which is O(writes²) across a build, and it
cannot dedup under the column's own equivalence relation. TOMB is the same CoW tuple tree as
the column — O(1) forks, and identical encoding by construction.

**This narrows a safety property, deliberately.** `dirty` was *touch*-keyed: any touch of an id
suppressed all of that id's BASE rows, which made it immune to a hook computing a wrong value.
TOMB is *remove*-keyed — a stale row survives unless the hook stages the exact matching encoded
tuple. The steady-state `Ready` path already depends on that precision (a hook staging a wrong
old value corrupts the index today, build or no build), so this extends an existing dependency
rather than creating a new class of failure. But it makes hook completeness an audit obligation,
not a footnote. Design §11 states the trade in full.

## Ordering is load-bearing

Install starts *from* BASE, so every snapshot-era tuple is present and the only question is
TOMB-vs-DELTA. Applying DELTA first would delete exactly `TOMB ∩ DELTA` — every tuple destroyed
and then recreated during the build (`v0 → v1 → v0`, or an id reused with the same value). By
I-W4′ no DELTA tuple is invalid at the version being installed into, so TOMB never needs to fire
after DELTA.

Install is also **one commit**, not N/1024. A partially-subtracted BASE is not a valid index at
any version, and `MvccGraph::commit` pays an O(attribute-store) `trim_attr_stores()` every time,
so chunking multiplied a cost the single install pays once. BASE is encoded off the write thread.

## Liveness

Dispatch-on-client-write sits on **one** of the write paths, so a `CREATE INDEX` through
MULTI/EXEC or a replica effect — or simply the last write the server sees — left the column
`Building` forever. It also could not recover a build dropped by a shutting-down pool, panicked,
or bailed on fork contention. A periodic sweep over the graph registry subsumes all of it;
dispatch is idempotent under the in-flight set, so a sweep that finds nothing costs one registry
lock plus a snapshot read per graph.

**The 500ms interval is a guess** — no measurement behind it. Worth a second opinion.

## Locking is unchanged

Design §11's "never L1" row is superseded by §7, which withdraws it: `MvccGraph::commit` takes
`&mut self`, so L1-write is unavoidable. `GIL → L1-write → try-slot` — the same GIL-before-L1
order every other writer uses — is what the code already did. The slot is *try*-acquired, never
blocked on, because a client can hold it while waiting for the GIL during escalation.

## Known-unsound, and not fixed here

Design §12 C9: **`GRAPH.BULK` during a build is unsound** (§13(A)) — the bulk path does not run
the index hooks, so its rows never reach DELTA/TOMB. That is pre-existing and tracked separately
(the native half of #2294); this PR neither introduces nor fixes it.

## Verification

140 tests pass with the flag on, 109 with it off, single-threaded (deterministic order).
`cargo fmt --all --check` clean; root crate builds with the flag on and off.

