### PR TITLE
fix(bulk): bound GRAPH.BULK declared counts and make id reservation fallible

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1301,12 +1301,21 @@ impl Graph {
         self.reserved_node_count += 1;
     }
 
+    /// Reserve `count` node ids, failing instead of aborting when `count` cannot be
+    /// allocated.
+    ///
+    /// `GRAPH.BULK` reserves from a client-declared count, so the allocation size is
+    /// attacker-influenced: `Vec::with_capacity` panicked on the capacity overflow, and the
+    /// panic hook (`src/module_init.rs`) exits the process, so it took the server down
+    /// (#2426). `try_reserve_exact` turns that into an error the command can report.
     pub fn reserve_nodes(
         &mut self,
         count: usize,
-    ) -> Vec<NodeId> {
+    ) -> Result<Vec<NodeId>, String> {
+        let mut ids = Vec::new();
+        ids.try_reserve_exact(count)
+            .map_err(|_| format!("failed to reserve {count} node ids"))?;
         let count = count as u64;
-        let mut ids = Vec::with_capacity(count as usize);
         let deleted_len = self.deleted_nodes.len();
         let available = deleted_len.saturating_sub(self.reserved_node_count);
         let reclaimed = count.min(available);
@@ -1335,7 +1344,7 @@ impl Graph {
         self.reserved_node_count += remaining;
         ids.extend((start..start + remaining).map(NodeId));
 
-        ids
+        Ok(ids)
     }
 
     pub fn create_nodes(
@@ -2022,12 +2031,16 @@ impl Graph {
         self.reserved_relationship_count += 1;
     }
 
+    /// Reserve `count` relationship ids. Fallible for the same reason as
+    /// [`Self::reserve_nodes`]: `GRAPH.BULK` sizes this from a client-declared count.
     pub fn reserve_relationships(
         &mut self,
         count: usize,
-    ) -> Vec<RelationshipId> {
+    ) -> Result<Vec<RelationshipId>, String> {
+        let mut ids = Vec::new();
+        ids.try_reserve_exact(count)
+            .map_err(|_| format!("failed to reserve {count} relationship ids"))?;
         let count = count as u64;
-        let mut ids = Vec::with_capacity(count as usize);
         let deleted_len = self.deleted_relationships.len();
         let available = deleted_len.saturating_sub(self.reserved_relationship_count);
         let reclaimed = count.min(available);
@@ -2051,7 +2064,7 @@ impl Graph {
         self.reserved_relationship_count += remaining;
         ids.extend((start..start + remaining).map(RelationshipId));
 
-        ids
+        Ok(ids)
     }
 
     /// Create relationships of a single type using flat arrays.

--- a/graph/src/runtime/ops/create.rs
+++ b/graph/src/runtime/ops/create.rs
@@ -150,7 +150,7 @@ impl Runtime<'_> {
             let active_len = batch.active_len();
 
             // Reserve all node IDs at once
-            let node_ids = self.g.borrow_mut().reserve_nodes(active_len);
+            let node_ids = self.g.borrow_mut().reserve_nodes(active_len)?;
 
             // Record creations and set labels in batch
             {
@@ -264,7 +264,7 @@ impl Runtime<'_> {
             }
 
             // Reserve all relationship IDs at once
-            let ids = self.g.borrow_mut().reserve_relationships(endpoints.len());
+            let ids = self.g.borrow_mut().reserve_relationships(endpoints.len())?;
 
             // Record all created relationships directly into pending (no intermediate Vec)
             let type_name = rel.types.first().unwrap().clone();

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -1,7 +1,7 @@
 use crate::query_session::{QuerySession, hold_gil};
 use crate::{
     config::CONFIGURATION_CACHE_SIZE,
-    graph_core::{BlockedClient, ThreadedGraph, ffi},
+    graph_core::{BlockedClient, ThreadedGraph, ffi, register_graph},
     redis_type::GRAPH_TYPE,
     telemetry,
 };
@@ -190,8 +190,12 @@ fn parse_header(
     // Read property count (4 bytes)
     let prop_count = read_u32_ne(data, idx)? as usize;
 
-    // Read property names
-    let mut prop_names = Vec::with_capacity(prop_count);
+    // Read property names. Cap the pre-allocation to the bytes that remain, exactly as
+    // `read_property` does for `BI_ARRAY` above: `prop_count` is 4 raw bytes of client
+    // input, so a declared count of `u32::MAX` would otherwise request ~34GB of `Arc`
+    // slots before the first name is even read.
+    let cap = prop_count.min(data.len().saturating_sub(*idx));
+    let mut prop_names = Vec::with_capacity(cap);
     for _ in 0..prop_count {
         let name = read_cstring(data, idx)?;
         validate_identifier_len(name, "Property name")?;
@@ -511,8 +515,8 @@ fn bulk_insert_sync(
     rel_token_count: usize,
     docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
-    let node_ids = g.reserve_nodes(node_count);
-    let rel_ids = g.reserve_relationships(edge_count);
+    let node_ids = g.reserve_nodes(node_count)?;
+    let rel_ids = g.reserve_relationships(edge_count)?;
     let mut node_id_cursor = 0usize;
     let mut rel_id_cursor = 0usize;
 
@@ -541,8 +545,8 @@ fn bulk_insert_sync_yield(
     raw_ctx: *mut raw::RedisModuleCtx,
     docs: &mut BulkIndexDocs,
 ) -> Result<(), String> {
-    let node_ids = g.reserve_nodes(node_count);
-    let rel_ids = g.reserve_relationships(edge_count);
+    let node_ids = g.reserve_nodes(node_count)?;
+    let rel_ids = g.reserve_relationships(edge_count)?;
     let mut node_id_cursor = 0usize;
     let mut rel_id_cursor = 0usize;
 
@@ -560,6 +564,62 @@ fn bulk_insert_sync_yield(
     // Flush delta-plus into base to prevent O(N²) dp accumulation across commands
     g.flush_for_bulk();
     Ok(())
+}
+
+/// Parse one of `GRAPH.BULK`'s four count arguments the way C's
+/// `RedisModule_StringToLongLong` (`string2ll`) does — canonical decimal only.
+///
+/// Negatives are the one deliberate divergence: C accepts them, truncates to `uint`, and
+/// reports the original value back. Refusing them keeps a nonsense count from ever
+/// reaching a reservation.
+fn parse_count(s: &str) -> Option<usize> {
+    // The empty string, which `string2ll` rejects on its length check.
+    if s.is_empty() {
+        return None;
+    }
+    // Any non-digit byte anywhere: sign (`+10`, `-5`), radix point and exponent (`1.5`,
+    // `1e1`), hex (`0x0a`), leading or trailing space. `string2ll` gets this from its
+    // digit-only scan plus its "not all bytes were used" check.
+    if !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    // Leading zeros (`010`, `00`): `string2ll` special-cases a lone `0`, then requires the
+    // first digit to be 1-9.
+    if s.len() > 1 && s.starts_with('0') {
+        return None;
+    }
+    // Through `i64` so the accepted range is `string2ll`'s and not `usize`'s — 2^63 is 19
+    // canonical digits that C rejects.
+    usize::try_from(s.parse::<i64>().ok()?).ok()
+}
+
+/// Bytes an edge record spends on its endpoints before any properties: the two
+/// `read_u64_ne` reads at the top of `process_edge_token`'s loop. Node records have no
+/// such fixed part.
+const EDGE_ENDPOINTS_LEN: usize = 16;
+
+/// Largest number of records `token` can describe, from the same arithmetic its reader uses.
+///
+/// Every property occupies at least its 1-byte type marker — `BI_NULL` is exactly that, and
+/// the bulk loader emits it for every empty CSV field — so a record costs at least
+/// `endpoints_len + P` bytes, where `P` is the property count in the token header. A node
+/// token whose header declares no properties describes no records at all: its record body is
+/// empty, so `process_node_token`'s `while idx < data.len()` loop never runs.
+///
+/// Parsing the header here also validates its identifier lengths before any graph state is
+/// touched, which is the order C uses (`_BulkInsert_ValidateTokens` in `bulk_insert.c`).
+fn max_records(
+    token: &[u8],
+    entity: &str,
+    endpoints_len: usize,
+) -> Result<usize, String> {
+    let mut idx = 0;
+    let (_, prop_names) = parse_header(token, &mut idx, entity)?;
+    let per_record = endpoints_len + prop_names.len();
+    if per_record == 0 {
+        return Ok(0);
+    }
+    Ok(token.len().saturating_sub(idx) / per_record)
 }
 
 pub fn graph_bulk_insert(
@@ -613,52 +673,45 @@ pub fn graph_bulk_insert(
         (false, next)
     };
 
-    // Get or create graph. The key handle is scoped to this block so a later
-    // failure can re-open the key to delete it (see `discard_created_graph`)
-    // without a second live handle to the same key.
-    let graph = {
+    // Resolve the graph without writing to the keyspace yet: reading the key first keeps
+    // the argument errors below from reporting ahead of "already exists" / "empty key",
+    // which is the order C uses (it retrieves the GraphContext before parsing the counts).
+    // Creating nothing until the whole batch has been validated is what lets a rejected
+    // batch leave no key behind, so the client can re-run the corrected one instead of
+    // tripping the "already exists" guard. The key handle is scoped to this block so the
+    // creation below — and `discard_created_graph` on the failure paths — can re-open the
+    // key without a second live handle to it.
+    let existing = {
         let key = ctx.open_key_writable(&key_str);
+        let found = key
+            .get_value::<Arc<RwLock<ThreadedGraph>>>(&GRAPH_TYPE)?
+            .cloned();
         if begin {
-            if key
-                .get_value::<Arc<RwLock<ThreadedGraph>>>(&GRAPH_TYPE)?
-                .is_some()
-            {
+            if found.is_some() {
                 return Err(redis_module::RedisError::String(format!(
                     "Graph with name '{key_str}' cannot be created, as key '{key_str}' already exists."
                 )));
             }
-            let g = Arc::new(RwLock::new(ThreadedGraph::new(
-                *CONFIGURATION_CACHE_SIZE.lock(ctx) as usize,
-                &key_str.to_string(),
-            )));
-            key.set_value(&GRAPH_TYPE, g.clone())?;
-            crate::graph_core::register_graph(key_str.to_string(), g.clone());
-            g
-        } else if let Some(g) = key.get_value::<Arc<RwLock<ThreadedGraph>>>(&GRAPH_TYPE)? {
-            g.clone()
-        } else {
+        } else if found.is_none() {
             return Err(redis_module::RedisError::Str(
                 "ERR Invalid graph operation on empty key",
             ));
         }
+        found
     };
 
     // Parse counts
-    let node_count: usize = node_count_str
-        .parse()
-        .map_err(|_| redis_module::RedisError::Str("Error parsing node count."))?;
-    let edge_count: usize = args
-        .next_str()?
-        .parse()
-        .map_err(|_| redis_module::RedisError::Str("Error parsing relation count."))?;
-    let node_token_count: usize = args
-        .next_str()?
-        .parse()
-        .map_err(|_| redis_module::RedisError::Str("Error parsing node token count."))?;
-    let rel_token_count: usize = args
-        .next_str()?
-        .parse()
-        .map_err(|_| redis_module::RedisError::Str("Error parsing relation token count."))?;
+    let node_count = parse_count(node_count_str)
+        .ok_or(redis_module::RedisError::Str("Error parsing node count."))?;
+    let edge_count = parse_count(args.next_str()?).ok_or(redis_module::RedisError::Str(
+        "Error parsing relation count.",
+    ))?;
+    let node_token_count = parse_count(args.next_str()?).ok_or(redis_module::RedisError::Str(
+        "Error parsing node token count.",
+    ))?;
+    let rel_token_count = parse_count(args.next_str()?).ok_or(redis_module::RedisError::Str(
+        "Error parsing relation token count.",
+    ))?;
 
     // Collect remaining binary token args
     let token_strings: Vec<RedisString> = args.collect();
@@ -667,6 +720,63 @@ pub fn graph_bulk_insert(
             "Bulk insert format error, token count mismatch.",
         ));
     }
+
+    //--------------------------------------------------------------------------
+    // Bound the declared counts by what the payload can describe.
+    //
+    // `node_count` and `edge_count` are pure client input, and they size a `Vec` of ids
+    // directly in `Graph::reserve_nodes` / `reserve_relationships`. Unbounded, that is a
+    // crash: `GRAPH.BULK g BEGIN 9223372036854775807 0 0 0` carries no payload at all, and
+    // the capacity overflow aborted the whole process (#2426). Below the overflow threshold
+    // it is a memory-amplification vector, since the reservation really happens.
+    //
+    // The sections are positional — the first `node_token_count` tokens hold nodes and the
+    // rest hold edges, the same split `bulk_insert_sync` iterates with — so each count is
+    // bounded by the records its own section describes.
+    //--------------------------------------------------------------------------
+    // A malformed header reports exactly what it reports when the insert itself trips over
+    // it below — only sooner, before any graph state exists to roll back.
+    let header_err =
+        |e: String| redis_module::RedisError::String(format!("ERR bulk insert failed: {e}"));
+    let (node_tokens, rel_tokens) = token_strings.split_at(node_token_count);
+
+    let mut node_ceiling = 0usize;
+    for token in node_tokens {
+        node_ceiling += max_records(token.as_slice(), "Label name", 0).map_err(header_err)?;
+    }
+    if node_count > node_ceiling {
+        return Err(redis_module::RedisError::String(format!(
+            "Bulk insert format error, declared node count {node_count} exceeds the \
+             {node_ceiling} node records the payload describes."
+        )));
+    }
+
+    let mut edge_ceiling = 0usize;
+    for token in rel_tokens {
+        edge_ceiling += max_records(token.as_slice(), "Relationship type", EDGE_ENDPOINTS_LEN)
+            .map_err(header_err)?;
+    }
+    if edge_count > edge_ceiling {
+        return Err(redis_module::RedisError::String(format!(
+            "Bulk insert format error, declared relation count {edge_count} exceeds the \
+             {edge_ceiling} edge records the payload describes."
+        )));
+    }
+
+    // Every argument checks out, so it is safe to put a graph in the keyspace.
+    let graph = match existing {
+        Some(g) => g,
+        None => {
+            let key = ctx.open_key_writable(&key_str);
+            let g = Arc::new(RwLock::new(ThreadedGraph::new(
+                *CONFIGURATION_CACHE_SIZE.lock(ctx) as usize,
+                &key_str.to_string(),
+            )));
+            key.set_value(&GRAPH_TYPE, g.clone())?;
+            register_graph(key_str.to_string(), g.clone());
+            g
+        }
+    };
 
     // Run inline on this thread; `inline` is decided above, before the arguments were
     // consumed. Replication here is verbatim: this is the real command context, so

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -3,6 +3,7 @@ import os
 import csv
 import time
 import random
+import struct
 import threading
 from common import *
 from click.testing import CliRunner
@@ -913,3 +914,85 @@ class testGraphBulkInsertFlow(FlowTestsBase):
 
         os.remove(node_csv)
         os.remove(rel_csv)
+
+    # The declared node / edge counts size an id reservation directly, so they have to be
+    # bounded by what the payload can describe, and they have to be parsed as strictly as
+    # C parses them.
+    #
+    # Regression (#2426): the counts went straight to `Vec::with_capacity`, so
+    # `GRAPH.BULK g BEGIN 9223372036854775807 0 0 0` — no payload at all — overflowed the
+    # capacity computation, and the panic hook takes the process down. Every case below
+    # therefore re-checks that the server is still answering, not merely that the command
+    # returned an error.
+    def test14_declared_counts_are_bounded(self):
+        conn = self.db.connection
+        graphname = "bulk_counts"
+
+        def assert_rejected(*args):
+            try:
+                self.db.execute_command("GRAPH.BULK", graphname, "BEGIN", *args)
+                self.env.assertTrue(False)
+            except redis.ResponseError as e:
+                # Still alive, and the rejected BEGIN batch left no key behind — otherwise
+                # the corrected re-run would trip the "already exists" guard.
+                self.env.assertTrue(conn.ping())
+                self.env.assertEqual(conn.exists(graphname), 0)
+                return str(e)
+
+        # one node token: label "N", one property "v", one BI_LONG record — 17 bytes total,
+        # of which a 9-byte record body describing a single node
+        node_token = b"N\0" + struct.pack("=I", 1) + b"v\0" + struct.pack("=Bq", 4, 7)
+        # one edge token: type "R", no properties, one 16-byte src/dest record
+        edge_token = b"R\0" + struct.pack("=I", 0) + struct.pack("=QQ", 0, 0)
+
+        #-----------------------------------------------------------------------
+        # counts with no payload to back them
+        #-----------------------------------------------------------------------
+
+        # i64::MAX: the crash
+        assert_rejected(9223372036854775807, 0, 0, 0)
+        assert_rejected(0, 9223372036854775807, 0, 0)
+        # below the overflow threshold, but still a 2.1B-id reservation
+        assert_rejected(2147483647, 0, 0, 0)
+        assert_rejected(0, 2147483647, 0, 0)
+
+        #-----------------------------------------------------------------------
+        # counts that outrun the payload they came with
+        #-----------------------------------------------------------------------
+
+        assert_rejected(1000000, 0, 1, 0, node_token)
+        assert_rejected(0, 1000000, 0, 1, edge_token)
+
+        # The ceiling counts records, not bytes: the node token is 17 bytes long but only 9
+        # of them are record body, and a record costs at least one byte per declared
+        # property. Ten nodes is under the byte count and still impossible.
+        assert_rejected(10, 0, 1, 0, node_token)
+        # Two edges need 32 bytes of endpoints; the token carries 16.
+        assert_rejected(0, 2, 0, 1, edge_token)
+
+        #-----------------------------------------------------------------------
+        # count parsing, against C's `string2ll`
+        #-----------------------------------------------------------------------
+
+        for bad in ["010", "+10", "-5", " 10", "10 ", "1e1", "1.5", "0x0a", "",
+                    "9223372036854775808"]:
+            self.env.assertContains("Error parsing node count.",
+                                    assert_rejected(bad, 0, 0, 0))
+        # each count reports itself, so a mis-ordered read would show up here
+        self.env.assertContains("Error parsing relation count.",
+                                assert_rejected(0, "+10", 0, 0))
+
+        #-----------------------------------------------------------------------
+        # positive control, on the very name every case above was rejected under:
+        # an honest batch still loads, and nothing the rejections left behind
+        # stands in its way
+        #-----------------------------------------------------------------------
+
+        res = self.db.execute_command("GRAPH.BULK", graphname, "BEGIN", 1, 1, 1, 1,
+                                      node_token, edge_token)
+        self.env.assertContains("1 nodes created", res)
+        self.env.assertContains("1 relations created", res)
+
+        graph = self.db.select_graph(graphname)
+        query_result = graph.query("MATCH (n:N)-[:R]->(n) RETURN n.v")
+        self.env.assertEqual(query_result.result_set, [[7]])


### PR DESCRIPTION
Closes #2426

## What was wrong

`GRAPH.BULK` trusted the client-declared `node_count` / `edge_count` and passed them
straight to `Vec::with_capacity`, so a single command aborted the process:

```console
$ redis-cli GRAPH.BULK g BEGIN 9223372036854775807 0 0 0
Error: Server closed the connection
```

```
# FalkorDB panic: panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow
   9: graph::graph::graph::Graph::reserve_nodes
```

Both count fields are affected — `reserve_relationships` has the identical shape. Nothing
validated the declared counts against the payload; the only existing check covered the number
of *tokens*, which is why the repro needs no payload at all: with `node_token_count == 0` the
token-count check passes and nothing is ever parsed.

Still present verbatim on `main` at `cf3ec7a6f`: `graph.rs:1309` and `graph.rs:2030`.

## The fix

**`src/commands/bulk_insert.rs`** — three changes at the trust boundary:

1. `parse_count` replaces the four `str::parse` calls, matching `string2ll`: rejects a leading
   `+`, leading zeros, and any non-digit byte, while keeping Rust's rejection of negatives.
2. A pre-pass bounds each declared count by what the payload can **describe**, not by its byte
   length. `max_records` reuses `parse_header` and the reader's own arithmetic — a record costs
   at least `endpoints_len + P` bytes (`P` = header property count; a property is ≥1 byte
   because `BI_NULL` is just its marker), and a node token with `P == 0` describes zero records
   since the read loop is byte-driven. The sections are positional, so each count is bounded by
   its own section: the first `node_token_count` tokens for nodes, the rest for edges.
3. The graph key is created **after** validation, so a rejected batch leaves the keyspace
   untouched. Key resolution stays first, preserving C's error precedence for
   `"…already exists."` and `"Invalid graph operation on empty key"`.

`parse_header`'s property pre-allocation is also capped by remaining bytes, the way
`read_property` already caps `BI_ARRAY`.

**`graph/src/graph/graph.rs`** — `reserve_nodes` / `reserve_relationships` return
`Result<_, String>` via `try_reserve_exact`, with four call sites propagating (two in bulk, two
in `create.rs`). An over-large request becomes a query error instead of an allocator abort,
which matters because the panic happened on a threadpool worker and took the process with it.

## Correction to the issue's C comparison

**#2426's "C does not do this" section is not reproducible, and its conclusion is inverted.**
Measured on `falkordb/falkordb-server:edge-c` and `:edge-rs`, 15.6 GB Docker VM, one fresh
container per probe:

| declared `node_count` | C (`edge-c`) | Rust (`edge-rs`, pre-fix) |
| --- | --- | --- |
| 2²⁴ | success; RSS 16 → 177 MiB, **retained** | success; RSS flat |
| 2²⁶ | success; RSS → 821 MiB, retained | success; RSS flat |
| 2²⁸ | success; RSS → **3.32 GiB**, retained | success; peak 1.9 GiB, **freed** (final 33 MiB) |
| 2³⁰ | **OOM-killed, exit 137** | **OOM-killed, exit 137** (peak 8.5 GiB) |
| `i64::MAX` | **OOM-killed, exit 137** | **panic `capacity overflow`, exit 1** |
| `-5` | **OOM-killed, exit 137** | rejected |

So:

- C **does** preallocate from the declared count — ~13 bytes per declared node, linear across
  2²⁰–2²⁸ — and unlike Rust it *retains* the allocation.
- C is not "alive" at 2³¹ as the issue records; it is OOM-killed at 2³⁰ on a 15.6 GB host.
- C accepting `-5` and replying `-5 nodes created` is not reproducible — `-5` OOM-kills it,
  consistent with a negative→unsigned cast.
- **Both** engines reply `N nodes created` for nodes that do not exist. C's graph after
  claiming `1048576 nodes created` returns `0` for `MATCH (n) RETURN count(n)`.

**This PR therefore does not aim at parity with C on this surface — C is the weaker side.** It
rejects the input outright, which is better than both engines' current behaviour. The one place
C *is* the reference is count parsing, and that part of the issue is accurate: C rejects `010`
and `+10` with `Error parsing node count.` while Rust accepted them. That gap is closed here.

The `-5` row needs no code change: Rust already rejected negatives and continues to.

## Verification

Anchored to `main` at `cf3ec7a6f`, all measured after the rebase.

**The issue's repro, fixed:**

```console
$ GRAPH.BULK g BEGIN 9223372036854775807 0 0 0
Bulk insert format error, declared node count 9223372036854775807 exceeds the 0 node records the payload describes.
$ GRAPH.BULK g2 BEGIN 0 9223372036854775807 0 0
Bulk insert format error, declared relation count 9223372036854775807 exceeds the 0 edge records the payload describes.
$ PING
PONG
$ KEYS *
(empty)
```

**Parsing matrix** — `010`, `+10`, `-5`, `' 10'`, `'10 '`, `0x0a`, `1e1`, `''` all return
`Error parsing node count.`; the server stays up for every input.

**The ceiling is record-based, not byte-based:** with a 17-byte node token (9-byte body), `10`
nodes is rejected and `9` accepted — a byte bound would have let `10` through.

**Red side:** the pre-fix panic is reproduced on `edge-rs`, and the responsible code is present
verbatim on `main` (`graph.rs:1309`, `:2030`), so the crash path is identical.

**Suites:**

| check | result |
| --- | --- |
| `tests/flow/test_bulk_insertion` | **14/14**, including the new `test14_declared_counts_are_bounded` |
| `cargo test -p graph` | **134 passed, 0 failed, 6 ignored** |
| `cargo check --all-targets` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets` | exit 0; 2 `too_many_arguments` warnings, both pre-existing — `bulk_insert_sync_yield` is already 8-arg on `main` (`bulk_insert.rs:534-543`, unchanged here) and `expand_row` (`cond_var_len_traverse.rs:491`) is not touched by this PR |

One `cargo test -p graph` run failed once early on (133 passed / 1 failed) and did not reproduce
in the 18 runs since; the failing test name was lost to output truncation, so it is recorded here
rather than attributed. Nothing in this diff is timing-dependent — the two changed signatures are
deterministic — but it is called out rather than papered over.

## Note on the replicated path

Since #2420, `GRAPH.BULK` is rebuilt and replicated, and the widened inline predicate means a
replica applies it on the `REPLICATED` path — so this validation now runs on the replica too. A
same-version master and replica always agree: identical code, and #2420 replicates the same
argument vector, so both reach the same verdict. A divergence is only reachable across mixed
versions, where an old master could accept a batch a new replica rejects. Worth recording, not
worth gating on.

## Follow-up, not in this PR

The C-side defects measured above — retained memory amplification from a client-declared count,
false `N nodes created` success, and the `-5` OOM — are `master`-branch bugs and need their own
issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk graph insertion validation for malformed, oversized, or payload-inconsistent node and relationship counts.
  * Prevented invalid batches from creating graph entries or causing allocation failures.
  * Allocation errors are now reported cleanly instead of potentially crashing the operation.
  * Valid bulk insertions continue to succeed and create the expected graph data.

* **Tests**
  * Added coverage for invalid count formats, excessive counts, rejected batches, and successful valid insertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->