### PR TITLE
perf(parser): read parameters straight into values, not an expression tree (6.5x)

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_runtime.rs
+++ b/fuzz/fuzz_targets/fuzz_target_runtime.rs
@@ -1,8 +1,6 @@
 // #![feature(c_variadic)]
 #![no_main]
 
-use std::collections::HashMap;
-
 // use libc::{atexit, calloc, free, malloc, realloc, strdup};
 
 use graph::{
@@ -22,7 +20,7 @@ use graph::{
     //         RedisModuleString,
     //     },
     // },
-    runtime::{eval::evaluate_param, functions::init_functions, runtime::Runtime},
+    runtime::{functions::init_functions, runtime::Runtime},
 };
 use libfuzzer_sys::{Corpus, fuzz_target};
 
@@ -126,13 +124,6 @@ fuzz_target!(init: {
         let Ok(Plan {
             plan, parameters, ..
         }) = g.read().borrow().get_plan(query)
-        else {
-            return Corpus::Reject;
-        };
-        let Ok(parameters) = parameters
-            .into_iter()
-            .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-            .collect::<Result<HashMap<_, _>, String>>()
         else {
             return Corpus::Reject;
         };

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -99,9 +99,9 @@ use crate::{
         Field,
         indexer::{Document, IndexInfo, IndexOptions, IndexQuery, IndexType, Indexer},
     },
-    parser::{ast::ExprIR, cypher::Parser},
+    parser::cypher::Parser,
     planner::{IR, Planner, binder::Binder, optimizer::optimize},
-    runtime::{eval::evaluate_param, orderset::OrderSet, value::Value, vec_distance},
+    runtime::{orderset::OrderSet, value::Value, vec_distance},
     threadpool::spawn,
 };
 
@@ -113,8 +113,8 @@ pub struct Plan {
     pub plan: Arc<DynTree<IR>>,
     /// Whether this plan was retrieved from cache
     pub cached: bool,
-    /// Query parameters extracted from CYPHER prefix
-    pub parameters: HashMap<String, DynTree<ExprIR<Arc<String>>>>,
+    /// Query parameters extracted from CYPHER prefix, already evaluated
+    pub parameters: HashMap<String, Value>,
     /// Time spent parsing the query
     pub parse_duration: Duration,
     /// Time spent planning/optimizing the query
@@ -205,7 +205,7 @@ impl Plan {
     pub const fn new(
         plan: Arc<DynTree<IR>>,
         cached: bool,
-        parameters: HashMap<String, DynTree<ExprIR<Arc<String>>>>,
+        parameters: HashMap<String, Value>,
         parse_duration: Duration,
         plan_duration: Duration,
         params_offset: usize,
@@ -1104,11 +1104,8 @@ impl Graph {
         let params_offset = query.len() - query_no_params.len();
         let query = query_no_params;
 
-        // Evaluate parameter expressions to values for the optimizer.
-        let param_values: HashMap<String, Value> = parameters
-            .iter()
-            .filter_map(|(k, v)| evaluate_param(&v.root()).ok().map(|val| (k.clone(), val)))
-            .collect();
+        // The optimizer wants the same values the runtime will see.
+        let param_values = parameters.clone();
 
         let current_udf_version = crate::runtime::functions::udf_version();
 

--- a/graph/src/parser/cypher.rs
+++ b/graph/src/parser/cypher.rs
@@ -109,7 +109,9 @@ use crate::tree;
 use crate::{
     parser::lexer::Token::RParen,
     runtime::{
+        eval::evaluate_param,
         functions::{FnType, get_functions},
+        ordermap::OrderMap,
         value::Value,
     },
 };
@@ -117,9 +119,25 @@ use itertools::Itertools;
 use orx_tree::{DynTree, NodeRef};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use thin_vec::ThinVec;
 /// Opening of every rejection [`Parser::too_deep`] produces, and what
 /// [`is_too_deep`] recognises.
 const TOO_DEEP: &str = "Query nesting exceeds the maximum depth of";
+
+/// Rejections [`evaluate_param`] produces for a value that is not a literal.
+///
+/// Each already names the parameter problem exactly, so like
+/// [`is_identifier_too_long`] they survive the "Failed to parse the value of
+/// parameter" summary that would otherwise replace them.
+const PARAM_VALUE_ERRORS: [&str; 3] = [
+    "Invalid parameter expression.",
+    "Map parameter key must be a string",
+    "ArgumentError: integer overflow in unary minus",
+];
+
+fn is_param_value_error(err: &str) -> bool {
+    PARAM_VALUE_ERRORS.contains(&err)
+}
 
 /// Whether `err` is a rejection produced by [`Parser::too_deep`].
 ///
@@ -258,9 +276,7 @@ impl<'a> Parser<'a> {
     ///
     /// Handles queries like: `CYPHER param1=value1 param2=value2 MATCH ...`
     /// Returns the parameters map and the remaining query string.
-    pub fn parse_parameters(
-        &mut self
-    ) -> Result<(HashMap<String, DynTree<ExprIR<Arc<String>>>>, &'a str), String> {
+    pub fn parse_parameters(&mut self) -> Result<(HashMap<String, Value>, &'a str), String> {
         let mut params = HashMap::new();
         while let Ok(Token::IdentifierOrKeyword {
             ident: id,
@@ -275,13 +291,14 @@ impl<'a> Parser<'a> {
                         self.restore_state(state);
                         break;
                     }
-                    let value = self.parse_expr(false).map_err(|e| {
+                    let value = self.parse_param_value().map_err(|e| {
                         // An over-long map key or too-deep nesting inside the
                         // value names the exact thing to fix, so it survives; a
                         // syntax error inside a parameter is more useful
                         // reported as the parameter that failed (see
                         // test_params).
-                        if is_identifier_too_long(&e) || is_too_deep(&e) {
+                        if is_identifier_too_long(&e) || is_too_deep(&e) || is_param_value_error(&e)
+                        {
                             e
                         } else {
                             format!("Failed to parse the value of parameter '{}'", id.as_str())
@@ -295,6 +312,123 @@ impl<'a> Parser<'a> {
             }
         }
         Ok((params, &self.lexer.str[self.lexer.pos(true)..]))
+    }
+
+    /// Parses one `CYPHER name=<value>` value.
+    ///
+    /// A parameter is a literal - [`evaluate_param`] accepts nothing else - so
+    /// the common case is read straight into a [`Value`], skipping the
+    /// expression tree that used to be built and then walked twice (once for
+    /// the optimizer, once for the runtime). On a bulk-loader payload that
+    /// tree is one node per literal, which dominated the whole query.
+    ///
+    /// Anything the fast path does not recognise, or that turns out to be an
+    /// expression rather than a literal, is handed back to `parse_expr` so its
+    /// result and its error message are exactly what they were before.
+    fn parse_param_value(&mut self) -> Result<Value, String> {
+        let state = self.save_state();
+        if let Ok(value) = self.parse_literal()
+            // A literal that runs into an operator (`p=1+2`) or an index
+            // (`p=[1,2][0]`) was never a literal; only an identifier - the
+            // next `name=` or the start of the query - or the end of input
+            // means the value stopped here.
+            && matches!(
+                self.lexer.current(),
+                Ok(Token::IdentifierOrKeyword { .. } | Token::EndOfFile)
+            )
+        {
+            return Ok(value);
+        }
+        self.restore_state(state);
+        evaluate_param(&self.parse_expr(false)?.root())
+    }
+
+    /// Reads a literal: `null`, a boolean, a number, a string, a list, a map,
+    /// or one of those negated.
+    fn parse_literal(&mut self) -> Result<Value, String> {
+        if optional_match_token!(self.lexer, Dash) {
+            // One `-` only: `--1` is not a literal, and was rejected before.
+            return Ok(match self.parse_unsigned_literal()? {
+                // `-9223372036854775808` is the one integer whose negation is
+                // itself; the lexer already hands back i64::MIN for the digits.
+                Value::Int(i64::MIN) => Value::Int(i64::MIN),
+                Value::Int(i) => Value::Int(i.checked_neg().ok_or_else(|| {
+                    String::from("ArgumentError: integer overflow in unary minus")
+                })?),
+                Value::Float(f) => Value::Float(-f),
+                // Negating anything else is Null, as `evaluate_param` had it.
+                _ => Value::Null,
+            });
+        }
+        let value = self.parse_unsigned_literal()?;
+        if matches!(value, Value::Int(i64::MIN)) {
+            // Unnegated, those digits were i64::MAX + 1.
+            return Err(format!(
+                "Integer overflow '{}'",
+                9_223_372_036_854_775_808_u64
+            ));
+        }
+        Ok(value)
+    }
+
+    fn parse_unsigned_literal(&mut self) -> Result<Value, String> {
+        let value = match self.lexer.current()? {
+            Token::IdentifierOrKeyword {
+                keyword: Some(Keyword::Null),
+                ..
+            } => Value::Null,
+            Token::IdentifierOrKeyword {
+                keyword: Some(Keyword::True),
+                ..
+            } => Value::Bool(true),
+            Token::IdentifierOrKeyword {
+                keyword: Some(Keyword::False),
+                ..
+            } => Value::Bool(false),
+            Token::Integer(i) => Value::Int(i),
+            Token::Float(f) => Value::Float(f),
+            Token::String(s) => Value::String(s),
+            // Nesting recurses, so it is bounded like every other descent.
+            Token::LBrace => return self.nested(Self::parse_literal_list),
+            Token::LBracket => return self.nested(Self::parse_literal_map),
+            token => {
+                return Err(self.lexer.format_error(&format!("Invalid input {token:?}")));
+            }
+        };
+        self.lexer.next();
+        Ok(value)
+    }
+
+    fn parse_literal_list(&mut self) -> Result<Value, String> {
+        self.lexer.next(); // '['
+        let mut items = ThinVec::new();
+        if optional_match_token!(self.lexer, RBrace) {
+            return Ok(Value::List(Arc::new(items)));
+        }
+        loop {
+            items.push(self.parse_literal()?);
+            if optional_match_token!(self.lexer, RBrace) {
+                return Ok(Value::List(Arc::new(items)));
+            }
+            match_token!(self.lexer, Comma);
+        }
+    }
+
+    fn parse_literal_map(&mut self) -> Result<Value, String> {
+        self.lexer.next(); // '{'
+        let mut entries = OrderMap::default();
+        if optional_match_token!(self.lexer, RBracket) {
+            return Ok(Value::Map(Arc::new(entries)));
+        }
+        loop {
+            let key = self.parse_ident()?;
+            match_token!(self.lexer, Colon);
+            entries.insert(key, self.parse_literal()?);
+            if optional_match_token!(self.lexer, RBracket) {
+                return Ok(Value::Map(Arc::new(entries)));
+            }
+            match_token!(self.lexer, Comma);
+        }
     }
 
     /// Consumes any trailing semicolons, then verifies end-of-file.
@@ -3365,6 +3499,125 @@ mod tests {
         );
         let err = Parser::new(&q).parse_parameters().unwrap_err();
         assert!(is_too_deep(&err), "wrapper hid the reason: {err}");
+    }
+
+    /// Parameter values that the fast literal path must handle, and that the
+    /// old `parse_expr` + `evaluate_param` path handled before it.
+    const LITERAL_PARAMS: [&str; 27] = [
+        "1",
+        "-1",
+        "0",
+        "-0",
+        "9223372036854775807",
+        "-9223372036854775808",
+        "1.5",
+        "-1.5",
+        "1e3",
+        "-1e-3",
+        ".5",
+        "-.5",
+        "0x1f",
+        "0o17",
+        "0b101",
+        "true",
+        "false",
+        "null",
+        "\"hi\"",
+        "'hi'",
+        "\"a\\nb\\tc\"",
+        "\"h\u{e9}llo\u{2192}\"",
+        "[]",
+        "[1,2,3]",
+        "[1,\"a\",true,null,1.5,-2,[3,[4]]]",
+        "{}",
+        "{`a`:1,`b`:{`c`:[1,-2]},`d`:null,`e`:\"x\"}",
+    ];
+
+    fn param_of(value: &str) -> Result<Value, String> {
+        Parser::new(&format!("CYPHER `p`={value} RETURN 1"))
+            .parse_parameters()
+            .map(|(mut p, _)| p.remove("p").expect("parameter p"))
+    }
+
+    /// The old path, kept as the oracle: parse the value as an expression and
+    /// evaluate it, which is what every parameter used to go through.
+    fn param_via_expr(value: &str) -> Result<Value, String> {
+        evaluate_param(&Parser::new(value).parse_expr(false)?.root())
+    }
+
+    // The fast literal path exists only to be faster - never to decide
+    // anything differently. Compared on `Debug` rather than `PartialEq`, which
+    // is Cypher's comparison and would call two nulls unequal.
+    #[test]
+    fn literal_params_match_the_expression_path() {
+        for value in LITERAL_PARAMS {
+            let fast = param_of(value);
+            let slow = param_via_expr(value);
+            assert_eq!(
+                fast.as_ref().map(|v| format!("{v:?}")),
+                slow.as_ref().map(|v| format!("{v:?}")),
+                "parameter `{value}` differs between the fast and expression paths",
+            );
+        }
+    }
+
+    // Negation of a non-number is Null, and i64::MIN negates to itself. Both
+    // were `evaluate_param`'s behaviour and both are easy to lose.
+    #[test]
+    fn negated_param_edge_cases() {
+        assert_eq!(
+            format!("{:?}", param_of("-9223372036854775808").unwrap()),
+            format!("{:?}", Value::Int(i64::MIN))
+        );
+        for value in ["-true", "-'a'", "-[1]", "-{`a`:1}", "-null"] {
+            assert_eq!(
+                format!("{:?}", param_of(value).unwrap()),
+                "Null",
+                "negating {value} should be Null"
+            );
+        }
+        // Unnegated, those digits are i64::MAX + 1 and must still be refused.
+        assert!(param_of("9223372036854775808").is_err());
+        // A second `-` is not part of a literal, and never parsed before.
+        assert!(param_of("--1").is_err());
+    }
+
+    // A value that is not a literal falls back to the expression path, so it
+    // must fail exactly the way it used to - including the message, which
+    // `parse_parameters` would otherwise replace with its own summary.
+    #[test]
+    fn non_literal_params_report_what_they_did_before() {
+        for value in ["1+2", "abs(-1)", "x", "$a", "[1,2][0]"] {
+            assert_eq!(
+                param_of(value).unwrap_err(),
+                "Invalid parameter expression.",
+                "parameter `{value}`",
+            );
+        }
+    }
+
+    // Malformed literals are parse errors, named by the parameter that failed.
+    #[test]
+    fn malformed_params_name_the_parameter() {
+        for value in ["[1,2", "{`a`:1", "{1:2}", "[1,]", "[,]", "{`a`}"] {
+            let err = param_of(value).unwrap_err();
+            assert!(
+                err.starts_with("Failed to parse the value of parameter 'p'"),
+                "parameter `{value}` gave: {err}",
+            );
+        }
+    }
+
+    // Several parameters, later ones shadowing earlier ones, and the query
+    // text that follows must all survive being read straight into values.
+    #[test]
+    fn parameters_and_remaining_query() {
+        let (params, rest) = Parser::new("CYPHER a=1 b=[2] a=3 MATCH (n) RETURN n")
+            .parse_parameters()
+            .unwrap();
+        assert_eq!(rest.trim_start(), "MATCH (n) RETURN n");
+        assert_eq!(format!("{:?}", params["a"]), format!("{:?}", Value::Int(3)));
+        assert_eq!(params.len(), 2);
     }
 
     // The speculative-ident path must still recognise what it probes for.

--- a/runtime-fuzz-target/src/main.rs
+++ b/runtime-fuzz-target/src/main.rs
@@ -1,15 +1,13 @@
 // Dependency version duplicates are from transitive dependencies.
 #![allow(clippy::multiple_crate_versions)]
 
-use std::collections::HashMap;
-
 use graph::{
     graph::{
         graph::Plan,
         graphblas::{GrB_Mode, GrB_init},
         mvcc_graph::MvccGraph,
     },
-    runtime::{eval::evaluate_param, functions::init_functions, runtime::Runtime},
+    runtime::{functions::init_functions, runtime::Runtime},
 };
 
 #[macro_use]
@@ -37,13 +35,6 @@ fn main() {
             let Ok(Plan {
                 plan, parameters, ..
             }) = g.read().borrow().get_plan(query)
-            else {
-                return;
-            };
-            let Ok(parameters) = parameters
-                .into_iter()
-                .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-                .collect::<Result<HashMap<_, _>, String>>()
             else {
                 return;
             };

--- a/src/commands/record.rs
+++ b/src/commands/record.rs
@@ -29,16 +29,13 @@ use crate::{
 use graph::{
     graph::graph::Plan,
     planner::IR,
-    runtime::{
-        eval::evaluate_param,
-        runtime::{GetVariables, Runtime},
-    },
+    runtime::runtime::{GetVariables, Runtime},
     threadpool::spawn,
 };
 use orx_tree::{Bfs, Collection, NodeRef};
 use parking_lot::RwLock;
 use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue, raw};
-use std::{collections::HashMap, os::raw::c_char, sync::Arc};
+use std::{os::raw::c_char, sync::Arc};
 
 #[inline]
 fn record_mut(
@@ -57,11 +54,6 @@ fn record_mut(
         plan, parameters, ..
     } = session
         .with_graph(|tg| tg.graph.read().borrow().get_plan(query))
-        .map_err(RedisError::String)?;
-    let parameters = parameters
-        .into_iter()
-        .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-        .collect::<Result<HashMap<_, _>, String>>()
         .map_err(RedisError::String)?;
     let is_write = plan.iter().any(|n| {
         matches!(

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -50,7 +50,6 @@ use graph::{
     },
     planner::{IR, plan_is_non_deterministic},
     runtime::{
-        eval::evaluate_param,
         pending::{
             EFFECT_CREATE_INDEX, EFFECT_DROP_INDEX, EFFECTS_VERSION, write_string, write_u16,
         },
@@ -492,10 +491,6 @@ pub fn execute_query(
         params_offset,
         ..
     } = session.with_graph(|tg| tg.graph.read().borrow().get_plan(query))?;
-    let parameters = parameters
-        .into_iter()
-        .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-        .collect::<Result<HashMap<_, _>, String>>()?;
     // Single pass over the plan: index DDL (CREATE/DROP INDEX) and a Commit
     // node both mean this is a write. Writes escalate to writer mode lazily
     // during execution (see `crate::query_session`), so no further plan
@@ -583,10 +578,6 @@ pub fn execute_profile(
     if is_write {
         return Ok(ProfileDetect::Write);
     }
-    let parameters = parameters
-        .into_iter()
-        .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-        .collect::<Result<HashMap<_, _>, String>>()?;
     let g = session.with_graph(|tg| tg.graph.read());
     let timeout_ms = compute_effective_timeout(per_query_timeout, false)?;
     let runtime = Runtime::new(
@@ -640,10 +631,6 @@ pub fn execute_query_write(
         ..
     } = session.with_graph(|tg| tg.graph.read().borrow().get_plan(query))?;
     let cached = first_cached;
-    let parameters = parameters
-        .into_iter()
-        .map(|(k, v)| Ok((k, evaluate_param(&v.root())?)))
-        .collect::<Result<HashMap<_, _>, String>>()?;
     debug_assert!(plan.iter().any(|n| matches!(
         n,
         IR::Commit | IR::CreateIndex { .. } | IR::DropIndex { .. }


### PR DESCRIPTION
Fixes #2463

> #2442 has merged, so this now targets `main` directly and is a single commit. Rebased onto the squashed merge — which dismissed the earlier approval, so it needs another look.

Follow-up to #2442. After that PR the 6.7 MB bulk-load batch was still **13.7× slower than the C module**, and the whole gap was parameter parsing. This closes most of it.

## The problem

A parameter is a literal — `evaluate_param` accepts constants, lists, maps and negation, and nothing else. But every parameter was parsed into an `ExprIR` tree first and then walked **twice**: once in `get_plan` for the optimizer, once in `graph_core` for the runtime.

For the payloads bulk loaders inline, that tree is one node per literal. A 6.7 MB batch of 1477 maps each with a 384-dim embedding is ~567k literals, and building their nodes *was* the query — profiling put `parse_expr_inner`, `parse_primary_expr` and `parse_map` at the top with `evaluate_param` barely registering.

Decomposition before this change (6.7 MB each):

| | C | Rust |
|---|---|---|
| params only (`RETURN 1`) | 20.6 ms | **302.3 ms** |
| params + `UNWIND` + count | 22.1 ms | 302.5 ms |
| no params, same bytes | 16.9 ms | **7.0 ms** ← Rust already wins |

Execution cost ~1.5 ms on both. Marginal cost per literal: C ≈ 27 ns, Rust ≈ 335 ns.

## The fix

`parse_param_value` reads the common case straight into a `Value` — no tree, no evaluation pass. `Plan::parameters` now holds values, which removes both walks.

Anything the fast path doesn't recognise, **or that turns out to be an expression rather than a literal** (`p=1+2`, `p=[1,2][0]`), is handed back to `parse_expr` + `evaluate_param`. So non-literal parameters keep their old result *and* their old error message by construction, rather than by me re-deriving them.

## Measured against C

6.7 MB batch, 21 iterations:

| engine | min | median | p95 | vs C |
|---|---|---|---|---|
| **C (reference)** | 23.9 ms | **26.2 ms** | 34.9 ms | — |
| **this PR** | 52.1 ms | **54.0 ms** | 63.9 ms | **2.06× slower** |

Re-measured after rebasing onto merged `main`. For context, on the pre-#2442 tree the
same payload took 2061 ms (82.6× C), and with #2442 alone 341 ms (13.7× C).

**6.5× on the query**, and the distance from C goes from 13.7× to 2.1×.

What remains is lexing the literals themselves — `get_token` and `lex_numeric` are now the top frames. Closing that last 2× is a lexer change, not a parser one, and is not attempted here.

## Behaviour is pinned, not assumed

I captured 54 parameter cases against the **previous build**, then re-ran them against this one and diffed. **53 identical**, including the ones easy to lose:

- `-true`, `-'a'`, `-[1]` → `Null`
- `-9223372036854775808` → `i64::MIN`; bare `9223372036854775808` → still refused
- `--1` → still refused
- `1+2`, `abs(-1)`, `x`, `$a`, `[1,2][0]` → still `"Invalid parameter expression."`
- `{1:2}`, `[1,]`, `[1,2`, `{a:1` → still `"Failed to parse the value of parameter 'p'"`
- hex/octal/binary, `.5`, `1e3`, escapes, unicode, empty list/map, keyword-ish map keys, shadowed params

**One deliberate difference**: `CYPHER p= RETURN $p` now reports `"Invalid parameter expression."` instead of `"Invalid input '$p': expected end of input"`. Evaluating parameters while reading them means a non-literal parameter is noticed at that point rather than after the query body fails. Both are errors; the new one names the actual problem.

## Tests

- `literal_params_match_the_expression_path` — 27 literal forms, asserting the fast path and the old `parse_expr` + `evaluate_param` path produce the same value. Compared on `Debug`, since `Value`'s `PartialEq` is Cypher comparison and would call two nulls unequal.
- `negated_param_edge_cases` — `-true`→Null, i64::MIN, unnegated overflow, `--1`.
- `non_literal_params_report_what_they_did_before` — the fallback's messages.
- `malformed_params_name_the_parameter` — parse errors name the parameter.
- `parameters_and_remaining_query` — multiple params, shadowing, remaining query text.

All suites pass on the rebased branch: 153 Rust unit, 136 e2e/function/MVCC/concurrency, 2456 TCK scenarios, 1411 flow. The 54-case parameter snapshot was re-run after the rebase and still differs in exactly the one case described above. `cargo fmt --check` clean; `clippy --all-targets` adds no new warnings. Both fuzz targets updated for the new type (they fail to *link* on macOS, pre-existing on the base branch, but type-check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Query parameters are now processed more efficiently before query execution.
  * Literal values, including nested lists and maps, numeric values, and negative numbers, are handled consistently.
  * Improved validation detects malformed values, numeric overflow, and excessive nesting.
  * Existing parameter behavior remains supported for more complex expressions.
* **Bug Fixes**
  * Preserved clearer parameter-related error messages.
  * Added safeguards to ensure trailing or invalid query text is reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
