### PR TITLE
Match GRAPH.QUERY arguments case-insensitively

### DIFF
--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -21,7 +21,9 @@ pub fn graph_profile(
     let query = args.next_str()?;
     let mut timeout: Option<i64> = None;
     while let Ok(arg) = args.next_str() {
-        if arg == "timeout"
+        // Matched case-insensitively, as the C dispatcher does with strcasecmp:
+        // `TIMEOUT` is the documented spelling.
+        if arg.eq_ignore_ascii_case("timeout")
             && let Ok(t_str) = args.next_str()
         {
             timeout = t_str.parse::<i64>().ok();

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -55,14 +55,16 @@ pub fn graph_query(
     let mut version_check: Option<u64> = None;
     let mut timeout: Option<i64> = None;
     while let Ok(arg) = args.next_str() {
-        if arg == "--compact" {
+        // Matched case-insensitively, as the C dispatcher does with strcasecmp:
+        // `TIMEOUT` is the documented spelling.
+        if arg.eq_ignore_ascii_case("--compact") {
             compact = true;
-        } else if arg == "--track-memory" {
+        } else if arg.eq_ignore_ascii_case("--track-memory") {
             track_memory = true;
-        } else if arg == "version" {
+        } else if arg.eq_ignore_ascii_case("version") {
             let ver_str = args.next_str()?;
             version_check = Some(ver_str.parse::<u64>()?);
-        } else if arg == "timeout" {
+        } else if arg.eq_ignore_ascii_case("timeout") {
             let t_str = args.next_str()?;
             timeout = Some(t_str.parse::<i64>()?);
         }

--- a/src/commands/ro_query.rs
+++ b/src/commands/ro_query.rs
@@ -36,14 +36,16 @@ pub fn graph_ro_query(
     let mut version_check: Option<u64> = None;
     let mut timeout: Option<i64> = None;
     while let Ok(arg) = args.next_str() {
-        if arg == "--compact" {
+        // Matched case-insensitively, as the C dispatcher does with strcasecmp:
+        // `TIMEOUT` is the documented spelling.
+        if arg.eq_ignore_ascii_case("--compact") {
             compact = true;
-        } else if arg == "--track-memory" {
+        } else if arg.eq_ignore_ascii_case("--track-memory") {
             track_memory = true;
-        } else if arg == "version" {
+        } else if arg.eq_ignore_ascii_case("version") {
             let ver_str = args.next_str()?;
             version_check = Some(ver_str.parse::<u64>()?);
-        } else if arg == "timeout"
+        } else if arg.eq_ignore_ascii_case("timeout")
             && let Ok(t_str) = args.next_str()
         {
             timeout = t_str.parse::<i64>().ok();

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -291,7 +291,32 @@ class testQueryTimeout():
         res = self.graph.query("RETURN 1")
         self.env.assertEqual(res.result_set[0][0], 1)
 
-    def test12_concurrent_timeout(self):
+    # Command arguments are matched case-insensitively, as the C dispatcher does
+    # with strcasecmp. Every test above goes through the Python client, which
+    # only ever sends `timeout` in lower case — so a case-sensitive match let the
+    # documented `TIMEOUT` spelling be silently dropped, and the query then ran
+    # with no deadline at all. Issue both spellings as raw commands.
+    def test12_timeout_argument_is_case_insensitive(self):
+        self.env.stop()
+        self.env, self.db = Env()
+        self.graph = self.db.select_graph(GRAPH_ID)
+
+        query = "UNWIND range(0, 1000000) AS x WITH x AS x WHERE x = 10000 RETURN x"
+        conn = self.env.getConnection()
+
+        for spelling in ("TIMEOUT", "timeout", "TimeOut"):
+            try:
+                # The query is expected to timeout
+                conn.execute_command("GRAPH.QUERY", GRAPH_ID, query, spelling, 1)
+                self.env.assertTrue(False)
+            except ResponseError as error:
+                self.env.assertContains("Query timed out", str(error))
+
+            # ...and to succeed given room to finish
+            res = conn.execute_command("GRAPH.QUERY", GRAPH_ID, query, spelling, 5000)
+            self.env.assertIsNotNone(res)
+
+    def test13_concurrent_timeout(self):
         self.env.stop()
         self.env, self.db = Env()
         self.graph = self.db.select_graph(GRAPH_ID)


### PR DESCRIPTION
Closes #2368

## Problem

`GRAPH.QUERY key "<query>" TIMEOUT 1` — the documented spelling — was **silently ignored**. The handlers compared each argument with `arg == "timeout"`, so anything but lower case fell through the `if`/`else if` chain and the query ran with **no deadline at all**:

```
$ redis-cli GRAPH.QUERY g "MATCH (a),(b),(c),(d) RETURN *" TIMEOUT 1
(runs forever)
$ redis-cli GRAPH.QUERY g "MATCH (a),(b),(c),(d) RETURN *" timeout 1
(error) Query timed out
```

The C dispatcher (`cmd_dispatcher.c`) compares these with `strcasecmp`. `--compact`, `--track-memory` and `version` had the same problem.

The existing timeout tests never caught this because they all go through falkordb-py, which only ever sends `timeout` in lower case (`command.extend(["timeout", timeout])`). Any client using the documented uppercase form got no timeout enforcement.

## Fix

`eq_ignore_ascii_case` in all three handlers — `GRAPH.QUERY`, `GRAPH.RO_QUERY`, `GRAPH.PROFILE`.

## Tests

Added `test12_timeout_argument_is_case_insensitive` to `tests/flow/test_timeout.py`, issuing raw commands with `TIMEOUT` / `timeout` / `TimeOut` and asserting each both times out at 1 ms and succeeds at 5000 ms. Verified it fails without the fix on exactly the two non-lowercase spellings and passes after.

Green on this branch: flow 1407, TCK 2456 scenarios, e2e/functions/mvcc/concurrency 136, rust unit 108. `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command options now accept mixed capitalization for `TIMEOUT`, `--compact`, `--track-memory`, and `version`.
  * Existing command behavior remains unchanged regardless of option capitalization.

* **Tests**
  * Added coverage confirming timeout options work with uppercase, lowercase, and mixed-case spellings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
