### PR TITLE
feat(index): serve `IN [...]` natively as a union of point lookups

### DIFF
--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -535,18 +535,48 @@ impl FalkorDbIndex {
         label: &Arc<String>,
         query: &IndexQuery<Value>,
     ) -> Option<DocIter> {
-        let (key, numeric) = match query {
+        let (key, servable) = match query {
             IndexQuery::Equal { key, value } => (key, encode_numeric(value).is_some()),
             IndexQuery::Range { key, min, max, .. } => (
                 key,
                 min.as_ref().is_none_or(|v| encode_numeric(v).is_some())
                     && max.as_ref().is_none_or(|v| encode_numeric(v).is_some()),
             ),
-            // And / Or / Point (geo) / InList / ArrayContains → not a numeric leaf.
+            // A union of `Equal`s — what `n.a IN [...]` becomes before it reaches the index.
+            // Every member must target this same attribute and encode numerically; a mixed or
+            // empty list is declined whole, because answering with only the numeric members
+            // would drop rows another kind still holds. `NumericIndex::union` re-checks the
+            // encodability, so this only has to agree on the key.
+            IndexQuery::Or(children) if !children.is_empty() => {
+                // Flatten nested unions: `a IN [..] OR a IN [..]` arrives as an `Or` of `Or`s.
+                fn keys_of<'a>(
+                    children: &'a [IndexQuery<Value>],
+                    out: &mut Vec<&'a Arc<String>>,
+                ) -> bool {
+                    children.iter().all(|c| match c {
+                        IndexQuery::Equal { key, .. } => {
+                            out.push(key);
+                            true
+                        }
+                        IndexQuery::Or(nested) => !nested.is_empty() && keys_of(nested, out),
+                        _ => false,
+                    })
+                }
+                let mut member_keys = Vec::new();
+                if !keys_of(children, &mut member_keys) || member_keys.is_empty() {
+                    return None;
+                }
+                let first_key = member_keys[0];
+                let same_key = member_keys.iter().all(|k| *k == first_key);
+                (first_key, same_key)
+            }
+            // And / Point (geo) / InList / ArrayContains → not a numeric leaf.
             _ => return None,
         };
-        if !numeric {
-            return None; // string / geo on a Range index — RediSearch owns those entries
+        if !servable {
+            // A string/geo leaf on a Range index (RediSearch owns those entries), or a union
+            // whose members do not all target this attribute.
+            return None;
         }
         let entry = self.columns(entity).get(&(label.clone(), key.clone()))?;
         if !matches!(entry.state, ColumnState::Ready) {

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -25,7 +25,33 @@ const DOC_BYTES: usize = 8;
 type Tree = CowBTree<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
 
 /// Lazy iterator of matching entity ids, yielded in `(value, id)` order.
-pub type DocIter = RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
+type TreeIter = RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
+
+/// Lazy iterator of matching entity ids.
+///
+/// `One` is a single cursor over a contiguous key range. `Many` chains several — the shape an
+/// `IN [...]` union takes, one cursor per distinct member. An enum rather than a boxed trait
+/// object because the scan op already boxes the result once; a second layer of dynamic dispatch
+/// per id would be pure overhead.
+///
+/// The chain is *not* merged into id order. Order is deliberately unspecified here: Cypher
+/// guarantees none without `ORDER BY`, and a merge would cost a comparison per id and force every
+/// branch to stay live. Nothing downstream may assume sortedness.
+pub enum DocIter {
+    One(TreeIter),
+    Many(std::iter::Flatten<std::vec::IntoIter<TreeIter>>),
+}
+
+impl Iterator for DocIter {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<u64> {
+        match self {
+            Self::One(it) => it.next(),
+            Self::Many(it) => it.next(),
+        }
+    }
+}
 
 /// A numeric property index over one `(label, attribute)`: entity ids keyed by
 /// the order-preserving encoding of their value, so `n.x <predicate> v` is a
@@ -180,7 +206,7 @@ impl NumericIndex {
         value: &Value,
     ) -> DocIter {
         match encode_numeric(value) {
-            Some(k) => self.tree.point(k),
+            Some(k) => DocIter::One(self.tree.point(k)),
             None => self.empty(),
         }
     }
@@ -235,7 +261,7 @@ impl NumericIndex {
         if lo > hi {
             return self.empty();
         }
-        self.tree.range(lo, hi)
+        DocIter::One(self.tree.range(lo, hi))
     }
 
     /// Dispatch the numeric *leaf* predicates. `Equal` → [`point`](Self::point),
@@ -255,13 +281,53 @@ impl NumericIndex {
                 include_max,
                 ..
             } => Some(self.range(min.as_ref(), max.as_ref(), *include_min, *include_max)),
+            IndexQuery::Or(children) => self.union(children),
             _ => None,
         }
     }
 
+    /// A union of `Equal` leaves — what `n.a IN [...]` desugars to before it reaches the index.
+    ///
+    /// Returns `None` unless **every** member encodes to a numeric key. Serving only the numeric
+    /// subset would silently drop rows: a member the numeric column cannot represent (a string,
+    /// say) may still match entities held by another kind, and answering without them is a wrong
+    /// answer rather than a slower one. Declining hands the whole query back to the caller intact.
+    ///
+    /// Members are deduplicated by encoded key, so `IN [1,1,2]` yields each entity once. That is
+    /// sufficient for uniqueness overall: a doc appears under one key per column (the encoder
+    /// rejects lists, so an array-valued property is not in this column at all), so distinct keys
+    /// cannot both hold the same doc.
+    fn union(
+        &self,
+        children: &[IndexQuery<Value>],
+    ) -> Option<DocIter> {
+        // Flatten nested unions. `a IN [..] OR a IN [..]` arrives as an `Or` of `Or`s, and each
+        // level is still a union of the same column, so the nesting carries no meaning here.
+        fn collect(
+            children: &[IndexQuery<Value>],
+            keys: &mut Vec<u64>,
+        ) -> Option<()> {
+            for child in children {
+                match child {
+                    IndexQuery::Equal { value, .. } => keys.push(encode_numeric(value)?),
+                    IndexQuery::Or(nested) => collect(nested, keys)?,
+                    // A range or other combinator inside the union — not this shape.
+                    _ => return None,
+                }
+            }
+            Some(())
+        }
+        let mut keys = Vec::with_capacity(children.len());
+        collect(children, &mut keys)?;
+        keys.sort_unstable();
+        keys.dedup();
+        let cursors: Vec<TreeIter> = keys.into_iter().map(|k| self.tree.point(k)).collect();
+        Some(DocIter::Many(cursors.into_iter().flatten()))
+    }
+
     /// An iterator over no entries (`lo > hi` yields nothing).
     fn empty(&self) -> DocIter {
-        self.tree.range(1, 0)
+        DocIter::One(self.tree.range(1, 0))
     }
 }
 
