### PR TITLE
refactor: derive the multi-edge pair count instead of maintaining it

### DIFF
--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -97,8 +97,8 @@ use super::{
     GxB_Matrix_isStoredElement, GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS,
     GxB_ONE_BOOL, GxB_Option_Field, GxB_Print_Level, GxB_SPARSE, GxB_init,
     GxB_load_Matrix_from_Container, GxB_rowIterator_attach, GxB_rowIterator_getColIndex,
-    GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol, GxB_rowIterator_nextRow,
-    GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
+    GxB_rowIterator_getRowIndex, GxB_rowIterator_kount, GxB_rowIterator_nextCol,
+    GxB_rowIterator_nextRow, GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
 };
 
 /// Initializes the GraphBLAS library in non-blocking mode.
@@ -572,6 +572,56 @@ impl<T> Matrix<T> {
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
         }
         self
+    }
+
+    /// Number of vectors (rows) the storage holds — for a hypersparse matrix,
+    /// the number of non-empty rows, read from the data structure rather than
+    /// counted.
+    ///
+    /// Two caveats, both measured rather than assumed:
+    ///
+    /// * `GxB_rowIterator_kount` is documented only as an *upper* bound: "if A
+    ///   is hypersparse, kount is the # of vectors held in the data structure,
+    ///   some of which may be empty". SuiteSparse in fact prunes emptied
+    ///   vectors on `wait`, so for an assembled hypersparse matrix the two
+    ///   coincide — verified directly, including after removals that empty a
+    ///   row, which is the case that matters. For a sparse, bitmap or full
+    ///   matrix kount is `nrows`, which is why this returns `None` unless the
+    ///   storage is hypersparse: at `me`'s dimensions `nrows` is meaningless as
+    ///   a row count and a caller must not silently compare against it.
+    /// * attaching an iterator materializes pending work, so `self` must
+    ///   already be waited. Callers reach this through
+    ///   [`Tensor::multi_pairs_in_me`], which waits first.
+    #[must_use]
+    pub fn hyper_vector_count(&self) -> Option<u64> {
+        debug_assert!(
+            !self.has_pending.load(Ordering::Relaxed),
+            "hyper_vector_count on a pending matrix: the attach below would \
+             materialize it, which is unsound on a shared layer"
+        );
+        let mut sparsity: i32 = 0;
+        let info = unsafe {
+            GrB_Matrix_get_INT32(
+                *self.m,
+                &raw mut sparsity,
+                GxB_Option_Field::GxB_SPARSITY_STATUS as _,
+            )
+        };
+        debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        if sparsity != GxB_HYPERSPARSE as i32 {
+            return None;
+        }
+        unsafe {
+            let mut it: GxB_Iterator = null_mut();
+            let info = GxB_Iterator_new(&raw mut it);
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            let info = GxB_rowIterator_attach(it, *self.m, null_mut());
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            let kount = GxB_rowIterator_kount(it);
+            let info = GxB_Iterator_free(&raw mut it);
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            Some(kount)
+        }
     }
 
     /// Transposes the matrix.

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -207,6 +207,24 @@ pub struct Tensor {
 /// collide with it (they are bounded by [`GrB_INDEX_MAX`]).
 pub const MULTI_EDGE: u64 = u64::MAX;
 
+/// What [`Tensor::remove_all`]'s read phase has worked out about one
+/// `(src, dst)` pair: the state it is in after replaying the batch's removals
+/// against the state the layers still hold, and hence what the write phase owes
+/// it. Named after the per-pair states in the [module docs](self).
+enum PairPlan {
+    /// Effective inline value is [`MULTI_EDGE`]: the ids still left in the
+    /// pair's `me` row, ascending. At least two — reaching one demotes the pair.
+    Multi(Vec<u64>),
+    /// One edge left, held inline. `demoted` marks the id as having arrived
+    /// there by a demotion in this batch, which the write phase must still put
+    /// in the inline slot; otherwise the pair was already single and untouched.
+    Single { id: u64, demoted: bool },
+    /// Emptied by this batch: its last edge was removed.
+    Emptied,
+    /// No edges when the batch reached it (absent, or deleted earlier).
+    Absent,
+}
+
 /// Shallow clone sharing the underlying GraphBLAS handles (no data copy),
 /// same semantics as `VersionedMatrix`'s `Clone`. Use [`Tensor::dup`] to
 /// create a new MVCC version instead.
@@ -485,53 +503,133 @@ impl Tensor {
         //  - single-edge pair: delete the pair.
         //  - multi-edge pair (inline == MULTI_EDGE): drop the id from `me`;
         //    when exactly one id remains, demote it back into the inline slot.
+        //
+        // Split into a read phase and a write phase, for the same reason as
+        // `set_all_from_slices`. Mutating a layer *and* reading it back in the
+        // same iteration is what makes a batch quadratic: a `set`/`remove`
+        // leaves GraphBLAS tuples pending, and the next iteration's read has to
+        // materialize them — an `O(|layer|)` merge (plus an OpenMP fan-out) per
+        // edge. Measured on a 1,000-pair demote batch: 9.9 ms of the 13.2 ms
+        // spent in this function went to the `me.iter` right after `me.remove`,
+        // and another 2.9 ms to the `eff_get` right after the `dp` write.
+        //
+        // So the read phase reads `dp`/`dm`/`me` and writes none of them: it
+        // replays each touched pair's transitions in `plans` and buffers the
+        // `me` removals. The write phase then writes without reading those
+        // layers back (probing only the committed bases, which never carry
+        // pending work).
+        self.wait_fwd();
+        let mut plans: FxHashMap<(u64, u64), PairPlan> = FxHashMap::default();
+        // `me` entries to drop, in discovery order.
+        let mut me_del: Vec<(u64, u64)> = Vec::new();
         let mut emptied = Vec::new();
         for &(id, src, dst) in rels {
             let key = compound_key(src, dst);
-            match self.eff_get(src, dst) {
-                Some(MULTI_EDGE) => {
-                    self.me.remove(key, id);
-                    let mut it = self.me.iter(key, key);
-                    let survivor = it.next();
-                    let still_multi = it.next().is_some();
-                    drop(it);
-                    if still_multi {
+            let plan = match plans.entry((src, dst)) {
+                Entry::Occupied(e) => e.into_mut(),
+                Entry::Vacant(e) => e.insert(match self.eff_get(src, dst) {
+                    // All of a MULTI pair's ids live in `me`; read the row once
+                    // and take every removal for this pair out of that list
+                    // instead of re-reading a row we are about to dirty.
+                    Some(MULTI_EDGE) => {
+                        let ids: Vec<u64> = self.me.iter(key, key).map(|(_, id)| id).collect();
+                        debug_assert!(
+                            ids.windows(2).all(|w| w[0] < w[1]),
+                            "`me` row ({src}, {dst}) not ascending; the search below needs it"
+                        );
+                        PairPlan::Multi(ids)
+                    }
+                    Some(inline) => PairPlan::Single {
+                        id: inline,
+                        demoted: false,
+                    },
+                    None => PairPlan::Absent,
+                }),
+            };
+            match plan {
+                PairPlan::Multi(ids) => {
+                    // Unknown id (another pair's, or already removed by an
+                    // earlier duplicate in this batch): nothing to remove.
+                    let Ok(pos) = ids.binary_search(&id) else {
                         continue;
-                    }
-                    // A MULTI pair keeps *all* of its ids in `me` and has at
-                    // least two of them, so removing one always leaves a
-                    // survivor and this pair cannot empty here — a
-                    // single-edge pair holds its id inline and is handled by
-                    // the arm below. Machine-checked as `removeOne_survivor`
-                    // in `proofs/tensor`, which is also what retired the
-                    // "all ids removed at once" branch this replaced.
-                    let Some((_, last)) = survivor else {
-                        unreachable!("MULTI pair ({src}, {dst}) held one id in `me`")
                     };
-                    self.multi_count -= 1;
-                    // Demote: the surviving id returns inline. If it *is* the
-                    // committed value, the deltas cancel and the pair returns
-                    // clean; otherwise `dp` shadows `m` with the live value
-                    // (no `dm` mask).
-                    self.me.remove(key, last);
-                    if self.m.get(src, dst) == Some(last) {
-                        self.dp.erase(src, dst);
-                    } else {
-                        self.dp.insert(src, dst, last);
+                    ids.remove(pos);
+                    me_del.push((key, id));
+                    match ids.len() {
+                        // A MULTI pair keeps *all* of its ids in `me` and has
+                        // at least two of them, so removing one always leaves
+                        // a survivor and this pair cannot empty here — a
+                        // single-edge pair holds its id inline and is handled
+                        // by the arm below. Machine-checked as
+                        // `removeOne_survivor` in `proofs/tensor`, which is
+                        // also what retired the "all ids removed at once"
+                        // branch this replaced.
+                        0 => unreachable!("MULTI pair ({src}, {dst}) held one id in `me`"),
+                        // Down to one edge: the pair demotes. Its `me` row
+                        // empties and the survivor goes back inline (in the
+                        // write phase); a later removal of that survivor now
+                        // sees a single-edge pair, exactly as if the demotion
+                        // had already been written.
+                        1 => {
+                            let last = ids[0];
+                            me_del.push((key, last));
+                            self.multi_count -= 1;
+                            *plan = PairPlan::Single {
+                                id: last,
+                                demoted: true,
+                            };
+                        }
+                        _ => {}
                     }
-                    // mt structure already has (dst, src); the pair survives.
                 }
-                Some(inline_id) if inline_id == id => {
+                PairPlan::Single { id: inline, .. } if *inline == id => {
+                    *plan = PairPlan::Emptied;
+                    emptied.push((src, dst));
+                }
+                // Unknown id, or a pair already emptied / never there.
+                PairPlan::Single { .. } | PairPlan::Emptied | PairPlan::Absent => {}
+            }
+        }
+
+        // Write phase: `me` first, then the forward/backward layers. Every
+        // probe here reads a committed base (`m`, and `me`/`mt`'s own bases,
+        // which `VersionedMatrix::remove` is careful to be the only thing it
+        // reads) — never a layer this phase writes, so no write materializes
+        // another write's pending tuples. `dp` erases are batched ahead of
+        // `dp` inserts for the same reason: a `GrB_Matrix_removeElement` that
+        // finds nothing may finish the matrix to be sure.
+        for &(key, id) in &me_del {
+            self.me.remove(key, id);
+        }
+        let mut dp_set: Vec<(u64, u64, u64)> = Vec::new();
+        for (&(src, dst), plan) in &plans {
+            match plan {
+                PairPlan::Emptied => {
                     self.dp.erase(src, dst);
                     if self.m.contains(src, dst) {
                         self.dm.insert(src, dst);
                     }
                     self.mt.remove(dst, src);
-                    emptied.push((src, dst));
                 }
-                // Unknown id or absent pair: nothing to remove.
-                _ => {}
+                // Demote: the surviving id returns inline. If it *is* the
+                // committed value, the deltas cancel and the pair returns
+                // clean; otherwise `dp` shadows `m` with the live value (no
+                // `dm` mask). `mt` already holds (dst, src): the pair survives.
+                PairPlan::Single { id, demoted: true } => {
+                    if self.m.get(src, dst) == Some(*id) {
+                        self.dp.erase(src, dst);
+                    } else {
+                        dp_set.push((src, dst, *id));
+                    }
+                }
+                // Untouched: still multi, or a single-edge pair whose inline
+                // id this batch never named.
+                PairPlan::Multi(_) | PairPlan::Single { demoted: false, .. } | PairPlan::Absent => {
+                }
             }
+        }
+        for &(src, dst, id) in &dp_set {
+            self.dp.insert(src, dst, id);
         }
         emptied
     }
@@ -1312,5 +1410,139 @@ mod tests {
         assert_eq!(t.fwd_m().nvals(), 0, "base kept its deleted entries");
         assert_eq!(t.fwd_dm().nvals(), 0, "tombstones kept alongside the base");
         assert!(t.get(0, 1).next().is_none(), "deleted edge still readable");
+    }
+
+    /// Enough entries for the fold policy's [`MIN_FOLD_DELTA`] floor, so a
+    /// `fold_oversized` really does move the deltas into the bases.
+    const FOLDABLE: u64 = 512;
+
+    /// A tensor whose every pair `(i, i + 1)` has two committed edges,
+    /// `2i` and `2i + 1`, with `me` and the `MULTI_EDGE` sentinels in the base.
+    fn committed_pairs(n: u64) -> Tensor {
+        let mut t = Tensor::new(n + 1, n + 1);
+        let srcs: Vec<u64> = (0..n).flat_map(|i| [i, i]).collect();
+        let dsts: Vec<u64> = (0..n).flat_map(|i| [i + 1, i + 1]).collect();
+        let ids: Vec<u64> = (0..n).flat_map(|i| [2 * i, 2 * i + 1]).collect();
+        t.set_all_from_slices(&srcs, &dsts, &ids);
+        // Commit: fold the pending adds into the bases, so the batch below
+        // demotes *committed* multi pairs (state E of the module's diagram).
+        t.fold_oversized();
+        t.wait();
+        assert_eq!(t.fwd_m().nvals(), n, "sentinels not folded into the base");
+        t.dup()
+    }
+
+    /// One batch that demotes many multi-edge pairs must leave every survivor
+    /// inline and every pair still there. Regression test for the read-after-
+    /// write in the per-edge slow path (issue #2429): each demotion wrote `me`
+    /// and `dp` and the next edge read them straight back, so GraphBLAS had to
+    /// materialize the tuples just queued — 95x C per demoted pair, growing
+    /// with the batch. Buffering those writes has to replay the same state
+    /// machine the old loop got for free by re-reading its own writes.
+    #[test]
+    fn batch_demote_leaves_every_survivor_inline() {
+        ensure_init();
+        const N: u64 = FOLDABLE;
+        let mut t = committed_pairs(N);
+
+        // Delete the odd id of every pair: each demotes 2 -> 1 edges.
+        let emptied = t.remove_all(&(0..N).map(|i| (2 * i + 1, i, i + 1)).collect::<Vec<_>>());
+
+        assert!(emptied.is_empty(), "demoted pairs reported as emptied");
+        assert_eq!(t.edge_count(), N, "edge count after demoting every pair");
+        assert_eq!(t.multi_count, 0, "multi_count not decremented per demotion");
+        assert_eq!(t.me.nvals(), 0, "`me` still holds ids of demoted pairs");
+        for i in 0..N {
+            assert_eq!(
+                t.get(i, i + 1).collect::<Vec<_>>(),
+                vec![2 * i],
+                "pair ({i}, {}) lost its surviving edge",
+                i + 1
+            );
+        }
+    }
+
+    /// The same batch may take a pair all the way down: the demotion is only
+    /// buffered, so the edge that removes the survivor has to see the pair as
+    /// single — not as the multi pair the layers still say it is. Foreign and
+    /// repeated ids in the batch must change nothing.
+    #[test]
+    fn batch_can_demote_and_then_empty_the_same_pair() {
+        ensure_init();
+        const N: u64 = FOLDABLE;
+        let mut t = committed_pairs(N);
+
+        let mut rels: Vec<(u64, u64, u64)> = Vec::new();
+        for i in 0..N {
+            rels.push((2 * i + 1, i, i + 1)); // demotes the pair
+            rels.push((2 * i + 1, i, i + 1)); // repeat: already gone
+            rels.push((7 * N + i, i, i + 1)); // id of no edge of this pair
+            rels.push((2 * i, i, i + 1)); // removes the survivor: pair empties
+            rels.push((2 * i, i, i + 1)); // repeat: pair already empty
+        }
+        let mut emptied = t.remove_all(&rels);
+        emptied.sort_unstable();
+
+        assert_eq!(
+            emptied,
+            (0..N).map(|i| (i, i + 1)).collect::<Vec<_>>(),
+            "every pair should be reported emptied exactly once"
+        );
+        assert_eq!(t.edge_count(), 0, "edges left after removing all of them");
+        assert_eq!(t.multi_count, 0, "multi_count not decremented per demotion");
+        assert_eq!(t.me.nvals(), 0, "`me` still holds ids of emptied pairs");
+        t.mt.wait();
+        assert_eq!(
+            t.mt.extract().nvals(),
+            0,
+            "backward adjacency kept the pairs"
+        );
+        for i in 0..N {
+            assert!(
+                t.get(i, i + 1).next().is_none(),
+                "pair ({i}, {}) still readable",
+                i + 1
+            );
+        }
+    }
+
+    /// Demoting back to the committed value must cancel the deltas to clean,
+    /// not leave `dp` shadowing `m` with the value `m` already holds (state F
+    /// -> D of the module's diagram). The write phase decides this from the
+    /// committed base, which the buffered `dp` writes must not disturb.
+    #[test]
+    fn demoting_to_the_committed_value_cancels_to_clean() {
+        ensure_init();
+        const N: u64 = FOLDABLE;
+        let mut t = Tensor::new(N + 1, N + 1);
+        let srcs: Vec<u64> = (0..N).collect();
+        let dsts: Vec<u64> = (0..N).map(|i| i + 1).collect();
+        let ids: Vec<u64> = (0..N).map(|i| i + 1).collect();
+        t.set_all_from_slices(&srcs, &dsts, &ids);
+        t.fold_oversized();
+        t.wait();
+        assert_eq!(t.fwd_m().get(0, 1), Some(1), "single edge not committed");
+
+        // Promote in this version (m = 1, dp = M, me = {1, 9}), then remove the
+        // new edge again: the survivor is the committed 1.
+        let mut t = t.dup();
+        t.set_all_from_slices(&[0], &[1], &[9]);
+        let emptied = t.remove_all(&[(9, 0, 1)]);
+
+        assert!(emptied.is_empty(), "surviving pair reported as emptied");
+        t.wait();
+        assert_eq!(
+            t.fwd_dp().nvals(),
+            0,
+            "dp still shadows m with m's own value"
+        );
+        assert_eq!(t.fwd_dm().nvals(), 0, "demotion left a tombstone");
+        assert_eq!(t.me.nvals(), 0, "`me` not emptied by the demotion");
+        assert_eq!(t.edge_count(), N, "edge count after promote + demote");
+        assert_eq!(
+            t.get(0, 1).collect::<Vec<_>>(),
+            vec![1],
+            "committed edge lost"
+        );
     }
 }

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -63,10 +63,11 @@
 //!   particular `dp = M` never shadows `m = M`).
 //! - A pair has ≥ 2 edges iff its effective inline value is the
 //!   [`MULTI_EDGE`] sentinel `M`; then *all* its ids live in `me` and the
-//!   pair is counted by `multi_count`. Otherwise its single id is inline and
+//!   pair is one of `multi_pairs()`. Otherwise its single id is inline and
 //!   `me` has no row for it.
 //! - `mt` mirrors the effective forward structure (BOOL, no ids).
-//! - `edge_count = |m| + |dp| − |dm| − |dp ∩ m| − multi_count + |me|`.
+//! - `edge_count = |m| + |dp| − |dm| − |dp ∩ m| − multi_pairs() + |me|`,
+//!   where `multi_pairs()` is read from `me`'s row structure, not tracked.
 //!
 //! ## Per-Pair State Diagram
 //!
@@ -195,8 +196,6 @@ pub struct Tensor {
     /// (BOOL). Holds *all* ids of pairs with more than one edge; empty
     /// otherwise.
     me: VersionedMatrix<bool>,
-    /// Number of pairs whose effective inline value is [`MULTI_EDGE`].
-    multi_count: u64,
     /// Whether the fold decisions latched on `dp`/`dm` are executable now; see
     /// `VersionedMatrix`'s field of the same name.
     needs_flush: AtomicBool,
@@ -236,7 +235,6 @@ impl Clone for Tensor {
             dm: self.dm.clone(),
             mt: self.mt.clone(),
             me: self.me.clone(),
-            multi_count: self.multi_count,
             needs_flush: AtomicBool::new(self.needs_flush.load(Ordering::Relaxed)),
         }
     }
@@ -254,7 +252,6 @@ impl Tensor {
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(ncols, nrows),
             me: VersionedMatrix::<bool>::new(GrB_INDEX_MAX, GrB_INDEX_MAX),
-            multi_count: 0,
             needs_flush: AtomicBool::new(false),
         }
     }
@@ -375,7 +372,6 @@ impl Tensor {
                         // pending inline slot in place.
                         self.me.set(key, m_ids[idx], true);
                         m_ids[idx] = MULTI_EDGE;
-                        self.multi_count += 1;
                         e.insert(usize::MAX);
                     }
                     self.me.set(key, id, true);
@@ -396,7 +392,6 @@ impl Tensor {
                         Some(cur_id) => {
                             self.me.set(key, cur_id, true);
                             self.me.set(key, id, true);
-                            self.multi_count += 1;
                             e.insert(usize::MAX);
                             m_srcs.push(s);
                             m_dsts.push(d);
@@ -573,7 +568,6 @@ impl Tensor {
                         1 => {
                             let last = ids[0];
                             me_del.push((key, last));
-                            self.multi_count -= 1;
                             *plan = PairPlan::Single {
                                 id: last,
                                 demoted: true,
@@ -847,7 +841,6 @@ impl Tensor {
             dm: self.dm.new_version(fold_dm),
             mt: self.mt.dup(),
             me: self.me.dup(),
-            multi_count: self.multi_count,
             needs_flush: AtomicBool::new(fold_dp || fold_dm),
         }
     }
@@ -912,7 +905,7 @@ impl Tensor {
     }
 
     /// Total number of edges. Each effective forward entry is one edge,
-    /// except `MULTI_EDGE` sentinels (counted by `multi_count`), whose real
+    /// except `MULTI_EDGE` sentinels (see [`Self::multi_pairs`]), whose real
     /// ids all live in `me`. Effective nvals is `|m| + |dp| − |dm| − |dp ∩ m|`
     /// (`dp` may shadow `m`; `dm ⊆ m` is disjoint from `dp`).
     #[must_use]
@@ -923,7 +916,7 @@ impl Tensor {
         } else {
             self.dp.intersection_nvals(&self.m)
         };
-        self.m.nvals() + self.dp.nvals() - self.dm.nvals() - shadow - self.multi_count
+        self.m.nvals() + self.dp.nvals() - self.dm.nvals() - shadow - self.multi_pairs()
             + self.me.nvals()
     }
 
@@ -956,6 +949,57 @@ impl Tensor {
         transpose: bool,
     ) -> Iter<'_> {
         Iter::new(self, min_row, max_row, transpose)
+    }
+
+    /// How many pairs are multi-edge, computed from `me` rather than tracked.
+    ///
+    /// Promotion completeness makes this a structural property of `me`:
+    /// `ε(p) = MULTI_EDGE` exactly when row `κ(p)` of `me` is non-empty. A
+    /// hypersparse matrix stores its non-empty vectors and nothing else, so once
+    /// `me` is assembled the answer is a metadata read rather than a count.
+    ///
+    /// While `me` carries live deltas the effective row set spans three layers
+    /// and has to be walked, which is `O(multi)` — never `O(|E|)`. That is the
+    /// price of not maintaining a counter, and the reason this is called from
+    /// [`Self::edge_count`] (statistics, planning, two graph algorithms) and not
+    /// from anything per-row.
+    #[cfg(test)]
+    fn eff_get_for_test(
+        &self,
+        src: u64,
+        dst: u64,
+    ) -> Option<u64> {
+        self.eff_get(src, dst)
+    }
+
+    #[cfg(test)]
+    fn fwd_me_nvals_for_test(&self) -> u64 {
+        self.me.nvals()
+    }
+
+    #[must_use]
+    pub fn multi_pairs(&self) -> u64 {
+        // A graph with no multi-edge pair anywhere — the dominant case, and the
+        // one the whole design is built around — answers from `nvals` without
+        // waiting `me` or attaching an iterator to it.
+        if self.me.nvals() == 0 {
+            return 0;
+        }
+        self.me.wait();
+        if self.me.dp().nvals() == 0 && self.me.dm().nvals() == 0 {
+            if let Some(kount) = self.me.m().hyper_vector_count() {
+                return kount;
+            }
+        }
+        let mut rows = 0u64;
+        let mut last: Option<u64> = None;
+        for (key, _) in self.me.iter(0, u64::MAX) {
+            if last != Some(key) {
+                rows += 1;
+                last = Some(key);
+            }
+        }
+        rows
     }
 
     /// Whether this tensor has any (src, dst) pair with more than one edge.
@@ -1110,7 +1154,6 @@ impl Decode<19> for Tensor {
         // the tensor section.
         let mut m = Matrix::<u64>::new(nrows, ncols);
         let mut me = VersionedMatrix::<bool>::new(GrB_INDEX_MAX, GrB_INDEX_MAX);
-        let mut multi_count: u64 = 0;
 
         let dm_empty = fwd_dm.nvals() == 0;
         for (src, dst, value) in fwd_m.iter(0, u64::MAX) {
@@ -1138,7 +1181,6 @@ impl Decode<19> for Tensor {
             // multi-edge pair lands in `me`; the inline value stays MULTI_EDGE.
             for _ in 0..2 {
                 let count = r.read_unsigned()?;
-                multi_count += count;
                 for _ in 0..count {
                     let src = r.read_unsigned()?;
                     let dst = r.read_unsigned()?;
@@ -1165,7 +1207,6 @@ impl Decode<19> for Tensor {
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(0, 0),
             me,
-            multi_count,
             needs_flush: AtomicBool::new(false),
         })
     }
@@ -1303,6 +1344,95 @@ mod tests {
     /// u64 edge id instead of reading only the sparsity pattern turns id 0
     /// into a `false` entry, which valued masks then treat as absent — the
     /// deletion is silently lost.
+    /// The bulk loader puts a pair's duplicate edges in ONE batch, which takes
+    /// `set_all_from_slices`' retro-promotion path rather than the plain promote.
+    #[test]
+    fn multi_pairs_after_within_batch_duplicates() {
+        ensure_init();
+        for &(pairs, dup) in &[(64u64, 2u64), (1_000, 2), (1_000, 4)] {
+            let n = pairs + 1;
+            let mut t = Tensor::new(n, n);
+            // one batch, each pair repeated `dup` times consecutively
+            let mut srcs = Vec::new();
+            let mut dsts = Vec::new();
+            let mut ids = Vec::new();
+            let mut next_id = 0u64;
+            for i in 0..pairs {
+                for _ in 0..dup {
+                    srcs.push(i);
+                    dsts.push(i + 1);
+                    ids.push(next_id);
+                    next_id += 1;
+                }
+            }
+            t.set_all_from_slices(&srcs, &dsts, &ids);
+            t.wait_fwd();
+            let sentinels = (0..pairs)
+                .filter(|&i| t.eff_get_for_test(i, i + 1) == Some(MULTI_EDGE))
+                .count() as u64;
+            let derived = t.multi_pairs();
+            let edges: u64 = (0..pairs).map(|i| t.get(i, i + 1).count() as u64).sum();
+            println!(
+                "one batch: pairs={pairs:>5} dup={dup}  sentinels={sentinels:>5} \
+                 derived={derived:>5} edge_count={:>7} true_edges={edges:>7}",
+                t.edge_count()
+            );
+            assert_eq!(
+                derived, sentinels,
+                "multi_pairs disagrees (within-batch dups)"
+            );
+            assert_eq!(
+                t.edge_count(),
+                edges,
+                "edge_count disagrees with a full scan"
+            );
+        }
+    }
+
+    /// Ground truth for `multi_pairs`: count the forward cells whose effective
+    /// value is the sentinel, which is what the quantity means, and compare
+    /// against the derivation from `me`'s row structure.
+    #[test]
+    fn multi_pairs_matches_the_sentinel_count() {
+        ensure_init();
+        for &(pairs, dup) in &[(64u64, 2u64), (1_000, 2), (1_000, 3), (5_000, 2)] {
+            let n = pairs + 1;
+            let mut t = Tensor::new(n, n);
+            let srcs: Vec<u64> = (0..pairs).collect();
+            let dsts: Vec<u64> = (0..pairs).map(|i| i + 1).collect();
+            // `dup` edges on every pair, inserted as separate batches
+            for round in 0..dup {
+                let ids: Vec<u64> = (0..pairs).map(|i| round * pairs + i).collect();
+                t.set_all_from_slices(&srcs, &dsts, &ids);
+            }
+            // ground truth: effective forward cells holding MULTI_EDGE
+            t.wait_fwd();
+            let mut sentinels = 0u64;
+            for (src, dst) in (0..pairs).map(|i| (i, i + 1)) {
+                if t.eff_get_for_test(src, dst) == Some(MULTI_EDGE) {
+                    sentinels += 1;
+                }
+            }
+            let derived = t.multi_pairs();
+            let edges: u64 = (0..pairs).map(|i| t.get(i, i + 1).count() as u64).sum();
+            println!(
+                "pairs={pairs:>5} dup={dup}  sentinels={sentinels:>5} \
+                 derived={derived:>5} me_nvals={:>6} edge_count={:>7} true_edges={edges:>7}",
+                t.fwd_me_nvals_for_test(),
+                t.edge_count()
+            );
+            assert_eq!(
+                derived, sentinels,
+                "multi_pairs disagrees with the sentinel count"
+            );
+            assert_eq!(
+                t.edge_count(),
+                edges,
+                "edge_count disagrees with a full scan"
+            );
+        }
+    }
+
     #[test]
     fn bulk_remove_and_extract_edge_id_zero() {
         ensure_init();
@@ -1450,7 +1580,7 @@ mod tests {
 
         assert!(emptied.is_empty(), "demoted pairs reported as emptied");
         assert_eq!(t.edge_count(), N, "edge count after demoting every pair");
-        assert_eq!(t.multi_count, 0, "multi_count not decremented per demotion");
+        assert_eq!(t.multi_pairs(), 0, "a demoted pair still counts as multi");
         assert_eq!(t.me.nvals(), 0, "`me` still holds ids of demoted pairs");
         for i in 0..N {
             assert_eq!(
@@ -1489,7 +1619,7 @@ mod tests {
             "every pair should be reported emptied exactly once"
         );
         assert_eq!(t.edge_count(), 0, "edges left after removing all of them");
-        assert_eq!(t.multi_count, 0, "multi_count not decremented per demotion");
+        assert_eq!(t.multi_pairs(), 0, "a demoted pair still counts as multi");
         assert_eq!(t.me.nvals(), 0, "`me` still holds ids of emptied pairs");
         t.mt.wait();
         assert_eq!(


### PR DESCRIPTION
Closes #2438. **Stacked on #2431** — that PR restructured `remove_all`, where the counter's decrement lived, so this targets it rather than `main`.

Implements the third and most ambitious of the paper's three repairs for this invariant: rather than police the counter, remove the obligation.

### Why the field can go

`multi_count` exists only to keep the cardinality identity O(1), but promotion completeness makes it the non-empty row count of `me` — a structure already present. It was a hand-maintained cache, and the maintenance is the whole problem: seven call sites add or remove a row of `me`, three touched the counter.

Two things made removal cheaper than expected:

- `has_multi_edge()` never used it — already `me.nvals() != 0`.
- `Decode` never read it from the blob, it derived it from the tensor-section counts. **The on-disk format is untouched.**

Which leaves `edge_count()` as the only consumer, reached from planning, `db.*` procedures and two graph algorithms — never per row.

### The derivation, and its worst case

| state of `me` | cost |
|---|---|
| no multi-edge pair anywhere (dominant case) | `nvals`, O(1) |
| assembled | its vector count — metadata, since a hypersparse matrix stores its non-empty vectors and nothing else |
| live deltas | walk the effective rows: O(multi), never O(\|E\|) |

The third row is the one to worry about, and it is not reached in practice: commit folds `me`, so by the time a query asks for a count the metadata path is taken.

### Measured

| | ratio |
|---|---|
| **full suite, instructions** (two independent pairs) | **0.9961x**, **1.0018x** |
| `write 1m` | 1.002x |
| `create 10k` | 1.000x |
| `multi-edge demote/promote` | 0.995x |
| `untyped edge scan` | 0.987x |

Worst case — a metadata count query over a graph of all-multi-edge pairs — is 1.03–1.12x of the counter build at 10,000 and 100,000 pairs, on a query costing ~0.5M instructions.

Two honesty notes on the measurements. The same microbenchmark is **not trustworthy at 400,000 pairs**: the unchanged counter build swung 6.7x between runs there, so I am not quoting it. And I make **no allocation claim** — that comparison's baseline CSV carries corrupt jemalloc deltas (one row at 351 trillion bytes, others negative), and removing a `u64` field has no allocation story to tell anyway.

### Correctness

Two tests pin the derivation against ground truth — the count of effective forward cells holding the sentinel, which is what the quantity *means* — for duplicates arriving in separate batches and within a single batch (the retro-promotion route, the second of the two former increment sites), and check `edge_count()` against a full scan of every pair.

`cargo test -p graph` 139 passed; e2e + mvcc + functions + concurrency 136; TCK green; clippy clean.

**Flow: 25 failures, against 23 on the same tree with the counter.** Of the two extra, `test12_load_large_graph` passes twice when run in isolation — it asserts an 80-second load budget and this machine had builds running — and `test_replication_states` fails on an RLTest API mismatch (`object has no attribute 'assertTrue'`). The 23 shared failures are the `himport_registry` client incompatibility. Worth a reviewer's eye on CI, since I could not fully clear those two locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reporting the number of stored vectors in hypersparse matrices.
  - Added a way to calculate multi-edge pair counts directly from graph structure.

- **Bug Fixes**
  - Improved consistency of edge counts when duplicate edges are inserted in batches.
  - Ensured edge-count reporting remains accurate across pending updates, cloning, encoding, and graph format conversions.

- **Tests**
  - Added regression coverage for duplicate insertions and consistency among structural, sentinel, and total edge counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->