### PR TITLE
fix(parser): quadratic parameter parsing (5.8x) and unbounded-nesting server abort

### DIFF
--- a/graph/src/parser/cypher.rs
+++ b/graph/src/parser/cypher.rs
@@ -198,7 +198,7 @@ impl<'a> Parser<'a> {
             if id.as_str() == "CYPHER" {
                 self.lexer.next();
                 let mut state = self.save_state();
-                while let Ok(id) = self.parse_ident() {
+                while let Some(id) = self.try_parse_ident() {
                     if !optional_match_token!(self.lexer, Equal) {
                         self.restore_state(state);
                         break;
@@ -1062,7 +1062,7 @@ impl<'a> Parser<'a> {
         let mut query_graph = QueryGraph::default();
         let mut nodes_alias = HashSet::new();
         loop {
-            if let Ok(ident) = self.parse_ident() {
+            if let Some(ident) = self.try_parse_ident() {
                 match_token!(self.lexer, Equal);
 
                 // Check for shortestPath/allShortestPaths in MATCH clause
@@ -1469,7 +1469,7 @@ impl<'a> Parser<'a> {
         let has_details = optional_match_token!(self.lexer, LBrace);
         let (rel_types, min_hops, max_hops, has_edge_filter) = if has_details {
             // Optional alias (ignored)
-            let _alias = self.parse_ident().ok();
+            let _alias = self.try_parse_ident();
 
             // Relationship types
             let mut types = Vec::new();
@@ -2291,6 +2291,23 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// [`Self::parse_ident`] for speculative parses, which discard the error.
+    ///
+    /// Formatting a message nobody reads is pure cost, and the alternatives a
+    /// parser probes for are the common case, not the exception: `[` alone
+    /// asks this twice before settling on a plain list literal.
+    fn try_parse_ident(&mut self) -> Option<Arc<String>> {
+        match self.lexer.current() {
+            Ok(Token::IdentifierOrKeyword { ident: id, .. })
+                if validate_identifier_len(id.as_str(), "Identifier").is_ok() =>
+            {
+                self.lexer.next();
+                Some(id)
+            }
+            _ => None,
+        }
+    }
+
     fn parse_property_name(&mut self) -> Result<Arc<String>, String> {
         match self.lexer.current() {
             Ok(Token::IdentifierOrKeyword { ident: id, .. }) => {
@@ -2382,7 +2399,7 @@ impl<'a> Parser<'a> {
         let saved = self.save_state();
 
         // 1) Try list comprehension: [var IN ...]
-        if let Ok(var) = self.parse_ident()
+        if let Some(var) = self.try_parse_ident()
             && optional_match_token!(self.lexer => In)
         {
             return Ok((
@@ -2393,7 +2410,7 @@ impl<'a> Parser<'a> {
         self.restore_state(saved);
 
         // 2) Try named pattern comprehension: [var = (pattern) ... | expr]
-        if let Ok(var) = self.parse_ident()
+        if let Some(var) = self.try_parse_ident()
             && optional_match_token!(self.lexer, Equal)
             && self.lexer.current()? == Token::LParen
             && let Ok(result) = self.parse_pattern_comprehension(Some(var), allow_pattern_predicate)
@@ -2522,7 +2539,7 @@ impl<'a> Parser<'a> {
 
     fn parse_node_pattern(&mut self) -> Result<Arc<QueryNode<Arc<String>, Arc<String>>>, String> {
         match_token!(self.lexer, LParen);
-        let alias = if let Ok(id) = self.parse_ident() {
+        let alias = if let Some(id) = self.try_parse_ident() {
             id
         } else {
             let name = Arc::new(format!("_anon_{}", self.anon_counter));
@@ -2558,7 +2575,7 @@ impl<'a> Parser<'a> {
         match_token!(self.lexer, Dash);
         let has_details = optional_match_token!(self.lexer, LBrace);
         let (alias, types, attrs, var_len) = if has_details {
-            let alias = if let Ok(id) = self.parse_ident() {
+            let alias = if let Some(id) = self.try_parse_ident() {
                 id
             } else {
                 let name = Arc::new(format!("_anon_{}", self.anon_counter));
@@ -3025,5 +3042,70 @@ impl<'a> Parser<'a> {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CYPHER batch=[{v:[..]}, ..]` - the shape a bulk loader sends, one list
+    /// literal per row on top of the outer one.
+    fn list_heavy_params(rows: usize) -> String {
+        let vec = std::iter::repeat_n("0.123456", 200).join(",");
+        let rows = (0..rows)
+            .map(|i| format!("{{`id`:{i},`v`:[{vec}]}}"))
+            .join(",");
+        format!("CYPHER `batch`=[{rows}] RETURN 1")
+    }
+
+    // Regression: `[` sends the parser probing for a list comprehension and a
+    // pattern comprehension before it settles on a plain list literal, and both
+    // probes used to build - then discard - an error message quoting the whole
+    // query. That made parsing quadratic in the payload: doubling the rows
+    // below took ~32x longer, so a 6.7MB bulk-load batch spent 1.7s in the
+    // parser alone. Time must now grow with the input, not with its square.
+    #[test]
+    fn list_literals_parse_in_linear_time() {
+        let small = list_heavy_params(250);
+        let large = list_heavy_params(2000);
+        let parse = |q: &str| Parser::new(q).parse_parameters().map(|(p, _)| p.len());
+
+        // Warm the allocator so the first parse is not charged for it.
+        assert_eq!(parse(&small).unwrap(), 1);
+
+        let t = std::time::Instant::now();
+        parse(&small).unwrap();
+        let small_elapsed = t.elapsed();
+
+        let t = std::time::Instant::now();
+        parse(&large).unwrap();
+        let large_elapsed = t.elapsed();
+
+        // 8x the input. Linear lands near 8x, the quadratic bug near 64x; the
+        // bound sits between the two with room for a noisy CI machine.
+        assert!(
+            large_elapsed < small_elapsed * 24,
+            "parse time grew super-linearly: {small_elapsed:?} for 250 rows \
+             vs {large_elapsed:?} for 2000",
+        );
+    }
+
+    // The speculative-ident path must still recognise what it probes for.
+    #[test]
+    fn bracket_alternatives_still_parse() {
+        for query in [
+            "RETURN [1, 2, 3] AS l",
+            "RETURN [x IN [1, 2] | x + 1] AS l",
+            "MATCH (a) RETURN [(a)-->(b) | b] AS l",
+            "MATCH (a) RETURN [p = (a)-->(b) | p] AS l",
+            "MATCH (n)-[r:R]->(m) RETURN n, r, m",
+            "MATCH ()-[:R]->() RETURN 1",
+        ] {
+            assert!(
+                Parser::new(query).parse().is_ok(),
+                "failed to parse: {query}"
+            );
+        }
     }
 }

--- a/graph/src/parser/cypher.rs
+++ b/graph/src/parser/cypher.rs
@@ -117,6 +117,20 @@ use itertools::Itertools;
 use orx_tree::{DynTree, NodeRef};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+/// Opening of every rejection [`Parser::too_deep`] produces, and what
+/// [`is_too_deep`] recognises.
+const TOO_DEEP: &str = "Query nesting exceeds the maximum depth of";
+
+/// Whether `err` is a rejection produced by [`Parser::too_deep`].
+///
+/// Lets a caller that would otherwise replace a nested failure with its own
+/// summary pass this one through, for the same reason
+/// [`is_identifier_too_long`] is passed through: it names the definite thing
+/// the user has to change, which "could not parse this" would hide.
+fn is_too_deep(err: &str) -> bool {
+    err.starts_with(TOO_DEEP)
+}
+
 #[derive(Debug)]
 enum ExpressionListType {
     OneOrMore,
@@ -155,16 +169,74 @@ pub struct Parser<'a> {
     lexer: Lexer<'a>,
     /// Counter for generating unique anonymous variable names
     anon_counter: u32,
+    /// Nesting level of the two recursive descents, see [`Parser::MAX_NESTING`].
+    depth: u32,
 }
 
 impl<'a> Parser<'a> {
+    /// How deeply expressions and subqueries may nest.
+    ///
+    /// Operator chains run on an explicit stack, but a nested expression
+    /// (`{k:{k:..}}`, `abs(abs(..))`, `[x IN [x IN ..]]`) re-enters
+    /// [`Parser::parse_expr`], and `CALL {}` re-enters
+    /// [`Parser::parse_query`]. Both are plain call-stack recursion, so
+    /// without a cap a few kilobytes of nesting overflow the stack and abort
+    /// the server. Rust cannot catch that, so the depth is bounded instead.
+    ///
+    /// 100 is far past any hand-written or generated query and leaves room for
+    /// builds with fatter stack frames than release (debug, sanitizers).
+    const MAX_NESTING: u32 = 100;
+
+    /// How deep an expression tree may get.
+    ///
+    /// Constructs that build on [`Parser::parse_expr_inner`]'s own stack
+    /// (`[[..]]`, `-(-(..))`, `x[0][0]`) cost no call frames here, but the
+    /// binder, planner and evaluator all walk the result recursively, so the
+    /// tree still has to be bounded - just by what those stages can walk
+    /// rather than by what this one can.
+    ///
+    /// Looser than [`Self::MAX_NESTING`] for that reason, and deliberately so:
+    /// `(((1)))` collapses to `1` and test_parentheses pins 10000 of them,
+    /// while test_nested_list pins 100 genuinely nested lists.
+    ///
+    /// 256 sits above the 100 that test pins and well below the shallowest
+    /// depth that overflowed a worker stack before this cap existed (1024,
+    /// for `-(-(..))`), leaving room for builds with fatter frames.
+    const MAX_TREE_DEPTH: usize = 256;
+
     /// Creates a new parser for the given query string.
     #[must_use]
     pub fn new(str: &'a str) -> Self {
         Self {
             lexer: Lexer::new(str),
             anon_counter: 0,
+            depth: 0,
         }
+    }
+
+    /// The rejection every nesting guard shares, naming the limit that fired.
+    fn too_deep(
+        &self,
+        limit: usize,
+    ) -> String {
+        self.lexer.format_error(&format!("{TOO_DEEP} {limit}"))
+    }
+
+    /// Runs `descend` one nesting level down, or fails if that is too deep.
+    ///
+    /// The level is released however `descend` returns, so a caller that
+    /// backtracks over a failed speculative parse keeps its depth budget.
+    fn nested<T>(
+        &mut self,
+        descend: impl FnOnce(&mut Self) -> Result<T, String>,
+    ) -> Result<T, String> {
+        if self.depth >= Self::MAX_NESTING {
+            return Err(self.too_deep(Self::MAX_NESTING as usize));
+        }
+        self.depth += 1;
+        let res = descend(self);
+        self.depth -= 1;
+        res
     }
 
     fn save_state(&self) -> ParserState {
@@ -204,11 +276,12 @@ impl<'a> Parser<'a> {
                         break;
                     }
                     let value = self.parse_expr(false).map_err(|e| {
-                        // An over-long map key inside the value names the exact
-                        // thing to fix, so it survives; a syntax error inside a
-                        // parameter is more useful reported as the parameter
-                        // that failed (see test_params).
-                        if is_identifier_too_long(&e) {
+                        // An over-long map key or too-deep nesting inside the
+                        // value names the exact thing to fix, so it survives; a
+                        // syntax error inside a parameter is more useful
+                        // reported as the parameter that failed (see
+                        // test_params).
+                        if is_identifier_too_long(&e) || is_too_deep(&e) {
                             e
                         } else {
                             format!("Failed to parse the value of parameter '{}'", id.as_str())
@@ -723,7 +796,7 @@ impl<'a> Parser<'a> {
         // CALL { subquery } — parse body as a self-contained query
         if self.lexer.current()? == Token::LBracket {
             self.lexer.next();
-            let body = self.parse_query()?;
+            let body = self.nested(Self::parse_query)?;
             match_token!(self.lexer, RBracket);
             let is_returning = Self::body_has_return(&body);
             return Ok(vec![QueryIR::CallSubquery {
@@ -1849,14 +1922,35 @@ impl<'a> Parser<'a> {
         Ok(tree!(ExprIR::Property(ident), expr))
     }
 
-    #[allow(clippy::too_many_lines)]
-    #[allow(clippy::cognitive_complexity)]
+    /// Parses one expression, one nesting level below its caller.
+    ///
+    /// Precedence climbing itself runs on `stack` and costs no call frames;
+    /// the level is spent by the sub-expressions inside maps, lists, calls and
+    /// comprehensions, which re-enter here.
     fn parse_expr(
         &mut self,
         allow_pattern_predicate: bool,
     ) -> Result<DynTree<ExprIR<Arc<String>>>, String> {
+        self.nested(|s| s.parse_expr_inner(allow_pattern_predicate))
+    }
+
+    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cognitive_complexity)]
+    fn parse_expr_inner(
+        &mut self,
+        allow_pattern_predicate: bool,
+    ) -> Result<DynTree<ExprIR<Arc<String>>>, String> {
         let mut stack = vec![(0, None::<DynTree<ExprIR<Arc<String>>>>)];
+        // Stack heights at which a tree level is still open. Constructs that
+        // nest on `stack` rather than the call stack are invisible to
+        // `nested`, so their depth is counted here instead. A level closes
+        // when the frame that opened it is popped, which is what the prune
+        // below detects.
+        let mut open: Vec<usize> = Vec::new();
         while let Some((current, res)) = stack.pop() {
+            while open.last().is_some_and(|&at| at >= stack.len()) {
+                open.pop();
+            }
             let Some(res) = res else {
                 if current < 3 || (current > 3 && current < 9) || current == 10 {
                     stack.push((current, None));
@@ -1890,6 +1984,12 @@ impl<'a> Parser<'a> {
                     }
 
                     let res = if is_negate {
+                        // `-(-(-1))` keeps a Negate per level even though the
+                        // parens around it collapse, so this is a real level.
+                        if open.len() >= Self::MAX_TREE_DEPTH {
+                            return Err(self.too_deep(Self::MAX_TREE_DEPTH));
+                        }
+                        open.push(stack.len());
                         Some(tree!(ExprIR::Negate))
                     } else {
                         None
@@ -1900,6 +2000,15 @@ impl<'a> Parser<'a> {
                     // primary expression
                     let (res, recurse) = self.parse_primary_expr(allow_pattern_predicate)?;
                     if recurse {
+                        // A list keeps a node per level; a parenthesis does
+                        // not - `(((1)))` collapses to `1` however deep it
+                        // goes, and test_parentheses pins 10000 of them.
+                        if !matches!(res.root().data(), ExprIR::Paren) {
+                            if open.len() >= Self::MAX_TREE_DEPTH {
+                                return Err(self.too_deep(Self::MAX_TREE_DEPTH));
+                            }
+                            open.push(stack.len());
+                        }
                         stack.push((current, Some(res)));
                         stack.push((0, None));
                         continue;
@@ -2202,7 +2311,18 @@ impl<'a> Parser<'a> {
                 10 => {
                     // None arithmetic operators
                     let mut res = res;
+                    // Each postfix step wraps what came before, so a chain
+                    // like `x[0][0][0]...` leans one level deeper per step
+                    // while the brackets stay balanced and this stack stays
+                    // flat - neither of the other two guards sees it. Wrapping
+                    // copies the accumulated tree, so an unbounded chain is
+                    // quadratic as well as deep.
+                    let mut steps = 0u32;
                     loop {
+                        steps += 1;
+                        if steps > Self::MAX_TREE_DEPTH as u32 {
+                            return Err(self.too_deep(Self::MAX_TREE_DEPTH));
+                        }
                         match self.lexer.current()? {
                             Token::LBrace => {
                                 self.lexer.next();
@@ -3048,6 +3168,13 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::functions::init_functions;
+
+    /// The function registry is a process-wide `OnceLock`; parsing `abs(..)`
+    /// or a quantifier looks names up in it.
+    fn with_functions() {
+        let _ = init_functions();
+    }
 
     /// `CYPHER batch=[{v:[..]}, ..]` - the shape a bulk loader sends, one list
     /// literal per row on top of the outer one.
@@ -3091,9 +3218,159 @@ mod tests {
         );
     }
 
+    /// Every way a query can nest, at a depth that used to abort the process.
+    ///
+    /// The parser reaches these three different ways - plain call recursion
+    /// (`{k:{k:..}}`, `CALL {}`), iteration on `parse_expr`'s own stack
+    /// (`[[..]]`, `-(-(..))`), and left-leaning postfix chains (`x[0][0]`) -
+    /// so each needs its own guard, and each is listed here.
+    fn nesting_shapes(n: usize) -> Vec<(&'static str, String)> {
+        vec![
+            (
+                "map",
+                format!(
+                    "CYPHER `b`={}1{} RETURN 1",
+                    "{`k`:".repeat(n),
+                    "}".repeat(n)
+                ),
+            ),
+            (
+                "list",
+                format!("CYPHER `b`={}1{} RETURN 1", "[".repeat(n), "]".repeat(n)),
+            ),
+            (
+                "func",
+                format!("RETURN {}1{}", "abs(".repeat(n), ")".repeat(n)),
+            ),
+            (
+                "case",
+                format!(
+                    "RETURN {}1{}",
+                    "CASE WHEN true THEN ".repeat(n),
+                    " END".repeat(n)
+                ),
+            ),
+            (
+                "listcomp",
+                format!("RETURN {}[1]{}", "[x IN ".repeat(n), "|x]".repeat(n)),
+            ),
+            (
+                "quantifier",
+                format!(
+                    "RETURN {}[1]{}",
+                    "all(x IN ".repeat(n),
+                    " WHERE true)".repeat(n)
+                ),
+            ),
+            (
+                "subquery",
+                format!("{} RETURN 1 AS v{}", "CALL {".repeat(n), "}".repeat(n)),
+            ),
+            (
+                "inline prop",
+                format!(
+                    "MATCH (a {{`k`:{}1{}}}) RETURN 1",
+                    "{`k`:".repeat(n),
+                    "}".repeat(n)
+                ),
+            ),
+            ("index", format!("RETURN [1]{}", "[0]".repeat(n))),
+            (
+                "unary minus",
+                format!("RETURN {}1{}", "-(".repeat(n), ")".repeat(n)),
+            ),
+            (
+                "map projection",
+                format!("MATCH (a) RETURN {}a{{.k}}{}", "[".repeat(n), "]".repeat(n)),
+            ),
+        ]
+    }
+
+    fn parse_fully(query: &str) -> Result<(), String> {
+        Parser::new(query)
+            .parse_parameters()
+            .and_then(|(_, rest)| Parser::new(rest).parse().map(|_| ()))
+    }
+
+    // Regression: nesting was unbounded, so a few kilobytes of `{k:{k:...`
+    // overflowed the stack and aborted the whole server - a remote client
+    // could kill it with one small query, and Rust cannot catch that. Every
+    // shape must now come back as an error, and quickly: rejecting only after
+    // building the tree would still let a deep literal burn quadratic time
+    // (20000 nested lists took 5.8s that way, and 65536 still died).
+    #[test]
+    fn deep_nesting_is_rejected_not_fatal() {
+        with_functions();
+        for (name, query) in nesting_shapes(20_000) {
+            let t = std::time::Instant::now();
+            let err =
+                parse_fully(&query).expect_err(&format!("{name}: 20000-deep nesting was accepted"));
+            // Inline properties refuse a map this shape long before depth
+            // enters into it; every other shape must name the depth.
+            assert!(
+                is_too_deep(&err) || name == "inline prop",
+                "{name}: rejected for the wrong reason: {err}",
+            );
+            assert!(
+                t.elapsed() < std::time::Duration::from_secs(5),
+                "{name}: took {:?} to reject - it is building the tree first",
+                t.elapsed(),
+            );
+        }
+    }
+
+    // Nesting that collapses costs the later stages nothing, so it is not
+    // capped: `(((1)))` folds to `1` and `NOT NOT x` to `x`, however many
+    // there are. test_parentheses in the e2e suite pins the first at 10000.
+    #[test]
+    fn collapsing_nesting_is_not_capped() {
+        for (name, query) in [
+            (
+                "paren",
+                format!("RETURN {}1{}", "(".repeat(20_000), ")".repeat(20_000)),
+            ),
+            ("not chain", format!("RETURN {}true", "NOT ".repeat(20_000))),
+        ] {
+            assert!(
+                parse_fully(&query).is_ok(),
+                "{name}: capped although it collapses"
+            );
+        }
+    }
+
+    // The cap must not be so eager that ordinary nesting stops working.
+    #[test]
+    fn ordinary_nesting_still_parses() {
+        with_functions();
+        for (name, query) in nesting_shapes(16) {
+            if let Err(e) = parse_fully(&query) {
+                // `CALL {}` nested this way is a semantic error on any build;
+                // what matters is that it is not rejected for being too deep.
+                assert!(
+                    !is_too_deep(&e),
+                    "{name}: 16 levels rejected as too deep: {e}"
+                );
+            }
+        }
+    }
+
+    // A parameter's nesting error must survive the wrapper `parse_parameters`
+    // puts around failures, or it reads as an unexplained "could not parse".
+    #[test]
+    fn nesting_error_survives_the_parameter_wrapper() {
+        let q = format!(
+            "CYPHER `b`={}1{} RETURN 1",
+            "[".repeat(500),
+            "]".repeat(500)
+        );
+        let err = Parser::new(&q).parse_parameters().unwrap_err();
+        assert!(is_too_deep(&err), "wrapper hid the reason: {err}");
+    }
+
     // The speculative-ident path must still recognise what it probes for.
     #[test]
     fn bracket_alternatives_still_parse() {
+        with_functions();
         for query in [
             "RETURN [1, 2, 3] AS l",
             "RETURN [x IN [1, 2] | x + 1] AS l",

--- a/graph/src/parser/lexer.rs
+++ b/graph/src/parser/lexer.rs
@@ -770,39 +770,22 @@ impl<'a> Lexer<'a> {
     /// The slice of the query quoted back in an error message: everything when
     /// the query is short, otherwise a window around the error position.
     fn err_ctx(&self) -> Cow<'a, str> {
+        // Both round away from `pos` to a char boundary, and both clamp to the
+        // string's length, so a window that runs off either end is still a
+        // slice this can take.
         let pos = self.pos.min(self.str.len());
-        let start = Self::floor_char_boundary(self.str, pos.saturating_sub(Self::ERR_CTX_WINDOW));
-        let end = Self::ceil_char_boundary(self.str, pos.saturating_add(Self::ERR_CTX_WINDOW));
+        let start = self
+            .str
+            .floor_char_boundary(pos.saturating_sub(Self::ERR_CTX_WINDOW));
+        let end = self
+            .str
+            .ceil_char_boundary(pos.saturating_add(Self::ERR_CTX_WINDOW));
         if start == 0 && end == self.str.len() {
             return Cow::Borrowed(self.str);
         }
         let prefix = if start == 0 { "" } else { "..." };
         let suffix = if end == self.str.len() { "" } else { "..." };
         Cow::Owned(format!("{prefix}{}{suffix}", &self.str[start..end]))
-    }
-
-    /// Largest char boundary `<= i`. `str::floor_char_boundary` is unstable.
-    fn floor_char_boundary(
-        str: &str,
-        i: usize,
-    ) -> usize {
-        let mut i = i.min(str.len());
-        while !str.is_char_boundary(i) {
-            i -= 1;
-        }
-        i
-    }
-
-    /// Smallest char boundary `>= i`. `str::ceil_char_boundary` is unstable.
-    fn ceil_char_boundary(
-        str: &str,
-        i: usize,
-    ) -> usize {
-        let mut i = i.min(str.len());
-        while !str.is_char_boundary(i) {
-            i += 1;
-        }
-        i
     }
 
     #[must_use]

--- a/graph/src/parser/lexer.rs
+++ b/graph/src/parser/lexer.rs
@@ -58,6 +58,7 @@
 //! [`crate::parser::string_escape::cypher_unescape`].
 
 use crate::parser::string_escape::cypher_unescape;
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::{num::IntErrorKind, str::Chars};
 
@@ -757,12 +758,59 @@ impl<'a> Lexer<'a> {
         )
     }
 
+    /// Longest run of query text quoted on either side of the error position.
+    ///
+    /// The whole query used to be echoed back verbatim. Parameter payloads
+    /// bulk loaders send run to megabytes, so every error message copied the
+    /// entire input — and the parser builds error messages on speculative
+    /// paths that discard them, making a single parse quadratic in the payload
+    /// size. A window keeps the message useful and its cost constant.
+    const ERR_CTX_WINDOW: usize = 80;
+
+    /// The slice of the query quoted back in an error message: everything when
+    /// the query is short, otherwise a window around the error position.
+    fn err_ctx(&self) -> Cow<'a, str> {
+        let pos = self.pos.min(self.str.len());
+        let start = Self::floor_char_boundary(self.str, pos.saturating_sub(Self::ERR_CTX_WINDOW));
+        let end = Self::ceil_char_boundary(self.str, pos.saturating_add(Self::ERR_CTX_WINDOW));
+        if start == 0 && end == self.str.len() {
+            return Cow::Borrowed(self.str);
+        }
+        let prefix = if start == 0 { "" } else { "..." };
+        let suffix = if end == self.str.len() { "" } else { "..." };
+        Cow::Owned(format!("{prefix}{}{suffix}", &self.str[start..end]))
+    }
+
+    /// Largest char boundary `<= i`. `str::floor_char_boundary` is unstable.
+    fn floor_char_boundary(
+        str: &str,
+        i: usize,
+    ) -> usize {
+        let mut i = i.min(str.len());
+        while !str.is_char_boundary(i) {
+            i -= 1;
+        }
+        i
+    }
+
+    /// Smallest char boundary `>= i`. `str::ceil_char_boundary` is unstable.
+    fn ceil_char_boundary(
+        str: &str,
+        i: usize,
+    ) -> usize {
+        let mut i = i.min(str.len());
+        while !str.is_char_boundary(i) {
+            i += 1;
+        }
+        i
+    }
+
     #[must_use]
     pub fn format_error(
         &self,
         err: &str,
     ) -> String {
-        format!("{}, errCtx: {}, pos {}", err, self.str, self.pos)
+        format!("{}, errCtx: {}, pos {}", err, self.err_ctx(), self.pos)
     }
 
     pub fn set_pos(
@@ -793,6 +841,51 @@ mod tests {
             lexer.next();
         }
         Ok(tokens)
+    }
+
+    #[test]
+    fn format_error_quotes_a_short_query_whole() {
+        let lexer = Lexer::new("MATCH (n) RETURN");
+        assert_eq!(
+            lexer.format_error("boom"),
+            "boom, errCtx: MATCH (n) RETURN, pos 0"
+        );
+    }
+
+    // Regression: the whole query used to be embedded in every error message,
+    // so a multi-megabyte parameter payload paid a multi-megabyte copy per
+    // error - and the parser builds errors on speculative paths it discards.
+    #[test]
+    fn format_error_windows_a_long_query() {
+        let query = format!("{}NEEDLE{}", "a".repeat(5000), "b".repeat(5000));
+        let mut lexer = Lexer::new(&query);
+        lexer.set_pos(5000);
+        let msg = lexer.format_error("boom");
+        assert!(
+            msg.len() < 300,
+            "error message not bounded: {} bytes",
+            msg.len()
+        );
+        assert!(msg.contains("NEEDLE"), "window lost the error site: {msg}");
+        assert!(
+            msg.contains("errCtx: ...a"),
+            "missing elision marker: {msg}"
+        );
+        assert!(
+            msg.ends_with("..., pos 5000"),
+            "missing elision marker: {msg}"
+        );
+    }
+
+    // The window is cut on char boundaries, not byte offsets: slicing a
+    // multi-byte character in half would panic.
+    #[test]
+    fn format_error_window_respects_char_boundaries() {
+        let query = format!("{}x", "é".repeat(5000));
+        let mut lexer = Lexer::new(&query);
+        lexer.set_pos(5000);
+        let msg = lexer.format_error("boom");
+        assert!(msg.contains('é'));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2443

Two parser defects found while sampling a live `redis-server` during a slow bulk load. Both are pre-existing on `main`.

---

## 1. Parsing an inlined parameter payload was quadratic (5.8x)

A `[` sends the expression parser probing for a list comprehension and then a pattern comprehension before it settles on a plain list literal. Both probes call `parse_ident`, and both **discard** its error — but the error was built first, and `Lexer::format_error` embedded the **entire query text** in every message:

```rust
format!("{}, errCtx: {}, pos {}", err, self.str, self.pos)
```

Bulk loaders inline their rows: `CYPHER batch=[{...},{...}]` payloads run to megabytes, with one list literal per embedding vector. Every `[` then paid two copies of the whole payload.

Sampling put **96% of the busy thread's samples** in `alloc::fmt::format` → `_platform_memmove` under `parse_ident`, with no graph work at all:

```
execute_query → Graph::get_plan → Parser::parse_parameters
  → parse_expr → parse_primary_expr → parse_map        (nested)
    → parse_expr → parse_primary_expr → parse_ident
        → alloc::fmt::format  ...  _platform_memmove   ← 7,100 / 7,393 samples
```

**Fix** — either half removes the quadratic term; together they also stop FalkorDB returning multi-megabyte error strings to clients:

- `format_error` quotes an 80-byte window around the error position instead of the whole query. Cut on char boundaries — slicing a multi-byte character in half would panic.
- `try_parse_ident` returns `Option` and formats nothing, for the seven call sites that were only ever probing.

**Measured** on a 6.7 MB batch of 1477 maps each with a 384-dim embedding — the shape the slow log recorded:

| | time |
|---|---|
| before | 1810 ms |
| after | **310 ms** |
| | **5.8x** |

Parse time is now linear. At a fixed 3.6 MB, splitting across more list literals used to cost 20x more; now flat:

| list literals | 1 | 100 | 1000 | 4000 |
|---|---|---|---|---|
| before | 154 ms | 165 ms | 616 ms | 3065 ms |
| after | 151 ms | 134 ms | 138 ms | 150 ms |

Same 3.6 MB payload with vs. without nested lists — isolating the cause: 3887 ms → 168 ms, against 19 ms for a list-free payload of identical size.

---

## 2. Unbounded nesting aborted the whole server

Nesting had no limit, so a few kilobytes of `{k:{k:{k:...` overflowed the stack and killed the process. Rust cannot catch a stack overflow, so **any client could kill the server with one small query**. Eleven shapes did it, at these depths on a release build:

| shape | crashes at | shape | crashes at |
|---|---|---|---|
| `CALL {}` | 512 | `{k:{k:..}}` | 1024 |
| `abs(abs(..))` | 1024 | `CASE WHEN..` | 1024 |
| `[x IN [x IN ..]]` | 1024 | `all(x IN ..)` | 1024 |
| `(n {k:{k:..}})` | 1024 | `-(-(..))` | 1024 |
| `x[0][0]..` | 2048 | `a{.k}` in `[..]` | 2048 |
| `[[..]]` | 16384 | | |

They arrive three different ways, so one guard cannot cover them:

- **Call recursion** — maps, calls, `CASE`, comprehensions, `CALL {}`. `nested` bounds the descent at `MAX_NESTING`, which is what the call stack can take.
- **Iteration on `parse_expr`'s own stack** — `[[..]]`, `-(-(..))`. These spend no call frames but still build a tree the binder, planner and evaluator each walk recursively, so `open` counts the levels that keep a node and bounds them at `MAX_TREE_DEPTH`. Rejecting *during* the parse rather than after is what keeps this cheap: every level copies the tree so far, so checking afterwards let 20000 nested lists burn 5.8 s and 65536 still die.
- **Left-leaning postfix chains** — `x[0][0]`, `a{.k}`. Brackets stay balanced and the stack stays flat, so the chain is counted directly.

Nesting that **collapses** is deliberately left alone: `(((1)))` folds to `1` and `NOT NOT x` to `x` however deep, and neither reaches the later stages — both still parse at any depth. `test_parentheses` pins the first at 10000.

`MAX_TREE_DEPTH` is 256: above the 100 `test_nested_list` pins, four times below the shallowest depth that used to overflow, leaving room for builds with fatter frames than release.

**After**: every shape is refused in **under 6 ms at depth 65536**, no crashes. The guards cost nothing on the hot path — the 6.7 MB batch above still parses in 310 ms.

---

## Tests

- `list_literals_parse_in_linear_time` — red/green verified: with the fix reverted it fails at 90x (23 ms → 2.07 s for 8x input); with it, 8x. Threshold 24x sits clear of both.
- `deep_nesting_is_rejected_not_fatal` — all 11 crash shapes at depth 20000, asserting both *rejected* and *fast* (a slow rejection means it built the tree first).
- `collapsing_nesting_is_not_capped` — 20000 parens and 20000 `NOT` still parse.
- `ordinary_nesting_still_parses` — 16 levels of every shape.
- `nesting_error_survives_the_parameter_wrapper` — the depth error is no longer masked by "Failed to parse the value of parameter".
- `bracket_alternatives_still_parse` — the speculative path still recognises what it probes for.
- Three `format_error` tests: short query, windowing, char boundaries.

All suites pass: 143 Rust unit, 136 e2e/function/MVCC/concurrency, 2456 TCK scenarios, 1409 flow. `cargo fmt --check` clean; `clippy --all-targets` adds no new warnings.

## Not included

`[(pattern) | expr]` comprehensions are quadratic in the **optimizer** (`replace_cartesian_with_hash_join::rebuild_with_hash_joins`) — 4.2x for 2x input, reproduced identically on the unpatched build. Parsing them is linear, so it is a different subsystem and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance when parsing large, list-heavy queries.
  * Added safeguards against excessively deep query nesting.
  * Preserved correct parsing and error handling across parameters, patterns, aliases, and list comprehensions.
  * Limited long-query error messages to a concise context window while preserving UTF-8 characters.

* **Tests**
  * Added coverage for performance, deep nesting, alternate parsing paths, error propagation, truncated messages, and multibyte text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->