@@ -444,5 +510,91 @@ mod tests {
             singly.remove(v, *id);
         }
         assert_eq!(all(&batched), all(&singly));
+    }
+
+    /// `IN [...]` reaches the index as a union of `Equal`s. It is served natively only when every
+    /// member is numeric — a mixed list must be declined whole, not answered from the numeric
+    /// members alone, or rows another kind holds would silently vanish.
+    #[test]
+    fn union_serves_all_numeric_and_declines_mixed() {
+        let attr = Arc::new("v".to_string());
+        let eq = |v: Value| IndexQuery::Equal {
+            key: attr.clone(),
+            value: v,
+        };
+        let idx = NumericIndex::from_entries(
+            [
+                (&Value::Int(10), 0u64),
+                (&Value::Int(20), 1),
+                (&Value::Int(30), 2),
+            ]
+            .into_iter(),
+        );
+
+        // all-numeric union -> every matching id, once each
+        let mut got = ids(idx
+            .query(&IndexQuery::Or(vec![
+                eq(Value::Int(10)),
+                eq(Value::Int(30)),
+            ]))
+            .expect("all-numeric union is servable"));
+        got.sort_unstable();
+        assert_eq!(got, vec![0, 2]);
+
+        // duplicate members must not yield an id twice
+        let mut dup = ids(idx
+            .query(&IndexQuery::Or(vec![
+                eq(Value::Int(20)),
+                eq(Value::Int(20)),
+            ]))
+            .expect("servable"));
+        dup.sort_unstable();
+        assert_eq!(dup, vec![1], "duplicate members must dedup");
+
+        // a non-numeric member declines the WHOLE union — not "just the numeric part"
+        assert!(
+            idx.query(&IndexQuery::Or(vec![
+                eq(Value::Int(10)),
+                eq(Value::String(Arc::new("a".to_string()))),
+            ]))
+            .is_none(),
+            "a mixed list must fall back rather than drop the non-numeric member"
+        );
+
+        // `a IN [..] OR a IN [..]` reaches the index as an Or of Ors — the nesting carries no
+        // meaning for a single column, so it must flatten rather than decline.
+        let mut nested = ids(idx
+            .query(&IndexQuery::Or(vec![
+                IndexQuery::Or(vec![eq(Value::Int(10)), eq(Value::Int(20))]),
+                IndexQuery::Or(vec![eq(Value::Int(30))]),
+            ]))
+            .expect("nested unions flatten"));
+        nested.sort_unstable();
+        assert_eq!(nested, vec![0, 1, 2]);
+
+        // a non-numeric member nested one level down still declines the whole union
+        assert!(
+            idx.query(&IndexQuery::Or(vec![
+                eq(Value::Int(10)),
+                IndexQuery::Or(vec![eq(Value::String(Arc::new("a".to_string())))]),
+            ]))
+            .is_none(),
+            "a nested non-numeric member must decline the whole union"
+        );
+
+        // a member that is not a plain Equal (a nested range) is likewise declined
+        assert!(
+            idx.query(&IndexQuery::Or(vec![
+                eq(Value::Int(10)),
+                IndexQuery::Range {
+                    key: attr.clone(),
+                    min: Some(Value::Int(0)),
+                    max: None,
+                    include_min: true,
+                    include_max: true,
+                },
+            ]))
+            .is_none()
+        );
     }
 }

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -7,6 +7,8 @@
 //! copy-on-write, so readers never see a torn write. Folding the root into the
 //! graph's committed version is P3.
 
