### PR TITLE
Resolve the cartesian product's column owners once, not per row

### DIFF
--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -219,6 +219,25 @@ QUERIES = [
     Q("EXISTS pattern",      False, "MATCH (p:Person) WHERE p.id < 100 AND (p)-[:KNOWS]->() RETURN count(p)", cg=True),
     Q("pattern OR filter",   False, "MATCH (p:Person) WHERE (p)-[:KNOWS]->(:Person {id: 1}) OR p.id = 0 RETURN count(p)", cg=True),
     Q("hash join",           False, "MATCH (a:Person), (b:Person) WHERE a.id = 9999 - b.id RETURN count(*)", cg=True),
+
+    # ---- cartesian product, by right-branch count --------------------------
+    # Nothing above reaches the operator with more than one row a side: every
+    # other multi-component `MATCH (a), (b)` here is an id-seek pair, or the
+    # `hash join` row, which is the ValueHashJoin rewrite of exactly this shape.
+    # A regression in the product itself was therefore invisible to this set.
+    #
+    # Cost is per output row and the row count is the *product* of the branches,
+    # so these are sized by product (~1-2M rows) rather than by node count, and
+    # each branch takes a different label so every output column has a distinct
+    # owner. `reps` is capped for the same reason the sized writes cap theirs: at
+    # the default 1000 a 10 ms query would outweigh the rest of the set.
+    # Person x Doc = 10,000 x 100.
+    Q("cartesian 1 branch", False, "MATCH (a:Person), (b:Doc) RETURN count(*)", 50),
+    # Doc x CIdx x Geo = 100^3.
+    Q("cartesian 2 branches", False, "MATCH (a:Doc), (b:CIdx), (c:Geo) RETURN count(*)", 50),
+    # Doc x CIdx x Geo x MEnd = 100^3 x 2 — the 2-row innermost branch wraps the
+    # odometer's fastest digit on every other row.
+    Q("cartesian 3 branches", False, "MATCH (a:Doc), (b:CIdx), (c:Geo), (d:MEnd) RETURN count(*)", 50),
     Q("shortestPath",        False, "MATCH (a:Person {id: 0}), (b:Person {id: 3}) RETURN length(shortestPath((a)-[:KNOWS*..5]->(b)))", cg=True),
     Q("allShortestPaths",    False, "MATCH (a:Person {id: 0}), (b:Person {id: 3}) WITH a, b MATCH p = allShortestPaths((a)-[:KNOWS*..5]->(b)) RETURN count(p)", cg=True),
     Q("CALL procedure",      False, "CALL db.labels() YIELD label RETURN label", cg=True),

--- a/graph/src/runtime/batch.rs
+++ b/graph/src/runtime/batch.rs
@@ -417,6 +417,64 @@ impl ColumnBuilder {
     }
 }
 
+/// Where a merged row's column comes from: one of the right-hand batches, or
+/// the left base row.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum MergeSource {
+    /// Take the slot from `rights[i]`, at that batch's cursor row.
+    Right(u32),
+    /// No right-hand batch binds the slot: fall back to the left base row.
+    Left,
+}
+
+/// The resolved per-column owner map for an N-way merge, consumed by
+/// [`BatchBuilder::push_planned`].
+///
+/// [`Batch::is_bound_at`] is a *column*-level predicate — it ignores its `row`
+/// argument, and so does the `value_only` flag it consults — so for a fixed set
+/// of right-hand batches, "which batch binds column `id`?" has the same answer
+/// for every row of the merge. Resolving it once collapses the per-row merge
+/// from a scan over every right batch per column into a single indexed read,
+/// which is what makes an N-way cross product cheap: its branches are fixed for
+/// the whole operator, so the plan is built once and reused for every row.
+pub struct MergePlan {
+    /// One entry per column slot the rights cover, indexed by var id. Slots at
+    /// or beyond `sources.len()` come from the left base row.
+    sources: Vec<MergeSource>,
+}
+
+impl MergePlan {
+    /// Resolves the owner of every column for a merge of some left base row with
+    /// `rights`. A later entry of `rights` wins where it is bound, matching
+    /// [`push_merged`](BatchBuilder::push_merged) chained through the slice in
+    /// order.
+    #[must_use]
+    pub fn for_rights(rights: &[Batch]) -> Self {
+        let width = rights.iter().map(Batch::num_columns).max().unwrap_or(0);
+        let sources = (0..width)
+            .map(|id| {
+                let vid = id as u32;
+                rights
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    // The row passed to `is_bound_at` is immaterial (the
+                    // predicate is column-level), so `0` is safe even for an
+                    // empty batch.
+                    .find(|(_, r)| r.is_bound_at(vid, 0))
+                    .map_or(MergeSource::Left, |(i, _)| MergeSource::Right(i as u32))
+            })
+            .collect();
+        Self { sources }
+    }
+
+    /// Number of column slots the right-hand batches cover.
+    #[must_use]
+    pub const fn width(&self) -> usize {
+        self.sources.len()
+    }
+}
+
 /// Builds a columnar [`Batch`] incrementally, one row at a time, transposing
 /// row-shaped bindings into per-variable columns.
 ///
