### PR TITLE
fix: re-check pause and role before a write commits, not just at admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "rustc-hash",
  "ryu",
  "thin-vec",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "falkordb"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = "2"
 atomic_refcell = "0.1.14"
 crossfire = "3.1.19"
 graph = { path = "graph", version = "0.1.0" }

--- a/docs/write-authorization.md
+++ b/docs/write-authorization.md
@@ -1,0 +1,193 @@
+# Write authorization
+
+Which graph writes are re-checked against live server state before they commit, and
+which are not — and why every case is covered.
+
+## The invariant
+
+Redis asserts that a command may not propagate while the server is paused for a
+failover, or after it has become a replica:
+
+```
+server.c  ==> '!(isPausedActions(PAUSE_ACTION_REPLICA) && !server.client_pause_in_transaction)'
+```
+
+It is an assert rather than an error return because by the time it fires the write is
+already applied: there is nothing to roll back, and letting it into the replication
+stream breaks the guarantee a failover is predicated on.
+
+Ordinary Redis commands satisfy this for free, because **admit → apply → propagate is
+one uninterrupted turn on the main thread**. FalkorDB breaks that atomicity: a write is
+admitted on the main thread but mutates and propagates later, from a worker. Anything in
+that gap — a `CLIENT PAUSE`, a `FAILOVER`, a demotion — invalidates the admission-time
+decision. So the check has to be made again, immediately before the commit.
+
+## Two independent axes
+
+Authorization is decided by two questions that are easy to conflate:
+
+| axis | question | answered by |
+| --- | --- | --- |
+| **where it runs** | inline on the main thread, or blocked + handed to the pool? | `dispatch::must_run_inline` — a property of the *command's context* |
+| **what is true now** | is a pause window open? are we a read-only replica? | `query_session::reauthorize_write` — a property of the *server*, read under the GIL |
+
+A write only needs re-authorization when it runs **off** the main thread — everything
+inline is already covered by Redis's own dispatch, for the reasons below.
+
+## Instance states
+
+`READONLY` — not `MASTER` — is the flag that decides. Redis sets it only when
+`SLAVE && repl_slave_ro`, so a replica running `replica-read-only no` deliberately
+accepts writes.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> MASTER: masterhost unset
+    [*] --> LOADING: restart, replay AOF/RDB
+
+    MASTER --> REPLICA_RO: REPLICAOF / failover
+    REPLICA_RO --> MASTER: REPLICAOF NO ONE / promotion
+    REPLICA_RO --> REPLICA_RW: CONFIG SET replica-read-only no
+    REPLICA_RW --> REPLICA_RO: CONFIG SET replica-read-only yes
+    REPLICA_RW --> MASTER: REPLICAOF NO ONE
+    REPLICA_RO --> ASYNC_LOADING: diskless full resync
+    ASYNC_LOADING --> REPLICA_RO: load complete
+    LOADING --> MASTER: load complete, no master configured
+    LOADING --> REPLICA_RO: load complete, replicaof in config
+
+    MASTER: MASTER
+    MASTER: READONLY clear — writes authorized
+    REPLICA_RO: REPLICA (read-only)
+    REPLICA_RO: SLAVE + READONLY — writes refused
+    REPLICA_RW: REPLICA (writable)
+    REPLICA_RW: SLAVE, READONLY clear — writes authorized
+    LOADING: LOADING
+    LOADING: replaying our own AOF/RDB
+    ASYNC_LOADING: ASYNC_LOADING
+    ASYNC_LOADING: serving reads while an RDB loads
+```
+
+**A pause is orthogonal to all of it.** `CLIENT PAUSE ... WRITE` and `FAILOVER` set
+`PAUSE_ACTION_REPLICA` in any of these states; it is a window, not a state, and it is
+read with `AvoidReplicaTraffic` rather than a context flag.
+
+The `MASTER → REPLICA_RO → MASTER` flip-flop needs no separate check: the only flip that
+matters resynced, which frees and re-registers the graph key, so `graph_is_registered`
+has already aborted the write. A flip that resynced nothing left the data unchanged.
+
+## Does this write need authorization?
+
+```mermaid
+flowchart TD
+    A[graph write command] --> B{must_run_inline?<br/>MULTI · REPLICATED · LUA<br/>DENY_BLOCKING · LOADING}
+
+    B -->|yes| C[runs inline on the main thread]
+    C --> C1[no session at all — takes the graph<br/>write lock directly and replicates<br/>GRAPH.CONSTRAINT · DELETE · RESTORE<br/>UDF · COPY · EFFECT]
+    C --> C2[begin_writer — already a writer,<br/>so escalate never runs<br/>query_sync · profile_sync]
+    C1 --> CZ([authorized by Redis at dispatch])
+    C2 --> CZ
+
+    B -->|no| D[block client, hand to pool]
+    D --> G[escalate: drop read lock,<br/>take GIL, take write lock]
+    G --> H{graph still registered?}
+    H -->|no| X1[abort: GraphUnregistered]
+    H -->|yes| J{facts.replicates<br/>AND traffic paused?}
+    J -->|yes| X2[abort: ReplicaTrafficPaused]
+    J -->|no| K{facts.originated_here<br/>AND READONLY?}
+    K -->|yes| X3[abort: NotAMaster]
+    K -->|no| L([commit and propagate])
+
+    S[spawned thread<br/>constraint validation] --> G
+```
+
+Everything from the `graph_is_registered` check to the commit happens under **one
+continuous GIL hold**. That is what makes the check race-free rather than merely
+well-timed: `CLIENT PAUSE` and role-change events both run on the main thread, which
+needs the GIL we are holding, so neither can move between the check and the commit.
+
+## Why an inline write needs no check of its own
+
+**Redis's dispatch is the authorization.** Every graph command is registered `write`
+(`src/lib.rs`), so `processCommand` postpones it while `PAUSE_ACTION_CLIENT_WRITE` is set
+and rejects it with `-READONLY` on a read-only replica — before the handler is ever
+called. And no pause or role change can land mid-command, because both are applied by the
+main thread, which the command is occupying.
+
+That is the whole justification, and it covers two shapes that look different in the code
+but are identical here:
+
+* **with a session** — `query_sync` / `profile_sync` use `begin_writer`, which is already
+  a writer, so `escalate` never runs and the check is never consulted;
+* **with no session at all** — `GRAPH.CONSTRAINT`, `GRAPH.DELETE`, `GRAPH.RESTORE`,
+  `GRAPH.UDF`, `GRAPH.COPY` and `GRAPH.EFFECT` take the graph write lock directly, commit,
+  and replicate inline. They never enter this machinery.
+
+So `GRAPH.CONSTRAINT` appears **twice** in the table below, and the two rows have
+different answers for different reasons: the command mutates and replicates inline and is
+covered by dispatch, while the validation thread it spawns is a separate write that
+outlives the command and has to answer for itself.
+
+## Coverage
+
+| write origin | runs | escalates | re-authorized | why |
+| --- | --- | --- | --- | --- |
+| client command (`GRAPH.QUERY` / `PROFILE` / `RECORD` / `BULK`) | pool | yes | **yes** | the case the guard exists for |
+| client command, no session (`CONSTRAINT` / `DELETE` / `RESTORE` / `UDF` / `COPY`) | inline | no | n/a | mutates and replicates on the main thread; dispatch already gated it |
+| replication stream (`REPLICATED`) | inline | no | n/a | our master committed it; rejecting diverges us |
+| AOF/RDB replay (`LOADING`) | inline | no | n/a | in `must_run_inline`, so it never reaches a worker |
+| diskless load (`ASYNC_LOADING`) | pool | yes | **no** | not in `must_run_inline`, so it does reach the check — bypassed there, and captured at admission by `bulk_insert` |
+| `MULTI` / `LUA` / `DENY_BLOCKING` | inline | no | n/a | Redis forbids blocking; nothing to re-check |
+| constraint validation thread | own thread | yes | **no** | outlives the command that spawned it — see below |
+| telemetry flusher | own thread | n/a — no session | **yes**, separately | replicates `XADD`s; checks pause *and* role itself |
+
+### How a call site answers
+
+`WriteFacts` carries two facts about the *write*, not two names for the checks — so a
+path that later starts replicating flips the field named after replication.
+
+| site | `replicates` | `originated_here` | why |
+| --- | --- | --- | --- |
+| query drainer, `record`, `bulk` (normal) | `true` | `true` | `WriteFacts::CLIENT`, the default |
+| `bulk` under `ASYNC_LOADING` | `true` | `false` | already authorized and persisted, but it still replicates, so only the role check is waived |
+| `constraint` validation thread | `false` | `false` | emits no replication of its own; also runs on a replica applying the master's command |
+| — once #2419 adds the re-announce | **`true`** | `false` | one field, flipped in the commit that adds the replication |
+
+Narrower than C on one point, deliberately: C's authorization bypass is wholesale on
+`REPLICATED | LOADING | ASYNC_LOADING`, which drops the pause check along with the role
+check. Here `ASYNC_LOADING` waives only the role check, because that worker does
+replicate.
+
+Both fields are independently load-bearing, and were ablated separately to prove it:
+forcing `replicates` false fails `test_pause_replication_race`; forcing `originated_here`
+true fails `test_constraint`.
+
+## The rule
+
+Answering it for a new or changed path is two questions, in this order:
+
+```mermaid
+flowchart TD
+    Q0[new or changed write path] --> Q1{does it mutate or replicate<br/>off the main thread?}
+    Q1 -->|no| N([nothing to carry —<br/>Redis's dispatch already<br/>authorized it])
+    Q1 -->|yes| Q2{can it reach the replication<br/>stream from that thread?}
+    Q2 -->|yes| R1["replicates: true<br/><i>a pause window must be respected</i>"]
+    Q2 -->|no| R0["replicates: false<br/><i>nothing to propagate into it</i>"]
+    R1 --> Q3{did this instance decide it,<br/>or is it replaying a decision<br/>made elsewhere?}
+    R0 --> Q3
+    Q3 -->|our decision| O1["originated_here: true<br/><i>we must still be a writable master</i>"]
+    Q3 -->|replaying| O0["originated_here: false<br/><i>rejecting it would diverge us</i>"]
+```
+
+The two are independent: a write can replicate without originating here (`bulk` under
+`ASYNC_LOADING`) or originate here without replicating (`constraint` validation today).
+That is exactly what a single "is it exempt" boolean could not express, and why the one
+it replaced waived the pause check on a path that replicates.
+
+## Adding a new write path
+
+Answer the two questions above and pass the result as [`WriteFacts`]; the guard derives
+the checks. The trap is assuming a path is exempt because it looks internal — the
+telemetry flusher needed both checks and had neither, and re-crashed the master under `CLIENT PAUSE` after the query path was
+already fixed. Ablate each guard — remove it and confirm a test fails — rather than
+assuming it is load-bearing.

--- a/flow_tests_done.txt
+++ b/flow_tests_done.txt
@@ -74,6 +74,7 @@ tests/flow/test_path.py
 tests/flow/test_path_algorithms.py
 tests/flow/test_path_filter
 tests/flow/test_path_projections.py
+tests/flow/test_pause_replication_race.py
 tests/flow/test_pending_queries_limit.py
 tests/flow/test_persistency.py
 tests/flow/test_point
@@ -87,6 +88,7 @@ tests/flow/test_redundant_ops
 tests/flow/test_relation_patterns.py
 tests/flow/test_replication.py
 tests/flow/test_replication_states.py
+tests/flow/test_role_change_race.py
 tests/flow/test_results.py
 tests/flow/test_reversed_patterns
 tests/flow/test_ro_query.py

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -1,5 +1,5 @@
 use crate::dispatch::must_run_inline;
-use crate::query_session::{QuerySession, hold_gil};
+use crate::query_session::{QuerySession, WriteFacts, hold_gil};
 use crate::{
     config::CONFIGURATION_CACHE_SIZE,
     graph_core::{BlockedClient, ThreadedGraph, ffi, register_graph},
@@ -824,17 +824,20 @@ pub fn graph_bulk_insert(
     // would diverge us. Decided here, on the main thread, because the worker's detached
     // context cannot see REPLICATED.
     //
-    // Down to one flag. `REPLICATED` and `LOADING` used to need capturing here too, but
-    // `must_run_inline` (#2420, widened to C's full dispatcher set in #2421) now routes
-    // both inline, so neither can reach this worker at all.
+    // `must_run_inline` (#2420, widened to C's full dispatcher set in #2421) routes
+    // REPLICATED and LOADING inline, so neither reaches this worker. ASYNC_LOADING is
+    // the exception: it is in C's *authorization* bypass but in neither C's dispatcher
+    // predicate nor ours, so such a batch still spawns a worker — and that worker can
+    // escalate after the loading window has closed, where a live read would reject a
+    // write that was already authorized and persisted.
     //
-    // `ASYNC_LOADING` is the exception, and deliberately so: it is in C's *authorization*
-    // bypass (`query_ctx.c`) but in neither C's dispatcher predicate nor ours, so a batch
-    // admitted during a diskless swapdb load still spawns a worker. It has to be captured
-    // rather than read live in `reauthorize_write`, because that worker can escalate after
-    // the loading window has closed, and the live read would then abort a write that was
-    // already authorized and persisted.
-    let preauthorized = ctx.get_flags().contains(ContextFlags::ASYNC_LOADING);
+    // Narrower than C, deliberately: C bypasses authorization wholesale on
+    // ASYNC_LOADING, dropping the pause check with it. This worker does replicate
+    // (phase 2 below), so it keeps `replicates: true` and only waives the role check.
+    let facts = WriteFacts {
+        replicates: true,
+        originated_here: !ctx.get_flags().contains(ContextFlags::ASYNC_LOADING),
+    };
     let bc = unsafe { BlockedClient::new(ctx.ctx) };
     let token_data: Vec<Vec<u8>> = token_strings
         .iter()
@@ -852,11 +855,7 @@ pub fn graph_bulk_insert(
             // Build, commit and replicate under one session, which releases its locks
             // when this block ends — before the client is unblocked below.
             let result: Result<(), String> = 'phase: {
-                let session = if preauthorized {
-                    QuerySession::begin_preauthorized(&graph)
-                } else {
-                    QuerySession::begin(&graph)
-                };
+                let session = QuerySession::begin_with(&graph, facts);
                 // Phase 1: build the new version as a reader, GIL-free. What we take
                 // here is the MVCC *write slot* — the single-writer marker on
                 // `MvccGraph`, not a lock — so if another writer holds it, fail with a

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -13,7 +13,7 @@ use graph::{
     threadpool::spawn,
 };
 use parking_lot::RwLock;
-use redis_module::{Context, NextArg, RedisResult, RedisString, RedisValue, raw};
+use redis_module::{Context, ContextFlags, NextArg, RedisResult, RedisString, RedisValue, raw};
 use roaring::RoaringTreemap;
 use rustc_hash::FxHashMap;
 use std::ffi::CString;
@@ -816,6 +816,25 @@ pub fn graph_bulk_insert(
 
     // Block the client and process on a background thread so the main
     // Redis thread stays free to handle PING and other commands.
+    //
+    // The background thread commits and replicates long after Redis authorized the
+    // command here, so escalation must re-authorize it against the pause state and role
+    // that are live then (#2371) — unless this insert arrived over the replication link,
+    // in which case it mirrors a write the master already committed and rejecting it
+    // would diverge us. Decided here, on the main thread, because the worker's detached
+    // context cannot see REPLICATED.
+    //
+    // Down to one flag. `REPLICATED` and `LOADING` used to need capturing here too, but
+    // `must_run_inline` (#2420, widened to C's full dispatcher set in #2421) now routes
+    // both inline, so neither can reach this worker at all.
+    //
+    // `ASYNC_LOADING` is the exception, and deliberately so: it is in C's *authorization*
+    // bypass (`query_ctx.c`) but in neither C's dispatcher predicate nor ours, so a batch
+    // admitted during a diskless swapdb load still spawns a worker. It has to be captured
+    // rather than read live in `reauthorize_write`, because that worker can escalate after
+    // the loading window has closed, and the live read would then abort a write that was
+    // already authorized and persisted.
+    let preauthorized = ctx.get_flags().contains(ContextFlags::ASYNC_LOADING);
     let bc = unsafe { BlockedClient::new(ctx.ctx) };
     let token_data: Vec<Vec<u8>> = token_strings
         .iter()
@@ -833,7 +852,11 @@ pub fn graph_bulk_insert(
             // Build, commit and replicate under one session, which releases its locks
             // when this block ends — before the client is unblocked below.
             let result: Result<(), String> = 'phase: {
-                let session = QuerySession::begin(&graph);
+                let session = if preauthorized {
+                    QuerySession::begin_preauthorized(&graph)
+                } else {
+                    QuerySession::begin(&graph)
+                };
                 // Phase 1: build the new version as a reader, GIL-free. What we take
                 // here is the MVCC *write slot* — the single-writer marker on
                 // `MvccGraph`, not a lock — so if another writer holds it, fail with a
@@ -870,7 +893,7 @@ pub fn graph_bulk_insert(
                     // clear it, so skipping this leaves the graph permanently
                     // unwritable.
                     session.with_graph(|tg| tg.graph.rollback());
-                    break 'phase Err(e);
+                    break 'phase Err(e.to_string());
                 }
                 // Publish the index documents inside the writer scope, matching
                 // `CommitOp`: the index is not MVCC, so readers must be excluded while

--- a/src/commands/constraint.rs
+++ b/src/commands/constraint.rs
@@ -1,4 +1,4 @@
-use crate::query_session::QuerySession;
+use crate::query_session::{QuerySession, WriteFacts};
 use crate::{config::CONFIGURATION_CACHE_SIZE, graph_core::ThreadedGraph, redis_type::GRAPH_TYPE};
 use graph::entity_type::EntityType;
 use graph::graph::constraint::ConstraintType;
@@ -187,34 +187,23 @@ pub fn graph_constraint(
                     // concurrent `db.constraints()` still sees the constraint UNDER
                     // CONSTRUCTION.
                     //
-                    // `begin_preauthorized`: escalation must NOT re-authorize this
-                    // write (#2371). It publishes no replication of its own, and it runs
-                    // on the replica too — applying the master's replicated
-                    // GRAPH.CONSTRAINT — where a read-only check would reject it and
-                    // leave the constraint stuck UNDER CONSTRUCTION, diverging from the
-                    // master.
+                    // `replicates: false` — this thread emits no replication of its
+                    // own, so no pause window can be propagated into. #2419 adds a
+                    // GRAPH.EFFECT re-announce here, and must flip this to `true` in
+                    // the same commit.
                     //
-                    // Both reasons expire with #2419, which re-announces the finished
-                    // constraint as a GRAPH.EFFECT from this very thread — making it a
-                    // background mutate-*and-replicate* path, the exact shape that kills
-                    // a master inside a CLIENT PAUSE / failover window — and installs the
-                    // primary's outcome on the replica instead of recomputing it.
-                    //
-                    // Its fix is to not reach here at all when mirrored, adapting C's
-                    // `sync = LOADING || REPLICATED` routing (`cmd_constraint.c:575-585`):
-                    // validate inline before the commit when the command is replicated or
-                    // replayed, and spawn only for a client's own write, which is then an
-                    // ordinary `begin`. `LOADING` matters as much as `REPLICATED` here —
-                    // a legacy AOF still holds the doubled verbatim GRAPH.CONSTRAINT
-                    // CREATE, which reaches this on a non-primary with `LOADING` set and
-                    // `REPLICATED` clear.
-                    //
-                    // What must not happen is this staying a plain `begin` while the
-                    // thread both replicates and still runs on a non-primary. The async
-                    // path needs >10_000 entities (`Graph::create_constraint`), so no
-                    // existing test would have caught that; `testConstraintReplication::
-                    // test_02_async_validation_reaches_operational_on_replica` now does.
-                    let session = QuerySession::begin_preauthorized(&graph_clone);
+                    // `originated_here: false` — it also runs on a replica, applying
+                    // the master's replicated GRAPH.CONSTRAINT, where a READONLY
+                    // rejection would strand the constraint UNDER CONSTRUCTION and
+                    // diverge. Covered by testConstraintReplication::
+                    // test_02_async_validation_reaches_operational_on_replica.
+                    let session = QuerySession::begin_with(
+                        &graph_clone,
+                        WriteFacts {
+                            replicates: false,
+                            originated_here: false,
+                        },
+                    );
                     let results = session.with_graph(|tg| {
                         tg.graph
                             .read()

--- a/src/commands/constraint.rs
+++ b/src/commands/constraint.rs
@@ -186,7 +186,35 @@ pub fn graph_constraint(
                     // Phase 1: the long-running validation runs as a reader, so
                     // concurrent `db.constraints()` still sees the constraint UNDER
                     // CONSTRUCTION.
-                    let session = QuerySession::begin(&graph_clone);
+                    //
+                    // `begin_preauthorized`: escalation must NOT re-authorize this
+                    // write (#2371). It publishes no replication of its own, and it runs
+                    // on the replica too — applying the master's replicated
+                    // GRAPH.CONSTRAINT — where a read-only check would reject it and
+                    // leave the constraint stuck UNDER CONSTRUCTION, diverging from the
+                    // master.
+                    //
+                    // Both reasons expire with #2419, which re-announces the finished
+                    // constraint as a GRAPH.EFFECT from this very thread — making it a
+                    // background mutate-*and-replicate* path, the exact shape that kills
+                    // a master inside a CLIENT PAUSE / failover window — and installs the
+                    // primary's outcome on the replica instead of recomputing it.
+                    //
+                    // Its fix is to not reach here at all when mirrored, adapting C's
+                    // `sync = LOADING || REPLICATED` routing (`cmd_constraint.c:575-585`):
+                    // validate inline before the commit when the command is replicated or
+                    // replayed, and spawn only for a client's own write, which is then an
+                    // ordinary `begin`. `LOADING` matters as much as `REPLICATED` here —
+                    // a legacy AOF still holds the doubled verbatim GRAPH.CONSTRAINT
+                    // CREATE, which reaches this on a non-primary with `LOADING` set and
+                    // `REPLICATED` clear.
+                    //
+                    // What must not happen is this staying a plain `begin` while the
+                    // thread both replicates and still runs on a non-primary. The async
+                    // path needs >10_000 entities (`Graph::create_constraint`), so no
+                    // existing test would have caught that; `testConstraintReplication::
+                    // test_02_async_validation_reaches_operational_on_replica` now does.
+                    let session = QuerySession::begin_preauthorized(&graph_clone);
                     let results = session.with_graph(|tg| {
                         tg.graph
                             .read()

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -52,6 +52,12 @@ fn record_mut(
     // private MVCC version), then commit and replicate exactly like `GRAPH.QUERY`.
     // RECORD adds the operator trace to a normal write; it does not turn it into a dry
     // run, so effects land and reach replicas.
+    //
+    // Plain `begin`, for both callers. The background path needs escalation
+    // re-authorized, since it commits long after Redis admitted the command. The inline
+    // caller (MULTI / replication stream, on the main thread) reaches the same check but
+    // returns early from it, because the main thread holds the GIL implicitly and there
+    // is no window to re-check.
     let session = QuerySession::begin(graph);
     let Plan {
         plan, parameters, ..

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -1473,6 +1473,11 @@ pub fn process_write_queued_query(graph: &Arc<RwLock<ThreadedGraph>>) {
         // The session lives only for this block, so its locks are released — the read
         // lock, or the GIL + write lock if the query escalated — on every path out,
         // including the error returns, and before the reply below.
+        //
+        // Plain `begin`: a client sent this write to this instance, so escalation
+        // re-authorizes it against the pause state and role that are live *then* — both
+        // can have changed since it was admitted and queued. Replicated commands never
+        // reach here; they run inline (see `query_mut`).
         let res = execute_query_write(
             QuerySession::begin(graph),
             &ctx,

--- a/src/query_session.rs
+++ b/src/query_session.rs
@@ -68,76 +68,65 @@ pub struct QuerySession {
     /// the only misuse is escalating inside a [`Self::with_graph`] closure, which
     /// panics loudly instead of dangling.
     mode: RefCell<Option<Mode>>,
-    /// True — this write was already authorized elsewhere (see
-    /// [`Self::begin_preauthorized`] for the three shapes), so escalation must not
-    /// re-authorize it. False — the default — means escalation re-authorizes.
-    ///
-    /// Only consulted if this session escalates, so it is moot for a reader and for
-    /// [`Self::begin_writer`], which is already a writer.
-    ///
-    /// The fact has to be carried because it cannot be read where the check runs:
-    /// escalation happens on a worker thread whose only context is the detached one
-    /// [`Gil::acquire`] made, which has no client behind it, so `REPLICATED` always
-    /// reads false there. C reads it directly off the command's own context instead.
-    ///
-    /// C carries no equivalent, but not because its routing makes one unnecessary — its
-    /// guard simply does not cover this ground. The pause/role check lives in
-    /// `QueryCtx_AcquireWriteLock`, and C's constraint path never calls it, taking
-    /// `GraphContext_AcquireWriteLock` directly (`cmd_constraint.c:288`, `:381`). C does
-    /// route mirrored commands inline — `sync = LOADING || REPLICATED` at `:575-585` —
-    /// but that governs only whether `Constraint_Op` itself runs on the command thread
-    /// pool; enforcement still goes to the Indexer pool either way (header, `:25-40`).
-    ///
-    /// **Scaffolding.** Both consumers are being retired, each by adopting that inline
-    /// routing for the work this engine actually backgrounds:
-    ///
-    /// * `commands::bulk_insert` — #2420 stops a replica reaching the worker at all;
-    /// * `commands::constraint` — #2419 validates inline when mirrored and spawns only
-    ///   otherwise, so its validation thread is never a mirrored write.
-    ///
-    /// After both, this field, its branch in [`Self::upgrade_to_write`] and
-    /// [`Self::begin_preauthorized`] collapse into the unconditional check.
-    preauthorized: bool,
+    /// What this write does and where it came from — see [`WriteFacts`]. Moot unless
+    /// the session escalates, so it is unread for a reader and for
+    /// [`Self::begin_writer`].
+    facts: WriteFacts,
+}
+
+/// The two facts about a write that decide which re-checks apply when it escalates.
+///
+/// Both are properties of the *write*, not of the checks, so a call site can answer them
+/// without knowing what the guard does with them — and a path that later starts
+/// replicating flips the field named after replication.
+///
+/// They have to be carried rather than read at the check: escalation runs on a worker
+/// whose only context is the detached one [`Gil::acquire`] made, which has no client
+/// behind it, so `REPLICATED` always reads false there. C reads it straight off the
+/// command's own context instead.
+///
+/// `docs/write-authorization.md` has the states, the coverage table and the call sites.
+#[derive(Clone, Copy, Debug)]
+pub struct WriteFacts {
+    /// It can reach the replication stream from this thread, so a replica-pause window
+    /// open at commit time would be propagated into.
+    pub replicates: bool,
+    /// This instance decided this write, rather than replaying one decided elsewhere.
+    /// Only our own decisions require that we are still a writable master; rejecting a
+    /// replayed one would diverge us from our master.
+    pub originated_here: bool,
+}
+
+impl WriteFacts {
+    /// A client's own write, which will replicate: both re-checks apply. The default,
+    /// and the right answer for every path that has no reason to differ.
+    pub const CLIENT: Self = Self {
+        replicates: true,
+        originated_here: true,
+    };
 }
 
 impl QuerySession {
     /// Enter **reader** mode: take the per-graph read lock.
     ///
-    /// If this session escalates, the write is re-authorized against live server state
-    /// (see [`Self::upgrade_to_write`]). Use [`Self::begin_preauthorized`] for a write that
-    /// replays a decision made elsewhere.
+    /// Assumes [`WriteFacts::CLIENT`] — if this session escalates, the write is
+    /// re-authorized against live server state. Use [`Self::begin_with`] for a write
+    /// that differs on either fact.
     pub fn begin(graph: &Arc<RwLock<ThreadedGraph>>) -> Self {
-        Self {
-            graph: Arc::clone(graph),
-            mode: RefCell::new(Some(Mode::Reader(RwLock::read_arc(graph)))),
-            preauthorized: false,
-        }
+        Self::begin_with(graph, WriteFacts::CLIENT)
     }
 
-    /// Enter **reader** mode for a write that was **already authorized elsewhere** and
-    /// so must not be re-authorized here. Two callers, for two different reasons, which
-    /// is why this is not named for either one:
-    ///
-    /// * `commands::bulk_insert`, when the command arrived over the replication stream
-    ///   (`REPLICATED`) — our master already committed it, so rejecting it here would
-    ///   diverge us;
-    /// * `commands::constraint`'s validation thread, which is a local follow-up to an
-    ///   already-committed command and replicates nothing of its own, so a pause has
-    ///   nothing to protect against. It takes this on a *master* too, where the
-    ///   originating command was an ordinary client write — which is why the transport
-    ///   name `begin_replicated` would be wrong.
-    ///
-    /// Not used for AOF/RDB replay, despite that being the same *kind* of exemption:
-    /// `LOADING` / `ASYNC_LOADING` describe what the server is doing rather than where
-    /// the write came from, so [`reauthorize_write`] reads them live instead. The one
-    /// case that would need this constructor is an escalation *spawned* during load,
-    /// which can outlive the loading window and so cannot rely on a live read — see the
-    /// note in `commands::constraint`.
-    pub fn begin_preauthorized(graph: &Arc<RwLock<ThreadedGraph>>) -> Self {
+    /// Enter **reader** mode for a write that is not a plain client write — see
+    /// [`WriteFacts`] for the two questions and `docs/write-authorization.md` for how
+    /// each caller answers them.
+    pub fn begin_with(
+        graph: &Arc<RwLock<ThreadedGraph>>,
+        facts: WriteFacts,
+    ) -> Self {
         Self {
             graph: Arc::clone(graph),
             mode: RefCell::new(Some(Mode::Reader(RwLock::read_arc(graph)))),
-            preauthorized: true,
+            facts,
         }
     }
 
@@ -155,7 +144,7 @@ impl QuerySession {
             // Moot: already a writer, so `escalate` never runs and this is never read.
             // These are the inline main-thread paths anyway, where Redis's own dispatch
             // gated the command and no pause or role-change window can open mid-command.
-            preauthorized: false,
+            facts: WriteFacts::CLIENT,
         }
     }
 
@@ -228,9 +217,7 @@ impl QuerySession {
             }
             // Same window, the other half of what C re-validates here: this instance
             // may no longer be allowed to originate a write at all.
-            if !self.preauthorized {
-                reauthorize_write()?;
-            }
+            reauthorize_write(self.facts)?;
         }
         Ok(())
     }
@@ -274,7 +261,7 @@ impl QuerySession {
 /// (`src/query_ctx.c` on `master`, PR #2372); the first two messages are byte-identical
 /// to its `EMSG_REPLICA_TRAFFIC_PAUSED` / `EMSG_NOT_MASTER` so clients and tests can
 /// match either engine.
-fn reauthorize_write() -> Result<(), WriteAbort> {
+fn reauthorize_write(facts: WriteFacts) -> Result<(), WriteAbort> {
     // Off the main thread the GIL is held through the detached context `Gil::acquire`
     // just created. On the main thread there is none — and nothing to re-check either,
     // since Redis gated the command at dispatch and no window can open mid-command.
@@ -287,45 +274,30 @@ fn reauthorize_write() -> Result<(), WriteAbort> {
     let ctx = Context::new(ctx.as_ptr());
     let flags = ctx.get_flags();
 
-    // Replaying our own AOF/RDB: the write was authorized and persisted before this
-    // process started, so re-authorizing it would be re-litigating a decision already
-    // made. On a replica it would also fail, since `masterhost` comes from config at
-    // startup and `READONLY` is set while the file is still replaying. Completes C's
-    // bypass set, whose other third (`REPLICATED`) reaches us through `preauthorized`
-    // because it is unreadable here.
-    //
-    // Parity and defence: no test here reaches this branch. Whether a replayed graph
-    // write can escalate on a read-only instance depends on whether it lands in the AOF
-    // as a command to re-execute or as a `GRAPH.EFFECT` that `commands::effect` applies
-    // inline, and that in turn depends on `should_use_effects` and on
-    // `aof-use-rdb-preamble` — so the answer is configuration-dependent and was not
-    // pinned down. Kept because it costs nothing (same `get_flags()` call) and because
-    // dropping a third of C's bypass set on the argument that we cannot currently reach
-    // it is how the next engine-shape change reintroduces the bug.
-    //
-    // Live rather than captured because these say what the *server* is doing, not where
-    // the write came from. That is exact for a write replayed inline, which is what
-    // replay will be once it works. A write that escalates asynchronously could outlive
-    // the loading window and miss this, so anything spawning a background escalation
-    // during load must decide at admission instead — see `preauthorized`.
-    if flags.contains(ContextFlags::LOADING) || flags.contains(ContextFlags::ASYNC_LOADING) {
-        return Ok(());
-    }
+    // `LOADING` cannot reach here: `dispatch::must_run_inline` contains it, so a command
+    // replaying from AOF/RDB runs inline and never escalates. Assert rather than bypass,
+    // so narrowing that predicate surfaces here instead of silently changing which writes
+    // get authorized.
+    debug_assert!(
+        !flags.contains(ContextFlags::LOADING),
+        "escalated with LOADING set: must_run_inline no longer routes replay inline"
+    );
 
-    if ctx.avoid_replication_traffic() {
+    if facts.replicates && ctx.avoid_replication_traffic() {
         return Err(WriteAbort::ReplicaTrafficPaused);
     }
-    // READONLY, not MASTER: a replica running `slave-read-only no` accepts writes, and
-    // rejecting them there would break replica-divergence testing. C corrected this the
-    // same way in PR #2372.
-    if flags.contains(ContextFlags::READONLY) {
-        return Err(WriteAbort::NotAMaster);
-    }
+    // `READONLY`, not `MASTER`: a replica running `replica-read-only no` accepts writes,
+    // and rejecting them there would break replica-divergence testing. C corrected this
+    // the same way in PR #2372.
+    //
     // No check for a role that flipped away and back (master -> replica -> master)
     // between admission and here: the only such flip that matters resynced from the new
-    // master, which frees and re-registers the graph key, so `graph_is_registered`
-    // above has already aborted this write. A flip that resynced nothing left the data
+    // master, which frees and re-registers the graph key, so `graph_is_registered` above
+    // has already aborted this write. A flip that resynced nothing left the data
     // unchanged and the write is still valid.
+    if facts.originated_here && flags.contains(ContextFlags::READONLY) {
+        return Err(WriteAbort::NotAMaster);
+    }
     Ok(())
 }
 

--- a/src/query_session.rs
+++ b/src/query_session.rs
@@ -23,7 +23,7 @@
 use crate::graph_core::{ThreadedGraph, ffi};
 use graph::locks::WriteEscalation;
 use parking_lot::{ArcRwLockReadGuard, ArcRwLockWriteGuard, RawRwLock, RwLock};
-use redis_module::raw;
+use redis_module::{Context, ContextFlags, raw};
 use std::{cell::Cell, cell::RefCell, marker::PhantomData, ptr::NonNull, sync::Arc};
 
 /// Which lock(s) a query holds.
@@ -39,6 +39,26 @@ enum Mode {
     },
 }
 
+/// Why an escalation to writer mode was refused.
+///
+/// The first two `Display` strings are byte-identical to C's `EMSG_REPLICA_TRAFFIC_PAUSED`
+/// and `EMSG_NOT_MASTER` (`src/errors/error_msgs.h`, PR #2372), so a client or a test can
+/// match either engine. Keeping them in one place is the point of the type: they are a
+/// compatibility contract, not incidental text, and they were previously written inline at
+/// their single use site each.
+#[derive(Debug, thiserror::Error)]
+pub enum WriteAbort {
+    /// A `CLIENT PAUSE` / `FAILOVER` window is open. Committing would propagate inside it.
+    #[error("Write query aborted: replica traffic is currently paused")]
+    ReplicaTrafficPaused,
+    /// This instance is a read-only replica now, whatever it was at admission.
+    #[error("Write query aborted: this instance is not a master")]
+    NotAMaster,
+    /// The graph key was deleted or replaced while no per-graph lock was held.
+    #[error("graph was deleted or replaced while the query was running, aborting")]
+    GraphUnregistered,
+}
+
 /// The locks held by one query, on one thread. Not `Send`, because the GIL must be
 /// released by the thread that took it.
 pub struct QuerySession {
@@ -48,14 +68,76 @@ pub struct QuerySession {
     /// the only misuse is escalating inside a [`Self::with_graph`] closure, which
     /// panics loudly instead of dangling.
     mode: RefCell<Option<Mode>>,
+    /// True — this write was already authorized elsewhere (see
+    /// [`Self::begin_preauthorized`] for the three shapes), so escalation must not
+    /// re-authorize it. False — the default — means escalation re-authorizes.
+    ///
+    /// Only consulted if this session escalates, so it is moot for a reader and for
+    /// [`Self::begin_writer`], which is already a writer.
+    ///
+    /// The fact has to be carried because it cannot be read where the check runs:
+    /// escalation happens on a worker thread whose only context is the detached one
+    /// [`Gil::acquire`] made, which has no client behind it, so `REPLICATED` always
+    /// reads false there. C reads it directly off the command's own context instead.
+    ///
+    /// C carries no equivalent, but not because its routing makes one unnecessary — its
+    /// guard simply does not cover this ground. The pause/role check lives in
+    /// `QueryCtx_AcquireWriteLock`, and C's constraint path never calls it, taking
+    /// `GraphContext_AcquireWriteLock` directly (`cmd_constraint.c:288`, `:381`). C does
+    /// route mirrored commands inline — `sync = LOADING || REPLICATED` at `:575-585` —
+    /// but that governs only whether `Constraint_Op` itself runs on the command thread
+    /// pool; enforcement still goes to the Indexer pool either way (header, `:25-40`).
+    ///
+    /// **Scaffolding.** Both consumers are being retired, each by adopting that inline
+    /// routing for the work this engine actually backgrounds:
+    ///
+    /// * `commands::bulk_insert` — #2420 stops a replica reaching the worker at all;
+    /// * `commands::constraint` — #2419 validates inline when mirrored and spawns only
+    ///   otherwise, so its validation thread is never a mirrored write.
+    ///
+    /// After both, this field, its branch in [`Self::upgrade_to_write`] and
+    /// [`Self::begin_preauthorized`] collapse into the unconditional check.
+    preauthorized: bool,
 }
 
 impl QuerySession {
     /// Enter **reader** mode: take the per-graph read lock.
+    ///
+    /// If this session escalates, the write is re-authorized against live server state
+    /// (see [`Self::upgrade_to_write`]). Use [`Self::begin_preauthorized`] for a write that
+    /// replays a decision made elsewhere.
     pub fn begin(graph: &Arc<RwLock<ThreadedGraph>>) -> Self {
         Self {
             graph: Arc::clone(graph),
             mode: RefCell::new(Some(Mode::Reader(RwLock::read_arc(graph)))),
+            preauthorized: false,
+        }
+    }
+
+    /// Enter **reader** mode for a write that was **already authorized elsewhere** and
+    /// so must not be re-authorized here. Two callers, for two different reasons, which
+    /// is why this is not named for either one:
+    ///
+    /// * `commands::bulk_insert`, when the command arrived over the replication stream
+    ///   (`REPLICATED`) — our master already committed it, so rejecting it here would
+    ///   diverge us;
+    /// * `commands::constraint`'s validation thread, which is a local follow-up to an
+    ///   already-committed command and replicates nothing of its own, so a pause has
+    ///   nothing to protect against. It takes this on a *master* too, where the
+    ///   originating command was an ordinary client write — which is why the transport
+    ///   name `begin_replicated` would be wrong.
+    ///
+    /// Not used for AOF/RDB replay, despite that being the same *kind* of exemption:
+    /// `LOADING` / `ASYNC_LOADING` describe what the server is doing rather than where
+    /// the write came from, so [`reauthorize_write`] reads them live instead. The one
+    /// case that would need this constructor is an escalation *spawned* during load,
+    /// which can outlive the loading window and so cannot rely on a live read — see the
+    /// note in `commands::constraint`.
+    pub fn begin_preauthorized(graph: &Arc<RwLock<ThreadedGraph>>) -> Self {
+        Self {
+            graph: Arc::clone(graph),
+            mode: RefCell::new(Some(Mode::Reader(RwLock::read_arc(graph)))),
+            preauthorized: true,
         }
     }
 
@@ -70,6 +152,10 @@ impl QuerySession {
                 guard: RwLock::write_arc(graph),
                 _gil: gil,
             })),
+            // Moot: already a writer, so `escalate` never runs and this is never read.
+            // These are the inline main-thread paths anyway, where Redis's own dispatch
+            // gated the command and no pause or role-change window can open mid-command.
+            preauthorized: false,
         }
     }
 
@@ -131,17 +217,19 @@ impl QuerySession {
     /// owns the single MVCC write slot for its whole lifetime, so no other writer
     /// can commit, and it has not yet touched the shared index — a reader entering
     /// the window sees a consistent older state.
-    pub fn upgrade_to_write(&self) -> Result<(), String> {
+    pub fn upgrade_to_write(&self) -> Result<(), WriteAbort> {
         if self.escalate() {
             // The key could have been deleted in the window where we held no
             // per-graph lock, so re-verify the graph is still reachable before
             // mutating it — as C does by re-opening the key under WRITE. The locks
             // stay held; the caller aborts the query and `Drop` releases them.
             if !crate::graph_core::graph_is_registered(&self.graph) {
-                return Err(
-                    "graph was deleted or replaced while the query was running, aborting"
-                        .to_string(),
-                );
+                return Err(WriteAbort::GraphUnregistered);
+            }
+            // Same window, the other half of what C re-validates here: this instance
+            // may no longer be allowed to originate a write at all.
+            if !self.preauthorized {
+                reauthorize_write()?;
             }
         }
         Ok(())
@@ -170,9 +258,83 @@ impl QuerySession {
     }
 }
 
+/// Re-check, under the GIL, that this instance may still originate a write.
+///
+/// A write is admitted on the Redis main thread, where the `write` command flag makes
+/// Redis's own dispatch postpone it while `CLIENT PAUSE ... WRITE` is in effect and
+/// reject it on a read-only replica. But it mutates and replicates much later, from a
+/// worker thread — so a `FAILOVER` / `CLIENT PAUSE` window can have opened, or this
+/// instance can have been demoted, in between. Replicating then trips Redis's
+/// `propagateNow()` invariant (`server.c`,
+/// `!(isPausedActions(PAUSE_ACTION_REPLICA) && !server.client_pause_in_transaction)`)
+/// and kills the master — the crash reported in #2359.
+///
+/// Holding the GIL is what makes this race-free: neither the pause state nor the role
+/// can change until it is released. Mirrors C's `QueryCtx_AcquireWriteLock`
+/// (`src/query_ctx.c` on `master`, PR #2372); the first two messages are byte-identical
+/// to its `EMSG_REPLICA_TRAFFIC_PAUSED` / `EMSG_NOT_MASTER` so clients and tests can
+/// match either engine.
+fn reauthorize_write() -> Result<(), WriteAbort> {
+    // Off the main thread the GIL is held through the detached context `Gil::acquire`
+    // just created. On the main thread there is none — and nothing to re-check either,
+    // since Redis gated the command at dispatch and no window can open mid-command.
+    let Some(ctx) = GIL_CTX.get() else {
+        return Ok(());
+    };
+    // SAFETY: `ctx` is the context this thread locked in `Gil::acquire` and still
+    // holds. `Context` is a borrowing wrapper with no `Drop`, so it frees nothing —
+    // the same construction `telemetry`'s flush thread uses under `hold_gil`.
+    let ctx = Context::new(ctx.as_ptr());
+    let flags = ctx.get_flags();
+
+    // Replaying our own AOF/RDB: the write was authorized and persisted before this
+    // process started, so re-authorizing it would be re-litigating a decision already
+    // made. On a replica it would also fail, since `masterhost` comes from config at
+    // startup and `READONLY` is set while the file is still replaying. Completes C's
+    // bypass set, whose other third (`REPLICATED`) reaches us through `preauthorized`
+    // because it is unreadable here.
+    //
+    // Parity and defence: no test here reaches this branch. Whether a replayed graph
+    // write can escalate on a read-only instance depends on whether it lands in the AOF
+    // as a command to re-execute or as a `GRAPH.EFFECT` that `commands::effect` applies
+    // inline, and that in turn depends on `should_use_effects` and on
+    // `aof-use-rdb-preamble` — so the answer is configuration-dependent and was not
+    // pinned down. Kept because it costs nothing (same `get_flags()` call) and because
+    // dropping a third of C's bypass set on the argument that we cannot currently reach
+    // it is how the next engine-shape change reintroduces the bug.
+    //
+    // Live rather than captured because these say what the *server* is doing, not where
+    // the write came from. That is exact for a write replayed inline, which is what
+    // replay will be once it works. A write that escalates asynchronously could outlive
+    // the loading window and miss this, so anything spawning a background escalation
+    // during load must decide at admission instead — see `preauthorized`.
+    if flags.contains(ContextFlags::LOADING) || flags.contains(ContextFlags::ASYNC_LOADING) {
+        return Ok(());
+    }
+
+    if ctx.avoid_replication_traffic() {
+        return Err(WriteAbort::ReplicaTrafficPaused);
+    }
+    // READONLY, not MASTER: a replica running `slave-read-only no` accepts writes, and
+    // rejecting them there would break replica-divergence testing. C corrected this the
+    // same way in PR #2372.
+    if flags.contains(ContextFlags::READONLY) {
+        return Err(WriteAbort::NotAMaster);
+    }
+    // No check for a role that flipped away and back (master -> replica -> master)
+    // between admission and here: the only such flip that matters resynced from the new
+    // master, which frees and re-registers the graph key, so `graph_is_registered`
+    // above has already aborted this write. A flip that resynced nothing left the data
+    // unchanged and the write is still valid.
+    Ok(())
+}
+
 impl WriteEscalation for QuerySession {
     fn upgrade_to_write(&self) -> Result<(), String> {
-        Self::upgrade_to_write(self)
+        // `graph::locks::WriteEscalation` is defined in the `graph` crate, which knows
+        // nothing about Redis roles or pauses, so its contract stays a plain message and
+        // the typed reason is flattened here at the boundary.
+        Self::upgrade_to_write(self).map_err(|e| e.to_string())
     }
 }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -7,7 +7,9 @@
 use crossfire::mpmc::{self, List};
 use crossfire::{MRx, MTx};
 use parking_lot::Mutex;
-use redis_module::{CallOptions, CallOptionsBuilder, Context, RedisString, RedisValue, raw};
+use redis_module::{
+    CallOptions, CallOptionsBuilder, Context, ContextFlags, RedisString, RedisValue, raw,
+};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
@@ -433,6 +435,12 @@ const FLUSH_BATCH_MAX: usize = 256;
 /// How long the flusher waits for the first entry before parking again.
 const FLUSH_INTERVAL: Duration = Duration::from_millis(5);
 
+/// Cap on XADDs held back while replica traffic is paused (see `flusher_loop`).
+/// Beyond this the oldest are dropped: the telemetry stream is already lossy —
+/// `MAX_INFO_QUERIES` trims it on every XADD — so bounding memory matters more
+/// than keeping every entry across a long failover pause.
+const DEFERRED_XADD_MAX: usize = 4 * FLUSH_BATCH_MAX;
+
 struct PendingEntry {
     graph_name: Arc<str>,
     entry: TelemetryEntry,
@@ -526,12 +534,21 @@ fn flusher_loop() {
     };
 
     let mut batch: Vec<PendingEntry> = Vec::with_capacity(FLUSH_BATCH_MAX);
+    // XADDs prepared but not yet dispatched because replica traffic was paused when
+    // their turn came. Retried on a later iteration — see the pause check below.
+    let mut deferred: Vec<PreparedXadd> = Vec::new();
 
     loop {
         // Block until at least one entry is available (or the channel closes).
         match rx.recv_timeout(FLUSH_INTERVAL) {
             Ok(first) => batch.push(first),
-            Err(crossfire::RecvTimeoutError::Timeout) => continue,
+            // Nothing new — but entries held back by a pause still need a retry, so
+            // only park again once there is genuinely nothing to do.
+            Err(crossfire::RecvTimeoutError::Timeout) => {
+                if deferred.is_empty() {
+                    continue;
+                }
+            }
             Err(crossfire::RecvTimeoutError::Disconnected) => break,
         }
         // Drain any additional entries non-blockingly, up to the batch cap.
@@ -551,14 +568,49 @@ fn flusher_loop() {
             .drain(..)
             .map(|pe| prepare_xadd(pe, &max_len))
             .collect();
+        deferred.extend(prepared);
+        // Oldest-first drop, so a long pause bounds memory instead of growing without
+        // limit. The stream is trimmed on every XADD anyway, so the entries most worth
+        // keeping are the newest.
+        if deferred.len() > DEFERRED_XADD_MAX {
+            deferred.drain(..deferred.len() - DEFERRED_XADD_MAX);
+        }
 
         // Single GIL acquisition for the whole batch, through the same guard queries
         // use, so every acquisition in the process funnels through one place.
         {
             let _gil = crate::query_session::hold_gil();
             let ctx = Context::new(tsc);
-            for p in &prepared {
-                dispatch_xadd(&ctx, p, &call_options);
+            // Both checks are read here, under the GIL, rather than trusted from when the
+            // entries were enqueued: a role change arrives as a server event on the main
+            // thread and a pause is opened from it, so neither can move while we hold the
+            // GIL. `enqueue_entry`'s `IS_REPLICA` check is on the producing thread and
+            // says nothing about what is true now, at dispatch.
+            if ctx.get_flags().contains(ContextFlags::SLAVE) {
+                // We have become a replica since these were enqueued. Discard rather than
+                // hold: our master is replicating its own telemetry to us, so dispatching
+                // here would both duplicate its entries and write directly to a replica —
+                // which is exactly what `enqueue_entry` refuses to do on the hot path.
+                //
+                // This interleaving is the *likely* one, not a corner case, and the pause
+                // check below is what makes it so: a FAILOVER opens a pause window, the
+                // batch is held for its duration, and the window closes at the moment this
+                // instance has become a replica. Without this the whole held batch would
+                // then be dispatched, from a replica.
+                deferred.clear();
+            } else if !ctx.avoid_replication_traffic() {
+                // These XADDs are replicated (`replicated_call_options`), so releasing the
+                // GIL below propagates them. Doing that while replica traffic is paused
+                // trips Redis's `propagateNow()` invariant and kills the master — the same
+                // #2359 crash the write path guards against in
+                // `query_session::reauthorize_write`, reached here from a timer-like
+                // background thread instead. Avoiding exactly this is what
+                // `RedisModule_AvoidReplicaTraffic` is documented for, so hold the batch
+                // and retry once the pause window closes.
+                for p in &deferred {
+                    dispatch_xadd(&ctx, p, &call_options);
+                }
+                deferred.clear();
             }
         }
     }

--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -1069,3 +1069,37 @@ class testConstraintReplication():
             elapsed -= 0.2
 
         self.env.assertEqual(len(self.monitor), 12)
+
+    def test_02_async_validation_reaches_operational_on_replica(self):
+        # Regression guard for the pause/role re-check added in #2371.
+        #
+        # Constraint validation above the async threshold runs on a spawned
+        # thread that escalates to writer. That escalation is deliberately NOT
+        # re-authorized (`QuerySession::begin_preauthorized`), because the thread
+        # runs on the replica too -- applying the master's replicated
+        # GRAPH.CONSTRAINT -- where a read-only check would reject it and strand
+        # the constraint at UNDER CONSTRUCTION while the master reports
+        # OPERATIONAL. Nothing else covers the async path with a replica.
+        #
+        # Needs > 10_000 entities: below that `Graph::create_constraint`
+        # validates synchronously on the main thread and never spawns.
+        lbl = 'AsyncValidated'
+        self.g.query(f"UNWIND range(1, 10500) AS x CREATE (:{lbl} {{v: x}})")
+        self.source.execute_command("WAIT", 1, 0)
+
+        create_mandatory_node_constraint(self.g, lbl, 'v', sync=True)
+
+        replica_g = Graph(self.replica, GRAPH_ID)
+        deadline = time.time() + 30
+        c = None
+        while time.time() < deadline:
+            self.source.execute_command("WAIT", 1, 0)
+            c = get_constraint(replica_g, 'MANDATORY', 'NODE', lbl, 'v')
+            if c is not None and c.status != 'UNDER CONSTRUCTION':
+                break
+            time.sleep(0.25)
+
+        master_c = get_constraint(self.g, 'MANDATORY', 'NODE', lbl, 'v')
+        self.env.assertEqual(master_c.status, 'OPERATIONAL')
+        self.env.assertIsNotNone(c)
+        self.env.assertEqual(c.status, 'OPERATIONAL')

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -9,9 +9,6 @@ A file goes to `spawn_files` if ANY Env() invocation passes one of:
   - env='oss-cluster' — needs a multi-node cluster
   - shardsCount      — same as above
 
-…or if it is listed in SPAWN_ONLY_FILES, for tests whose *behaviour* — rather
-than their Env() arguments — makes a shared instance unsafe.
-
 NOT spawn-forcing (the services job handles these directly):
   - enableDebugCommand — services container is launched with
                          REDIS_ARGS=--enable-debug-command yes
@@ -30,21 +27,6 @@ import json
 import os
 import re
 import sys
-
-# Files that must never ride a shared service container, for reasons the Env()
-# arguments don't reveal. Keyed by path exactly as written in
-# flow_tests_done.txt. Keep each entry's reason with it.
-SPAWN_ONLY_FILES = {
-    # Pulses CLIENT PAUSE against the whole server and asserts the master
-    # survives. On a shared container that pause stalls every other class in
-    # the cell, and a regression takes them all down with it.
-    "tests/flow/test_pause_replication_race.py",
-    # Demotes the server with REPLICAOF mid-test. On a shared container every
-    # other class in the cell would find itself writing to a read-only replica,
-    # and a failure that skips the restore leaves it that way for the rest of
-    # the run.
-    "tests/flow/test_role_change_race.py",
-}
 
 # Cluster topology forces spawn regardless of moduleArgs.
 CLUSTER_RE = re.compile(
@@ -121,9 +103,6 @@ def files_for_entry(entry):
 
 def needs_spawn(paths):
     for p in paths:
-        # Behavioural opt-out — nothing in the Env() call reveals these.
-        if p in SPAWN_ONLY_FILES:
-            return True
         try:
             with open(p, encoding="utf-8") as f:
                 content = f.read()

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -9,6 +9,9 @@ A file goes to `spawn_files` if ANY Env() invocation passes one of:
   - env='oss-cluster' — needs a multi-node cluster
   - shardsCount      — same as above
 
+…or if it is listed in SPAWN_ONLY_FILES, for tests whose *behaviour* — rather
+than their Env() arguments — makes a shared instance unsafe.
+
 NOT spawn-forcing (the services job handles these directly):
   - enableDebugCommand — services container is launched with
                          REDIS_ARGS=--enable-debug-command yes
@@ -27,6 +30,21 @@ import json
 import os
 import re
 import sys
+
+# Files that must never ride a shared service container, for reasons the Env()
+# arguments don't reveal. Keyed by path exactly as written in
+# flow_tests_done.txt. Keep each entry's reason with it.
+SPAWN_ONLY_FILES = {
+    # Pulses CLIENT PAUSE against the whole server and asserts the master
+    # survives. On a shared container that pause stalls every other class in
+    # the cell, and a regression takes them all down with it.
+    "tests/flow/test_pause_replication_race.py",
+    # Demotes the server with REPLICAOF mid-test. On a shared container every
+    # other class in the cell would find itself writing to a read-only replica,
+    # and a failure that skips the restore leaves it that way for the rest of
+    # the run.
+    "tests/flow/test_role_change_race.py",
+}
 
 # Cluster topology forces spawn regardless of moduleArgs.
 CLUSTER_RE = re.compile(
@@ -103,6 +121,9 @@ def files_for_entry(entry):
 
 def needs_spawn(paths):
     for p in paths:
+        # Behavioural opt-out — nothing in the Env() call reveals these.
+        if p in SPAWN_ONLY_FILES:
+            return True
         try:
             with open(p, encoding="utf-8") as f:
                 content = f.read()

--- a/tests/flow/test_pause_replication_race.py
+++ b/tests/flow/test_pause_replication_race.py
@@ -1,0 +1,154 @@
+import time
+import threading
+from common import *
+
+GRAPH_ID = "pause_replication_race"
+
+WRITER_THREADS      = 24   # concurrent connections hammering the master with writes
+STRESS_DURATION_SEC = 3    # wall-clock budget to try to hit the race
+POLL_INTERVAL_SEC   = 0.1  # how often we check whether the master died
+PAUSE_MS            = 10   # duration of each CLIENT PAUSE pulse
+PAUSE_GAP_SEC       = 0.01 # gap between pulses, so postponed writes get a chance to drain
+
+# expected, transient rejections a writer can hit while stressing the pause
+# window / role-check this test targets - retrying past these keeps write
+# pressure up for the full stress budget; anything else is unexpected and
+# likely means the master died, so the writer gives up
+_EXPECTED_WRITE_ERRORS = (
+    "replica traffic is currently paused",
+    "this instance is not a master",
+    "Max pending queries exceeded",
+    "another write is in progress, retry the query",
+)
+
+stop_event = threading.Event()
+
+
+def _writer(env, idx, create_counts):
+    conn = env.getConnection()
+    while not stop_event.is_set():
+        try:
+            conn.execute_command("GRAPH.QUERY", GRAPH_ID, "CREATE (n:P) RETURN 1")
+            create_counts[idx] += 1
+        except ResponseError as e:
+            if any(msg in str(e) for msg in _EXPECTED_WRITE_ERRORS):
+                continue
+            return
+        except Exception:
+            # a real connection-level failure - most likely the master
+            # crashed; the main thread will notice via the liveness check
+            return
+
+
+def _pauser(env):
+    conn = env.getConnection()
+    while not stop_event.is_set():
+        try:
+            # PAUSE ... WRITE sets PAUSE_ACTION_REPLICA, the same bit a
+            # FAILOVER / CLUSTER FAILOVER opens for its pause window
+            conn.execute_command("CLIENT", "PAUSE", str(PAUSE_MS), "WRITE")
+        except Exception:
+            return
+        time.sleep(PAUSE_GAP_SEC)
+
+
+def _master_died(env, probe_conn):
+    """True once the master process is gone.
+
+    `envRunner.masterProcess` exists only when RLTest spawned redis itself
+    (local dev). Both CI modes in common.py build `Environment(env='existing-env')`,
+    whose runner has no such attribute, so fall back to probing the server.
+    """
+    proc = getattr(env.envRunner, "masterProcess", None)
+    if proc is not None:
+        return proc.poll() is not None
+    try:
+        probe_conn.ping()
+        return False
+    except Exception:
+        return True
+
+
+# Regression test for the master crash described in #2359:
+#   server.c:3600 '!(isPausedActions(PAUSE_ACTION_REPLICA) &&
+#                    (!server.client_pause_in_transaction))'
+#
+# GRAPH.QUERY writes are admitted on the Redis main thread but actually
+# mutate the graph and replicate later, from a worker thread (see
+# process_write_queued_query / execute_query_write in src/graph_core.rs). If a
+# CLIENT PAUSE / FAILOVER opens a replica-pause window in between admission
+# and that later write+replicate step, nothing re-checked the pause state -
+# the write proceeded anyway and crashed on propagateNow()'s invariant that
+# nothing may propagate while replica traffic is paused.
+#
+# QuerySession::upgrade_to_write now re-validates pause and role under the GIL
+# before anything is mutated (src/query_session.rs), matching what C does in
+# QueryCtx_AcquireWriteLock.
+#
+# This continuously hammers the master with concurrent writes while pulsing
+# CLIENT PAUSE ... WRITE, trying to land a pause pulse inside that window.
+class testPauseReplicationRace(FlowTestsBase):
+    def __init__(self):
+        # replication timing doesn't play well with sanitizers
+        if SANITIZER:
+            Environment.skip(None)
+
+        self.env, self.db = Env(env='oss', useSlaves=True)
+
+    def test_pause_during_inflight_write_does_not_crash_master(self):
+        env = self.env
+        stop_event.clear()
+
+        # dedicated connection for the liveness probe, opened before the stress
+        # starts so its handshake can't be caught by a pause pulse
+        probe_conn = env.getConnection()
+
+        create_counts = [0] * WRITER_THREADS
+        writers = [threading.Thread(target=_writer, args=(env, i, create_counts),
+                                    daemon=True)
+                   for i in range(WRITER_THREADS)]
+        pauser = threading.Thread(target=_pauser, args=(env,), daemon=True)
+
+        for t in writers:
+            t.start()
+        pauser.start()
+
+        crashed = False
+        deadline = time.time() + STRESS_DURATION_SEC
+        while time.time() < deadline:
+            if _master_died(env, probe_conn):
+                crashed = True
+                break
+            time.sleep(POLL_INTERVAL_SEC)
+
+        stop_event.set()
+        for t in writers:
+            t.join(timeout=5)
+        pauser.join(timeout=5)
+
+        if crashed:
+            # don't let RLTest's teardown try to interact with the dead
+            # process / print its own crash report
+            if getattr(env.envRunner, "masterProcess", None) is not None:
+                env.envRunner.masterProcess = None
+
+        env.assertFalse(crashed,
+            message="master crashed under concurrent CLIENT PAUSE + "
+                    "GRAPH.QUERY writes - see the master log for details")
+
+        # data integrity: every write that came back successful must have
+        # landed exactly once - no writes silently duplicated (double
+        # applied around a rejected commit) or lost (dropped despite a
+        # success reply) under the pause/race stress
+        expected_count = sum(create_counts)
+        env.assertTrue(expected_count > 0,
+            message="no writes ever succeeded - the stress loop isn't "
+                    "exercising the write path")
+
+        master_graph = Graph(env.getConnection(), GRAPH_ID)
+        actual_count = master_graph.ro_query(
+            "MATCH (n:P) RETURN count(n)").result_set[0][0]
+        env.assertEquals(actual_count, expected_count,
+            message="node count diverged from the number of writes "
+                    "reported successful - possible duplication or loss "
+                    "under pause/race stress")

--- a/tests/flow/test_pause_replication_race.py
+++ b/tests/flow/test_pause_replication_race.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from common import *
+from common import Env, Environment, FlowTestsBase, Graph, ResponseError, SANITIZER
 
 GRAPH_ID = "pause_replication_race"
 
@@ -24,15 +24,19 @@ _EXPECTED_WRITE_ERRORS = (
 stop_event = threading.Event()
 
 
-def _writer(env, idx, create_counts):
+def _writer(env, idx, create_counts, unexpected):
     conn = env.getConnection()
     while not stop_event.is_set():
         try:
             conn.execute_command("GRAPH.QUERY", GRAPH_ID, "CREATE (n:P) RETURN 1")
             create_counts[idx] += 1
         except ResponseError as e:
-            if any(msg in str(e) for msg in _EXPECTED_WRITE_ERRORS):
+            msg = str(e)
+            if any(m in msg for m in _EXPECTED_WRITE_ERRORS):
                 continue
+            # anything else means the write path is broken in a new way; record
+            # it so an adaptive expected_count can't quietly absorb it
+            unexpected.append(msg)
             return
         except Exception:
             # a real connection-level failure - most likely the master
@@ -104,7 +108,9 @@ class testPauseReplicationRace(FlowTestsBase):
         probe_conn = env.getConnection()
 
         create_counts = [0] * WRITER_THREADS
-        writers = [threading.Thread(target=_writer, args=(env, i, create_counts),
+        unexpected = []
+        writers = [threading.Thread(target=_writer,
+                                    args=(env, i, create_counts, unexpected),
                                     daemon=True)
                    for i in range(WRITER_THREADS)]
         pauser = threading.Thread(target=_pauser, args=(env,), daemon=True)
@@ -141,7 +147,10 @@ class testPauseReplicationRace(FlowTestsBase):
         # applied around a rejected commit) or lost (dropped despite a
         # success reply) under the pause/race stress
         expected_count = sum(create_counts)
-        env.assertTrue(expected_count > 0,
+        env.assertEqual(unexpected, [],
+            message=f"writers saw unexpected errors: {unexpected[:3]}")
+
+        env.assertGreater(expected_count, 0,
             message="no writes ever succeeded - the stress loop isn't "
                     "exercising the write path")
 

--- a/tests/flow/test_role_change_race.py
+++ b/tests/flow/test_role_change_race.py
@@ -1,6 +1,6 @@
 import time
 import threading
-from common import *
+from common import Env, Environment, FlowTestsBase, ResponseError, SANITIZER
 
 GRAPH_ID = "role_change_race"
 
@@ -93,6 +93,9 @@ class testRoleChangeRace(FlowTestsBase):
         try:
             self.env.getConnection().execute_command("REPLICAOF", "NO", "ONE")
         except Exception:
+            # Best-effort: a test that crashed the server, or left it mid
+            # transition, may leave nothing reachable to restore. Raising here
+            # would replace the real failure with a teardown error.
             pass
 
     def test01_demotion_during_inflight_write_does_not_crash_master(self):
@@ -163,10 +166,10 @@ class testRoleChangeRace(FlowTestsBase):
         confirmed = sum(create_counts) + 1  # +1 for the CREATE just above
         ambiguous = sum(unblocked_counts)
         actual = graph.query("MATCH (n:P) RETURN count(n)").result_set[0][0]
-        env.assertTrue(actual >= confirmed,
+        env.assertGreaterEqual(actual, confirmed,
             message=f"writes were lost: {actual} nodes for {confirmed} successful "
                     f"replies")
-        env.assertTrue(actual <= confirmed + ambiguous,
+        env.assertLessEqual(actual, confirmed + ambiguous,
             message=f"writes were duplicated: {actual} nodes exceeds "
                     f"{confirmed} successful replies plus {ambiguous} "
                     f"force-unblocked writes of unknown outcome")
@@ -191,6 +194,11 @@ class testRoleChangeRace(FlowTestsBase):
         graph.query("CREATE (:P {v: 1})")
         time.sleep(0.5)
         before = conn.execute_command("XLEN", stream)
+        # Positive control: without this, a build with telemetry disabled would
+        # satisfy every assertion below with an always-empty stream.
+        env.assertGreater(before, 0,
+            message="telemetry stream is empty before the pause - the flusher "
+                    "never dispatched, so this test would pass vacuously")
 
         # PAUSE WRITE sets PAUSE_ACTION_REPLICA, so the flusher holds its batch.
         # Reads still run, and every query enqueues a telemetry entry.

--- a/tests/flow/test_role_change_race.py
+++ b/tests/flow/test_role_change_race.py
@@ -1,0 +1,216 @@
+import time
+import threading
+from common import *
+
+GRAPH_ID = "role_change_race"
+
+WRITER_THREADS      = 24   # concurrent connections hammering the master with writes
+STRESS_DURATION_SEC = 3    # wall-clock budget to try to hit the race
+POLL_INTERVAL_SEC   = 0.1  # how often we check whether the master died
+DEMOTE_AT_SEC       = 1.0  # demote this far into the stress window
+
+# A demotion is driven by pointing the master at a master that does not exist:
+# it becomes a replica (READONLY / SLAVE set, master_link_status:down) without
+# disturbing the real replica RLTest attached, and `REPLICAOF NO ONE` restores it.
+DEAD_MASTER_HOST = "127.0.0.1"
+DEAD_MASTER_PORT = "1"
+
+# Expected, transient rejections a writer can hit across a demotion.
+#
+# Two of these come from different layers and both are correct:
+#   * "READONLY You can't write against a read only replica" - Redis rejecting a
+#     *new* command at dispatch, once the instance is already a replica;
+#   * "Write query aborted: this instance is not a master" - our own guard in
+#     QuerySession::reauthorize_write, for a write that was already admitted on a
+#     master and only reaches its commit after the demotion. That is the window
+#     this test exists for, and the one Redis cannot close for us.
+_EXPECTED_WRITE_ERRORS = (
+    "this instance is not a master",
+    # redis-py strips the `READONLY` error-code prefix, so match the text only
+    "You can't write against a read only replica",
+    "replica traffic is currently paused",
+    "Max pending queries exceeded",
+    "another write is in progress, retry the query",
+    "graph was deleted or replaced while the query was running",
+)
+
+# Redis force-unblocks every blocked client when the role changes. The reply says
+# the *blocking operation* was aborted - it is not a statement about whether the
+# write landed, and measurement says it sometimes had: a run with 3 of these ended
+# with exactly 3 more nodes than replies reported success. So these are counted
+# separately and their writes treated as of unknown outcome.
+_UNBLOCKED_ERROR = "UNBLOCKED force unblock from blocking operation"
+
+stop_event = threading.Event()
+
+
+def _writer(env, idx, create_counts, unblocked_counts, unexpected):
+    conn = env.getConnection()
+    while not stop_event.is_set():
+        try:
+            conn.execute_command("GRAPH.QUERY", GRAPH_ID, "CREATE (n:P) RETURN 1")
+            create_counts[idx] += 1
+        except ResponseError as e:
+            msg = str(e)
+            if _UNBLOCKED_ERROR in msg:
+                unblocked_counts[idx] += 1
+                continue
+            if any(m in msg for m in _EXPECTED_WRITE_ERRORS):
+                continue
+            unexpected.append(msg)
+            return
+        except Exception:
+            # connection-level failure - most likely the master died; the main
+            # thread notices via the liveness check
+            return
+
+
+def _master_died(env, probe_conn):
+    proc = getattr(env.envRunner, "masterProcess", None)
+    if proc is not None:
+        return proc.poll() is not None
+    try:
+        probe_conn.ping()
+        return False
+    except Exception:
+        return True
+
+
+class testRoleChangeRace(FlowTestsBase):
+    def __init__(self):
+        # replication timing doesn't play well with sanitizers
+        if SANITIZER:
+            Environment.skip(None)
+
+        # useSlaves so the master has a replica attached: propagation is only
+        # attempted at all when there is somewhere to propagate to
+        # (Redis `shouldPropagate`), which is what makes these paths live.
+        self.env, self.db = Env(env='oss', useSlaves=True)
+
+    def tearDown(self):
+        # Always hand the instance back as a master, or RLTest's teardown and
+        # every later class inherit a read-only server.
+        try:
+            self.env.getConnection().execute_command("REPLICAOF", "NO", "ONE")
+        except Exception:
+            pass
+
+    def test01_demotion_during_inflight_write_does_not_crash_master(self):
+        env = self.env
+        stop_event.clear()
+
+        probe_conn = env.getConnection()
+        admin_conn = env.getConnection()
+
+        create_counts = [0] * WRITER_THREADS
+        unblocked_counts = [0] * WRITER_THREADS
+        unexpected = []
+        writers = [threading.Thread(target=_writer,
+                                    args=(env, i, create_counts,
+                                          unblocked_counts, unexpected),
+                                    daemon=True)
+                   for i in range(WRITER_THREADS)]
+        for t in writers:
+            t.start()
+
+        demoted = False
+        crashed = False
+        started = time.time()
+        deadline = started + STRESS_DURATION_SEC
+        while time.time() < deadline:
+            if _master_died(env, probe_conn):
+                crashed = True
+                break
+            if not demoted and time.time() - started >= DEMOTE_AT_SEC:
+                # writes are in flight right now; some were admitted as master and
+                # will not reach their commit until after this returns
+                admin_conn.execute_command("REPLICAOF", DEAD_MASTER_HOST, DEAD_MASTER_PORT)
+                demoted = True
+            time.sleep(POLL_INTERVAL_SEC)
+
+        stop_event.set()
+        for t in writers:
+            t.join(timeout=5)
+
+        if crashed and getattr(env.envRunner, "masterProcess", None) is not None:
+            # keep RLTest's teardown away from the dead process
+            env.envRunner.masterProcess = None
+
+        env.assertFalse(crashed,
+            message="master crashed when demoted with writes in flight - "
+                    "see the master log for details")
+        env.assertTrue(demoted,
+            message="the demotion never ran, so this test proved nothing")
+        env.assertEqual(unexpected, [],
+            message=f"writers saw unexpected errors: {unexpected[:3]}")
+
+        # Back to master, and verify the instance is actually usable again rather
+        # than merely alive.
+        admin_conn.execute_command("REPLICAOF", "NO", "ONE")
+        graph = self.db.select_graph(GRAPH_ID)
+        graph.query("CREATE (:P)")
+
+        # Data integrity across the demotion, stated as a range rather than an
+        # equality, because a force-unblocked write has a genuinely unknown outcome:
+        # Redis told the client its blocking operation was aborted, which says
+        # nothing about whether the write had already been applied.
+        #
+        #   lower bound - every write that *reported success* must have landed:
+        #                 anything less is silent loss
+        #   upper bound - nothing may land twice: at most one node per reported
+        #                 success plus one per force-unblocked write of unknown
+        #                 outcome. Anything more is duplication.
+        confirmed = sum(create_counts) + 1  # +1 for the CREATE just above
+        ambiguous = sum(unblocked_counts)
+        actual = graph.query("MATCH (n:P) RETURN count(n)").result_set[0][0]
+        env.assertTrue(actual >= confirmed,
+            message=f"writes were lost: {actual} nodes for {confirmed} successful "
+                    f"replies")
+        env.assertTrue(actual <= confirmed + ambiguous,
+            message=f"writes were duplicated: {actual} nodes exceeds "
+                    f"{confirmed} successful replies plus {ambiguous} "
+                    f"force-unblocked writes of unknown outcome")
+
+    def test02_telemetry_batch_held_by_a_pause_is_dropped_on_demotion(self):
+        # The flusher's pause check holds prepared XADDs until replica traffic
+        # resumes. That makes one interleaving the *likely* one rather than a
+        # corner case: a FAILOVER opens the pause, the batch is held for its
+        # duration, and the window closes at the moment this instance has become a
+        # replica. Dispatching the held batch then would write telemetry directly
+        # to a replica - which `enqueue_entry` refuses to do on the hot path,
+        # because the master replicates its own entries to us.
+        #
+        # Deterministic, unlike test01: the pause guarantees the batch is still
+        # pending when the demotion lands.
+        env = self.env
+        conn = env.getConnection()
+        graph = self.db.select_graph(GRAPH_ID)
+        stream = f"telemetry{{{GRAPH_ID}}}"
+
+        # a graph to read from, and a settled telemetry stream to measure against
+        graph.query("CREATE (:P {v: 1})")
+        time.sleep(0.5)
+        before = conn.execute_command("XLEN", stream)
+
+        # PAUSE WRITE sets PAUSE_ACTION_REPLICA, so the flusher holds its batch.
+        # Reads still run, and every query enqueues a telemetry entry.
+        conn.execute_command("CLIENT", "PAUSE", "3000", "WRITE")
+        for _ in range(20):
+            graph.ro_query("MATCH (n:P) RETURN count(n)")
+        held = conn.execute_command("XLEN", stream)
+        env.assertEqual(held, before,
+            message="the flusher dispatched during a pause - the pause guard "
+                    "is not holding the batch, so this test cannot prove anything "
+                    "about what happens to a held batch")
+
+        # Demote while that batch is still held, then let the pause lapse so the
+        # flusher wakes up as a replica.
+        conn.execute_command("REPLICAOF", DEAD_MASTER_HOST, DEAD_MASTER_PORT)
+        time.sleep(4)
+
+        after = conn.execute_command("XLEN", stream)
+        env.assertEqual(after, before,
+            message="telemetry entries were written after this instance became a "
+                    "replica - the held batch was dispatched instead of discarded")
+
+        conn.execute_command("REPLICAOF", "NO", "ONE")


### PR DESCRIPTION
Closes #2371

## What was wrong

A graph write is **admitted** on the Redis main thread — where Redis has already vetted the
pause state and the role — but it **mutates and replicates later, from a background thread**.
Nothing re-checked either condition in between. So a `CLIENT PAUSE` / `FAILOVER` window opening
in that gap, or a demotion to replica, let the write proceed and crash the master:

```
# === ASSERTION FAILED ===
# ==> server.c:3600 '!(isPausedActions(PAUSE_ACTION_REPLICA) &&
#                      (!server.client_pause_in_transaction))'
```

Redis's own comment at `server.c:3613` gives the reason: *"the dataset should be fixed during
replica pause (otherwise data may be lost during a failover)"*. It is a `serverAssert` rather
than an error return because by then the write is already applied — there is nothing to roll
back, and letting it into the replication stream would break the guarantee a failover is
predicated on.

The invariant holds for ordinary Redis commands because admit → apply → propagate happens in one
uninterrupted turn. FalkorDB breaks that atomicity, so it has to re-establish the check itself.

## 1. Query write path

`upgrade_to_write` re-validates **under the GIL, immediately before mutating**. Holding the GIL
is what makes it race-free: `CLIENT PAUSE` and role-change events both run on the main thread,
which needs the GIL we are holding, so neither can move between the check and the commit.

Mirrors C's `QueryCtx_AcquireWriteLock` (`src/query_ctx.c`, PR #2372): bypass on
`LOADING`/`ASYNC_LOADING`, then `AvoidReplicaTraffic`, then `READONLY`.

Two details carried over deliberately:

* **`READONLY`, not `MASTER`** — a replica running `replica-read-only no` accepts writes, and
  rejecting them there would break replica-divergence testing. C corrected this the same way in
  #2372. Confirmed against Redis source: `READONLY` is set only when `SLAVE && repl_slave_ro`
  (`module.c:3999-4002`).
* **No check for a role that flipped away and back.** The only flip that matters resynced, which
  frees and re-registers the graph key, so `graph_is_registered` has already aborted the write.
  A flip that resynced nothing left the data unchanged and the write is still valid.

## 2. Telemetry flusher

The flusher replicates XADDs from a background thread, so it needs both checks — and it had
neither.

**Pause:** hold the batch, retry once the window closes. Bounded by `DEFERRED_XADD_MAX` with
oldest-first drop: the stream is already lossy (`MAX_INFO_QUERIES` trims it on every XADD), so
bounding memory matters more than keeping every entry across a long pause.

**Role:** discard the batch. `enqueue_entry` already skips on replicas, but that check runs on
the *producing* thread and says nothing about what is true later, at dispatch.

Worth calling out: **the pause guard is what makes this interleaving likely rather than exotic.**
A `FAILOVER` opens the window, the batch is held for its duration, and the window closes at the
moment this instance has become a replica — so without the role check the entire held batch would
be dispatched *from a replica*, duplicating entries the new master is already replicating to us
and writing directly to a replica, which `enqueue_entry` refuses to do on the hot path.

Both conditions are read under the GIL for the same reason as the query path.

## 3. Bulk

`preauthorized` narrows from three flags to `ASYNC_LOADING` alone. #2420 and #2421 route
`REPLICATED` and `LOADING` inline, so neither reaches that worker any more — this is the collapse
the previous comment predicted (*"#2420 closes that, after which this collapses to a plain
`begin`"*). `ASYNC_LOADING` stays because it is in C's authorization bypass but in neither C's
dispatcher predicate nor ours, so such a batch still spawns a worker — and that worker can
escalate after the loading window closes, where a live read would abort a write already
authorized and persisted.

## 4. `thiserror`

`WriteAbort` replaces inline string literals: `ReplicaTrafficPaused`, `NotAMaster`,
`GraphUnregistered`. The first two `Display` strings are byte-identical to C's
`EMSG_REPLICA_TRAFFIC_PAUSED` / `EMSG_NOT_MASTER`, so a client or a test can match either
engine — they are a compatibility contract, and a typo in one previously had no compiler help.
`graph::locks::WriteEscalation` keeps its `Result<(), String>` contract, since that crate knows
nothing about Redis roles or pauses; the typed reason is flattened at the impl boundary.

## Tests

**`test_pause_replication_race.py`** — ported from C's #2372. 24 writers hammering `CREATE` while
pulsing `CLIENT PAUSE … WRITE`, asserting the master survives and that node count matches
reported successes.

**`test_role_change_race.py`** — new, two tests, because the two halves need different
instruments:

* `test01` — stress. Demotes the master mid-flight via `REPLICAOF`. Redis rejects *new* writes at
  dispatch itself, so our guard only matters for a write admitted as master that reaches its
  commit afterwards; hitting that window needs load rather than determinism.
* `test02` — **deterministic**, and the one that pins the telemetry role fix. `CLIENT PAUSE` holds
  the flusher's batch, reads fill it, the demotion lands while it is held, then the pause lapses.
  Asserts the intermediate state as well, so it fails loudly instead of vacuously if the pause
  guard ever stops holding the batch.

Demotion points the instance at a master that does not exist, which sets `SLAVE`/`READONLY`
without disturbing the replica RLTest attached; `tearDown` restores `REPLICAOF NO ONE`
unconditionally so a failure cannot leave a read-only server behind. Both files are in
`SPAWN_ONLY_FILES` — on a shared CI container `CLIENT PAUSE` stalls every other class in the cell
and `REPLICAOF` would leave them all read-only.

### One finding that changed a test

Integrity across a demotion is asserted as a **range**, not an equality:

```
confirmed ≤ actual ≤ confirmed + ambiguous
```

Redis force-unblocks blocked clients on a role change, and that reply says the *blocking
operation* was aborted — not that the write did not land. Measured twice, with different splits:
3 `UNBLOCKED` → 3 extra nodes, and 2 `UNBLOCKED` → 1 extra node. So an equality assertion there
is simply untrue, while the range still catches both real failures: loss below the lower bound,
duplication above the upper.

## Verification

| check | result |
| --- | --- |
| `tests/flow/test_role_change_race` (new) | **2/2** |
| `tests/flow/test_pause_replication_race` | 1/1 |
| `tests/flow/test_constraint` | 17/17 |
| `tests/flow/test_bulk_insertion` | 14/14 |
| `tests/flow/test_aof` | 1/1 |
| `tests/flow/test_replication` | 2/2 |
| `tests/flow/test_effects` | 22/22 |
| `tests/flow/test_persistency` | 11/11 |
| `tests/flow/test_graph_info` | 7/7 |
| `cargo test -p graph` | 139 passed, 0 failed, 6 ignored |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets` | exit 0; 3 warnings, all present on `main` (`tensor.rs:989`, `cond_var_len_traverse.rs:491`, `bulk_insert_sync_yield`) |

`test_pause_replication_race` failed once in ~7 runs early on and did not reproduce in the 6
after; the failing assertion was not captured, so it is recorded here rather than attributed. It
is a 24-thread stress test that spends roughly half its time paused, so writer starvation on a
loaded machine is the likely cause.

## Deliberately not in this PR

**The constraint validation thread's `preauthorized` exemption stays.** That thread mutates the
graph outside any query and is exempt from both checks, which is coarser than it needs to be — it
requires only the *role* exemption, because it also runs on the replica applying the master's
replicated `GRAPH.CONSTRAINT`, where a `READONLY` rejection would strand the constraint
`UNDER CONSTRUCTION` and diverge.

Skipping the *pause* check there is currently harmless: that thread replicates nothing of its own
(no replicate call in the spawned closure; `mvcc_graph.rs` has zero replication references), so
`propagateNow` has nothing to fire on. It stops being harmless when #2419 makes that thread
re-announce the finished constraint, and the fix belongs there, next to the replication that
makes it necessary.

For the record, this is worth knowing when #2419 is scoped: **C has the same hole and it is a live
crash there.** C's Indexer thread does replicate the completion — `Constraint_Replicate` at
`indexer.c:279`, then `RedisModule_ThreadSafeContextUnlock` at `:282` flushes it — with no pause
check anywhere on that path, because #2372 only covered `query_ctx.c`. Reproduced 3/3 on
`falkordb/falkordb-server:edge-c` at `a8190a3e7` (latest `master`) with a replica attached and a
pause outlasting validation. Wants its own issue against `master`; not filed yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when writes occur during replication pauses, role changes, or master failover.
  * Preserved asynchronous bulk inserts and constraint validation across replicas.
  * Prevented telemetry events from being written incorrectly after a server becomes a replica.

* **Tests**
  * Added coverage for concurrent writes, replication pauses, role changes, failover scenarios, and telemetry handling.

* **Documentation**
  * Documented graph-write authorization behavior across client, replication, loading, validation, and telemetry operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->