+use std::sync::Arc;
+
 use super::data_structures::cow_btree::{CowBTree, RangeIter};
 use super::encode::encode_numeric;
 use crate::index::IndexQuery;
@@ -39,7 +41,7 @@ type TreeIter = RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
 /// branch to stay live. Nothing downstream may assume sortedness.
 pub enum DocIter {
     One(TreeIter),
-    Many(std::iter::Flatten<std::vec::IntoIter<TreeIter>>),
+    Many(UnionIter),
 }
 
 impl Iterator for DocIter {
@@ -49,6 +51,39 @@ impl Iterator for DocIter {
         match self {
             Self::One(it) => it.next(),
             Self::Many(it) => it.next(),
+        }
+    }
+}
+
+/// The cursor chain behind a union: the keys still to visit, and a cursor over the current one.
+///
+/// **One cursor exists at a time, and none until the first `next()`.** `RangeIter::new` performs a
+/// full root-to-leaf descent in its constructor, so building a cursor per member up front made
+/// `IN $list` with 100k members do 100k descents — and hold 100k live snapshots — before yielding
+/// a single row. Under a `LIMIT`, almost all of that work is thrown away.
+///
+/// The tree is **owned**, not borrowed. That is load-bearing rather than a lifetime convenience:
+/// the eager version happened to share one root because every `point()` call sat inside a single
+/// `&self` borrow. Deferring those calls past the borrow means the snapshot has to be pinned here,
+/// or a member visited after a concurrent write would descend into a newer root and the union
+/// would be a torn read. The clone is an `O(1)` root-`Arc` bump.
+pub struct UnionIter {
+    tree: Tree,
+    keys: std::vec::IntoIter<u64>,
+    current: Option<TreeIter>,
+}
+
+impl Iterator for UnionIter {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<u64> {
+        loop {
+            if let Some(doc) = self.current.as_mut().and_then(Iterator::next) {
+                return Some(doc);
+            }
+            // Current member exhausted (or not started): descend for the next one. Keys are
+            // distinct, so this advances — it cannot spin.
+            self.current = Some(self.tree.point(self.keys.next()?));
         }
     }
 }