@@ -574,35 +632,40 @@ impl BatchBuilder {
     }
 
     /// N-way [`push_merged`](Self::push_merged): appends one row formed by
-    /// overlaying every `(batch, row)` in `rights` — in slice order, so a later
-    /// entry wins where it is bound — on top of `left[left_row]`.
+    /// overlaying every right-hand batch — `rights[i]` read at row `cursor[i]`,
+    /// in slice order, so a later entry wins where it is bound — on top of
+    /// `left[left_row]`.
     ///
-    /// Equivalent to chaining `push_merged` through intermediate batches, but
-    /// without building them: an N-branch cross product emits its rows one at a
-    /// time from N cursors instead of materializing the intermediate products.
-    pub fn push_merged_many(
+    /// Row-for-row identical to chaining `push_merged` through the rights, but
+    /// without building the intermediate batches, and with the per-column source
+    /// search hoisted out of the row loop into `plan`: an N-branch cross product
+    /// emits its rows straight from N cursors, paying one indexed read per
+    /// output column rather than a scan over every branch.
+    ///
+    /// `plan` must be the [`MergePlan::for_rights`] of this exact `rights`
+    /// slice, and `cursor` must be one in-bounds row index per right batch.
+    pub fn push_planned(
         &mut self,
         left: &Batch,
         left_row: usize,
-        rights: &[(&Batch, usize)],
+        rights: &[Batch],
+        cursor: &[usize],
+        plan: &MergePlan,
         origin: u32,
     ) {
-        self.grow_cols(
-            rights
-                .iter()
-                .map(|(b, _)| b.columns.len())
-                .fold(left.columns.len(), usize::max),
-        );
-        'cols: for (id, col) in self.cols.iter_mut().enumerate() {
-            let vid = id as u32;
-            for &(right, right_row) in rights.iter().rev() {
-                if right.is_bound_at(vid, right_row) {
-                    col.push_bound(right.value_at(vid, right_row).unwrap_or(Value::Null));
-                    continue 'cols;
-                }
+        debug_assert_eq!(cursor.len(), rights.len());
+        self.grow_cols(plan.width().max(left.columns.len()));
+        for (id, col) in self.cols.iter_mut().enumerate() {
+            // `plan` covers only the slots the rights bind; every other slot —
+            // and any slot no right binds — falls back to the left base row.
+            if let Some(&MergeSource::Right(i)) = plan.sources.get(id) {
+                let i = i as usize;
+                // The plan proved this column bound, so it is neither absent nor
+                // `Unbound`: reading it is the `value_at(..).unwrap()` case.
+                col.push_bound(rights[i].column(id as u32).get(cursor[i]));
+            } else {
+                col.push_left_of(left, id, left_row);
             }
-            // No right binds this slot: fall back to the left base row.
-            col.push_left_of(left, id, left_row);
         }
         self.finish_row(origin);
     }

--- a/graph/src/runtime/ops/cartesian_product.rs
+++ b/graph/src/runtime/ops/cartesian_product.rs
@@ -21,15 +21,20 @@
 //!                  └───────────────┘
 //! ```
 //!
-//! With multiple right children, each branch is materialized independently and
-//! the branches are then walked as an odometer: memory is the *sum* of the
-//! branch sizes, never their product, and rows leave the operator
-//! [`BATCH_SIZE`] at a time so timeout and memory-capacity checks get a chance
-//! to fire.
+//! Each right child is materialized independently and the branches are then
+//! walked as an odometer: memory is the *sum* of the branch sizes, never their
+//! product, and rows leave the operator [`BATCH_SIZE`] at a time so timeout and
+//! memory-capacity checks get a chance to fire.
+//!
+//! Which branch supplies which output column is fixed for the operator's whole
+//! life, so it is resolved once into a [`MergePlan`] and a row then costs one
+//! indexed read per column regardless of how many branches there are. That makes
+//! a single right branch the odometer's degenerate case rather than a shape
+//! worth special-casing.
 
 use crate::planner::IR;
 use crate::runtime::{
-    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp},
+    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp, MergePlan},
     runtime::Runtime,
 };
 use orx_tree::{Dyn, NodeIdx};
