### PR TITLE
perf: skip the edge-id lookup when nothing reads the edge (1.99x)

### DIFF
--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -200,6 +200,15 @@ pub enum IR {
         /// producing no expansion are emitted with the traverse-introduced
         /// variables (edge + destination) bound to NULL.
         optional: bool,
+        /// When false, nothing above this operator reads the edge alias, so it
+        /// skips the per-row tensor lookup that resolves a representative edge
+        /// id and leaves the edge column unbound. Distinct from
+        /// `emit_relationship`, which only decides row *multiplicity*: an
+        /// anonymous edge inside a named path emits one row per pair yet still
+        /// has to be bound, because `PathBuilder` reads it. Conservatively
+        /// `true` at planning time; lowered to `false` by the
+        /// `reduce_bound_edge` optimizer pass.
+        bind_relationship: bool,
     },
     /// Variable-length traversal (BFS) from known nodes
     CondVarLenTraverse {
@@ -1912,6 +1921,7 @@ impl Planner {
                     transposed: false,
                     chain: Vec::new(),
                     optional: false,
+                    bind_relationship: true,
                 });
                 if let Some(filter_expr) = edge_attr_filter {
                     ct = tree!(IR::Filter(Arc::new(filter_expr)), ct);
@@ -2071,6 +2081,7 @@ impl Planner {
                             transposed: false,
                             chain: Vec::new(),
                             optional: false,
+                            bind_relationship: true,
                         },
                         res
                     );