@@ -293,6 +328,13 @@ impl NumericIndex {
     /// say) may still match entities held by another kind, and answering without them is a wrong
     /// answer rather than a slower one. Declining hands the whole query back to the caller intact.
     ///
+    /// Also returns `None` unless every member targets the **same attribute**. This index is one
+    /// column: answering `a = 1 OR b = 2` from it would look up both `1` and `2` in `a` and return
+    /// `{a=1} ∪ {a=2}` — wrong rows, not missing ones. The facade checks this too before routing
+    /// here, but the check belongs on this side of the boundary as well: it is a precondition of
+    /// the operation, not of one caller, and it was previously possible to reach `union` directly
+    /// and bypass it.
+    ///
     /// Members are deduplicated by encoded key, so `IN [1,1,2]` yields each entity once. That is
     /// sufficient for uniqueness overall: a doc appears under one key per column (the encoder
     /// rejects lists, so an array-valued property is not in this column at all), so distinct keys
@@ -303,14 +345,22 @@ impl NumericIndex {
     ) -> Option<DocIter> {
         // Flatten nested unions. `a IN [..] OR a IN [..]` arrives as an `Or` of `Or`s, and each
         // level is still a union of the same column, so the nesting carries no meaning here.
-        fn collect(
-            children: &[IndexQuery<Value>],
+        fn collect<'a>(
+            children: &'a [IndexQuery<Value>],
             keys: &mut Vec<u64>,
+            attr: &mut Option<&'a Arc<String>>,
         ) -> Option<()> {
             for child in children {
                 match child {
-                    IndexQuery::Equal { value, .. } => keys.push(encode_numeric(value)?),
-                    IndexQuery::Or(nested) => collect(nested, keys)?,
+                    IndexQuery::Equal { key, value } => {
+                        match attr {
+                            Some(first) if *first != key => return None,
+                            Some(_) => {}
+                            None => *attr = Some(key),
+                        }
+                        keys.push(encode_numeric(value)?);
+                    }
+                    IndexQuery::Or(nested) => collect(nested, keys, attr)?,
                     // A range or other combinator inside the union — not this shape.
                     _ => return None,
                 }
@@ -318,11 +368,16 @@ impl NumericIndex {
             Some(())
         }
         let mut keys = Vec::with_capacity(children.len());
-        collect(children, &mut keys)?;
+        collect(children, &mut keys, &mut None)?;
         keys.sort_unstable();
         keys.dedup();
-        let cursors: Vec<TreeIter> = keys.into_iter().map(|k| self.tree.point(k)).collect();
-        Some(DocIter::Many(cursors.into_iter().flatten()))
+        // No cursor is built here — see [`UnionIter`]. The tree snapshot is taken now, so every
+        // member is answered from the same version however late its cursor is created.
+        Some(DocIter::Many(UnionIter {
+            tree: self.tree.clone(),
+            keys: keys.into_iter(),
+            current: None,
+        }))
     }
 
     /// An iterator over no entries (`lo > hi` yields nothing).
@@ -595,6 +650,99 @@ mod tests {
                 },
             ]))
             .is_none()
+        );
+    }
+
+    /// One `NumericIndex` is one column, so a union spanning two attributes cannot be answered
+    /// here: looking both values up in this column returns `{a=1} ∪ {a=2}` — wrong rows, not
+    /// missing ones. The facade declines this before routing, but the guard has to hold on this
+    /// side too, and this test reaches `query` directly the way a future caller would.
+    #[test]
+    fn union_declines_members_targeting_different_attributes() {
+        let idx =
+            NumericIndex::from_entries([(&Value::Int(1), 10u64), (&Value::Int(2), 20)].into_iter());
+        let eq = |attr: &str, v: i64| IndexQuery::Equal {
+            key: Arc::new(attr.to_string()),
+            value: Value::Int(v),
+        };
+
+        assert!(
+            idx.query(&IndexQuery::Or(vec![eq("a", 1), eq("b", 2)]))
+                .is_none(),
+            "a cross-attribute union must be declined, not answered from one column"
+        );
+        // Nested the same way `a IN [..] OR b IN [..]` arrives.
+        assert!(
+            idx.query(&IndexQuery::Or(vec![
+                IndexQuery::Or(vec![eq("a", 1)]),
+                IndexQuery::Or(vec![eq("b", 2)]),
+            ]))
+            .is_none(),
+            "nesting must not smuggle a second attribute past the check"
+        );
+        // The same-attribute case still works.
+        let mut same = ids(idx
+            .query(&IndexQuery::Or(vec![eq("a", 1), eq("a", 2)]))
+            .expect("one attribute is servable"));
+        same.sort_unstable();
+        assert_eq!(same, vec![10, 20]);
+    }
+
+    /// A union must not descend for a member until it is reached. Building every cursor up front
+    /// makes `IN $list` pay one root-to-leaf descent per member — 100k of them, plus 100k live
+    /// snapshots — before the first row, which a `LIMIT` then throws away.
+    #[test]
+    fn union_builds_no_cursor_before_the_first_row() {
+        let attr = Arc::new("v".to_string());
+        let eq = |v: i64| IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+        let values: Vec<(Value, u64)> = (0..100u64).map(|i| (Value::Int(i as i64), i)).collect();
+        let idx = NumericIndex::from_entries(values.iter().map(|(v, id)| (v, *id)));
+
+        let q = IndexQuery::Or((0..100).map(eq).collect());
+        let DocIter::Many(mut u) = idx.query(&q).expect("all-numeric union is servable") else {
+            panic!("a union must produce DocIter::Many");
+        };
+        assert!(
+            u.current.is_none(),
+            "no cursor may exist before the first next()"
+        );
+        assert_eq!(u.keys.len(), 100, "and every member is still pending");
+
+        assert_eq!(u.next(), Some(0));
+        assert!(u.current.is_some(), "the first row descends for its member");
+        assert_eq!(u.keys.len(), 99, "exactly one member consumed");
+    }
+
+    /// Deferring the descents means later members are visited after the caller has moved on, so
+    /// the iterator has to pin the snapshot itself. Otherwise a write landing mid-scan would be
+    /// half-visible: invisible to members already started, visible to the rest.
+    #[test]
+    fn union_pins_one_snapshot_across_lazily_built_cursors() {
+        let attr = Arc::new("v".to_string());
+        let eq = |v: i64| IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(1), 1);
+        idx.add(&Value::Int(2), 2);
+
+        let mut it = idx
+            .query(&IndexQuery::Or(vec![eq(1), eq(2)]))
+            .expect("servable");
+        assert_eq!(it.next(), Some(1), "first member started");
+
+        // A write between the first member and the second — whose cursor does not exist yet.
+        idx.add(&Value::Int(2), 99);
+
+        let rest: Vec<u64> = it.collect();
+        assert_eq!(
+            rest,
+            vec![2],
+            "the second member must be answered from the snapshot the union started on"
         );
     }
 }