@@ -40,32 +45,78 @@ pub struct CartesianProductOp<'a> {
     /// Pre-built right branch operators, seeded via set_argument_batch.
     pub(crate) right_children: Vec<BatchOp<'a>>,
     pub(crate) idx: NodeIdx<Dyn<IR>>,
-    /// Lazily materialized right-side rows, one dense batch per right branch.
-    /// `None` means not yet computed.
-    materialized_right: Option<Vec<Batch<'a>>>,
+    /// Lazily materialized right-hand side. `None` means not yet computed.
+    right: Option<RightSide<'a>>,
     /// Current block of left-side rows being cross-joined.
     left_batch: Option<Batch<'a>>,
     /// Current position within `left_batch`.
     left_pos: usize,
-    /// Odometer position within each materialized right branch.
-    right_pos: Vec<usize>,
 }
 
-/// Advances `pos` to the next combination of right-branch rows, rightmost digit
-/// first. Returns `false` once it wraps back to all-zeros, i.e. the current left
-/// row has been cross-joined against every combination.
-fn advance(
-    pos: &mut [usize],
-    rights: &[Batch],
-) -> bool {
-    for (p, branch) in pos.iter_mut().zip(rights).rev() {
-        *p += 1;
-        if *p < branch.len() {
-            return true;
+/// The materialized right-hand side: one dense [`Batch`] per right branch, each
+/// holding that branch's *entire* output rather than one batch of its stream,
+/// together with the odometer cursor over them and the [`MergePlan`] that says
+/// which branch supplies which output column.
+///
+/// The cursor lives here rather than beside the branches in the operator so the
+/// two cannot fall out of step: `cursor.len() == branches.len()` holds by
+/// construction, and stepping it is [`advance`](Self::advance)'s business alone —
+/// no caller does position arithmetic.
+struct RightSide<'a> {
+    /// One dense batch per branch — a whole branch, not a batch of its stream.
+    branches: Vec<Batch<'a>>,
+    /// `cursor[i]` is the current row of `branches[i]`.
+    cursor: Vec<usize>,
+    /// `lens[i] == branches[i].len()`, carried separately so stepping the
+    /// odometer touches two flat `usize` slices and never chases a pointer into
+    /// a [`Batch`] — this is a per-row cost on every shape.
+    lens: Vec<usize>,
+    /// Resolved once at materialization: the branches, and therefore which of
+    /// them binds each column, are fixed for the operator's whole life.
+    plan: MergePlan,
+}
+
+impl<'a> RightSide<'a> {
+    fn new(branches: Vec<Batch<'a>>) -> Self {
+        // Every branch comes out of `Batch::concat`, which drops the selection
+        // vector, so the odometer indexes rows `0..len()` directly instead of
+        // walking `active_indices()`.
+        debug_assert!(branches.iter().all(|b| b.selection().is_none()));
+        Self {
+            plan: MergePlan::for_rights(&branches),
+            cursor: vec![0; branches.len()],
+            lens: branches.iter().map(Batch::len).collect(),
+            branches,
         }
-        *p = 0;
     }
-    false
+
+    /// An empty branch makes the whole cross-product empty.
+    fn is_empty(&self) -> bool {
+        self.branches.iter().any(Batch::is_empty)
+    }
+
+    /// Steps to the next combination of branch rows, rightmost branch fastest —
+    /// the row order the nested per-branch merge produced. Returns `false` once
+    /// the odometer wraps back to all-zeros, i.e. the current left row has been
+    /// cross-joined against every combination.
+    ///
+    /// With no branches at all (a degenerate plan) this reports a wrap
+    /// immediately, so the operator passes its left rows through unchanged.
+    fn advance(&mut self) -> bool {
+        for (pos, &len) in self.cursor.iter_mut().zip(&self.lens).rev() {
+            *pos += 1;
+            if *pos < len {
+                return true;
+            }
+            *pos = 0;
+        }
+        false
+    }
+
+    /// Rewinds the odometer for a fresh block of left rows.
+    fn rewind(&mut self) {
+        self.cursor.fill(0);
+    }
 }
 
 impl<'a> CartesianProductOp<'a> {
@@ -80,10 +131,9 @@ impl<'a> CartesianProductOp<'a> {
             child,
             right_children,
             idx,
-            materialized_right: None,
+            right: None,
             left_batch: None,
             left_pos: 0,
-            right_pos: Vec::new(),
         }
     }
 
@@ -110,57 +160,52 @@ impl<'a> Iterator for CartesianProductOp<'a> {
     type Item = Result<Batch<'a>, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Lazy materialization of right side (runs once).
-        if self.materialized_right.is_none() {
+        // Lazy materialization of right side (runs once). The result is recorded
+        // even when a branch came back empty, so a re-poll after `None`
+        // short-circuits below instead of running every right sub-plan again.
+        if self.right.is_none() {
             match self.materialize_right() {
-                Ok(rights) => {
-                    // An empty branch makes the whole cross-product empty.
-                    if rights.iter().any(Batch::is_empty) {
-                        return None;
-                    }
-                    self.right_pos = vec![0; rights.len()];
-                    self.materialized_right = Some(rights);
-                }
+                Ok(branches) => self.right = Some(RightSide::new(branches)),
                 Err(e) => return Some(Err(e)),
             }
         }
 
-        let rights = self.materialized_right.as_ref().unwrap();
-        let mut cursor: Vec<(&Batch<'a>, usize)> = Vec::with_capacity(rights.len());
+        let right = self.right.as_mut().unwrap();
+        if right.is_empty() {
+            return None;
+        }
+
         let mut builder = BatchBuilder::new();
 
         loop {
-            // Produce cross-product rows from current (left_pos, right_pos).
+            // Produce cross-product rows from the current (left_pos, cursor).
+            // One shape for every branch count: `advance` owns the wrap, so this
+            // loop does no position arithmetic of its own.
+            //
+            // The nesting is what keeps it cheap. Resolving the left batch and
+            // reading its `origin_row` are invariant across every combination of
+            // one left row, so they are hoisted out of the inner loop rather than
+            // repeated per output row — for a 1,000-row branch that is once per
+            // 1,000 rows instead of a million times.
             let left_len = self.left_batch.as_ref().map_or(0, Batch::len);
-            if let [right] = rights.as_slice() {
-                // Single branch — the overwhelmingly common shape. One cursor
-                // means no odometer: scan the branch's rows in a tight loop with
-                // the position held in a local.
-                let right_len = right.len();
-                let mut pos = self.right_pos[0];
-                while builder.len() < BATCH_SIZE && self.left_pos < left_len {
-                    let left = self.left_batch.as_ref().unwrap();
-                    let origin = left.origin_row(self.left_pos);
-                    while builder.len() < BATCH_SIZE && pos < right_len {
-                        builder.push_merged(left, self.left_pos, right, pos, origin);
-                        pos += 1;
-                    }
-                    if pos >= right_len {
-                        self.left_pos += 1;
-                        pos = 0;
-                    }
-                }
-                self.right_pos[0] = pos;
-            } else {
-                while builder.len() < BATCH_SIZE && self.left_pos < left_len {
-                    let left = self.left_batch.as_ref().unwrap();
-                    let origin = left.origin_row(self.left_pos);
-                    cursor.clear();
-                    cursor.extend(rights.iter().zip(self.right_pos.iter().copied()));
-                    builder.push_merged_many(left, self.left_pos, &cursor, origin);
-                    if !advance(&mut self.right_pos, rights) {
+            while builder.len() < BATCH_SIZE && self.left_pos < left_len {
+                let left = self.left_batch.as_ref().unwrap();
+                let origin = left.origin_row(self.left_pos);
+                // Emit this left row against every combination, or until the
+                // batch fills — in which case the cursor holds where to resume.
+                while builder.len() < BATCH_SIZE {
+                    builder.push_planned(
+                        left,
+                        self.left_pos,
+                        &right.branches,
+                        &right.cursor,
+                        &right.plan,
+                        origin,
+                    );
+                    if !right.advance() {
                         // Odometer wrapped: this left row is fully cross-joined.
                         self.left_pos += 1;
+                        break;
                     }
                 }
             }
@@ -173,7 +218,7 @@ impl<'a> Iterator for CartesianProductOp<'a> {
             // Current left block exhausted. Load next batch from left child.
             self.left_batch = None;
             self.left_pos = 0;
-            self.right_pos.fill(0);
+            right.rewind();
 
             match self.child.next() {
                 Some(Ok(batch)) => {
@@ -188,5 +233,192 @@ impl<'a> Iterator for CartesianProductOp<'a> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RightSide;
+    use crate::runtime::batch::{Batch, BatchBuilder, Column, MergePlan};
+
+    /// A dense batch binding each `(var_id, values)` pair as an `Int` column.
+    fn batch(cols: &[(u32, &[i64])]) -> Batch<'static> {
+        let mut b = Batch::new(0);
+        for (id, vals) in cols {
+            b.set_column(*id, Column::Ints(vals.to_vec()));
+        }
+        b
+    }
+
+    /// Asserts two batches agree row-for-row on every column's value *and* its
+    /// bound bit — `Value` has no `PartialEq`, so values compare via `Debug`.
+    fn assert_same(
+        expected: &Batch,
+        actual: &Batch,
+    ) {
+        assert_eq!(expected.len(), actual.len(), "row count");
+        let width = expected.num_columns().max(actual.num_columns()) as u32;
+        for row in 0..expected.len() {
+            assert_eq!(
+                expected.origin_row(row),
+                actual.origin_row(row),
+                "origin_row at row {row}"
+            );
+            for id in 0..width {
+                assert_eq!(
+                    expected.is_bound_at(id, row),
+                    actual.is_bound_at(id, row),
+                    "bound bit of col {id} at row {row}"
+                );
+                assert_eq!(
+                    format!("{:?}", expected.value_at(id, row)),
+                    format!("{:?}", actual.value_at(id, row)),
+                    "value of col {id} at row {row}"
+                );
+            }
+        }
+    }
+
+    /// The odometer + [`MergePlan`] must produce byte-for-byte what the original
+    /// implementation did: cross-multiply the branches into one flat batch by
+    /// chaining `push_merged`, then join that against the left rows. Covers a
+    /// slot only the left binds (0), a slot two branches bind so the later one
+    /// must win (1), slots single branches bind (2, 3), and a slot nobody binds
+    /// (4).
+    #[test]
+    fn push_planned_matches_chained_push_merged() {
+        let left = {
+            let mut b = batch(&[(0, &[10, 20])]);
+            b.set_column(4, Column::Unbound);
+            b
+        };
+        let branches = vec![
+            batch(&[(1, &[1, 2, 3])]),
+            batch(&[(1, &[7, 8]), (2, &[70, 80])]),
+            batch(&[(3, &[100])]),
+        ];
+
+        // Reference: the deleted algorithm, verbatim.
+        let mut accumulated = branches[0].clone();
+        for branch in &branches[1..] {
+            let mut builder = BatchBuilder::new();
+            for l in accumulated.active_indices() {
+                let origin = accumulated.origin_row(l);
+                for r in branch.active_indices() {
+                    builder.push_merged(&accumulated, l, branch, r, origin);
+                }
+            }
+            accumulated = builder.finish();
+        }
+        let mut expected = BatchBuilder::new();
+        for l in left.active_indices() {
+            let origin = left.origin_row(l);
+            for r in accumulated.active_indices() {
+                expected.push_merged(&left, l, &accumulated, r, origin);
+            }
+        }
+        let expected = expected.finish();
+
+        // Under test: stream the branches as an odometer.
+        let mut right = RightSide::new(branches);
+        let mut actual = BatchBuilder::new();
+        for l in 0..left.len() {
+            let origin = left.origin_row(l);
+            loop {
+                actual.push_planned(
+                    &left,
+                    l,
+                    &right.branches,
+                    &right.cursor,
+                    &right.plan,
+                    origin,
+                );
+                if !right.advance() {
+                    break;
+                }
+            }
+        }
+        let actual = actual.finish();
+
+        assert_eq!(expected.len(), 2 * 3 * 2 * 1, "2 left rows x 3 x 2 x 1");
+        assert_same(&expected, &actual);
+    }
+
+    /// The odometer steps its rightmost branch fastest and reports the wrap only
+    /// after every combination has been visited exactly once.
+    #[test]
+    fn odometer_visits_every_combination_rightmost_first() {
+        let mut right = RightSide::new(vec![batch(&[(0, &[0, 1, 2])]), batch(&[(1, &[0, 1])])]);
+        let mut seen = vec![right.cursor.clone()];
+        while right.advance() {
+            seen.push(right.cursor.clone());
+        }
+        assert_eq!(
+            seen,
+            vec![
+                vec![0, 0],
+                vec![0, 1],
+                vec![1, 0],
+                vec![1, 1],
+                vec![2, 0],
+                vec![2, 1]
+            ]
+        );
+        // The wrap left the cursor rewound, ready for the next left row.
+        assert_eq!(right.cursor, vec![0, 0]);
+    }
+
+    /// One branch is the odometer's degenerate case, not a special case: it
+    /// advances until its rows run out, then wraps.
+    #[test]
+    fn odometer_with_one_branch_counts_its_rows() {
+        let mut right = RightSide::new(vec![batch(&[(0, &[5, 6, 7])])]);
+        let mut visited = 1;
+        while right.advance() {
+            visited += 1;
+        }
+        assert_eq!(visited, 3);
+        assert_eq!(right.cursor, vec![0]);
+    }
+
+    /// An empty branch makes the whole product empty, whichever branch it is.
+    #[test]
+    fn any_empty_branch_makes_the_product_empty() {
+        let empty = Batch::new(0);
+        assert!(RightSide::new(vec![batch(&[(0, &[1])]), empty.clone()]).is_empty());
+        assert!(RightSide::new(vec![empty, batch(&[(0, &[1])])]).is_empty());
+        assert!(!RightSide::new(vec![batch(&[(0, &[1])])]).is_empty());
+    }
+
+    /// A degenerate plan with no right branches at all wraps immediately, so the
+    /// operator emits each left row once instead of panicking.
+    #[test]
+    fn odometer_with_no_branches_wraps_immediately() {
+        let mut right = RightSide::new(Vec::new());
+        assert!(!right.is_empty());
+        assert!(!right.advance());
+
+        let left = batch(&[(0, &[10, 20])]);
+        let mut out = BatchBuilder::new();
+        for l in 0..left.len() {
+            out.push_planned(&left, l, &right.branches, &right.cursor, &right.plan, 0);
+        }
+        assert_same(&left, &out.finish());
+    }
+
+    /// `MergePlan` resolves the owner of every column once; a later branch wins
+    /// where two bind the same slot.
+    #[test]
+    fn merge_plan_lets_the_later_branch_win() {
+        let left = batch(&[(0, &[10])]);
+        let branches = vec![batch(&[(1, &[1])]), batch(&[(1, &[2])])];
+        let plan = MergePlan::for_rights(&branches);
+        assert_eq!(plan.width(), 2);
+
+        let mut out = BatchBuilder::new();
+        out.push_planned(&left, 0, &branches, &[0, 0], &plan, 0);
+        let out = out.finish();
+        assert_eq!(format!("{:?}", out.value_at(0, 0)), "Some(Int(10))");
+        assert_eq!(format!("{:?}", out.value_at(1, 0)), "Some(Int(2))");
     }
 }

--- a/tests/flow/test_multi_pattern.py
+++ b/tests/flow/test_multi_pattern.py
@@ -123,7 +123,10 @@ class testGraphMultiPatternQueryFlow(FlowTestsBase):
         # materializing the branches took over two minutes.
         self.env.assertLess(time.time() - start, 10)
 
-        # Nor may LIMIT pay for the whole product before emitting a row.
+        # Nor may LIMIT pay for the product before emitting a row. Each branch is
+        # still materialized in full (3 x 1001 rows), but only the combinations
+        # actually consumed are ever merged, so one row costs one merge instead
+        # of 1001^3 of them.
         start = time.time()
         res = g.query(q + " LIMIT 1")
         self.env.assertEqual(len(res.result_set), 1)


### PR DESCRIPTION
Stacked on #2365 — base is `fix/cartesian-product-stream-branches`, so this diff shows only what changes on top of it. Review or merge #2365 first.

#2365 fixed the real bug (a 4-way product materialized 10⁹ rows inside one `next()` call, honoring neither the deadline nor the memory cap). It noted one cost: the multi-branch shape ended up 2.8% dearer per row than reading a pre-flattened batch. That residue is two loop-invariant computations left inside the row loop. Removing them makes multi-branch products **22–26% cheaper in instructions** than before #2365, not 2.8% dearer.

## Counter diff

`bench/` instructions, three reps a side, reproducible to 0.1%. Base is 59a278bf (#2365 tip).

```
                       rows   ────────── instructions ──────────   per row   cycles
  cartesian 1 branch     1M    312,065,818 →   314,162,700  1.01     +2.1     0.96
  cartesian 2 branches   1M    529,856,325 →   411,558,708  0.78    -118.3    0.70
  cartesian 3 branches   2M  1,384,175,860 → 1,029,818,281  0.74    -177.2    0.69
```

`bench compare` reports no regressions. Cycles are shown for direction only — instructions are the deterministic signal here; the single-branch row is +0.7% instructions against ~4% fewer cycles and flat wall-clock.

## What changed

**1. The per-column owner map (`MergePlan`).** `push_merged_many` asked, for every output row and every column, which right branch binds that column. The answer cannot differ between rows — `Batch::is_bound_at` discards its `row` argument (`batch.rs:1202` is literally `let _ = row;`) and so does the `value_only` flag it consults, because both are properties of a column. A 4-way product paid up to 12 `is_bound_at` calls per row, plus a rebuilt `Vec<(&Batch, usize)>` cursor, to recompute a constant.

`MergePlan::for_rights` resolves it once into a `Vec<MergeSource>` indexed by variable id, so `push_planned` does one indexed read per column:

```
                     column / variable id
                 ┌─────┬─────┬─────┬─────┐
                 │  0  │  1  │  2  │  3  │
  left           │ ███ │  ·  │  ·  │  ·  │
  branch 0       │  ·  │ ███ │  ·  │  ·  │
  branch 1       │  ·  │  ·  │ ███ │  ·  │
  branch 2       │  ·  │  ·  │  ·  │ ███ │
                 └─────┴─────┴─────┴─────┘
  sources    =    Left  R(0)  R(1)  R(2)      built once, read per row
```

This is a hoist, not a cache: the branches are materialized once and never replaced, so nothing can make the plan stale and there is no invalidation logic. That is also why the plan lives inside `RightSide`, beside the branches it was derived from, and why `for_rights` deliberately ignores the left batch — left batches keep arriving as the left child streams, and if `width` depended on them the plan could no longer be built once.

**2. The nested emit loop.** Resolving `self.left_batch` and reading its `origin_row` are invariant across every combination of a single left row, but the flattened loop redid both per output row. The emit loop nests again, so for a 1,000-row branch that work happens once per 1,000 rows instead of a million times.

**3. `RightSide`.** The branches and their odometer were two parallel `Vec`s whose lengths the operator maintained by hand (`vec![0; rights.len()]`, `right_pos.fill(0)`, `self.right_pos[0]`). They are now one struct where `cursor.len() == branches.len()` holds by construction and stepping the cursor is `advance`'s business alone. Branch lengths are copied into a flat `lens` vector so stepping never chases a pointer into a `Batch`, and `RightSide::new` asserts the invariant the row indexing silently relied on — branches are dense, because `Batch::concat` drops the selection vector, which is what makes `0..len()` safe instead of `active_indices()`.

**4. The single-branch fast path is deleted.** With the per-column search gone it no longer earns its keep (+0.7% instructions, −4% cycles), and one branch becomes the odometer's degenerate case. That removes the duplicated `if pos >= right_len { self.left_pos += 1; pos = 0 }` bookkeeping, which shadowed what `advance` already did.

## How (2) was found

Worth recording, because both obvious explanations for the single-branch delta are wrong and each candidate fix measured *worse*. callgrind cannot run on arm64-macOS, so attribution came from ablation, which the harness's 0.1%-reproducible counters make viable — 1-branch query, 1M rows:

```
  base (#2365, with its fast path)                          312.1M    —
  ablation: route k=1 through the old push_merged           321.9M  +3.1%
  ablation: inline the single-digit odometer, no advance()  324.8M  +4.1%
  plan + lens, flat emit loop                               318.9M  +2.2%
  plan + lens + nested emit loop  (this PR)                 314.2M  +0.7%
```

So `push_planned`'s indexed read beats `is_bound_at` plus a second `column()` lookup even with a single branch to search, and `advance()` was never the cost either. The nesting was, worth 4.6 of the 6.8 instructions per row — and being general it improved the multi-branch shapes too, rather than special-casing one. About 2.2 instructions per row remain unattributed.

## Two fixes fall out

- Materialization is recorded *before* the empty-branch bail-out, so a re-poll after `None` short-circuits instead of re-running every right sub-plan.
- A plan with no right branches passes its left rows through instead of indexing a `rights[0]` that isn't there.

## Benchmark coverage

The three `cartesian *` queries are new. **No query in the 317-row set reached this operator with more than one row a side** — every other multi-component `MATCH (a), (b)` is an id-seek pair or the `hash join` row, which is the `ValueHashJoin` rewrite of exactly this shape. A regression in the product itself was invisible to the harness, which is plausibly how the 10⁹-row materialization shipped. They are sized by row *product* rather than node count, take a different label per branch so every output column has a distinct owner, and cap `reps` for the same reason the sized writes cap theirs. `cg=False`: `CG_SETUP` has none of those labels, so under callgrind they would silently measure empty scans.

## Testing

- 6 new Rust unit tests, including a differential one: a 3-branch product with an overlapping column is built both by the odometer and by the deleted chain-`push_merged`-through-intermediate-batches algorithm, and the two must agree row-for-row on every value *and* bound bit. Precedence (later branch wins) is pinned separately.
- `cargo test -p graph --lib`: 114 pass. `bench/tests/test_queries.py`: 13 pass.
- Flow `test_multi_pattern`: 7/7. TCK: pass. MVCC + concurrency: 14 pass. e2e/functions: 121 pass, 1 unrelated failure (`test_graph_list` asserts a server with zero other graphs; passes in isolation).
- Full flow suite: 20 failures, a strict subset of the 28 the base module fails on this machine — all concurrency/stress/asyncio flakes, none new.
- `cargo fmt --all -- --check` clean; clippy adds no warnings.

## Not done

Each branch is still materialized in full before the first row leaves, so `MATCH (a), (b) ... LIMIT 1` scans all of `b` where C streams it. Lazily spooling the branches would need either O(N²) incremental `Batch::concat` or a two-level `(batch, row)` cursor per branch — reintroducing the parallel-position bookkeeping this PR removes, one level deeper — plus genuine `MergePlan` invalidation, since the plan would then be derived from batches that get replaced mid-flight. The spool is retained regardless (the left side streams, so branches must be replayed), so only true early-exit benefits. The flow test's LIMIT comment is corrected here to claim only what it checks.