--- a/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
+++ b/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
@@ -94,6 +94,7 @@ fn can_fuse(
             transposed: p_trans,
             chain: _p_chain,
             optional: p_opt,
+            bind_relationship: true,
         },
         IR::CondTraverse {
             relationship: c_rel,
@@ -102,6 +103,7 @@ fn can_fuse(
             transposed: c_trans,
             chain: c_chain,
             optional: c_opt,
+            bind_relationship: true,
         },
     ) = (parent_ct, child_ct)
     else {
@@ -269,6 +271,7 @@ pub(super) fn fuse_anonymous_traverse(plan: &mut DynTree<IR>) {
             transposed: false,
             chain: merged_chain,
             optional: false,
+            bind_relationship: true,
         };
         // Attach the original grandchildren under the merged op (now parent
         // has [child_CT, g1, g2, ...]).

--- a/graph/src/planner/optimizer/fuse_optional_traverse.rs
+++ b/graph/src/planner/optimizer/fuse_optional_traverse.rs
@@ -46,6 +46,7 @@ fn fusable_traverse(
         transposed,
         chain,
         optional: false,
+        bind_relationship: true,
         ..
     } = sub.data()
     else {
@@ -94,6 +95,7 @@ fn fused_traverse(sub: &DynNode<IR>) -> IR {
             transposed: *transposed,
             chain: chain.clone(),
             optional: true,
+            bind_relationship: true,
         }
     } else {
         unreachable!();

--- a/graph/src/planner/optimizer/mod.rs
+++ b/graph/src/planner/optimizer/mod.rs
@@ -50,6 +50,7 @@ mod eliminate_true_filters;
 mod fuse_anonymous_traverse;
 mod fuse_optional_traverse;
 mod push_filters_down;
+mod reduce_bound_edge;
 mod reduce_count;
 mod reduce_expand_into;
 mod reduce_var_len_path;
@@ -76,6 +77,7 @@ use eliminate_true_filters::eliminate_true_filters;
 use fuse_anonymous_traverse::fuse_anonymous_traverse;
 use fuse_optional_traverse::fuse_optional_traverse;
 use push_filters_down::push_filters_down;
+use reduce_bound_edge::reduce_bound_edge;
 use reduce_count::reduce_count;
 use reduce_expand_into::reduce_expand_into;
 use reduce_var_len_path::reduce_var_len_path;
@@ -148,6 +150,10 @@ pub fn optimize(
 
     // Runs last so no earlier pass has to reason about optional traverses.
     fuse_optional_traverse(&mut optimized_plan);
+
+    // After every pass that rebuilds a CondTraverse or moves its ancestors, so
+    // the "does anything read this edge" answer is the final plan's.
+    reduce_bound_edge(&mut optimized_plan);
 
     optimized_plan
 }

--- a/graph/src/planner/optimizer/reduce_bound_edge.rs
+++ b/graph/src/planner/optimizer/reduce_bound_edge.rs
@@ -1,0 +1,169 @@
+//! Reduces `CondTraverse`'s `bind_relationship` to false when the edge alias
+//! is not consumed by any ancestor operator.
+//!
+//! A chain-less `CondTraverse` binds its edge alias to a representative edge
+//! id, and finding one costs a tensor lookup per surviving row — up to three
+//! GraphBLAS `extractElement` calls, since the effective value has to be read
+//! through the `dp`/`dm`/`m` delta layers. That is dead work whenever the query
+//! never reads the edge (`MATCH (a)-[:R]->(b) RETURN count(b)`).
+//!
+//! This is *not* what [`emit_relationship`] already decides. That flag governs
+//! row multiplicity: false means one row per (src, dst) pair instead of one per
+//! edge. An anonymous edge inside a named path gets `emit_relationship: false`
+//! — one row per pair is right — and still has to be bound, because
+//! `PathBuilder` reads the alias to assemble the path. So the two questions
+//! ("how many rows" and "does anything read the edge") need separate answers,
+//! and only the second one licenses skipping the lookup.
+//!
+//! Runs last in the pipeline, after every pass that rebuilds a `CondTraverse`
+//! or changes its ancestors — including `fuse_optional_traverse`. Every
+//! constructor sets `bind_relationship: true`, so a pass that rebuilds a node
+//! can only ever be conservative, and this pass has the final say.
+//!
+//! [`emit_relationship`]: super::super::IR::CondTraverse
+
+use orx_tree::{Bfs, DynTree, NodeRef};
+
+use super::super::IR;
+use super::reduce_expand_into::ir_references_variable;
+
+pub(super) fn reduce_bound_edge(plan: &mut DynTree<IR>) {
+    let indices: Vec<_> = plan.root().indices::<Bfs>().collect();
+    for idx in indices {
+        let (alias_id, alias_scope_id) = match plan.node(idx).data() {
+            // A fused chain binds no edge at all, so there is nothing to
+            // reduce; `chain` non-empty already suppresses the lookup.
+            IR::CondTraverse {
+                bind_relationship: true,
+                relationship,
+                chain,
+                ..
+            } if chain.is_empty() => (relationship.alias.id, relationship.alias.scope_id),
+            _ => continue,
+        };
+
+        // Walk ancestors to check if the edge alias is referenced.
+        let mut referenced = false;
+        let mut cur = idx;
+        while let Some(parent) = plan.node(cur).parent() {
+            if ir_references_variable(parent.data(), alias_id, alias_scope_id) {
+                referenced = true;
+                break;
+            }
+            cur = parent.idx();
+        }
+
+        if !referenced
+            && let IR::CondTraverse {
+                bind_relationship, ..
+            } = plan.node_mut(idx).data_mut()
+        {
+            *bind_relationship = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use orx_tree::{Bfs, DynTree, NodeRef};
+
+    use super::super::fuse_optional_traverse::fuse_optional_traverse;
+    use super::super::reduce_expand_into::reduce_expand_into;
+    use super::reduce_bound_edge;
+    use crate::parser::cypher::Parser;
+    use crate::planner::{IR, Planner, binder::Binder};
+    use crate::runtime::functions::init_functions;
+
+    /// Compiles `query` through parse → bind → plan, then runs the Graph-free
+    /// subset of the pipeline that governs `bind_relationship`, in pipeline
+    /// order. The skipped passes (`select_scan_node`, `utilize_index`, ...)
+    /// need a live GraphBLAS context and do not change which operators consume
+    /// an edge alias.
+    fn optimized_plan(query: &str) -> DynTree<IR> {
+        // Aggregate calls make the planner resolve names against the function
+        // registry, which is process-global and initialized once.
+        let _ = init_functions();
+        let mut parser = Parser::new(query);
+        parser.parse_parameters().expect("parse parameters");
+        let raw = parser.parse().expect("parse");
+        let (ir, scope_vars) = Binder::default().bind(raw).expect("bind");
+        let mut plan = Planner::new(scope_vars).plan(ir);
+
+        reduce_expand_into(&mut plan);
+        fuse_optional_traverse(&mut plan);
+        reduce_bound_edge(&mut plan);
+        plan
+    }
+
+    fn bound_edges(plan: &DynTree<IR>) -> Vec<bool> {
+        plan.root()
+            .indices::<Bfs>()
+            .filter_map(|idx| match plan.node(idx).data() {
+                IR::CondTraverse {
+                    bind_relationship,
+                    chain,
+                    ..
+                } if chain.is_empty() => Some(*bind_relationship),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unread_edge_is_not_bound() {
+        let plan = optimized_plan("MATCH (a:N)-[:R]->(b:N) RETURN count(b)");
+        assert_eq!(bound_edges(&plan), vec![false]);
+    }
+
+    #[test]
+    fn named_but_unread_edge_is_not_bound() {
+        // Naming an edge is not reading it — the same case `reduce_expand_into`
+        // already lowers `emit_relationship` for.
+        let plan = optimized_plan("MATCH (a:N)-[r:R]->(b:N) RETURN a.v, b.v");
+        assert_eq!(bound_edges(&plan), vec![false]);
+    }
+
+    #[test]
+    fn returned_edge_is_bound() {
+        let plan = optimized_plan("MATCH (a:N)-[r:R]->(b:N) RETURN r");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+
+    #[test]
+    fn filtered_edge_is_bound() {
+        let plan = optimized_plan("MATCH (a:N)-[r:R]->(b:N) WHERE r.k > 1 RETURN b.v");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+
+    #[test]
+    fn deleted_edge_is_bound() {
+        let plan = optimized_plan("MATCH (a:N)-[r:R]->(b:N) DELETE r");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+
+    /// The case `emit_relationship` cannot express: an *anonymous* edge inside a
+    /// named path collapses to one row per pair, yet `PathBuilder` still reads
+    /// the alias to assemble the path. Skipping the lookup here would hand it
+    /// an unbound column.
+    #[test]
+    fn anonymous_edge_in_a_named_path_is_bound() {
+        let plan = optimized_plan("MATCH p = (a:N)-[:R]->(b:N) RETURN p");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+
+    #[test]
+    fn edge_read_after_a_with_barrier_is_bound() {
+        let plan = optimized_plan("MATCH (a:N)-[r:R]->(b:N) WITH r AS e RETURN e");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+
+    #[test]
+    fn optional_traverse_keeps_the_distinction() {
+        // `fuse_optional_traverse` rebuilds the CondTraverse; this pass runs
+        // after it, so the rebuilt node still gets the right answer.
+        let plan = optimized_plan("MATCH (a:N) OPTIONAL MATCH (a)-[:R]->(b:N) RETURN count(b)");
+        assert_eq!(bound_edges(&plan), vec![false]);
+        let plan = optimized_plan("MATCH (a:N) OPTIONAL MATCH (a)-[r:R]->(b:N) RETURN r");
+        assert_eq!(bound_edges(&plan), vec![true]);
+    }
+}

--- a/graph/src/planner/optimizer/select_scan_node.rs
+++ b/graph/src/planner/optimizer/select_scan_node.rs
@@ -739,6 +739,7 @@ pub(super) fn select_scan_node(
                     transposed: true,
                     chain: Vec::new(),
                     optional: false,
+                    bind_relationship: true,
                 };
 
                 if is_leaf || child_is_planner_scan || arg_transparent {
@@ -852,6 +853,7 @@ pub(super) fn select_scan_node(
                         transposed,
                         chain: Vec::new(),
                         optional: false,
+                        bind_relationship: true,
                     },
                     subtree
                 );
@@ -949,6 +951,7 @@ pub(super) fn select_scan_node(
                         transposed: trans,
                         chain: Vec::new(),
                         optional: false,
+                        bind_relationship: true,
                     };
 
                     op.push_child_tree(scan_subtree);

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -134,6 +134,13 @@ pub struct CondTraverseOp<'a> {
     /// one row per (src, dst) pair (false). Set by the planner based on
     /// whether the edge is named or referenced in a named path.
     emit_relationship: bool,
+    /// False when nothing above this operator reads the edge alias, so the
+    /// per-row lookup that resolves a representative edge id is dead work and
+    /// the edge column is left unbound. Distinct from `emit_relationship`,
+    /// which governs row multiplicity only: an anonymous edge inside a named
+    /// path collapses to one row per pair yet still has to be bound, because
+    /// `PathBuilder` reads it. Lowered by the `reduce_bound_edge` pass.
+    bind_relationship: bool,
     /// Alias IDs of sibling relationship variables in the same MATCH clause.
     sibling_edges: &'a [u32],
     /// When true, from/to have been swapped by the optimizer relative to the
@@ -246,6 +253,7 @@ impl<'a> CondTraverseOp<'a> {
         transposed: bool,
         chain: &'a [Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>],
         optional: bool,
+        bind_relationship: bool,
         idx: NodeIdx<Dyn<IR>>,
         record_cap: Option<usize>,
     ) -> Self {
@@ -332,6 +340,7 @@ impl<'a> CondTraverseOp<'a> {
             emitter,
             pending_batches: VecDeque::new(),
             emit_relationship,
+            bind_relationship,
             sibling_edges,
             transposed,
             chain,
@@ -617,6 +626,10 @@ impl<'a> CondTraverseOp<'a> {
             (&rp.to.alias, state.fwd_dst_label_ids.as_slice())
         };
         let chain_is_empty = self.chain.is_empty();
+        // A chain-less traverse binds the edge column, and getting a value for
+        // it costs a tensor lookup per surviving row. Skip both when nothing
+        // above reads the alias.
+        let bind_edge = chain_is_empty && self.bind_relationship;
         let mut out_indices = Vec::new();
         let mut out_dest_ids = Vec::new();
         let mut out_edge_ids = Vec::new();
@@ -647,15 +660,17 @@ impl<'a> CondTraverseOp<'a> {
                 continue;
             }
 
-            if chain_is_empty {
+            if bind_edge {
                 // Look up one representative edge id (mirrors expand_row's
-                // anonymous-edge fast path). Required because downstream
-                // PathBuilder reads the edge alias even when emit_relationship
-                // is false. Storage matrix orientation: src=F's seed
-                // (matrix-src), dst=F*A result (matrix-dst), regardless of
-                // self.transposed (which only affects alias→storage mapping,
-                // not the underlying matrix orientation since
-                // build_relationship_matrix_unrestricted is non-transposed).
+                // anonymous-edge fast path). Needed whenever the alias is read
+                // downstream — including by PathBuilder, which reads it even
+                // when emit_relationship is false, so `emit_relationship`
+                // alone cannot decide this. Storage matrix orientation:
+                // src=F's seed (matrix-src), dst=F*A result (matrix-dst),
+                // regardless of self.transposed (which only affects
+                // alias→storage mapping, not the underlying matrix orientation
+                // since build_relationship_matrix_unrestricted is
+                // non-transposed).
                 let Some(Value::Node(src_id)) = batch.value_at(from_alias.id, row_idx) else {
                     continue;
                 };
@@ -679,9 +694,13 @@ impl<'a> CondTraverseOp<'a> {
                     }
                 }
             } else {
-                // Fused chain: edges across hops are anonymous & unreferenced
-                // (enforced by the fusion pass), so no edge id is bound and
-                // no intermediate node alias is exposed.
+                // No edge column to fill: either a fused chain, whose per-hop
+                // edges are anonymous & unreferenced by construction (the
+                // fusion pass enforces it) and whose intermediate node aliases
+                // are not exposed, or a single hop whose alias nothing reads.
+                // Dropping the lookup also drops its `found_id` guard, which
+                // never fired: `f` is built from these same tensors, so every
+                // pair it yields has at least one edge in one of them.
                 out_indices.push(row_idx);
                 out_dest_ids.push(dest_id);
                 if self.optional {
@@ -691,7 +710,7 @@ impl<'a> CondTraverseOp<'a> {
 
             if out_indices.len() >= BATCH_SIZE {
                 let mut out_batch = batch.gather(&out_indices);
-                if chain_is_empty {
+                if bind_edge {
                     out_batch.set_column(
                         rp.alias.id,
                         Column::RelIds(std::mem::take(&mut out_edge_ids)),
@@ -708,7 +727,7 @@ impl<'a> CondTraverseOp<'a> {
 
         if !out_indices.is_empty() {
             let mut out_batch = batch.gather(&out_indices);
-            if chain_is_empty {
+            if bind_edge {
                 out_batch.set_column(rp.alias.id, Column::RelIds(out_edge_ids));
             }
             out_batch.set_column(to_alias.id, Column::NodeIds(out_dest_ids));

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -866,6 +866,7 @@ impl<'a> Runtime<'a> {
                 transposed,
                 chain,
                 optional,
+                bind_relationship,
             } => {
                 // Account for both limit and skip so the traverse produces
                 // enough rows for a downstream SkipOp + LimitOp pipeline.
@@ -880,6 +881,7 @@ impl<'a> Runtime<'a> {
                     *transposed,
                     chain,
                     *optional,
+                    *bind_relationship,
                     idx,
                     record_cap,
                 )))


### PR DESCRIPTION
Closes #2427.

A chain-less `CondTraverse` binds its edge alias to a representative edge id for every row it emits, and finding one costs a tensor lookup per row — `Tensor::get` → `eff_get`, up to three GraphBLAS `extractElement` calls to read the effective value through the `dp`/`dm`/`m` delta layers. On a traversal that never reads the edge, all of it is waste.

### Why `emit_relationship` couldn't already decide this

`emit_relationship` answers row *multiplicity*: false means one row per `(src, dst)` pair instead of one per edge. An anonymous edge inside a named path gets `emit_relationship: false` — one row per pair is correct — and still has to be bound, because `PathBuilder` reads the alias to assemble the path. The runtime comment said exactly that, and resolved it by always doing the lookup.

So the two questions get two answers. `CondTraverse` gains `bind_relationship`, conservatively `true` at planning time and lowered by a new `reduce_bound_edge` pass that walks ancestors looking for a reference to the edge alias. This is the same shape as the existing `emit_path` / `reduce_var_len_path` pair, and reuses its `ir_references_variable`.

The pass runs **last** in the pipeline, after everything that rebuilds a `CondTraverse` or moves its ancestors (including `fuse_optional_traverse`). Every constructor sets `bind_relationship: true`, so a rebuilding pass can only ever be conservative and this pass has the final say.

Dropping the lookup also drops its `found_id` guard, which never fired: `f` is built from these same tensors, so every pair it yields has at least one edge in one of them.

### Measured

1,000 nodes, 88,000 `(src, dst)` pairs, release build, instructions per pair (median of 5, macOS `proc_pid_rusage`):

| query | before | after | |
|---|---:|---:|---|
| `MATCH (a:N)-[:R]->(x:N) RETURN count(x)` | 1,467 | 736 | **1.99x** |
| `MATCH (a:N)-[r:R]->(x:N) RETURN sum(r.k)` | 3,944 | 3,938 | unchanged |

Identical at multiplicity 2 (735/pair) — one row per pair either way, so the win does not depend on multi-edges.

Full `bench measure` suite, instructions:

| query | ratio |
|---|---:|
| traversal + count | 0.677x |
| expand-into inline rel attrs | 0.710x |
| multi-type traverse | 0.879x |
| **suite total** | **0.9771x** |
| suite total allocated bytes | 1.0000x |

The handful of rows above 1.0x are all sub-600k-instruction queries, inside the run-to-run band that same-binary repeat runs show on this host.

### Correctness

- **Differential against `main`**: 19 traversal queries — named paths, `relationships(p)` element values, multi-type `:R|S`, `OPTIONAL MATCH`, var-length, bidirectional, inline edge filters, `SKIP`/`LIMIT`, `DISTINCT`, `WITH` barriers — plus the `EXPLAIN` output. All byte-identical.
- **8 new planner unit tests**, including the regression that matters: an anonymous edge inside a named path must stay bound.
- `cargo test -p graph` 134 passed; e2e + functions + mvcc + concurrency 136 passed; TCK green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved traversal efficiency by skipping unnecessary relationship lookups and output columns when relationship aliases are not used.
  * Preserved relationship data for filters, projections, deletes, path construction, and optional traversals.
* **Bug Fixes**
  * Improved consistency when optimizing and combining conditional traversals.
  * Added coverage for unread, filtered, deleted, path-based, barrier, and optional traversal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->