### PR TITLE
feat(index): index numeric array elements, and serve conjunctions

### DIFF
--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -83,6 +83,24 @@ SETUP = [
     # the constraint goes OPERATIONAL (unlike the SIMILAR one, which fails).
     "CREATE INDEX FOR ()-[r:UREL]-() ON (r.uid)",
     "MATCH (a:Person {id: 1}), (b:Person {id: 2}) CREATE (a)-[:UREL {uid: 1}]->(b), (a)-[:UREL {uid: 2}]->(b)",
+    # ---- write-path index-maintenance corpus --------------------------------
+    # Deliberately NOT constrained. A unique constraint is enforced by scanning
+    # the whole label matrix and rebuilding every node's composite key, per
+    # affected node — that cost would swamp the index maintenance this corpus
+    # exists to isolate. `WIdx` carries `v` (indexed) beside `w` (not), so a
+    # write to each is identical apart from the index.
+    "CREATE INDEX FOR (n:WIdx) ON (n.id)",
+    "CREATE INDEX FOR (n:WIdx) ON (n.v)",
+    "UNWIND range(0, 999) AS i CREATE (:WIdx {id: i, v: i, w: i})",
+    # Deletion pool. Sized for `mass delete indexed`'s explicit rep count with
+    # room to spare: running dry does not fail, it quietly measures a no-op.
+    "CREATE INDEX FOR (n:WDel) ON (n.v)",
+    "UNWIND range(0, 5999) AS i CREATE (:WDel {v: i})",
+    # Indexed label for create/delete round trips.
+    "CREATE INDEX FOR (n:WTmp) ON (n.v)",
+    # Edge equivalent: `wv` indexed, `ww` not, no constraint.
+    "CREATE INDEX FOR ()-[r:WREL]-() ON (r.wv)",
+    "MATCH (a:WIdx {id: 0}), (b:WIdx {id: 1}) CREATE (a)-[:WREL {wv: 1, ww: 1}]->(b)",
 ]
 
 # Raw redis commands run after SETUP (redis-cli arg lists). {graph} is
