### PR TITLE
fix(dispatch): widen the cannot-block predicate to C's five flags

### DIFF
--- a/flow_tests_done.txt
+++ b/flow_tests_done.txt
@@ -1,6 +1,7 @@
 tests/flow/test_access_del_entity
 tests/flow/test_aggregation
 tests/flow/test_all_shortest_paths.py
+tests/flow/test_aof.py
 tests/flow/test_betweenness.py
 tests/flow/test_bfs.py
 tests/flow/test_bidirectional_traversals.py

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -1,3 +1,4 @@
+use crate::dispatch::must_run_inline;
 use crate::query_session::{QuerySession, hold_gil};
 use crate::{
     config::CONFIGURATION_CACHE_SIZE,
@@ -12,7 +13,7 @@ use graph::{
     threadpool::spawn,
 };
 use parking_lot::RwLock;
-use redis_module::{Context, ContextFlags, NextArg, RedisResult, RedisString, RedisValue, raw};
+use redis_module::{Context, NextArg, RedisResult, RedisString, RedisValue, raw};
 use roaring::RoaringTreemap;
 use rustc_hash::FxHashMap;
 use std::ffi::CString;
@@ -570,30 +571,12 @@ pub fn graph_bulk_insert(
         return Err(redis_module::RedisError::WrongArity);
     }
 
-    // Contexts that cannot block run inline, with RM_Yield so Redis still handles
-    // PING between tokens. The predicate mirrors C's dispatcher
-    // (`cmd_dispatcher.c`), which is the reference for "this context must not
-    // block":
-    //   * REPLICATED — a replica has to apply the batch *before* the handler
-    //     returns. Blocking instead lets Redis advance the replication offset
-    //     while the write is still queued, so the master's WAIT reports the
-    //     replica in sync when it is not (same reasoning as `graph_core`).
-    //   * MULTI / LUA — Redis rejects blocking outright in both.
-    //   * DENY_BLOCKING / LOADING — AOF replay drives a fake client that carries
-    //     no CLIENT_MASTER, so REPLICATED is *not* set for it. Blocking that client
-    //     is not merely wrong, it is fatal: Redis asserts
-    //     `(fakeClient->flags & CLIENT_BLOCKED) == 0` (`aof.c`) while loading, so
-    //     any AOF-enabled server crashed on restart after a bulk load.
+    // Contexts that cannot block run inline, with RM_Yield so Redis still handles PING
+    // between tokens — see `must_run_inline` for the flag set and why each one is in it.
     //
-    // Decided up front, before the argument vector is consumed, so the background
-    // path can hold the arguments while they are still to hand.
-    let inline = ctx.get_flags().intersects(
-        ContextFlags::MULTI
-            | ContextFlags::REPLICATED
-            | ContextFlags::LUA
-            | ContextFlags::DENY_BLOCKING
-            | ContextFlags::LOADING,
-    );
+    // Decided up front, before the argument vector is consumed, so the background path
+    // can hold the arguments while they are still to hand.
+    let inline = must_run_inline(ctx);
 
     // Hold everything after the command name for replication (see `HeldArgs`). No
     // inspection or reassembly: the argument vector is already exactly what has to be

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -18,6 +18,7 @@
 //! deadlock: the handler holds the GIL while waiting for the graph read lock, and a
 //! committing write holds the write lock while waiting for the GIL (issue #726).
 
+use crate::dispatch::must_run_inline;
 use crate::query_session::QuerySession;
 use crate::{
     commands::EMPTY_KEY_ERR,
@@ -27,9 +28,7 @@ use crate::{
 use graph::{graph::graph::Plan, threadpool::spawn};
 use orx_tree::{Dfs, NodeRef};
 use parking_lot::RwLock;
-use redis_module::{
-    Context, ContextFlags, NextArg, RedisError, RedisResult, RedisString, RedisValue, raw,
-};
+use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue, raw};
 use std::{os::raw::c_char, sync::Arc};
 
 /// Acquire the graph read lock, build the plan, reply the linearized tree. Runs on a
@@ -72,12 +71,9 @@ pub fn graph_explain(
     };
     let graph = graph.clone();
 
-    // Blocking clients are not allowed inside MULTI/EXEC, and replicated
-    // commands must complete before the handler returns (same rules as
-    // GRAPH.QUERY) — run synchronously in those cases.
-    if ctx.get_flags().contains(ContextFlags::MULTI)
-        || ctx.get_flags().contains(ContextFlags::REPLICATED)
-    {
+    // Contexts that cannot block run inline — same rules as GRAPH.QUERY, see
+    // `must_run_inline`.
+    if must_run_inline(ctx) {
         return explain(ctx, &graph, query);
     }
 

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -37,6 +37,7 @@
 //! handler holds the GIL while waiting for the read lock, and the write holds the
 //! write lock while waiting for the GIL.
 
+use crate::dispatch::must_run_inline;
 use crate::query_session::QuerySession;
 use crate::{
     graph_core::{BlockedClient, ThreadedGraph, ffi},
@@ -44,9 +45,7 @@ use crate::{
 };
 use graph::threadpool::spawn;
 use parking_lot::RwLock;
-use redis_module::{
-    Context, ContextFlags, NextArg, RedisError, RedisResult, RedisString, RedisValue,
-};
+use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue};
 use std::sync::Arc;
 
 const MB: usize = 1 << 20;
@@ -220,12 +219,9 @@ pub fn graph_memory(
         .ok_or(RedisError::Str("Graph does not exist"))?
         .clone();
 
-    // Blocking clients are not allowed inside MULTI/EXEC, and replicated
-    // commands must complete before the handler returns (same rules as
-    // GRAPH.QUERY) — run synchronously in those cases.
-    if ctx.get_flags().contains(ContextFlags::MULTI)
-        || ctx.get_flags().contains(ContextFlags::REPLICATED)
-    {
+    // Contexts that cannot block run inline — same rules as GRAPH.QUERY, see
+    // `must_run_inline`.
+    if must_run_inline(ctx) {
         return memory_report(&graph, samples);
     }
 

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -18,6 +18,7 @@
 //! Like `GRAPH.QUERY`, execution happens on the thread pool with the client
 //! blocked; the main thread only resolves (or creates) the graph key.
 
+use crate::dispatch::must_run_inline;
 use crate::query_session::QuerySession;
 use crate::{
     config::{CONFIGURATION_CACHE_SIZE, CONFIGURATION_IMPORT_FOLDER},
@@ -36,9 +37,7 @@ use graph::{
 };
 use orx_tree::{Bfs, Collection, NodeRef};
 use parking_lot::RwLock;
-use redis_module::{
-    Context, ContextFlags, NextArg, RedisError, RedisResult, RedisString, RedisValue, raw,
-};
+use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue, raw};
 use std::{collections::HashMap, os::raw::c_char, sync::Arc};
 
 #[inline]
@@ -241,12 +240,9 @@ pub fn graph_record(
         graph
     };
 
-    // Blocking clients are not allowed inside MULTI/EXEC, and replicated
-    // commands must complete before the handler returns (same rules as
-    // GRAPH.QUERY) — run synchronously in those cases.
-    if ctx.get_flags().contains(ContextFlags::MULTI)
-        || ctx.get_flags().contains(ContextFlags::REPLICATED)
-    {
+    // Contexts that cannot block run inline — same rules as GRAPH.QUERY, see
+    // `must_run_inline`.
+    if must_run_inline(ctx) {
         return record_mut(ctx, &graph, &key_name, query);
     }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,44 @@
+//! Where a graph command runs: inline on the calling thread, or blocked and handed to
+//! the thread pool.
+
+use redis_module::{Context, ContextFlags};
+
+/// True when this context must not block, so the command has to run inline on the
+/// calling thread.
+///
+/// Mirrors C's dispatcher (`src/commands/cmd_dispatcher.c` on `master`), which is the
+/// reference for "this context must not block":
+///
+/// ```c
+/// bool main_thread = (is_replicated ||
+///     (flags & (REDISMODULE_CTX_FLAGS_MULTI       |
+///             REDISMODULE_CTX_FLAGS_LUA           |
+///             REDISMODULE_CTX_FLAGS_DENY_BLOCKING |
+///             REDISMODULE_CTX_FLAGS_LOADING))) ;
+/// ```
+///
+/// Every flag earns its place:
+///
+/// * `REPLICATED` — a replica has to apply the command *before* the handler returns.
+///   Blocking instead lets Redis advance the replication offset while the write is
+///   still queued, so the master's `WAIT` reports the replica in sync when it is not.
+/// * `MULTI` / `LUA` — Redis rejects blocking outright in both. `LUA` is defensive
+///   only: every graph command is registered `deny-script`, so Redis rejects the call
+///   before the handler runs.
+/// * `DENY_BLOCKING` / `LOADING` — AOF replay drives a fake client carrying
+///   `CLIENT_DENY_BLOCKING` but *not* `CLIENT_MASTER`, so `REPLICATED` is not set for
+///   it. Blocking that client is fatal rather than merely wrong: Redis asserts
+///   `(fakeClient->flags & CLIENT_BLOCKED) == 0` (`aof.c`) while loading, so any
+///   AOF-enabled server crashed on restart (#2421).
+///
+/// Keep this the single definition. The bug it closes was five call sites having each
+/// grown a narrower copy of C's one predicate, and drifting from it independently.
+pub fn must_run_inline(ctx: &Context) -> bool {
+    ctx.get_flags().intersects(
+        ContextFlags::MULTI
+            | ContextFlags::REPLICATED
+            | ContextFlags::LUA
+            | ContextFlags::DENY_BLOCKING
+            | ContextFlags::LOADING,
+    )
+}

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -74,6 +74,7 @@ use std::{
 use crate::allocator::{
     current_thread_usage, disable_tracking, enable_tracking, net_thread_usage, reset_counter,
 };
+use crate::dispatch::must_run_inline;
 use crate::query_session::QuerySession;
 
 /// Global registry of all live graph instances.
@@ -923,14 +924,13 @@ pub fn query_mut(
         }
     }
 
-    // Inside MULTI/EXEC: execute synchronously (blocking commands not allowed).
-    // Also run replicated commands synchronously on the main thread (matches
-    // FalkorDB C): otherwise the replica's handler returns NoReply before the
-    // query actually executes, Redis advances the replication offset, and
-    // master's WAIT reports the replica in-sync while writes are still queued.
-    if ctx.get_flags().contains(ContextFlags::MULTI)
-        || ctx.get_flags().contains(ContextFlags::REPLICATED)
-    {
+    // Contexts that cannot block run inline on this thread — see `must_run_inline` for
+    // why each flag is in the set. Two of them are load-bearing here: a replica has to
+    // apply the query before the handler returns, or Redis advances the replication
+    // offset while the write is still queued and the master's WAIT reports the replica
+    // in-sync when it is not; and an AOF-replay client must never be blocked, which
+    // used to crash the server on restart (#2421).
+    if must_run_inline(ctx) {
         return query_sync(
             ctx,
             graph,
@@ -1236,11 +1236,9 @@ pub fn profile_mut(
     key_name: &Arc<str>,
     per_query_timeout: Option<i64>,
 ) -> RedisResult {
-    // Inside MULTI/EXEC: execute synchronously.
-    // Also run replicated commands synchronously (see query_mut for rationale).
-    if ctx.get_flags().contains(ContextFlags::MULTI)
-        || ctx.get_flags().contains(ContextFlags::REPLICATED)
-    {
+    // Contexts that cannot block run inline (see `query_mut` for the rationale, and
+    // `must_run_inline` for the flag set).
+    if must_run_inline(ctx) {
         return profile_sync(ctx, graph, query, key_name, per_query_timeout);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 mod allocator;
 mod commands;
 mod config;
+mod dispatch;
 mod graph_core;
 mod module_init;
 mod query_session;

--- a/tests/flow/test_aof.py
+++ b/tests/flow/test_aof.py
@@ -1,0 +1,74 @@
+from common import *
+from time import sleep
+
+GRAPH_ID = "aof_replay"
+
+
+class testAOFReplay():
+    def __init__(self):
+        self.env, self.db = Env(enableDebugCommand=True)
+        self.conn = self.env.getConnection()
+
+    def tearDown(self):
+        # Leave AOF off for whatever runs next in this environment.
+        try:
+            self.conn.config_set("appendonly", "no")
+        except Exception:
+            pass
+        self.conn.flushall()
+
+    def _wait_for_aof_rewrite(self, timeout=30):
+        # Turning AOF on kicks off a background rewrite. Writes issued while it runs
+        # still land in the incr file, but waiting keeps the test deterministic.
+        while timeout > 0:
+            if self.conn.info("persistence").get("aof_rewrite_in_progress", 0) == 0:
+                return
+            sleep(0.1)
+            timeout -= 0.1
+        raise RuntimeError("AOF rewrite did not finish in time")
+
+    def test01_verbatim_query_survives_aof_replay(self):
+        # AOF replay drives a fake client that carries CLIENT_DENY_BLOCKING but *not*
+        # CLIENT_MASTER, so REPLICATED is not set for it. The write path used to guard
+        # on MULTI || REPLICATED only, so that client took the blocking path — and
+        # Redis asserts `(fakeClient->flags & CLIENT_BLOCKED) == 0` (aof.c) while
+        # loading, killing the server with SIGSEGV. Any AOF-enabled server therefore
+        # failed to restart (#2421).
+        #
+        # The crash needs a *verbatim* GRAPH.QUERY in the AOF. At the 300us default for
+        # EFFECTS_THRESHOLD, whether a write replicates verbatim or as GRAPH.EFFECT
+        # depends on timing, so push the threshold up to pin the verbatim branch.
+        self.db.config_set("EFFECTS_THRESHOLD", 999999)
+
+        # Start from a known-empty AOF. In CI this environment may be a container shared
+        # with earlier test classes in the same matrix cell, and DEBUG LOADAOF replays
+        # the *whole* AOF — so without this the replay would also re-apply their
+        # commands. FLUSHALL clears the data, and toggling appendonly off then on starts
+        # a fresh AOF sequence whose base is that empty dataset, bounding the replay
+        # below to the two writes this test makes.
+        self.conn.flushall()
+        self.conn.config_set("appendonly", "no")
+        self.conn.config_set("appendonly", "yes")
+        self._wait_for_aof_rewrite()
+
+        graph = self.db.select_graph(GRAPH_ID)
+        graph.query("CREATE (:P {n:1})")
+        graph.query("CREATE (:P {n:2})")
+
+        # DEBUG LOADAOF empties the dataset and replays the AOF in-process, driving the
+        # same fake loading client a restart would — it reproduces the crash exactly
+        # (verified: SIGSEGV, aof.c:1692) without needing to stop the server.
+        #
+        # Deliberately not RLTest's restartAndReload(): it calls BGREWRITEAOF first,
+        # and with aof-use-rdb-preamble on (the default) the rewritten AOF is an RDB
+        # preamble, so the graph returns via RDB load and the command is never
+        # replayed. Such a test passes against the unfixed build and proves nothing.
+        self.conn.execute_command("DEBUG", "LOADAOF")
+
+        # The server survived the replay...
+        self.env.assertTrue(self.conn.ping())
+
+        # ...and the graph came back through it, so the command really was replayed
+        # rather than skipped.
+        result = graph.query("MATCH (n) RETURN count(n)")
+        self.env.assertEqual(result.result_set[0][0], 2)


### PR DESCRIPTION
Closes #2421

## What was wrong

**An AOF-enabled server could not restart.** Not a clean failure — `SIGSEGV`, and the server
never came up.

AOF replay drives a fake client that carries `CLIENT_DENY_BLOCKING` but *not* `CLIENT_MASTER`,
so `REPLICATED` is not set for it. Every Rust guard site checked only `MULTI || REPLICATED`, so
that client took the blocking path and was left blocked, which Redis asserts against:

```
# === ASSERTION FAILED ===
# ==> aof.c:1692 '(fakeClient->flags & CLIENT_BLOCKED) == 0' is not true
# Redis 255.255.255 crashed by signal: 11, si_code: 2
```

C's dispatcher (`src/commands/cmd_dispatcher.c` on `master`) treats five flags as "this context
must not block" — `MULTI | LUA | DENY_BLOCKING | LOADING`, plus `is_replicated`. The Rust ports
checked two.

This does not need index or constraint DDL to trigger. `should_use_effects` falls back to
verbatim `GRAPH.QUERY` whenever a write's average per-effect time is under `EFFECTS_THRESHOLD`
(default 300µs), so two ordinary `CREATE` statements reach it — which is what the reproduction
below uses.

## Measured, both engines

Same commands, same conditions (`appendonly yes` at startup, RDB removed, no `BGREWRITEAOF`):

| | C (`edge-c`) | Rust (`main` @ `cf3ec7a6f`) | Rust (this PR) |
| --- | --- | --- | --- |
| nodes before restart | 2 | 2 | 2 |
| AOF contents | 2 × verbatim `GRAPH.QUERY` | 2 × verbatim `GRAPH.QUERY` | 2 × verbatim `GRAPH.QUERY` |
| survives restart | yes | **no — signal 11** | **yes** |
| nodes after restart | 2 | — | **2** |
| load source | `DB loaded from append only file` | — | `DB loaded from append only file` |
| assertion lines in log | 0 | 4 | **0** |

## The fix

The issue suggests inlining the widened predicate at each of the five sites. That would have
produced **six** copies once you count the one #2420 already landed in `bulk_insert.rs` — and
five sites each having grown their own narrower copy of C's single predicate is precisely what
caused this bug. So this adds one definition and routes every site through it:

**`src/dispatch.rs`** (new) — `must_run_inline(ctx)`, carrying the C reference and the reason
each flag is in the set.

Call sites now sharing it:

* `src/graph_core.rs` — `GRAPH.QUERY` write path, `GRAPH.PROFILE`
* `src/commands/memory.rs`, `record.rs`, `explain.rs`
* `src/commands/bulk_insert.rs` — already had the correct five-flag set inline from #2420; now
  refactored onto the shared helper so there is one definition rather than two

Only `GRAPH.QUERY` was crash-reachable (it is the only command that is both AOF-persisted and
has a blocking path). The other four were latent, and the same one-line change covers them.

## Verification

**Red, on this branch with only the `src/` changes stashed:** the new test takes the server down
and its log holds the assertion —
`tests/flow/logs/…test_aof_testAOFReplay-oss.log` contains `aof.c:1692` and
`crashed by signal: 11`. Note the red manifestation is a server crash, so RLTest reports it as a
dead worker rather than a clean assertion failure.

**Green:** all of the below on the rebuilt module.

| check | result |
| --- | --- |
| `tests/flow/test_aof` (new) | **1/1**, and repeatable across consecutive runs |
| `test_replication` | 2/2 |
| `test_effects` | 22/22 |
| `test_persistency` | 11/11 |
| `test_bulk_insertion` | 13/13 |
| `test_multi_exec` | 2/2 |
| `test_profile` | 2/2 |
| `test_maintain_record_order` | 5/5 |
| `test_memory_usage` | 16/16 |
| `test_mvcc.py` + `test_concurrency.py` | 14 passed |
| `cargo test -p graph` | 134 passed, 0 failed, 6 ignored |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets` | exit 0; 2 `too_many_arguments` warnings, both pre-existing (`cond_var_len_traverse.rs:491`, `bulk_insert.rs:535` — the latter's line only moved because this PR removed comment lines above it) |

## On the regression test

Two things about `tests/flow/test_aof.py` worth calling out, because both were load-bearing:

**It uses `DEBUG LOADAOF`, not a restart.** `DEBUG LOADAOF` empties the dataset and replays the
AOF in-process through the same fake loading client, and reproduces the crash exactly (verified:
`SIGSEGV`, `aof.c:1692`). RLTest's `restartAndReload()` is unusable here — it calls
`bgrewriteaof()` before restarting (`RLTest/redis_std.py:597`), and with `aof-use-rdb-preamble`
on by default the rewritten AOF is an RDB preamble, so the graph comes back via RDB load and the
command is never replayed. A test built on it passes against the unfixed module.

**It starts from a known-empty AOF.** The classifier in `tests/flow/test_matrix_split.py` does
not treat `enableDebugCommand` as spawn-forcing, so in CI this file runs against a container
shared with earlier classes in the same matrix cell — and `DEBUG LOADAOF` replays the *whole*
AOF. The test therefore `FLUSHALL`s and toggles `appendonly` off/on to start a fresh AOF
sequence, bounding the replay to its own two writes.

`EFFECTS_THRESHOLD` is pushed up so the writes deterministically take the verbatim
`GRAPH.QUERY` branch; at the 300µs default the choice depends on timing.

The file is registered in `flow_tests_done.txt` so CI actually runs it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command execution reliability across transactions, replicas, scripting, loading, and other restricted execution contexts.
  - Ensured graph queries, profiling, memory usage, recording, explanations, and bulk inserts remain responsive when synchronous execution is required.
  - Improved graph data recovery and server responsiveness during append-only file (AOF) replay.

- **Tests**
  - Added automated coverage validating graph queries survive AOF replay and restore data correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->