### PR DESCRIPTION
Closes #2381

**Based on #2351** — review that first; the diff here is only
this layer.

## What it does

`n.a IN [...]` reaches the index as `Or(Equal, ..)` — the scan ops desugar it before the index
sees it — and `query_numeric` declined every `Or`, so the whole shape fell through to RediSearch.
It is now served natively.

The union is a **lazy chain of point cursors** over the deduplicated member keys, not a merge.
Merging would only buy id-ordered output, and nothing requires that: Cypher guarantees no order
without `ORDER BY`, and I checked that the scan ops, the index bridge and the optimizer make no
sortedness assumption. Chaining is O(1) per result, allocates no heap, and stays droppable
mid-scan, so a `LIMIT` still exits early. Nested unions flatten — `a IN [..] OR a IN [..]` arrives
as an `Or` of `Or`s and the nesting means nothing for a single column.

Deduplicating member keys is sufficient for each entity to appear once: a doc is indexed under one
key per column (the encoder rejects lists, so an array-valued property is not in the numeric
column at all), so two distinct keys cannot hold the same doc.

`DocIter` becomes an enum — one cursor, or a chain — rather than a boxed trait object, because the
scan op already boxes the result once and a second layer of dynamic dispatch per id would be pure
overhead.

## The semantics decision, taken from the C core

A member the numeric column cannot represent declines the **whole** union rather than serving the
numeric subset. A string member may still match entities another kind holds, and answering without
them is a wrong answer, not a slower one.

That is what C does. Verified against `falkordb-server:edge-c` with nodes `v ∈ {1,2,3,4}` plus one
node with `v = [1,2]`:

| query | C plan | C result |
|---|---|---|
| `IN [1,2,3]` | Index Scan | 1, 2, 3 |
| `IN [3,'a']` | Index Scan | 3 |
| `IN [[1,2],3]` | **Filter + Label Scan** | `[1,2]`, 3 |

A scalar of the wrong type still uses the index and matches nothing; a *non-scalar* member makes C
abandon the index entirely.

## Verification

Six index flow suites, run with the RediSearch fallback disabled so nothing can pass by falling
through: **14 failures before, 10 after** — the five `IN` entries, node and edge.

In the shipped configuration (fallback intact) nothing changes from fail to pass, because those
tests already passed *via RediSearch*: 111/112 before and after, the one failure being a
pre-existing case that also fails on `main` with the flag off. What changes is which engine answers them,
so those five tests now exercise native code that nothing exercised before. Until #2382 lands, the
four unit tests added here are the only guard on this path.

Unit tests cover: all-numeric union, duplicate members deduping, a mixed list declining as a whole,
a nested non-numeric member declining, and nested unions flattening.

142 tests pass with the flag on, 110 with it off, deterministic order; `cargo fmt --all --check`
clean; root crate builds with the flag on and off.

## Not addressed here

`And` — two range predicates on the same key — is still declined and remains in the ledger. It
wants an arithmetic collapse (take the tighter min and max, run one cursor) rather than a
doc-stream intersection, and that is its own change.