@@ -581,6 +599,37 @@ QUERIES = [
     Q("runtime-bound index range", False, "MATCH (a:Person {id: 9990}) WITH a MATCH (b:Person) WHERE b.id > a.id RETURN count(b)"),
     # Distance index scan over the Geo point index (IndexQuery::Point).
     Q("distance index scan geo", False, "MATCH (g:Geo) WHERE distance(g.loc, point({latitude: 0.0, longitude: 0.0})) < 10000 RETURN count(g)"),
+
+    # ---- write-path index maintenance ---------------------------------------
+    # Each indexed write is paired with the identical write to an UNINDEXED
+    # property of the same node, so the delta between the pair is the index
+    # maintenance cost and nothing else — same match, same commit, same
+    # attribute-store write.
+    #
+    # Values are incremented rather than assigned a constant: `SET n.v = 42`
+    # writes the same value every rep after the first, and an update that does
+    # not move the key is not the update this is meant to measure.
+    # Read-only baseline for the pair below: the same indexed lookup with no
+    # write at all. Both SET queries pay this lookup, and it is itself served by
+    # a different engine in each build, so it has to be measured separately
+    # before the pair's delta can be attributed to write-side maintenance.
+    Q("WIdx lookup only",      False, "MATCH (n:WIdx {id: 500}) RETURN n.w"),
+    Q("SET indexed prop",      True, "MATCH (n:WIdx {id: 500}) SET n.v = n.v + 1 RETURN n.v"),
+    Q("SET unindexed prop",    True, "MATCH (n:WIdx {id: 500}) SET n.w = n.w + 1 RETURN n.w"),
+    Q("SET += indexed map",    True, "MATCH (n:WIdx {id: 501}) SET n += {v: n.v + 1, x: 1} RETURN n.v"),
+    Q("SET += unindexed map",  True, "MATCH (n:WIdx {id: 501}) SET n += {w: n.w + 1, x: 1} RETURN n.w"),
+    # Create/delete round trips. The unindexed twin is the existing
+    # "CREATE + DELETE" on :Tmp.
+    Q("create indexed node",   True, "CREATE (:WTmp {v: 1})"),
+    Q("create+delete indexed", True, "CREATE (t:WTmp {v: 1}) WITH t DELETE t"),
+    # Scattered mass delete — the `remove_batch` path. Explicit reps because
+    # this drains its pool: 50 x 100 against 6,000 :WDel.
+    Q("mass delete indexed",   True, "MATCH (t:WDel) WITH t LIMIT 100 DELETE t", 50),
+    # Label add/remove re-routes which columns a node belongs to.
+    Q("label churn indexed",   True, "MATCH (n:WIdx {id: 502}) SET n:WExtra REMOVE n:WExtra"),
+    # Edge pair.
+    Q("SET indexed edge prop",   True, "MATCH ()-[r:WREL]->() SET r.wv = r.wv + 1 RETURN r.wv"),
+    Q("SET unindexed edge prop", True, "MATCH ()-[r:WREL]->() SET r.ww = r.ww + 1 RETURN r.ww"),
 
     # ---- sized writes ------------------------------------------------------
     # Kept LAST: they inflate node capacity / matrix dimension to max(N),

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -84,7 +84,7 @@ use parking_lot::{Mutex, MutexGuard};
 use roaring::RoaringTreemap;
 
 #[cfg(feature = "index-falkordb")]
-use crate::index::falkordb::falkordb_index::NumericAnswer;
+use crate::index::falkordb::{falkordb_index::NumericAnswer, numeric::EncodedTuples};
 use crate::{
     entity_type::EntityType,
     graph::{
@@ -3536,7 +3536,7 @@ impl Graph {
         entity: EntityType,
         label: &Arc<String>,
         attr: &Arc<String>,
-    ) -> Option<Vec<(u64, u64)>> {
+    ) -> Option<EncodedTuples> {
         let entries = match entity {
             EntityType::Node => self.collect_node_index_entries(label, attr),
             EntityType::Relationship => self.collect_edge_index_entries(label, attr),
@@ -3564,20 +3564,17 @@ impl Graph {
         label: &Arc<String>,
         attr: &Arc<String>,
         epoch: u64,
-        base: Vec<(u64, u64)>,
+        mut base: EncodedTuples,
     ) -> bool {
-        let survivors: Vec<(u64, u64)> = match entity {
-            EntityType::Node => base
-                .into_iter()
-                .filter(|(_, id)| !self.is_node_deleted(NodeId(*id)))
-                .collect(),
-            EntityType::Relationship => base
-                .into_iter()
-                .filter(|(_, id)| !self.is_relationship_deleted(RelationshipId(*id)))
-                .collect(),
-        };
+        // Both key spaces, or a node deleted during the build survives in its array half.
+        match entity {
+            EntityType::Node => base.retain_docs(|id| !self.is_node_deleted(NodeId(id))),
+            EntityType::Relationship => {
+                base.retain_docs(|id| !self.is_relationship_deleted(RelationshipId(id)));
+            }
+        }
         self.falkordb_index
-            .install_base(entity, label, attr, epoch, survivors)
+            .install_base(entity, label, attr, epoch, base)
     }
 
     /// Stage `(value, edge_id)` into the index column `(type, attr)` for the edge `id`'s single type,

--- a/graph/src/index/falkordb/encode.rs
+++ b/graph/src/index/falkordb/encode.rs
@@ -37,6 +37,55 @@ pub fn encode_numeric(value: &Value) -> Option<u64> {
     (!x.is_nan()).then(|| encode_f64(x))
 }
 
+/// Append the keys a **stored** value contributes, and say which tree they belong in.
+///
+/// A scalar contributes at most one key to the *scalar* tree. A list contributes one key per
+/// numeric element to the *array* tree — so `1 IN n.samples` is an ordinary point lookup.
+///
+/// The two key spaces must stay separate. If a list's elements landed in the scalar tree, a node
+/// with `v = [1, 2]` would carry the key for `1`, and `WHERE n.v = 1` — which is **false** in
+/// Cypher — would match it. `Equal` retains no post-filter (the plan is a bare `Node By Index
+/// Scan`), so that false positive would be returned to the user. RediSearch avoids the same
+/// collision with a separate `numeric:arr` sub-field; this is the native equivalent.
+///
+/// Keys are deduplicated, so `[1, 1.0, 2]` contributes two tuples rather than three: `(key, doc)`
+/// is a set member in the tree, and a removal must not depend on how many times the value
+/// happened to list the same number. Nested lists are not flattened — Cypher's `IN` does not look
+/// inside them.
+///
+/// Deliberately separate from [`encode_numeric`], which answers a different question: the key of
+/// a **query** value. A query value is a single scalar; one that is a list is declined rather
+/// than expanded, because `n.v = [1,2]` asks about the list itself.
+#[must_use]
+pub fn encode_stored(
+    value: &Value,
+    out: &mut Vec<u64>,
+) -> StoredKeys {
+    out.clear();
+    match value {
+        Value::List(items) => {
+            out.extend(items.iter().filter_map(encode_numeric));
+            out.sort_unstable();
+            out.dedup();
+            StoredKeys::Array
+        }
+        _ => {
+            out.extend(encode_numeric(value));
+            StoredKeys::Scalar
+        }
+    }
+}
+
+/// Which tree [`encode_stored`] filled `out` for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StoredKeys {
+    /// The value was a scalar: at most one key, for the scalar tree.
+    Scalar,
+    /// The value was a list: one key per numeric element, for the array tree. `out` may be empty
+    /// (a list with no numeric elements) — that is still an array-kind value, not a scalar.
+    Array,
+}
+
 /// Monotone total order over non-`NaN` `f64`, as a `u64`: for non-`NaN` `a`, `b`,
 /// `a < b`  ⇔  `encode_f64(a) < encode_f64(b)`.
 ///

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -17,7 +17,7 @@ use crate::index::IndexQuery;
 use crate::runtime::value::Value;
 
 use super::encode::encode_numeric;
-use super::numeric::{DocIter, NumericIndex};
+use super::numeric::{DocIter, EncodedTuples, NumericIndex};
 
 /// Identifies one index column: `(label, attribute)`.
 ///
@@ -93,7 +93,7 @@ impl IndexColumn {
     pub fn encode_entries(
         &self,
         entries: Vec<(Value, u64)>,
-    ) -> Vec<(u64, u64)> {
+    ) -> EncodedTuples {
         match self {
             Self::Numeric(_) => NumericIndex::encode_entries(entries),
         }
@@ -104,10 +104,10 @@ impl IndexColumn {
     #[must_use]
     pub fn new_like_from_encoded(
         &self,
-        pairs: Vec<(u64, u64)>,
+        tuples: EncodedTuples,
     ) -> Self {
         match self {
-            Self::Numeric(_) => Self::Numeric(NumericIndex::from_encoded(pairs)),
+            Self::Numeric(_) => Self::Numeric(NumericIndex::from_encoded(tuples)),
         }
     }
 
@@ -116,7 +116,7 @@ impl IndexColumn {
     /// the column it will be subtracted from, and decoding to re-encode would be a second
     /// trip through a many-to-one map.
     #[must_use]
-    pub fn encoded_tuples(&self) -> Vec<(u64, u64)> {
+    pub fn encoded_tuples(&self) -> EncodedTuples {
         match self {
             Self::Numeric(idx) => idx.encoded_tuples(),
         }
@@ -125,20 +125,20 @@ impl IndexColumn {
     /// Add already-encoded tuples (install: replay DELTA onto BASE).
     pub fn add_encoded(
         &mut self,
-        pairs: &mut Vec<(u64, u64)>,
+        tuples: &mut EncodedTuples,
     ) {
         match self {
-            Self::Numeric(idx) => idx.add_encoded(pairs),
+            Self::Numeric(idx) => idx.add_encoded(tuples),
         }
     }
 
     /// Remove already-encoded tuples (install: subtract TOMB from BASE).
     pub fn remove_encoded(
         &mut self,
-        pairs: &mut Vec<(u64, u64)>,
+        tuples: &mut EncodedTuples,
     ) {
         match self {
-            Self::Numeric(idx) => idx.remove_encoded(pairs),
+            Self::Numeric(idx) => idx.remove_encoded(tuples),
         }
     }
 
@@ -497,7 +497,7 @@ impl FalkorDbIndex {
         label: &Arc<String>,
         attr: &Arc<String>,
         epoch: u64,
-        base: Vec<(u64, u64)>,
+        base: EncodedTuples,
     ) -> bool {
         let Some(entry) = self
             .columns_mut(entity)
@@ -530,7 +530,7 @@ impl FalkorDbIndex {
         label: &Arc<String>,
         attr: &Arc<String>,
         entries: Vec<(Value, u64)>,
-    ) -> Option<Vec<(u64, u64)>> {
+    ) -> Option<EncodedTuples> {
         self.columns(entity)
             .get(&(label.clone(), attr.clone()))
             .map(|entry| entry.column.encode_entries(entries))
@@ -609,7 +609,11 @@ impl FalkorDbIndex {
                 let same_key = member_keys.iter().all(|k| *k == first_key);
                 (first_key, same_key)
             }
-            // And / Point (geo) / InList / ArrayContains → not a numeric leaf.
+            // `value IN n.prop`, where the property holds a list. Served from the column's
+            // separate array tree — see `NumericIndex::array_contains`. Servable when the probed
+            // value encodes; the elements themselves were filtered at write time.
+            IndexQuery::ArrayContains { key, value } => (key, encode_numeric(value).is_some()),
+            // And / Point (geo) / InList → not a numeric leaf.
             _ => return None,
         };
         if !servable {
@@ -699,7 +703,13 @@ mod tests {
         // A stale epoch — as if the column had been dropped and re-created — installs nothing and
         // must not flip the column `Ready`.
         assert!(
-            !idx.install_base(Node, &label, &attr, epoch + 1, vec![(key(99), 9)]),
+            !idx.install_base(
+                Node,
+                &label,
+                &attr,
+                epoch + 1,
+                EncodedTuples::scalars(vec![(key(99), 9)])
+            ),
             "stale epoch cannot install"
         );
         assert!(building(&idx, 99), "stale epoch cannot publish");
@@ -710,7 +720,13 @@ mod tests {
         );
 
         // The real install, one commit: BASE holds the snapshot-era rows 10 and 20.
-        assert!(idx.install_base(Node, &label, &attr, epoch, vec![(key(10), 0), (key(20), 1)]));
+        assert!(idx.install_base(
+            Node,
+            &label,
+            &attr,
+            epoch,
+            EncodedTuples::scalars(vec![(key(10), 0), (key(20), 1)])
+        ));
         assert!(idx.building_columns().is_empty(), "no longer building");
         assert_eq!(hits(&idx, 10), vec![0], "untouched base row survives");
         assert!(

--- a/graph/src/index/falkordb/falkordb_index.rs
+++ b/graph/src/index/falkordb/falkordb_index.rs
@@ -10,6 +10,8 @@
 //! avoids. The write path mutates a version's own copy instead.
 
 use std::collections::HashMap;
+
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 use crate::entity_type::EntityType;
@@ -521,6 +523,74 @@ impl FalkorDbIndex {
         true
     }
 
+    /// A conjunction spanning several attributes: intersect one column per attribute.
+    ///
+    /// Each attribute's own conjuncts are folded by its own column first (see
+    /// `NumericIndex::intersect_same_key`), so this only combines one doc stream per attribute.
+    ///
+    /// **Set probe, not a sorted merge.** `DocIter` yields docs in *value* order, not id order —
+    /// deliberately, since Cypher guarantees no order without `ORDER BY`, and merging would cost
+    /// a comparison per doc and force every branch to stay live. Value-ordered streams cannot be
+    /// merge-intersected, so the first attribute is materialised into a set and the rest probe it.
+    /// Memory is proportional to the first attribute's match count; there is no cardinality
+    /// estimate to pick the smallest side with, so the order is the query's.
+    ///
+    /// Every attribute needs a `Ready` numeric column. One still `Building` makes the whole
+    /// conjunction `NotReady` — intersecting against a half-built column would silently drop rows,
+    /// which is worse than scanning.
+    fn intersect_columns(
+        &self,
+        entity: EntityType,
+        label: &Arc<String>,
+        children: &[IndexQuery<Value>],
+    ) -> Option<NumericAnswer> {
+        // Regroup the leaves per attribute, keeping each attribute's own conjuncts together so
+        // its column can fold them into one window.
+        fn group<'a>(
+            children: &'a [IndexQuery<Value>],
+            out: &mut Vec<(&'a Arc<String>, Vec<&'a IndexQuery<Value>>)>,
+        ) -> Option<()> {
+            for child in children {
+                let key = match child {
+                    IndexQuery::Equal { key, .. } | IndexQuery::Range { key, .. } => key,
+                    IndexQuery::And(nested) => {
+                        group(nested, out)?;
+                        continue;
+                    }
+                    _ => return None,
+                };
+                match out.iter_mut().find(|(k, _)| *k == key) {
+                    Some((_, qs)) => qs.push(child),
+                    None => out.push((key, vec![child])),
+                }
+            }
+            Some(())
+        }
+        let mut per_attr: Vec<(&Arc<String>, Vec<&IndexQuery<Value>>)> = Vec::new();
+        group(children, &mut per_attr)?;
+        if per_attr.len() < 2 {
+            return None; // the caller already handles the single-column case
+        }
+
+        let mut result: Option<FxHashSet<u64>> = None;
+        for (attr, conjuncts) in per_attr {
+            let entry = self.columns(entity).get(&(label.clone(), attr.clone()))?;
+            if !matches!(entry.state, ColumnState::Ready) {
+                return Some(NumericAnswer::NotReady);
+            }
+            let IndexColumn::Numeric(idx) = &entry.column;
+            let folded = idx.intersect_refs(&conjuncts)?;
+            result = Some(match result {
+                None => folded.collect(),
+                Some(seen) => folded.filter(|doc| seen.contains(doc)).collect(),
+            });
+            if result.as_ref().is_some_and(FxHashSet::is_empty) {
+                break; // a later conjunct can only remove rows, never add them
+            }
+        }
+        result.map(|docs| NumericAnswer::Rows(DocIter::Set(docs.into_iter())))
+    }
+
     /// Encode `entries` under the kind of the column `(entity, label, attr)`, if it exists.
     /// `None` when there is no such column — the build was for a column since dropped.
     #[must_use]
@@ -608,6 +678,45 @@ impl FalkorDbIndex {
                 let first_key = member_keys[0];
                 let same_key = member_keys.iter().all(|k| *k == first_key);
                 (first_key, same_key)
+            }
+            // A conjunction constraining ONE attribute — `v = 5 AND v > 2`, or two bounds the
+            // planner could not fold because they were still expressions. `NumericIndex`
+            // collapses it arithmetically into a single window. A conjunction spanning two
+            // attributes is a different problem (it needs a real intersection across columns)
+            // and is declined here, so the error names that rather than blaming the values.
+            IndexQuery::And(children) if !children.is_empty() => {
+                fn leaves<'a>(
+                    children: &'a [IndexQuery<Value>],
+                    out: &mut Vec<(&'a Arc<String>, bool)>,
+                ) -> bool {
+                    children.iter().all(|c| match c {
+                        IndexQuery::Equal { key, value } => {
+                            out.push((key, encode_numeric(value).is_some()));
+                            true
+                        }
+                        IndexQuery::Range { key, min, max, .. } => {
+                            let numeric = min.as_ref().is_none_or(|v| encode_numeric(v).is_some())
+                                && max.as_ref().is_none_or(|v| encode_numeric(v).is_some());
+                            out.push((key, numeric));
+                            true
+                        }
+                        IndexQuery::And(nested) => !nested.is_empty() && leaves(nested, out),
+                        _ => false,
+                    })
+                }
+                let mut found = Vec::new();
+                if !leaves(children, &mut found) || found.is_empty() {
+                    return None;
+                }
+                if !found.iter().all(|(_, numeric)| *numeric) {
+                    return None; // a non-numeric member: no column can answer the conjunction
+                }
+                let first = found[0].0;
+                if found.iter().any(|(k, _)| *k != first) {
+                    // Spans several attributes: intersect one column per attribute.
+                    return self.intersect_columns(entity, label, children);
+                }
+                (first, true)
             }
             // `value IN n.prop`, where the property holds a list. Served from the column's
             // separate array tree — see `NumericIndex::array_contains`. Servable when the probed
@@ -876,15 +985,35 @@ mod tests {
             value: Value::String(Arc::new("x".to_string())),
         };
         assert!(idx.query_numeric(Node, &label, &str_eq).is_none());
-        // Composite, missing-column, and the wrong entity all fall through.
+        // A conjunction on ONE attribute is served — it folds to a single window.
         let eq2 = IndexQuery::Equal {
             key: key.clone(),
             value: Value::Int(30),
         };
+        assert!(matches!(
+            idx.query_numeric(Node, &label, &IndexQuery::And(vec![eq2])),
+            Some(NumericAnswer::Rows(_))
+        ));
+        // A conjunction spanning TWO attributes is not: that needs an intersection across
+        // columns, which this column-scoped lookup cannot do.
         assert!(
-            idx.query_numeric(Node, &label, &IndexQuery::And(vec![eq2]))
-                .is_none()
+            idx.query_numeric(
+                Node,
+                &label,
+                &IndexQuery::And(vec![
+                    IndexQuery::Equal {
+                        key: key.clone(),
+                        value: Value::Int(30),
+                    },
+                    IndexQuery::Equal {
+                        key: arc("height"),
+                        value: Value::Int(5),
+                    },
+                ])
+            )
+            .is_none()
         );
+        // Missing column and the wrong entity still fall through.
         let other = IndexQuery::Equal {
             key: arc("height"),
             value: Value::Int(5),
@@ -894,5 +1023,98 @@ mod tests {
             idx.query_numeric(Relationship, &label, &eq).is_none(),
             "no edge column of this name"
         );
+    }
+
+    /// A conjunction across two attributes is answered by intersecting their columns.
+    ///
+    /// The streams are in **value** order, not id order, so this cannot be a sorted merge — the
+    /// first attribute is materialised into a set and the rest probe it. Verified against the
+    /// RediSearch build: same rows, different order, which Cypher permits without `ORDER BY`.
+    #[test]
+    fn cross_attribute_conjunctions_intersect_columns() {
+        let label = arc("C");
+        let (a, b) = (arc("a"), arc("b"));
+        let mut idx = FalkorDbIndex::new();
+        idx.create_numeric(Node, &label, &a);
+        idx.create_numeric(Node, &label, &b);
+        // ids 0..9; a = id % 2, b = id
+        for id in 0..10u64 {
+            idx.numeric_mut(Node, &label, &a)
+                .unwrap()
+                .add(&Value::Int((id % 2) as i64), id);
+            idx.numeric_mut(Node, &label, &b)
+                .unwrap()
+                .add(&Value::Int(id as i64), id);
+        }
+        let eq = |k: &Arc<String>, v: i64| IndexQuery::Equal {
+            key: k.clone(),
+            value: Value::Int(v),
+        };
+        let gt = |k: &Arc<String>, v: i64| IndexQuery::Range {
+            key: k.clone(),
+            min: Some(Value::Int(v)),
+            max: None,
+            include_min: false,
+            include_max: true,
+        };
+        let got = |q: IndexQuery<Value>| {
+            let mut v = rows(idx.query_numeric(Node, &label, &q));
+            v.sort_unstable();
+            v
+        };
+
+        // odd ids above 4
+        assert_eq!(
+            got(IndexQuery::And(vec![eq(&a, 1), gt(&b, 4)])),
+            vec![5, 7, 9]
+        );
+        // Each attribute's own conjuncts are folded by its column first, so three conjuncts
+        // across two attributes still means two streams.
+        assert_eq!(
+            got(IndexQuery::And(vec![eq(&a, 1), gt(&b, 4), eq(&b, 7)])),
+            vec![7]
+        );
+        // An empty intersection is an answer, not a decline.
+        assert!(got(IndexQuery::And(vec![eq(&a, 0), eq(&b, 7)])).is_empty());
+
+        // A missing column cannot be intersected — decline rather than answer from a subset,
+        // which would return rows the conjunction excludes.
+        assert!(
+            idx.query_numeric(
+                Node,
+                &label,
+                &IndexQuery::And(vec![eq(&a, 1), eq(&arc("nope"), 1)])
+            )
+            .is_none()
+        );
+    }
+
+    /// A column still building makes the whole conjunction `NotReady`. Intersecting against a
+    /// half-populated column would silently drop rows, which is worse than scanning.
+    #[test]
+    fn a_building_column_makes_the_intersection_not_ready() {
+        let label = arc("C");
+        let (a, b) = (arc("a"), arc("b"));
+        let mut idx = FalkorDbIndex::new();
+        idx.create_numeric(Node, &label, &a);
+        idx.numeric_mut(Node, &label, &a)
+            .unwrap()
+            .add(&Value::Int(1), 1);
+        idx.create_building(Node, &label, &b);
+
+        let q = IndexQuery::And(vec![
+            IndexQuery::Equal {
+                key: a,
+                value: Value::Int(1),
+            },
+            IndexQuery::Equal {
+                key: b,
+                value: Value::Int(1),
+            },
+        ]);
+        assert!(matches!(
+            idx.query_numeric(Node, &label, &q),
+            Some(NumericAnswer::NotReady)
+        ));
     }
 }

--- a/graph/src/index/falkordb/mod.rs
+++ b/graph/src/index/falkordb/mod.rs
@@ -105,7 +105,13 @@ fn describe_predicate(query: &crate::index::IndexQuery<crate::runtime::value::Va
         ),
         Q::InList { key, .. } => format!("an IN list on `{key}`"),
         Q::Point { key, .. } => format!("a geo predicate on `{key}`"),
-        Q::ArrayContains { key, .. } => format!("an array-contains on `{key}`"),
+        Q::ArrayContains { key, value } => {
+            if encode::encode_numeric(value).is_some() {
+                format!("an array-contains on `{key}`")
+            } else {
+                format!("an array-contains on `{key}` with a non-numeric value")
+            }
+        }
     }
 }
 

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -992,4 +992,52 @@ mod tests {
             "the array half must survive the encode/install round trip"
         );
     }
+
+    /// A value changing kind must move its tuples between the two trees, not leave a copy behind.
+    ///
+    /// The dangerous case is the same key crossing over: scalar `1` becoming `[1]` and back. A
+    /// remove that routed on the *new* value's kind instead of the old one would delete from the
+    /// wrong tree, stranding a tuple that no later write can reach — and on the scalar side
+    /// nothing re-checks the index's answer, so the stale tuple becomes a wrong row.
+    #[test]
+    fn a_value_changing_kind_moves_between_trees() {
+        let attr = Arc::new("v".to_string());
+        let list = |xs: &[i64]| {
+            Value::List(Arc::new(
+                xs.iter().map(|&x| Value::Int(x)).collect::<ThinVec<_>>(),
+            ))
+        };
+        let eq = |v: i64| IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+        let contains = |v: i64| IndexQuery::ArrayContains {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(1), 1);
+        assert_eq!(ids(idx.query(&eq(1)).unwrap()), vec![1]);
+        assert!(ids(idx.query(&contains(1)).unwrap()).is_empty());
+
+        // scalar 1 -> array [1]: the SAME key crosses into the other tree.
+        idx.remove(&Value::Int(1), 1);
+        idx.add(&list(&[1]), 1);
+        assert!(
+            ids(idx.query(&eq(1)).unwrap()).is_empty(),
+            "the scalar tuple must be gone, not shadowed"
+        );
+        assert_eq!(ids(idx.query(&contains(1)).unwrap()), vec![1]);
+
+        // array [1] -> scalar 1: and back again.
+        idx.remove(&list(&[1]), 1);
+        idx.add(&Value::Int(1), 1);
+        assert_eq!(ids(idx.query(&eq(1)).unwrap()), vec![1]);
+        assert!(ids(idx.query(&contains(1)).unwrap()).is_empty());
+
+        // Removing whatever it currently is leaves nothing on either side.
+        idx.remove(&Value::Int(1), 1);
+        assert!(idx.is_empty(), "no tuple stranded in either tree");
+    }
 }

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use super::data_structures::cow_btree::{CowBTree, RangeIter};
-use super::encode::encode_numeric;
+use super::encode::{StoredKeys, encode_numeric, encode_stored};
 use crate::index::IndexQuery;
 use crate::runtime::value::Value;
 
@@ -98,7 +98,60 @@ impl Iterator for UnionIter {
 /// [`FalkorDbIndex`](super::falkordb_index::FalkorDbIndex)).
 #[derive(Clone, Default)]
 pub struct NumericIndex {
+    /// Scalar values: exactly one tuple per indexed entity.
     tree: Tree,
+    /// Elements of **list**-valued properties: one tuple per distinct numeric element.
+    ///
+    /// A separate key space, not a convenience. Sharing one tree would make a node with
+    /// `v = [1, 2]` carry the key for `1`, so `WHERE n.v = 1` — false in Cypher — would match it,
+    /// and `Equal` has no post-filter to catch that (its plan is a bare `Node By Index Scan`).
+    /// RediSearch keeps the same separation with its `numeric:arr` sub-field.
+    ///
+    /// Read only by `ArrayContains` (`value IN n.prop`), which is a point lookup, so a doc is
+    /// reached through exactly one key per query and cannot be yielded twice.
+    array_tree: Tree,
+}
+
+/// Encoded tuples for one column, split by the tree they belong to.
+///
+/// The online build moves BASE, DELTA and TOMB around as raw `(key, doc)` tuples; each of those
+/// artifacts has to keep the two key spaces apart for the same reason the trees do.
+#[derive(Default, Debug, Clone)]
+pub struct EncodedTuples {
+    pub scalar: Vec<(u64, u64)>,
+    pub array: Vec<(u64, u64)>,
+}
+
+impl EncodedTuples {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.scalar.is_empty() && self.array.is_empty()
+    }
+
+    /// Total tuples across both key spaces.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.scalar.len() + self.array.len()
+    }
+
+    /// Scalar-only tuples — the shape a column with no list values produces.
+    #[must_use]
+    pub fn scalars(scalar: Vec<(u64, u64)>) -> Self {
+        Self {
+            scalar,
+            array: Vec::new(),
+        }
+    }
+
+    /// Drop every tuple whose doc fails `keep` — the install's deleted-entity backstop, which
+    /// must sweep both key spaces or a deleted node survives in its array half.
+    pub fn retain_docs(
+        &mut self,
+        mut keep: impl FnMut(u64) -> bool,
+    ) {
+        self.scalar.retain(|&(_, doc)| keep(doc));
+        self.array.retain(|&(_, doc)| keep(doc));
+    }
 }
 
 impl NumericIndex {
@@ -114,15 +167,16 @@ impl NumericIndex {
     /// traversal.
     #[must_use]
     pub fn from_entries<'a>(entries: impl IntoIterator<Item = (&'a Value, u64)>) -> Self {
-        let mut pairs: Vec<(u64, u64)> = entries
-            .into_iter()
-            .filter_map(|(v, id)| encode_numeric(v).map(|k| (k, id)))
-            .collect();
-        pairs.sort_unstable();
-        pairs.dedup();
-        Self {
-            tree: Tree::from_sorted(&pairs),
+        let mut out = EncodedTuples::default();
+        let mut keys = Vec::new();
+        for (v, id) in entries {
+            let dest = match encode_stored(v, &mut keys) {
+                StoredKeys::Scalar => &mut out.scalar,
+                StoredKeys::Array => &mut out.array,
+            };
+            dest.extend(keys.iter().map(|&k| (k, id)));
         }
+        Self::from_encoded(out)
     }
 
     /// Index `id` under `value`. A no-op for non-numeric / `NaN` values and
@@ -132,11 +186,17 @@ impl NumericIndex {
         value: &Value,
         id: u64,
     ) {
-        if let Some(k) = encode_numeric(value) {
+        let mut keys = Vec::new();
+        let kind = encode_stored(value, &mut keys);
+        let tree = match kind {
+            StoredKeys::Scalar => &mut self.tree,
+            StoredKeys::Array => &mut self.array_tree,
+        };
+        for k in keys {
             // The bool reports whether the tuple was newly inserted — for callers keeping an
             // exact live count. This index derives its counts from the tree, so it is discarded
             // deliberately rather than ignored.
-            let _newly_inserted = self.tree.insert(k, id);
+            let _newly_inserted = tree.insert(k, id);
         }
     }
 
@@ -146,8 +206,14 @@ impl NumericIndex {
         value: &Value,
         id: u64,
     ) {
-        if let Some(k) = encode_numeric(value) {
-            let _was_present = self.tree.remove(k, id);
+        let mut keys = Vec::new();
+        let kind = encode_stored(value, &mut keys);
+        let tree = match kind {
+            StoredKeys::Scalar => &mut self.tree,
+            StoredKeys::Array => &mut self.array_tree,
+        };
+        for k in keys {
+            let _was_present = tree.remove(k, id);
         }
     }
 
@@ -159,9 +225,11 @@ impl NumericIndex {
         &mut self,
         entries: impl IntoIterator<Item = (Value, u64)>,
     ) {
-        let mut pairs = Self::encode_pairs(entries);
-        pairs.sort_unstable();
-        self.tree.insert_batch(&pairs);
+        let mut t = Self::encode_pairs(entries);
+        t.scalar.sort_unstable();
+        t.array.sort_unstable();
+        self.tree.insert_batch(&t.scalar);
+        self.array_tree.insert_batch(&t.array);
     }
 
     /// Remove a batch of `(value, id)` entries, consuming any iterator. Non-numeric / `NaN` dropped;
@@ -170,42 +238,57 @@ impl NumericIndex {
         &mut self,
         entries: impl IntoIterator<Item = (Value, u64)>,
     ) {
-        let mut pairs = Self::encode_pairs(entries);
-        pairs.sort_unstable();
-        self.tree.remove_batch(&pairs);
+        let mut t = Self::encode_pairs(entries);
+        t.scalar.sort_unstable();
+        t.array.sort_unstable();
+        self.tree.remove_batch(&t.scalar);
+        self.array_tree.remove_batch(&t.array);
     }
 
     /// Encode `(value, id)` entries to `(key, id)` tree tuples, dropping non-numeric / `NaN` values.
-    fn encode_pairs(entries: impl IntoIterator<Item = (Value, u64)>) -> Vec<(u64, u64)> {
-        entries
-            .into_iter()
-            .filter_map(|(v, id)| encode_numeric(&v).map(|k| (k, id)))
-            .collect()
+    fn encode_pairs(entries: impl IntoIterator<Item = (Value, u64)>) -> EncodedTuples {
+        let mut out = EncodedTuples::default();
+        let mut keys = Vec::new();
+        for (v, id) in entries {
+            let dest = match encode_stored(&v, &mut keys) {
+                StoredKeys::Scalar => &mut out.scalar,
+                StoredKeys::Array => &mut out.array,
+            };
+            dest.extend(keys.iter().map(|&k| (k, id)));
+        }
+        out
     }
 
     /// Build directly from already-encoded `(key, doc)` tuples, in any order — how the
     /// install adopts a background-built BASE without re-encoding or re-sorting it per row.
     #[must_use]
-    pub fn from_encoded(mut pairs: Vec<(u64, u64)>) -> Self {
-        pairs.sort_unstable();
-        pairs.dedup();
+    pub fn from_encoded(mut tuples: EncodedTuples) -> Self {
+        let build = |pairs: &mut Vec<(u64, u64)>| {
+            pairs.sort_unstable();
+            pairs.dedup();
+            Tree::from_sorted(pairs)
+        };
         Self {
-            tree: Tree::from_sorted(&pairs),
+            tree: build(&mut tuples.scalar),
+            array_tree: build(&mut tuples.array),
         }
     }
 
     /// Encode `(value, id)` entries to tree tuples, dropping non-numeric / `NaN`.
     /// Public so a background build can encode BASE off the write thread.
     #[must_use]
-    pub fn encode_entries(entries: Vec<(Value, u64)>) -> Vec<(u64, u64)> {
+    pub fn encode_entries(entries: Vec<(Value, u64)>) -> EncodedTuples {
         Self::encode_pairs(entries)
     }
 
     /// Every `(key, doc)` tuple, in key order — the install's DELTA/TOMB enumeration.
     /// `O(n)`; intended for build-sized artifacts, not a populated column.
     #[must_use]
-    pub fn encoded_tuples(&self) -> Vec<(u64, u64)> {
-        self.tree.range_tuples(0, u64::MAX).collect()
+    pub fn encoded_tuples(&self) -> EncodedTuples {
+        EncodedTuples {
+            scalar: self.tree.range_tuples(0, u64::MAX).collect(),
+            array: self.array_tree.range_tuples(0, u64::MAX).collect(),
+        }
     }
 
     /// Add already-encoded tuples. Used by the install to replay DELTA onto BASE, where the
@@ -213,25 +296,29 @@ impl NumericIndex {
     /// decoded key would be a second trip through a many-to-one map.
     pub fn add_encoded(
         &mut self,
-        pairs: &mut Vec<(u64, u64)>,
+        tuples: &mut EncodedTuples,
     ) {
-        pairs.sort_unstable();
-        self.tree.insert_batch(pairs);
+        tuples.scalar.sort_unstable();
+        tuples.array.sort_unstable();
+        self.tree.insert_batch(&tuples.scalar);
+        self.array_tree.insert_batch(&tuples.array);
     }
 
     /// Remove already-encoded tuples — the install subtracting TOMB from BASE.
     pub fn remove_encoded(
         &mut self,
-        pairs: &mut Vec<(u64, u64)>,
+        tuples: &mut EncodedTuples,
     ) {
-        pairs.sort_unstable();
-        self.tree.remove_batch(pairs);
+        tuples.scalar.sort_unstable();
+        tuples.array.sort_unstable();
+        self.tree.remove_batch(&tuples.scalar);
+        self.array_tree.remove_batch(&tuples.array);
     }
 
     /// Whether the index holds no tuples.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.tree.is_empty()
+        self.tree.is_empty() && self.array_tree.is_empty()
     }
 
     /// Entity ids whose value equals `value`. Empty for a non-numeric value.
@@ -299,6 +386,28 @@ impl NumericIndex {
         DocIter::One(self.tree.range(lo, hi))
     }
 
+    /// Entity ids whose **list**-valued property contains `value` — `value IN n.prop`.
+    ///
+    /// A point lookup into the array tree, so each matching doc is reached through one key and
+    /// appears once. The scalar tree is deliberately not consulted: `1 IN n.v` must not match a
+    /// node whose `v` is the scalar `1`.
+    ///
+    /// May over-return relative to Cypher: a list element the encoder cannot represent is absent,
+    /// and a `Range`-indexed column holds no type tag, so `1 IN n.v` also matches `v = [true]`
+    /// (the encoder maps `true` to `1.0`). `utilize_index` keeps the original filter on this
+    /// predicate precisely so the runtime rechecks it — which is why the array tree is allowed to
+    /// be approximate where the scalar tree is not.
+    #[must_use]
+    pub fn array_contains(
+        &self,
+        value: &Value,
+    ) -> DocIter {
+        match encode_numeric(value) {
+            Some(k) => DocIter::One(self.array_tree.point(k)),
+            None => self.empty(),
+        }
+    }
+
     /// Dispatch the numeric *leaf* predicates. `Equal` → [`point`](Self::point),
     /// `Range` → [`range`](Self::range). Composite (`And`/`Or`) and non-numeric
     /// variants return `None` — the query router composes or rejects those (P5).
@@ -317,6 +426,7 @@ impl NumericIndex {
                 ..
             } => Some(self.range(min.as_ref(), max.as_ref(), *include_min, *include_max)),
             IndexQuery::Or(children) => self.union(children),
+            IndexQuery::ArrayContains { value, .. } => Some(self.array_contains(value)),
             _ => None,
         }
     }
@@ -390,6 +500,7 @@ impl NumericIndex {
 mod tests {
     use super::*;
     use std::sync::Arc;
+    use thin_vec::ThinVec;
 
     fn ids(it: DocIter) -> Vec<u64> {
         it.collect()
@@ -743,6 +854,142 @@ mod tests {
             rest,
             vec![2],
             "the second member must be answered from the snapshot the union started on"
+        );
+    }
+
+    /// The reason the array elements live in their own tree.
+    ///
+    /// A node whose `v` is the list `[1, 2]` must NOT be returned by `WHERE n.v = 1` — that is
+    /// false in Cypher — and a node whose `v` is the scalar `1` must NOT be returned by
+    /// `WHERE 1 IN n.v`. One shared key space cannot tell those apart, and `Equal` carries no
+    /// post-filter to clean up after it (its plan is a bare `Node By Index Scan`), so the wrong
+    /// row would reach the caller.
+    #[test]
+    fn a_scalar_and_a_list_element_do_not_share_a_key_space() {
+        let attr = Arc::new("v".to_string());
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(1), 10); // scalar 1
+        idx.add(
+            &Value::List(Arc::new(
+                [Value::Int(1), Value::Int(2)].into_iter().collect(),
+            )),
+            20,
+        ); // list [1, 2]
+
+        let eq = IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(1),
+        };
+        assert_eq!(
+            ids(idx.query(&eq).expect("servable")),
+            vec![10],
+            "`n.v = 1` must match the scalar only, never the list that contains 1"
+        );
+
+        let contains = IndexQuery::ArrayContains {
+            key: attr.clone(),
+            value: Value::Int(1),
+        };
+        assert_eq!(
+            ids(idx.query(&contains).expect("servable")),
+            vec![20],
+            "`1 IN n.v` must match the list only, never the scalar 1"
+        );
+
+        // A range over the scalar tree must not see list elements either.
+        let rng = IndexQuery::Range {
+            key: attr,
+            min: Some(Value::Int(0)),
+            max: Some(Value::Int(5)),
+            include_min: true,
+            include_max: true,
+        };
+        assert_eq!(ids(idx.query(&rng).expect("servable")), vec![10]);
+    }
+
+    /// Every numeric element is reachable, and a repeated element contributes one tuple — the
+    /// tree stores `(key, doc)` as a set, so a removal must not depend on how many times the
+    /// value happened to list the same number.
+    #[test]
+    fn every_element_is_indexed_once() {
+        let attr = Arc::new("v".to_string());
+        let list = |xs: &[i64]| {
+            Value::List(Arc::new(
+                xs.iter().map(|&x| Value::Int(x)).collect::<ThinVec<_>>(),
+            ))
+        };
+        let mut idx = NumericIndex::new();
+        idx.add(&list(&[1, 1, 2]), 7);
+
+        let contains = |v: i64| IndexQuery::ArrayContains {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+        assert_eq!(ids(idx.query(&contains(1)).expect("servable")), vec![7]);
+        assert_eq!(ids(idx.query(&contains(2)).expect("servable")), vec![7]);
+        assert!(ids(idx.query(&contains(3)).expect("servable")).is_empty());
+
+        // Removing the same value takes every element with it, duplicates included.
+        idx.remove(&list(&[1, 1, 2]), 7);
+        assert!(idx.is_empty(), "both trees must be empty again");
+    }
+
+    /// Non-numeric elements are skipped individually rather than rejecting the whole list — they
+    /// belong to a text kind, exactly as a non-numeric scalar does.
+    #[test]
+    fn mixed_lists_index_their_numeric_elements() {
+        let attr = Arc::new("v".to_string());
+        let mixed = Value::List(Arc::new(
+            [Value::Int(4), Value::String(Arc::new("x".to_string()))]
+                .into_iter()
+                .collect::<ThinVec<_>>(),
+        ));
+        let mut idx = NumericIndex::new();
+        idx.add(&mixed, 3);
+        assert_eq!(
+            ids(idx
+                .query(&IndexQuery::ArrayContains {
+                    key: attr,
+                    value: Value::Int(4),
+                })
+                .expect("servable")),
+            vec![3]
+        );
+    }
+
+    /// The encoded artifacts the online build passes around must keep the split, or a
+    /// background-built column loses its array half on install.
+    #[test]
+    fn encoded_tuples_round_trip_both_trees() {
+        let attr = Arc::new("v".to_string());
+        let mut idx = NumericIndex::new();
+        idx.add(&Value::Int(1), 10);
+        idx.add(
+            &Value::List(Arc::new(
+                [Value::Int(1)].into_iter().collect::<ThinVec<_>>(),
+            )),
+            20,
+        );
+
+        let rebuilt = NumericIndex::from_encoded(idx.encoded_tuples());
+        assert_eq!(
+            ids(rebuilt
+                .query(&IndexQuery::Equal {
+                    key: attr.clone(),
+                    value: Value::Int(1),
+                })
+                .expect("servable")),
+            vec![10]
+        );
+        assert_eq!(
+            ids(rebuilt
+                .query(&IndexQuery::ArrayContains {
+                    key: attr,
+                    value: Value::Int(1),
+                })
+                .expect("servable")),
+            vec![20],
+            "the array half must survive the encode/install round trip"
         );
     }
 }

--- a/graph/src/index/falkordb/numeric.rs
+++ b/graph/src/index/falkordb/numeric.rs
@@ -42,6 +42,9 @@ type TreeIter = RangeIter<LEAF_MAX, BRANCH_MAX, DOC_BYTES>;
 pub enum DocIter {
     One(TreeIter),
     Many(UnionIter),
+    /// An already-materialised doc set — a cross-attribute intersection, which cannot be produced
+    /// lazily from value-ordered streams. Distinct by construction.
+    Set(std::collections::hash_set::IntoIter<u64>),
 }
 
 impl Iterator for DocIter {
@@ -51,6 +54,7 @@ impl Iterator for DocIter {
         match self {
             Self::One(it) => it.next(),
             Self::Many(it) => it.next(),
+            Self::Set(it) => it.next(),
         }
     }
 }
@@ -344,46 +348,43 @@ impl NumericIndex {
         include_min: bool,
         include_max: bool,
     ) -> DocIter {
-        // Map value bounds to inclusive key bounds. Exclusive bounds step one key
-        // inward: encodings of distinct f64 are adjacent u64, so `k+1` / `k-1` is
-        // exactly the next / previous representable value. The `checked_*` guards
-        // catch the ±∞ edges (`x > +inf`, `x < -inf`) as empty.
+        match Self::bounds(min, max, include_min, include_max) {
+            Some((lo, hi)) if lo <= hi => DocIter::One(self.tree.range(lo, hi)),
+            _ => self.empty(),
+        }
+    }
+
+    /// The inclusive encoded key window a range predicate selects, or `None` when a bound is not
+    /// numeric (nothing in this column can satisfy it).
+    ///
+    /// Exclusive bounds step one key inward: encodings of distinct `f64` are adjacent `u64`, so
+    /// `k+1` / `k-1` is exactly the next / previous representable value. The `checked_*` guards
+    /// catch the ±∞ edges (`x > +inf`, `x < -inf`), which select nothing.
+    ///
+    /// An empty window is reported as `Some((lo, hi))` with `lo > hi` rather than `None`, so a
+    /// caller intersecting several predicates can tell "unsatisfiable" from "not numeric" — the
+    /// first is an answer, the second means this column cannot be consulted at all.
+    fn bounds(
+        min: Option<&Value>,
+        max: Option<&Value>,
+        include_min: bool,
+        include_max: bool,
+    ) -> Option<(u64, u64)> {
         let lo = match min {
             None => 0,
             Some(v) => {
-                let Some(k) = encode_numeric(v) else {
-                    return self.empty();
-                };
-                if include_min {
-                    k
-                } else {
-                    match k.checked_add(1) {
-                        Some(k1) => k1,
-                        None => return self.empty(),
-                    }
-                }
+                let k = encode_numeric(v)?;
+                if include_min { k } else { k.checked_add(1)? }
             }
         };
         let hi = match max {
             None => u64::MAX,
             Some(v) => {
-                let Some(k) = encode_numeric(v) else {
-                    return self.empty();
-                };
-                if include_max {
-                    k
-                } else {
-                    match k.checked_sub(1) {
-                        Some(k1) => k1,
-                        None => return self.empty(),
-                    }
-                }
+                let k = encode_numeric(v)?;
+                if include_max { k } else { k.checked_sub(1)? }
             }
         };
-        if lo > hi {
-            return self.empty();
-        }
-        DocIter::One(self.tree.range(lo, hi))
+        Some((lo, hi))
     }
 
     /// Entity ids whose **list**-valued property contains `value` — `value IN n.prop`.
@@ -426,9 +427,100 @@ impl NumericIndex {
                 ..
             } => Some(self.range(min.as_ref(), max.as_ref(), *include_min, *include_max)),
             IndexQuery::Or(children) => self.union(children),
+            IndexQuery::And(children) => self.intersect_same_key(children),
             IndexQuery::ArrayContains { value, .. } => Some(self.array_contains(value)),
             _ => None,
         }
+    }
+
+    /// A conjunction of `Equal`/`Range` leaves that all constrain the **same** attribute,
+    /// collapsed into one cursor.
+    ///
+    /// `WHERE n.v = 5 AND n.v > 2` and `WHERE n.id > 10 AND n.id >= 20` both arrive here. The
+    /// planner cannot fold them itself: `merge_range_queries` gives up whenever two conjuncts
+    /// specify the same side of the window, because at plan time the bounds may still be
+    /// expressions it cannot compare. By the time the index sees them they are concrete values,
+    /// so the intersection is arithmetic — take the tightest low and the tightest high — and the
+    /// result is a single range scan rather than a doc-stream intersection.
+    ///
+    /// An `Equal` is just a degenerate window (`lo == hi`), which is why it needs no special case.
+    ///
+    /// Returns `None` if any member targets a different attribute, or is not a numeric
+    /// `Equal`/`Range`: this index is one column, so a cross-attribute conjunction is not
+    /// something it can answer. An empty window is served as an empty iterator rather than
+    /// declined — `v > 5 AND v < 2` is answerable, and the answer is no rows.
+    fn intersect_same_key(
+        &self,
+        children: &[IndexQuery<Value>],
+    ) -> Option<DocIter> {
+        let refs: Vec<&IndexQuery<Value>> = children.iter().collect();
+        self.intersect_refs(&refs)
+    }
+
+    /// [`intersect_same_key`](Self::intersect_same_key) over borrowed conjuncts, so a caller that
+    /// has regrouped leaves by attribute can fold one attribute's share without cloning them —
+    /// `IndexQuery` is deliberately not `Clone`.
+    pub(super) fn intersect_refs(
+        &self,
+        children: &[&IndexQuery<Value>],
+    ) -> Option<DocIter> {
+        // Flatten nested conjunctions: `And(And(a, b), c)` constrains the same column.
+        fn fold<'a>(
+            children: &[&'a IndexQuery<Value>],
+            attr: &mut Option<&'a Arc<String>>,
+            window: &mut (u64, u64),
+        ) -> Option<()> {
+            for child in children {
+                let (key, bounds) = match *child {
+                    IndexQuery::Equal { key, value } => {
+                        let k = encode_numeric(value)?;
+                        (key, (k, k))
+                    }
+                    IndexQuery::Range {
+                        key,
+                        min,
+                        max,
+                        include_min,
+                        include_max,
+                    } => (
+                        key,
+                        NumericIndex::bounds(
+                            min.as_ref(),
+                            max.as_ref(),
+                            *include_min,
+                            *include_max,
+                        )?,
+                    ),
+                    IndexQuery::And(nested) if !nested.is_empty() => {
+                        let refs: Vec<&IndexQuery<Value>> = nested.iter().collect();
+                        fold(&refs, attr, window)?;
+                        continue;
+                    }
+                    _ => return None,
+                };
+                match attr {
+                    Some(first) if *first != key => return None,
+                    Some(_) => {}
+                    None => *attr = Some(key),
+                }
+                window.0 = window.0.max(bounds.0);
+                window.1 = window.1.min(bounds.1);
+            }
+            Some(())
+        }
+
+        if children.is_empty() {
+            return None;
+        }
+        let mut attr = None;
+        let mut window = (0, u64::MAX);
+        fold(children, &mut attr, &mut window)?;
+        attr?; // an `And` of nothing but empty nested `And`s names no column
+        Some(if window.0 <= window.1 {
+            DocIter::One(self.tree.range(window.0, window.1))
+        } else {
+            self.empty()
+        })
     }
 
     /// A union of `Equal` leaves — what `n.a IN [...]` desugars to before it reaches the index.
@@ -640,8 +732,23 @@ mod tests {
             include_max: true,
         };
         assert_eq!(ids(idx.query(&rg).unwrap()), vec![1, 2, 3]);
-        // composite predicates are the router's job, not a single index's
-        assert!(idx.query(&IndexQuery::And(vec![eq])).is_none());
+        // A conjunction on this column IS answerable now — it folds to one window. What a
+        // single column still cannot do is a conjunction spanning two attributes.
+        assert_eq!(ids(idx.query(&IndexQuery::And(vec![eq])).unwrap()), vec![3]);
+        assert!(
+            idx.query(&IndexQuery::And(vec![
+                IndexQuery::Equal {
+                    key: Arc::new("a".to_string()),
+                    value: Value::Int(1),
+                },
+                IndexQuery::Equal {
+                    key: Arc::new("b".to_string()),
+                    value: Value::Int(2),
+                },
+            ]))
+            .is_none(),
+            "two attributes need a cross-column intersection, not this column"
+        );
     }
 
     #[test]
@@ -1039,5 +1146,120 @@ mod tests {
         // Removing whatever it currently is leaves nothing on either side.
         idx.remove(&Value::Int(1), 1);
         assert!(idx.is_empty(), "no tuple stranded in either tree");
+    }
+
+    /// Two bounds on one attribute collapse to a single window rather than needing a doc-stream
+    /// intersection. The planner cannot do this itself — `merge_range_queries` bails whenever two
+    /// conjuncts constrain the same side, because at plan time the bounds may still be
+    /// expressions it cannot compare. Here they are concrete.
+    #[test]
+    fn same_key_conjunctions_fold_to_one_window() {
+        let attr = Arc::new("v".to_string());
+        let idx = NumericIndex::from_entries(
+            [
+                (&Value::Int(1), 1u64),
+                (&Value::Int(5), 5),
+                (&Value::Int(9), 9),
+                (&Value::Int(20), 20),
+            ]
+            .into_iter(),
+        );
+        let range =
+            |min: Option<i64>, max: Option<i64>, inc_min: bool, inc_max: bool| IndexQuery::Range {
+                key: attr.clone(),
+                min: min.map(Value::Int),
+                max: max.map(Value::Int),
+                include_min: inc_min,
+                include_max: inc_max,
+            };
+        let eq = |v: i64| IndexQuery::Equal {
+            key: attr.clone(),
+            value: Value::Int(v),
+        };
+        let got = |q: IndexQuery<Value>| {
+            let mut v = ids(idx.query(&q).expect("servable"));
+            v.sort_unstable();
+            v
+        };
+
+        // Two lower bounds: the tighter one wins.
+        assert_eq!(
+            got(IndexQuery::And(vec![
+                range(Some(1), None, false, true),
+                range(Some(9), None, true, true),
+            ])),
+            vec![9, 20]
+        );
+        // Lower and upper from different conjuncts.
+        assert_eq!(
+            got(IndexQuery::And(vec![
+                range(Some(5), None, true, true),
+                range(None, Some(9), true, true),
+            ])),
+            vec![5, 9]
+        );
+        // `Equal` is a degenerate window, and an equality inside a satisfied range survives.
+        assert_eq!(
+            got(IndexQuery::And(vec![
+                eq(5),
+                range(Some(2), None, true, true)
+            ])),
+            vec![5]
+        );
+        // An equality outside the range yields nothing — answerable, and the answer is no rows.
+        assert!(
+            got(IndexQuery::And(vec![
+                eq(1),
+                range(Some(8), None, true, true)
+            ]))
+            .is_empty()
+        );
+        // Contradictory bounds likewise.
+        assert!(
+            got(IndexQuery::And(vec![
+                range(Some(9), None, true, true),
+                range(None, Some(2), true, true),
+            ]))
+            .is_empty()
+        );
+        // Nesting is flattened — it still constrains one column.
+        assert_eq!(
+            got(IndexQuery::And(vec![
+                IndexQuery::And(vec![range(Some(5), None, true, true)]),
+                range(None, Some(9), true, true),
+            ])),
+            vec![5, 9]
+        );
+    }
+
+    /// The fold must decline anything it cannot fold, rather than answering from a subset of the
+    /// conjuncts — that would return rows the query excludes.
+    #[test]
+    fn unfoldable_conjunctions_are_declined() {
+        let idx = NumericIndex::from_entries([(&Value::Int(1), 1u64)].into_iter());
+        let eq = |attr: &str, v: i64| IndexQuery::Equal {
+            key: Arc::new(attr.to_string()),
+            value: Value::Int(v),
+        };
+        assert!(
+            idx.query(&IndexQuery::And(vec![eq("a", 1), eq("b", 2)]))
+                .is_none(),
+            "two attributes need a cross-column intersection"
+        );
+        assert!(
+            idx.query(&IndexQuery::And(vec![
+                eq("a", 1),
+                IndexQuery::Equal {
+                    key: Arc::new("a".to_string()),
+                    value: Value::String(Arc::new("x".to_string())),
+                },
+            ]))
+            .is_none(),
+            "a non-numeric member makes the whole conjunction unservable here"
+        );
+        assert!(
+            idx.query(&IndexQuery::And(vec![])).is_none(),
+            "an empty conjunction names no column"
+        );
     }
 }

--- a/tests/flow/nextgen_index_xfail.txt
+++ b/tests/flow/nextgen_index_xfail.txt
@@ -25,13 +25,20 @@
 # test_34, test10, test17). Their passing is not evidence of native array support.
 
 # ---------------------------------------------------------------------------
-# Array-valued properties — `ArrayContains`.
-#   error: "an array-contains on `samples`"
-# The numeric encoder rejects lists outright, so an array-valued property is not in the numeric
-# column at all — there is nothing for the native index to answer from. Needs an array/list kind.
+# STRING elements inside array-valued properties.
+#   error: "an array-contains on `samples` with a non-numeric value"
+#
+# Numeric array elements ARE served now: each one is a tuple in the column's separate array tree,
+# and `value IN n.prop` is a point lookup into it. `test_29_array_index` passes on that and has
+# been removed from this file.
+#
+# What is left is the string half. These tests index a list of strings and probe it, and there is
+# no native text kind — so this group closes with the text work, not with more array work.
+#
+# The two key spaces are separate on purpose: sharing one would make `WHERE n.v = 1` match a node
+# whose `v` is `[1, 2]`, and `Equal` has no post-filter to catch it.
 # ---------------------------------------------------------------------------
 test_index_scans:testIndexScanFlow.test_28_array_index
-test_index_scans:testIndexScanFlow.test_29_array_index
 test_index_scans:testIndexScanFlow.test_30_update_array_index
 test_index_scans:testIndexScanFlow.test_31_remove_array_index
 test_index_scans:testIndexScanFlow.test_32_multiple_array_indexed_entities

--- a/tests/flow/nextgen_index_xfail.txt
+++ b/tests/flow/nextgen_index_xfail.txt
@@ -66,23 +66,23 @@ test_edge_index_scans:testEdgeByIndexScanFlow.test15_chained_optional_match_inde
 test_edge_index_scans:testEdgeByIndexScanRegressionsFlow.test17_child_var_reference_safety
 
 # ---------------------------------------------------------------------------
-# Conjunctions — `And` the planner could not fold at plan time. The message names the children,
-# because the three shapes that land here need completely different work:
-#   [equality on `v`; range on `v`]     same key  -> arithmetic collapse, one cursor
-#   [range on `id`; range on `id`]      same key  -> tighter min/max, one cursor
-#   [equality on `a`; equality on `b`]  two keys  -> a real intersection
+# Conjunctions — CLOSED. Nothing left in this group.
 #
-# A fourth shape used to dominate and is now gone: the *same* predicate twice, from an inline
-# property map on a traversal endpoint (`MATCH (a:L {p: v})-[]->(b)`). `push_filters_down` merged
-# the planner's filter and `select_scan_node`'s identical copy into an `And` without dedup. It now
-# dedups, which removed 31 of the bench suite's 40 failures and one entry from this file — that
-# entry, `test_07_reset_order`, turned out to be a plain string gap underneath and has moved to
-# the group above.
+# Three shapes used to land here and all three are served now:
+#   the same predicate twice          -> collapsed in `push_filters_down` (#2390)
+#   several bounds on ONE attribute   -> folded arithmetically into a single window
+#   bounds across TWO attributes      -> one column per attribute, intersected
 #
-# Only the same-key Equal+Range case is left here. An `Equal` is a degenerate range, so this one
-# collapses without any doc-stream intersection machinery.
+# The same-key fold happens in the index rather than the planner because
+# `merge_range_queries` gives up whenever two conjuncts constrain the same side of the window —
+# at plan time the bounds may still be expressions it cannot compare, and by the time the index
+# sees them they are concrete values.
+#
+# The cross-attribute case is a **set probe, not a sorted merge**: `DocIter` yields docs in value
+# order, not id order, so the first attribute is materialised and the rest probe it. Verified
+# against the RediSearch build — same rows, different order, which Cypher permits without
+# `ORDER BY`.
 # ---------------------------------------------------------------------------
-test_edge_index_scans:testEdgeByIndexScanRegressionsFlow.test28_post_filter_keeps_pushed_conjuncts
 
 # ---------------------------------------------------------------------------
 # IGNORED in both directions (`!` prefix) — NOT a native-index gap.

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -1247,3 +1247,64 @@ class testIndexScanFlow():
         res = self.graph.query(q).result_set
         # `n.v` is a scalar int, never a list — no row should match.
         self.env.assertEqual(res, [])
+
+    def test_36_scalar_array_scalar_round_trip(self):
+        # A property changing kind — scalar -> array -> scalar — must re-index
+        # cleanly each time.
+        #
+        # Scalars and array elements are held apart (RediSearch keeps a
+        # `numeric:arr` sub-field; the native index keeps a second tree), because
+        # `n.v = 1` must NOT match a node whose `v` is `[1, 2]`, and `1 IN n.v`
+        # must NOT match a node whose `v` is the scalar `1`. Every transition
+        # therefore has to delete from one side and insert into the other. A
+        # remove that routed on the NEW value's kind rather than the OLD one
+        # would leave a tuple stranded on the wrong side, and nothing in the
+        # scalar path re-checks the index's answer.
+        self.graph.create_node_range_index('rt', 'v')
+        wait_for_indices_to_sync(self.graph)
+
+        self.graph.query("CREATE (:rt {v: 1})")
+
+        def eq(x):
+            q = "MATCH (n:rt) WHERE n.v = $x RETURN count(n)"
+            return self.graph.query(q, {'x': x}).result_set[0][0]
+
+        def contains(x):
+            q = "MATCH (n:rt) WHERE $x IN n.v RETURN count(n)"
+            return self.graph.query(q, {'x': x}).result_set[0][0]
+
+        # scalar
+        self.env.assertEqual(eq(1), 1)
+        self.env.assertEqual(contains(1), 0)
+
+        # -> array. The scalar tuple must be gone, not merely shadowed.
+        self.graph.query("MATCH (n:rt) SET n.v = [1, 2]")
+        self.env.assertEqual(eq(1), 0)
+        self.env.assertEqual(contains(1), 1)
+        self.env.assertEqual(contains(2), 1)
+
+        # -> array with one element dropped
+        self.graph.query("MATCH (n:rt) SET n.v = [2]")
+        self.env.assertEqual(contains(1), 0)
+        self.env.assertEqual(contains(2), 1)
+
+        # -> back to a scalar holding a value that was previously an *element*.
+        # The same key crosses back, which is the case a kind-confused remove
+        # gets wrong in both directions at once.
+        self.graph.query("MATCH (n:rt) SET n.v = 2")
+        self.env.assertEqual(eq(2), 1)
+        self.env.assertEqual(contains(2), 0)
+
+        # Both transitions inside a single transaction: the pending layer
+        # collapses multi-SET to (first_old, final_new), so the intermediate
+        # array must never reach the index at all.
+        self.graph.query("MATCH (n:rt) SET n.v = [7, 8] SET n.v = 9")
+        self.env.assertEqual(eq(9), 1)
+        self.env.assertEqual(contains(7), 0)
+        self.env.assertEqual(contains(8), 0)
+
+        # Deleting the entity must clear whichever side currently holds it.
+        self.graph.query("MATCH (n:rt) SET n.v = [4, 5]")
+        self.graph.query("MATCH (n:rt) DELETE n")
+        self.env.assertEqual(contains(4), 0)
+        self.env.assertEqual(eq(9), 0)


### PR DESCRIPTION
Closes #2452

**Based on #2386** — review that first; the diff here is only this layer.

Two gaps from the ledger that #2386 introduced, closed here. Both are read-path capability, which
is why they are their own layer rather than part of the no-fallback change.

## Numeric array elements

A numeric array is indexed element-wise into a **separate array tree** on the same column, so
`value IN n.samples` is a point lookup into it. Scalars and array elements never share a key
space — sharing one would make `WHERE n.v = 1` match a node whose `v` is `[1, 2]`, and the
`Equal` plan carries no post-filter to catch that. This mirrors how RediSearch keeps `numeric`
and `numeric:arr` as separate sub-fields.

`EncodedTuples { scalar, array }` is the transport the online build already needed: BASE, DELTA
and TOMB each carry both halves, so a build that starts mid-write stages array elements the same
way it stages scalars. A value changing between scalar and array — and back — re-indexes into
the right tree, which is pinned by a round-trip test.

## Conjunctions

All three shapes are served:

| shape | how |
|---|---|
| the same predicate twice | collapsed before the index sees it |
| several bounds on ONE attribute | folded arithmetically into a single window |
| bounds across TWO attributes | one column per attribute, intersected |

The same-attribute fold happens **in the index, not the planner**: `merge_range_queries` gives up
whenever two conjuncts constrain the same side of the window, because at plan time the bounds may
still be expressions it cannot compare — by the time the index sees them they are concrete values.

The cross-attribute case is a **set probe, not a sorted merge**. `DocIter` yields docs in value
order, not id order, so a merge would need both sides sorted by id; instead the first attribute is
materialised and the rest probe it. Rows match the RediSearch build; order differs, which Cypher
permits without `ORDER BY`. A column still building declines the whole intersection rather than
returning a partial answer.

## Ledger

19 entries to 17 — `test_29_array_index` and `test28_post_filter_keeps_pushed_conjuncts`. The
conjunction group is now empty and annotated as closed.

The four remaining array entries are **string** elements inside arrays. They fail on
`an array-contains on 'samples' with a non-numeric value` — no native text kind — so that group
closes with the text work, not with more array work. Grouping is by the error each run actually
emitted, not by test name.

Also adds a write-path bench corpus (`WIdx`/`WDel`/`WTmp`/`WREL`, plus paired indexed and
unindexed queries), because index maintenance cost was previously not measurable at all.