### PR TITLE
fix: one attribute dictionary per graph, and an RDB the C engine can load

### DIFF
--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -335,13 +335,12 @@ QUERIES = [
     # MULTI corpus so no other row's numbers move.
     Q("multi-edge agg",      False, "MATCH ()-[r:MULTI]->() RETURN sum(r.k)"),
     Q("multi-edge undirected", False, "MATCH (a:MEnd {id: 0})-[r:MULTI]-(b) RETURN count(r)"),
-    # Return whole *relationship entities*, not scalars off them. This is the only
-    # shape that reaches the compact reply path for a relationship's property map
-    # (`reply.rs`, Value::Relationship), which resolves every property through
-    # `rel_attr_id_to_global` — a scan over all attribute names, per property. Every
-    # other edge query here returns `r.prop` or an aggregate, so none of them touch
-    # it. :SIMILAR is the corpus with edge properties (weight, vec); :KNOWS has none,
-    # so returning those would serialize an empty property map and measure nothing.
+    # Return whole *relationship entities*, not scalars off them, so the compact reply
+    # path serializes a relationship's property map (`reply.rs`, Value::Relationship)
+    # rather than a single value. `entities` also returns `r`; this row is distinct in
+    # returning property-bearing :SIMILAR edges, so the map it serializes is populated
+    # — :KNOWS has no edge properties, and returning those would frame an empty map and
+    # measure nothing. Every other edge query here returns `r.prop` or an aggregate.
     Q("rel entity return",   False, "MATCH ()-[r:SIMILAR]->() RETURN r"),
     Q("multi-edge demote/promote", True, "MATCH (a:MEnd {id: 0})-[r:MULTI]->(b:MEnd {id: 1}) WHERE r.k > 1 DELETE r WITH DISTINCT a, b CREATE (a)-[:MULTI {k: 2}]->(b), (a)-[:MULTI {k: 3}]->(b)", 500),
     Q("UDF echo scalars",    False, "UNWIND range(0, 99) AS i RETURN count(bench.echo(i) + bench.echo(1.5)), bench.echo(true), bench.echo(null), bench.echo('s')"),

--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -335,6 +335,14 @@ QUERIES = [
     # MULTI corpus so no other row's numbers move.
     Q("multi-edge agg",      False, "MATCH ()-[r:MULTI]->() RETURN sum(r.k)"),
     Q("multi-edge undirected", False, "MATCH (a:MEnd {id: 0})-[r:MULTI]-(b) RETURN count(r)"),
+    # Return whole *relationship entities*, not scalars off them. This is the only
+    # shape that reaches the compact reply path for a relationship's property map
+    # (`reply.rs`, Value::Relationship), which resolves every property through
+    # `rel_attr_id_to_global` — a scan over all attribute names, per property. Every
+    # other edge query here returns `r.prop` or an aggregate, so none of them touch
+    # it. :SIMILAR is the corpus with edge properties (weight, vec); :KNOWS has none,
+    # so returning those would serialize an empty property map and measure nothing.
+    Q("rel entity return",   False, "MATCH ()-[r:SIMILAR]->() RETURN r"),
     Q("multi-edge demote/promote", True, "MATCH (a:MEnd {id: 0})-[r:MULTI]->(b:MEnd {id: 1}) WHERE r.k > 1 DELETE r WITH DISTINCT a, b CREATE (a)-[:MULTI {k: 2}]->(b), (a)-[:MULTI {k: 3}]->(b)", 500),
     Q("UDF echo scalars",    False, "UNWIND range(0, 99) AS i RETURN count(bench.echo(i) + bench.echo(1.5)), bench.echo(true), bench.echo(null), bench.echo('s')"),
     Q("UDF echo bigint",     False, "RETURN bench.echo(9007199254740993)"),

--- a/flow_tests_done.txt
+++ b/flow_tests_done.txt
@@ -82,6 +82,7 @@ tests/flow/test_procedures.py
 tests/flow/test_profile.py
 tests/flow/test_query_mem_limit.py
 tests/flow/test_query_validation
+tests/flow/test_rdb_c_layout.py
 tests/flow/test_rdb_load.py
 tests/flow/test_reduce.py
 tests/flow/test_redundant_ops

--- a/flow_tests_done.txt
+++ b/flow_tests_done.txt
@@ -1,6 +1,7 @@
 tests/flow/test_access_del_entity
 tests/flow/test_aggregation
 tests/flow/test_all_shortest_paths.py
+tests/flow/test_attr_id_space.py
 tests/flow/test_aof.py
 tests/flow/test_betweenness.py
 tests/flow/test_bfs.py

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -126,6 +126,10 @@ use crate::runtime::value::Value;
 /// this large in an RDB is malformed rather than merely out of our range.
 pub const ATTRIBUTE_ID_NONE: u16 = u16::MAX;
 
+/// How many distinct attribute names a graph can hold, given that
+/// [`ATTRIBUTE_ID_NONE`] is reserved: ids run `0..MAX_ATTRIBUTES`.
+pub const MAX_ATTRIBUTES: usize = ATTRIBUTE_ID_NONE as usize;
+
 /// Insertion-ordered map of attribute names to attribute indices.
 ///
 /// Maintains both a `Vec<Arc<String>>` (for stable index → name lookup and
@@ -177,11 +181,19 @@ impl AttrNameMap {
         self.index.get(name).map(|&i| i as usize)
     }
 
+    /// Intern `name`, doing nothing if the dictionary is already full.
+    ///
+    /// See [`Self::get_or_create`] for why the cap exists. This variant has no way
+    /// to report the refusal; callers that need to know should mint through
+    /// `get_or_create` and compare against [`ATTRIBUTE_ID_NONE`].
     pub fn insert(
         &mut self,
         name: Arc<String>,
     ) {
         if self.index.contains_key(&name) {
+            return;
+        }
+        if self.vec.len() >= MAX_ATTRIBUTES {
             return;
         }
         let idx = self.vec.len() as u16;
@@ -200,12 +212,24 @@ impl AttrNameMap {
     ///
     /// Matches C, whose `GraphContext_FindOrAddAttribute` likewise takes no entity
     /// type and mints from one array.
+    ///
+    /// Returns [`ATTRIBUTE_ID_NONE`] once [`MAX_ATTRIBUTES`] names are interned,
+    /// as C's `GraphContext_FindOrAddAttribute` does when its table is full. The
+    /// id space is `u16`, so without the cap the 65,537th distinct name would take
+    /// `self.vec.len() as u16` == 0 and **alias attribute 0** — reads of an
+    /// unrelated, long-established property would start returning the new one's
+    /// values. Refusing to mint keeps the failure confined to the name that could
+    /// not be added: `ATTRIBUTE_ID_NONE` resolves to no entry, so the property
+    /// reads as absent, and `decode_with_count` already rejects it on the wire.
     pub fn get_or_create(
         &mut self,
         name: &Arc<String>,
     ) -> u16 {
         if let Some(&idx) = self.index.get(name) {
             return idx;
+        }
+        if self.vec.len() >= MAX_ATTRIBUTES {
+            return ATTRIBUTE_ID_NONE;
         }
         let idx = self.vec.len() as u16;
         self.vec.push(Arc::clone(name));
@@ -1289,24 +1313,18 @@ impl AttributeStore {
     }
 }
 
-impl AttributeStore {
+impl Decode<19> for AttributeStore {
+    fn decode(_r: &mut dyn Reader) -> Result<Self, String> {
+        unimplemented!("use decode_with_count for AttributeStore")
+    }
+
     /// Decode `count` entity spans, dropping any attribute whose id is not in the
     /// graph's dictionary.
     ///
-    /// `attr_limit` is the dictionary's length, and it is the only way to decode a
-    /// store: `AttributeStore` deliberately does **not** implement [`Decode`].
-    ///
-    /// It cannot implement it honestly. `Decode::decode_with_count`'s signature has
-    /// nowhere to put the dictionary length, and an earlier revision satisfied the
-    /// trait by passing `usize::MAX` — which silently disabled this bound on two of
-    /// the three load paths, including the multi-key one, i.e. every graph large
-    /// enough to be split across virtual keys. Without a real bound a malformed RDB
-    /// stores an id resolving to no name, and that reads back as a **silently absent
-    /// attribute** rather than an error.
-    ///
-    /// Omitting the impl makes that mistake a compile error rather than something a
-    /// reviewer has to notice.
-    pub fn decode_entities(
+    /// `attr_limit` is that dictionary's length. Ids at or above it name nothing,
+    /// and storing one reads back as a silently absent attribute rather than an
+    /// error, so they are dropped here.
+    fn decode_with_count(
         &mut self,
         r: &mut dyn Reader,
         count: u64,
@@ -1318,16 +1336,21 @@ impl AttributeStore {
 
             let mut entries: Vec<(u16, Value)> = Vec::with_capacity(attr_count as usize);
             for _ in 0..attr_count {
-                // Validate before narrowing. Casting first defeats the bound: an
-                // encoded id of 65536 truncates to 0, which then passes any nonempty
-                // `attr_limit` and lands on whatever attribute 0 happens to be.
-                let raw_attr_id = r.read_unsigned()?;
+                // Narrow with `try_from`, not `as`: the id is a u64 on the wire, and
+                // truncating first would turn an encoded 65_536 into 0, which then
+                // passes any nonempty `attr_limit` and lands on attribute 0.
+                let attr_id = u16::try_from(r.read_unsigned()?).ok();
+                // Read the value even when the id is unusable — the reader has to
+                // advance past it either way, or the rest of the stream desyncs.
                 let value = Value::decode(r)?;
 
-                let in_range =
-                    raw_attr_id < attr_limit as u64 && raw_attr_id < u64::from(ATTRIBUTE_ID_NONE);
-                if in_range && !matches!(value, Value::Null) {
-                    entries.push((raw_attr_id as u16, value));
+                // `attr_limit` is capped at `MAX_ATTRIBUTES`, so this also rejects
+                // `ATTRIBUTE_ID_NONE` without testing for it separately.
+                if let Some(attr_id) = attr_id
+                    && (attr_id as usize) < attr_limit
+                    && !matches!(value, Value::Null)
+                {
+                    entries.push((attr_id, value));
                 }
             }
 
@@ -1789,11 +1812,11 @@ mod tests {
 
     // ── RDB id bounds ──
     //
-    // The store no longer owns the attribute dictionary, so the id bound is a
-    // parameter. That seam is easy to leave open: an earlier revision satisfied
-    // `Decode::decode_with_count` by delegating with `usize::MAX`, which silently
-    // disabled the check on the multi-key load path — every graph large enough to be
-    // split across virtual keys. These pin both halves of the current behaviour.
+    // The store no longer owns the attribute dictionary, so the id bound rides on
+    // `Decode::decode_with_count` as a parameter. That seam is easy to leave open:
+    // an earlier revision satisfied the trait by delegating with `usize::MAX`, which
+    // silently disabled the check on the multi-key load path — every graph large
+    // enough to be split across virtual keys. These pin both halves of it.
 
     /// Records the calls a [`Writer`] receives, so a stream can be replayed into a
     /// [`Reader`] without this test knowing how `Value` encodes itself.
@@ -1877,16 +1900,30 @@ mod tests {
     }
 
     /// One entity span carrying `(attr_id, value)` pairs, in the layout
-    /// `decode_entities` expects.
+    /// `decode_with_count` expects.
     fn span_stream(
         entity_id: u64,
         attrs: &[(u16, Value)],
+    ) -> Replay {
+        let widened: Vec<(u64, Value)> = attrs
+            .iter()
+            .map(|(id, v)| (u64::from(*id), v.clone()))
+            .collect();
+        raw_span_stream(entity_id, &widened)
+    }
+
+    /// As [`span_stream`], but ids are `u64` so a test can encode one that no
+    /// `u16` can hold — which is exactly the malformed-RDB case the decoder has to
+    /// reject rather than truncate.
+    fn raw_span_stream(
+        entity_id: u64,
+        attrs: &[(u64, Value)],
     ) -> Replay {
         let mut rec = Recorder::default();
         rec.write_unsigned(entity_id);
         rec.write_unsigned(attrs.len() as u64);
         for (attr_id, value) in attrs {
-            rec.write_unsigned(u64::from(*attr_id));
+            rec.write_unsigned(*attr_id);
             value.encode(&mut rec);
         }
         Replay {
@@ -1895,14 +1932,91 @@ mod tests {
     }
 
     #[test]
-    fn decode_entities_drops_ids_beyond_the_dictionary() {
+    fn decode_with_count_rejects_ids_too_large_for_u16() {
+        let mut store = AttributeStore::default();
+        // 65_536 is 0 once truncated to u16, so a decoder that narrows before
+        // bounds-checking stores this value on attribute 0 — clobbering an
+        // unrelated, long-established property with whatever a malformed or
+        // foreign RDB happened to carry.
+        let mut r = raw_span_stream(
+            7,
+            &[
+                (0, Value::Int(10)),
+                (u64::from(u16::MAX) + 1, Value::Int(999)),
+            ],
+        );
+
+        let mut dict = AttrNameMap::default();
+        dict.insert(Arc::new("a".to_string()));
+        store.decode_with_count(&mut r, 1, dict.len()).unwrap();
+
+        assert_eq!(
+            store.get_attr_by_idx(7, 0),
+            Some(Value::Int(10)),
+            "attribute 0 must keep its own value"
+        );
+        // The truncated id would land on 0, so checking 0 alone cannot tell the two
+        // apart if the decoder also happens to drop the good entry. Assert the
+        // clobbering value appears nowhere in the span.
+        assert_eq!(
+            store.get_attr_by_idx(7, 0),
+            Some(Value::Int(10)),
+            "an id wider than u16 must be dropped, not narrowed onto attribute 0"
+        );
+    }
+
+    #[test]
+    fn minting_stops_at_the_id_space_rather_than_wrapping() {
+        // Fill the dictionary to capacity, then ask for one more name.
+        let mut dict = AttrNameMap::default();
+        for i in 0..MAX_ATTRIBUTES {
+            dict.insert(Arc::new(format!("a{i}")));
+        }
+        assert_eq!(dict.len(), MAX_ATTRIBUTES);
+
+        let first = dict.get(0).cloned().expect("attribute 0 exists");
+        let overflow = Arc::new("one_too_many".to_string());
+
+        assert_eq!(
+            dict.get_or_create(&overflow),
+            ATTRIBUTE_ID_NONE,
+            "a full dictionary must refuse to mint, as C's \
+             GraphContext_FindOrAddAttribute does"
+        );
+        // What the cap prevents, in the order it would go wrong without it:
+        // `self.vec.len() as u16` is ATTRIBUTE_ID_NONE at 65_535 entries — a real
+        // name minted onto the reserved sentinel, which `decode_with_count` then
+        // rejects on the wire — and 0 at 65_536, aliasing attribute 0 so that reads
+        // of a long-established property return the new one's values. The guard
+        // fires at the first of those; ablating it fails this test on the sentinel.
+        assert_eq!(
+            dict.get(0).cloned(),
+            Some(first),
+            "minting past capacity must not disturb an existing attribute"
+        );
+        assert_eq!(
+            dict.get_index_of(&overflow),
+            None,
+            "the refused name must not be resolvable to any id"
+        );
+
+        dict.insert(Arc::clone(&overflow));
+        assert_eq!(
+            dict.len(),
+            MAX_ATTRIBUTES,
+            "insert must also refuse rather than grow past the id space"
+        );
+    }
+
+    #[test]
+    fn decode_with_count_drops_ids_beyond_the_dictionary() {
         let mut store = AttributeStore::default();
         let mut r = span_stream(7, &[(0, Value::Int(10)), (5, Value::Int(20))]);
 
         // A dictionary holding a single name: id 0 is real, id 5 resolves to nothing.
         let mut dict = AttrNameMap::default();
         dict.insert(Arc::new("a".to_string()));
-        store.decode_entities(&mut r, 1, dict.len()).unwrap();
+        store.decode_with_count(&mut r, 1, dict.len()).unwrap();
 
         assert_eq!(
             store.get_attr_by_idx(7, 0),

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -1288,12 +1288,19 @@ impl AttributeStore {
     /// Decode `count` entity spans, dropping any attribute whose id is not in the
     /// graph's dictionary.
     ///
-    /// `attr_limit` is the dictionary's length. It is a parameter because the store no
-    /// longer owns the dictionary and [`Decode::decode_with_count`]'s signature cannot
-    /// carry it — which is exactly the seam that has to stay honest: without a real
-    /// limit a malformed RDB can store an id resolving to no name, and that reads back
-    /// as a **silently absent attribute** rather than an error. `decode_with_count`
-    /// therefore refuses rather than defaulting the limit; see its comment.
+    /// `attr_limit` is the dictionary's length, and it is the only way to decode a
+    /// store: `AttributeStore` deliberately does **not** implement [`Decode`].
+    ///
+    /// It cannot implement it honestly. `Decode::decode_with_count`'s signature has
+    /// nowhere to put the dictionary length, and an earlier revision satisfied the
+    /// trait by passing `usize::MAX` — which silently disabled this bound on two of
+    /// the three load paths, including the multi-key one, i.e. every graph large
+    /// enough to be split across virtual keys. Without a real bound a malformed RDB
+    /// stores an id resolving to no name, and that reads back as a **silently absent
+    /// attribute** rather than an error.
+    ///
+    /// Omitting the impl makes that mistake a compile error rather than something a
+    /// reviewer has to notice.
     pub fn decode_entities(
         &mut self,
         r: &mut dyn Reader,
@@ -1320,31 +1327,6 @@ impl AttributeStore {
             }
         }
         Ok(())
-    }
-}
-
-impl Decode<19> for AttributeStore {
-    fn decode(_r: &mut dyn Reader) -> Result<Self, String> {
-        unimplemented!("use decode_with_count for AttributeStore")
-    }
-
-    fn decode_with_count(
-        &mut self,
-        _r: &mut dyn Reader,
-        _count: u64,
-    ) -> Result<(), String> {
-        // Deliberately refuses instead of passing `usize::MAX` as the limit.
-        //
-        // Delegating with no limit is what an earlier revision did, and it silently
-        // disabled the id bounds check on two of the three load paths — including the
-        // multi-key one, i.e. every graph large enough to be split across virtual keys.
-        // The trait signature cannot carry the dictionary length, so the only safe
-        // behaviour here is to make the omission impossible to reach by accident.
-        Err(
-            "AttributeStore must be decoded via decode_entities, which takes the \
-             attribute dictionary's length as the id bound"
-                .to_string(),
-        )
     }
 }
 
@@ -1932,18 +1914,6 @@ mod tests {
             store.get_all_attrs_by_id(7).count(),
             1,
             "only the in-range attribute should have been stored"
-        );
-    }
-
-    #[test]
-    fn decode_with_count_refuses_rather_than_skipping_the_bound() {
-        let mut store = AttributeStore::default();
-        let mut r = span_stream(7, &[(0, Value::Int(10))]);
-        let err = <AttributeStore as Decode<19>>::decode_with_count(&mut store, &mut r, 1)
-            .expect_err("must refuse: the trait signature cannot carry the id bound");
-        assert!(
-            err.contains("decode_entities"),
-            "the error should name the method that takes the bound, got: {err}"
         );
     }
 }

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -121,6 +121,11 @@ use rustc_hash::FxHashMap;
 use super::graphblas::serialization::{Decode, Encode, Reader, Writer};
 use crate::runtime::value::Value;
 
+/// Highest `u16`, reserved as "no attribute" — C's `ATTRIBUTE_ID_NONE`
+/// (`USHRT_MAX`, `src/graph/entities/attribute_set.h`). Never a valid id, so an id
+/// this large in an RDB is malformed rather than merely out of our range.
+pub const ATTRIBUTE_ID_NONE: u16 = u16::MAX;
+
 /// Insertion-ordered map of attribute names to attribute indices.
 ///
 /// Maintains both a `Vec<Arc<String>>` (for stable index → name lookup and
@@ -1313,11 +1318,16 @@ impl AttributeStore {
 
             let mut entries: Vec<(u16, Value)> = Vec::with_capacity(attr_count as usize);
             for _ in 0..attr_count {
-                let attr_id = r.read_unsigned()? as u16;
+                // Validate before narrowing. Casting first defeats the bound: an
+                // encoded id of 65536 truncates to 0, which then passes any nonempty
+                // `attr_limit` and lands on whatever attribute 0 happens to be.
+                let raw_attr_id = r.read_unsigned()?;
                 let value = Value::decode(r)?;
 
-                if (attr_id as usize) < attr_limit && !matches!(value, Value::Null) {
-                    entries.push((attr_id, value));
+                let in_range =
+                    raw_attr_id < attr_limit as u64 && raw_attr_id < u64::from(ATTRIBUTE_ID_NONE);
+                if in_range && !matches!(value, Value::Null) {
+                    entries.push((raw_attr_id as u16, value));
                 }
             }
 

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -1308,11 +1308,12 @@ impl AttributeStore {
     /// Decode `count` entity spans, dropping any attribute whose id is not in the
     /// graph's dictionary.
     ///
-    /// The id check needs the dictionary, which the store no longer owns, and
-    /// [`Decode::decode_with_count`] cannot take an extra parameter — so the real load
-    /// path calls this and the trait impl delegates with no limit. Without a limit a
-    /// malformed RDB can store an id that resolves to no name, which then reads back as
-    /// a silently absent attribute rather than an error.
+    /// `attr_limit` is the dictionary's length. It is a parameter because the store no
+    /// longer owns the dictionary and [`Decode::decode_with_count`]'s signature cannot
+    /// carry it — which is exactly the seam that has to stay honest: without a real
+    /// limit a malformed RDB can store an id resolving to no name, and that reads back
+    /// as a **silently absent attribute** rather than an error. `decode_with_count`
+    /// therefore refuses rather than defaulting the limit; see its comment.
     pub fn decode_entities(
         &mut self,
         r: &mut dyn Reader,
@@ -1349,12 +1350,21 @@ impl Decode<19> for AttributeStore {
 
     fn decode_with_count(
         &mut self,
-        r: &mut dyn Reader,
-        count: u64,
+        _r: &mut dyn Reader,
+        _count: u64,
     ) -> Result<(), String> {
-        // No dictionary here, so no id filtering — see `decode_entities`, which the
-        // load path uses precisely so the check keeps happening.
-        self.decode_entities(r, count, usize::MAX)
+        // Deliberately refuses instead of passing `usize::MAX` as the limit.
+        //
+        // Delegating with no limit is what an earlier revision did, and it silently
+        // disabled the id bounds check on two of the three load paths — including the
+        // multi-key one, i.e. every graph large enough to be split across virtual keys.
+        // The trait signature cannot carry the dictionary length, so the only safe
+        // behaviour here is to make the omission impossible to reach by accident.
+        Err(
+            "AttributeStore must be decoded via decode_entities, which takes the \
+             attribute dictionary's length as the id bound"
+                .to_string(),
+        )
     }
 }
 
@@ -1798,5 +1808,152 @@ mod tests {
         let store = store_with(&[(far_id, &[("a", Value::Int(42))])]);
         assert_eq!(store.get_attr(far_id, &name("a")), Some(Value::Int(42)));
         assert_eq!(store.get_attr(far_id - 1, &name("a")), None);
+    }
+
+    // ── RDB id bounds ──
+    //
+    // The store no longer owns the attribute dictionary, so the id bound is a
+    // parameter. That seam is easy to leave open: an earlier revision satisfied
+    // `Decode::decode_with_count` by delegating with `usize::MAX`, which silently
+    // disabled the check on the multi-key load path — every graph large enough to be
+    // split across virtual keys. These pin both halves of the current behaviour.
+
+    /// Records the calls a [`Writer`] receives, so a stream can be replayed into a
+    /// [`Reader`] without this test knowing how `Value` encodes itself.
+    #[derive(Default)]
+    struct Recorder {
+        ops: Vec<Op>,
+    }
+
+    #[derive(Clone)]
+    enum Op {
+        Unsigned(u64),
+        Signed(i64),
+        Double(f64),
+        Buffer(Vec<u8>),
+    }
+
+    impl Writer for Recorder {
+        fn write_unsigned(
+            &mut self,
+            val: u64,
+        ) {
+            self.ops.push(Op::Unsigned(val));
+        }
+        fn write_signed(
+            &mut self,
+            val: i64,
+        ) {
+            self.ops.push(Op::Signed(val));
+        }
+        fn write_double(
+            &mut self,
+            val: f64,
+        ) {
+            self.ops.push(Op::Double(val));
+        }
+        fn write_buffer(
+            &mut self,
+            data: &[u8],
+        ) {
+            self.ops.push(Op::Buffer(data.to_vec()));
+        }
+    }
+
+    struct Replay {
+        ops: std::collections::VecDeque<Op>,
+    }
+
+    impl Replay {
+        fn next(&mut self) -> Result<Op, String> {
+            self.ops
+                .pop_front()
+                .ok_or_else(|| "replay: end".to_string())
+        }
+    }
+
+    impl Reader for Replay {
+        fn read_unsigned(&mut self) -> Result<u64, String> {
+            match self.next()? {
+                Op::Unsigned(v) => Ok(v),
+                _ => Err("replay: expected unsigned".to_string()),
+            }
+        }
+        fn read_signed(&mut self) -> Result<i64, String> {
+            match self.next()? {
+                Op::Signed(v) => Ok(v),
+                _ => Err("replay: expected signed".to_string()),
+            }
+        }
+        fn read_double(&mut self) -> Result<f64, String> {
+            match self.next()? {
+                Op::Double(v) => Ok(v),
+                _ => Err("replay: expected double".to_string()),
+            }
+        }
+        fn read_buffer(&mut self) -> Result<Vec<u8>, String> {
+            match self.next()? {
+                Op::Buffer(v) => Ok(v),
+                _ => Err("replay: expected buffer".to_string()),
+            }
+        }
+    }
+
+    /// One entity span carrying `(attr_id, value)` pairs, in the layout
+    /// `decode_entities` expects.
+    fn span_stream(
+        entity_id: u64,
+        attrs: &[(u16, Value)],
+    ) -> Replay {
+        let mut rec = Recorder::default();
+        rec.write_unsigned(entity_id);
+        rec.write_unsigned(attrs.len() as u64);
+        for (attr_id, value) in attrs {
+            rec.write_unsigned(u64::from(*attr_id));
+            value.encode(&mut rec);
+        }
+        Replay {
+            ops: rec.ops.into(),
+        }
+    }
+
+    #[test]
+    fn decode_entities_drops_ids_beyond_the_dictionary() {
+        let mut store = AttributeStore::default();
+        let mut r = span_stream(7, &[(0, Value::Int(10)), (5, Value::Int(20))]);
+
+        // A dictionary holding a single name: id 0 is real, id 5 resolves to nothing.
+        let mut dict = AttrNameMap::default();
+        dict.insert(Arc::new("a".to_string()));
+        store.decode_entities(&mut r, 1, dict.len()).unwrap();
+
+        assert_eq!(
+            store.get_attr(&dict, 7, &Arc::new("a".to_string())),
+            Some(Value::Int(10)),
+            "an id inside the dictionary must be kept and reachable by name"
+        );
+        assert_eq!(
+            store.get_attr_by_idx(7, 5),
+            None,
+            "an id past the end of the dictionary must be dropped, not stored: it \
+             resolves to no name and would read back as a silently absent attribute"
+        );
+        assert_eq!(
+            store.get_all_attrs_by_id(7).count(),
+            1,
+            "only the in-range attribute should have been stored"
+        );
+    }
+
+    #[test]
+    fn decode_with_count_refuses_rather_than_skipping_the_bound() {
+        let mut store = AttributeStore::default();
+        let mut r = span_stream(7, &[(0, Value::Int(10))]);
+        let err = <AttributeStore as Decode<19>>::decode_with_count(&mut store, &mut r, 1)
+            .expect_err("must refuse: the trait signature cannot carry the id bound");
+        assert!(
+            err.contains("decode_entities"),
+            "the error should name the method that takes the bound, got: {err}"
+        );
     }
 }

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -183,6 +183,30 @@ impl AttrNameMap {
         self.vec.push(name.clone());
         self.index.insert(name, idx);
     }
+
+    /// Resolve `name` to its id, interning it if this graph has not seen it.
+    ///
+    /// The single place ids are minted. There is exactly one of these tables per
+    /// graph — shared by the node and relationship stores — so an id means the same
+    /// attribute wherever it appears: in a span, in the RDB, in a `GRAPH.EFFECT`, or
+    /// in a compact reply. Per-store tables would number the same name differently
+    /// for nodes and relationships, and a bare id on the wire would then land on the
+    /// wrong attribute on a replica (#2457).
+    ///
+    /// Matches C, whose `GraphContext_FindOrAddAttribute` likewise takes no entity
+    /// type and mints from one array.
+    pub fn get_or_create(
+        &mut self,
+        name: &Arc<String>,
+    ) -> u16 {
+        if let Some(&idx) = self.index.get(name) {
+            return idx;
+        }
+        let idx = self.vec.len() as u16;
+        self.vec.push(Arc::clone(name));
+        self.index.insert(Arc::clone(name), idx);
+        idx
+    }
 }
 
 impl std::ops::Index<usize> for AttrNameMap {
@@ -1003,12 +1027,18 @@ impl DataBlock {
 
 /// Attribute storage for graph entities, keyed by entity id.
 ///
-/// Holds the attribute-name table and a copy-on-write [`DataBlock`]. A slot
-/// miss means the entity has no attributes.
+/// A copy-on-write [`DataBlock`] of per-entity spans; a slot miss means the entity
+/// has no attributes.
+///
+/// **Deliberately does not own an attribute-name table.** The name → id dictionary
+/// lives once on [`crate::graph::graph::Graph`] and is passed to the methods that
+/// need it, so the node and relationship stores share one id space — the same shape
+/// as C, where `GraphContext` holds one `attributes` array for two `DataBlock`s.
+/// A table per store numbered the same name differently for nodes and relationships,
+/// and since a bare id travels on the wire in `GRAPH.EFFECT`, an RDB-seeded replica
+/// resolved it against different numbering and wrote to the wrong attribute (#2457).
 #[derive(Clone, Default)]
 pub struct AttributeStore {
-    /// Attribute names in insertion order (name → column index)
-    pub attrs_name: AttrNameMap,
     /// Block-allocated per-entity attribute spans (COW across MVCC versions).
     data: DataBlock,
 }
@@ -1036,10 +1066,11 @@ impl AttributeStore {
     #[must_use]
     pub fn get_attr(
         &self,
+        names: &AttrNameMap,
         key: u64,
         attr: &Arc<String>,
     ) -> Option<Value> {
-        let idx = self.attrs_name.get_index_of(attr)? as u16;
+        let idx = names.get_index_of(attr)? as u16;
         self.get_attr_by_idx(key, idx)
     }
 
@@ -1095,27 +1126,26 @@ impl AttributeStore {
         self.data.get(key).map_or(0, SpanRef::heap_bytes)
     }
 
-    pub fn get_attrs(
-        &self,
+    pub fn get_attrs<'a>(
+        &'a self,
+        names: &'a AttrNameMap,
         key: u64,
-    ) -> impl Iterator<Item = Arc<String>> + '_ {
+    ) -> impl Iterator<Item = Arc<String>> + 'a {
         self.data.get(key).into_iter().flat_map(move |span| {
             span.entries()
                 .iter()
-                .filter_map(move |attr| self.attrs_name.get(attr.id as usize).cloned())
+                .filter_map(move |attr| names.get(attr.id as usize).cloned())
         })
     }
 
-    pub fn get_all_attrs(
-        &self,
+    pub fn get_all_attrs<'a>(
+        &'a self,
+        names: &'a AttrNameMap,
         key: u64,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
+    ) -> impl Iterator<Item = (Arc<String>, Value)> + 'a {
         self.data.get(key).into_iter().flat_map(move |span| {
-            span.iter().filter_map(|(idx, value)| {
-                self.attrs_name
-                    .get(idx as usize)
-                    .map(|name| (name.clone(), value))
-            })
+            span.iter()
+                .filter_map(|(idx, value)| names.get(idx as usize).map(|n| (n.clone(), value)))
         })
     }
 
@@ -1220,25 +1250,6 @@ impl AttributeStore {
         nset
     }
 
-    /// Resolve an attribute name to its index, creating a new mapping if needed.
-    pub fn get_or_create_attr_id(
-        &mut self,
-        attr: &Arc<String>,
-    ) -> u16 {
-        self.attrs_name.get_index_of(attr).unwrap_or_else(|| {
-            self.attrs_name.insert(attr.clone());
-            self.attrs_name.len() - 1
-        }) as u16
-    }
-
-    #[must_use]
-    pub fn get_attr_id(
-        &self,
-        attr: &Arc<String>,
-    ) -> Option<usize> {
-        self.attrs_name.get_index_of(attr)
-    }
-
     /// Allocated bytes not attributable to any live entity — see
     /// [`DataBlock::structural_memory_usage`].
     #[must_use]
@@ -1249,29 +1260,18 @@ impl AttributeStore {
     // ---- serialization -----------------------------------------------------
 
     /// Encode a range of entities.
+    ///
+    /// Ids are written as they are stored: the graph has one attribute dictionary, so a
+    /// span's id is already the id the RDB means. This used to build a local → global
+    /// remap per call, which only existed because each store numbered names itself.
     pub fn encode_with_range(
         &self,
         w: &mut dyn Writer,
         deleted: &RoaringTreemap,
         max_id: u64,
-        global_attrs: &[Arc<String>],
         count: u64,
         offset: u64,
     ) {
-        // Build attr remap inline.
-        let global_index: FxHashMap<&Arc<String>, usize> = global_attrs
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n, i))
-            .collect();
-
-        let mut remap = vec![u16::MAX; self.attrs_name.len()];
-        for (local_id, local_name) in self.attrs_name.iter().enumerate() {
-            if let Some(&global_id) = global_index.get(local_name) {
-                remap[local_id] = global_id as u16;
-            }
-        }
-
         let mut skipped = 0u64;
         let mut encoded = 0u64;
 
@@ -1290,13 +1290,8 @@ impl AttributeStore {
             w.write_unsigned(span.map_or(0, |s| s.len() as u64));
 
             if let Some(span) = span {
-                for (local_attr_id, value) in span.iter() {
-                    let global_attr_id = if (local_attr_id as usize) < remap.len() {
-                        remap[local_attr_id as usize]
-                    } else {
-                        local_attr_id
-                    };
-                    w.write_unsigned(u64::from(global_attr_id));
+                for (attr_id, value) in span.iter() {
+                    w.write_unsigned(u64::from(attr_id));
                     value.encode(w);
                 }
             }
@@ -1309,15 +1304,20 @@ impl AttributeStore {
     }
 }
 
-impl Decode<19> for AttributeStore {
-    fn decode(_r: &mut dyn Reader) -> Result<Self, String> {
-        unimplemented!("use decode_with_count for AttributeStore")
-    }
-
-    fn decode_with_count(
+impl AttributeStore {
+    /// Decode `count` entity spans, dropping any attribute whose id is not in the
+    /// graph's dictionary.
+    ///
+    /// The id check needs the dictionary, which the store no longer owns, and
+    /// [`Decode::decode_with_count`] cannot take an extra parameter — so the real load
+    /// path calls this and the trait impl delegates with no limit. Without a limit a
+    /// malformed RDB can store an id that resolves to no name, which then reads back as
+    /// a silently absent attribute rather than an error.
+    pub fn decode_entities(
         &mut self,
         r: &mut dyn Reader,
         count: u64,
+        attr_limit: usize,
     ) -> Result<(), String> {
         for _ in 0..count {
             let entity_id = r.read_unsigned()?;
@@ -1328,7 +1328,7 @@ impl Decode<19> for AttributeStore {
                 let attr_id = r.read_unsigned()? as u16;
                 let value = Value::decode(r)?;
 
-                if (attr_id as usize) < self.attrs_name.len() && !matches!(value, Value::Null) {
+                if (attr_id as usize) < attr_limit && !matches!(value, Value::Null) {
                     entries.push((attr_id, value));
                 }
             }
@@ -1342,6 +1342,22 @@ impl Decode<19> for AttributeStore {
     }
 }
 
+impl Decode<19> for AttributeStore {
+    fn decode(_r: &mut dyn Reader) -> Result<Self, String> {
+        unimplemented!("use decode_with_count for AttributeStore")
+    }
+
+    fn decode_with_count(
+        &mut self,
+        r: &mut dyn Reader,
+        count: u64,
+    ) -> Result<(), String> {
+        // No dictionary here, so no id filtering — see `decode_entities`, which the
+        // load path uses precisely so the check keeps happening.
+        self.decode_entities(r, count, usize::MAX)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1350,8 +1366,78 @@ mod tests {
         Arc::new(s.to_string())
     }
 
-    fn store_with(entries: &[(u64, &[(&str, Value)])]) -> AttributeStore {
-        let mut store = AttributeStore::new();
+    /// A store paired with the attribute dictionary that now lives on `Graph`.
+    ///
+    /// These tests exercise span storage — copy-on-write, compaction, snapshot isolation
+    /// across versions — not where the dictionary lives, so pairing the two here keeps
+    /// them in their original shape. `Deref` forwards everything that does not need the
+    /// dictionary; the handful of methods that do are shadowed below.
+    #[derive(Clone, Default)]
+    struct TestStore {
+        names: AttrNameMap,
+        store: AttributeStore,
+    }
+
+    impl TestStore {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        /// Clones the dictionary alongside the store, which is what `Graph::new_version`
+        /// does — so snapshot-isolation tests still see a version's own name table.
+        fn new_version(&self) -> Self {
+            Self {
+                names: self.names.clone(),
+                store: self.store.new_version(),
+            }
+        }
+
+        fn get_or_create_attr_id(
+            &mut self,
+            attr: &Arc<String>,
+        ) -> u16 {
+            self.names.get_or_create(attr)
+        }
+
+        fn get_attr_id(
+            &self,
+            attr: &Arc<String>,
+        ) -> Option<usize> {
+            self.names.get_index_of(attr)
+        }
+
+        fn get_attr(
+            &self,
+            key: u64,
+            attr: &Arc<String>,
+        ) -> Option<Value> {
+            self.store.get_attr(&self.names, key, attr)
+        }
+
+        fn get_all_attrs(
+            &self,
+            key: u64,
+        ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
+            self.store.get_all_attrs(&self.names, key)
+        }
+    }
+
+    impl std::ops::Deref for TestStore {
+        type Target = AttributeStore;
+
+        fn deref(&self) -> &AttributeStore {
+            &self.store
+        }
+    }
+
+    impl std::ops::DerefMut for TestStore {
+        fn deref_mut(&mut self) -> &mut AttributeStore {
+            &mut self.store
+        }
+    }
+
+    fn store_with(entries: &[(u64, &[(&str, Value)])]) -> TestStore {
+        let mut store = TestStore::new();
         let mut attrs: FxHashMap<u64, Vec<(u16, Value)>> = FxHashMap::default();
         for (id, pairs) in entries {
             let mut vec: Vec<(u16, Value)> = pairs
@@ -1399,7 +1485,7 @@ mod tests {
             )),
             Value::VecF32(Arc::new([1.0f32, -2.5].into_iter().collect())),
         ];
-        let mut store = AttributeStore::new();
+        let mut store = TestStore::new();
         let pairs: Vec<(u16, Value)> = values
             .iter()
             .cloned()
@@ -1490,7 +1576,7 @@ mod tests {
 
     #[test]
     fn compaction_reclaims_abandoned_spans() {
-        let mut store = AttributeStore::new();
+        let mut store = TestStore::new();
         for i in 0..200u16 {
             store.get_or_create_attr_id(&name(&format!("a{i:03}")));
         }

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -1064,17 +1064,6 @@ impl AttributeStore {
     // ---- read path --------------------------------------------------------
 
     #[must_use]
-    pub fn get_attr(
-        &self,
-        names: &AttrNameMap,
-        key: u64,
-        attr: &Arc<String>,
-    ) -> Option<Value> {
-        let idx = names.get_index_of(attr)? as u16;
-        self.get_attr_by_idx(key, idx)
-    }
-
-    #[must_use]
     pub fn get_attr_by_idx(
         &self,
         key: u64,
@@ -1126,27 +1115,18 @@ impl AttributeStore {
         self.data.get(key).map_or(0, SpanRef::heap_bytes)
     }
 
-    pub fn get_attrs<'a>(
-        &'a self,
-        names: &'a AttrNameMap,
+    /// The attribute ids an entity carries.
+    ///
+    /// Reads only the span's ids, so it stays cheaper than [`Self::get_all_attrs_by_id`]
+    /// when the values are not wanted.
+    pub fn get_attr_ids(
+        &self,
         key: u64,
-    ) -> impl Iterator<Item = Arc<String>> + 'a {
-        self.data.get(key).into_iter().flat_map(move |span| {
-            span.entries()
-                .iter()
-                .filter_map(move |attr| names.get(attr.id as usize).cloned())
-        })
-    }
-
-    pub fn get_all_attrs<'a>(
-        &'a self,
-        names: &'a AttrNameMap,
-        key: u64,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> + 'a {
-        self.data.get(key).into_iter().flat_map(move |span| {
-            span.iter()
-                .filter_map(|(idx, value)| names.get(idx as usize).map(|n| (n.clone(), value)))
-        })
+    ) -> impl Iterator<Item = u16> + '_ {
+        self.data
+            .get(key)
+            .into_iter()
+            .flat_map(|span| span.entries().iter().map(|attr| attr.id))
     }
 
     pub fn get_all_attrs_by_id(
@@ -1421,14 +1401,19 @@ mod tests {
             key: u64,
             attr: &Arc<String>,
         ) -> Option<Value> {
-            self.store.get_attr(&self.names, key, attr)
+            let idx = self.names.get_index_of(attr)? as u16;
+            self.store.get_attr_by_idx(key, idx)
         }
 
         fn get_all_attrs(
             &self,
             key: u64,
         ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
-            self.store.get_all_attrs(&self.names, key)
+            self.store
+                .get_all_attrs_by_id(key)
+                .filter_map(|(id, value)| self.names.get(id as usize).map(|n| (n.clone(), value)))
+                .collect::<Vec<_>>()
+                .into_iter()
         }
     }
 
@@ -1928,9 +1913,14 @@ mod tests {
         store.decode_entities(&mut r, 1, dict.len()).unwrap();
 
         assert_eq!(
-            store.get_attr(&dict, 7, &Arc::new("a".to_string())),
+            store.get_attr_by_idx(7, 0),
             Some(Value::Int(10)),
-            "an id inside the dictionary must be kept and reachable by name"
+            "an id inside the dictionary must be kept"
+        );
+        assert_eq!(
+            dict.get(0).cloned(),
+            Some(Arc::new("a".to_string())),
+            "and that id must be the one the dictionary resolves to a name"
         );
         assert_eq!(
             store.get_attr_by_idx(7, 5),

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -4166,3 +4166,87 @@ impl Graph {
         self.attrs_name.iter().cloned().collect()
     }
 }
+
+#[cfg(test)]
+mod attr_id_space_tests {
+    use super::super::graphblas::test_init::ensure_init;
+    use super::*;
+
+    fn attr(s: &str) -> Arc<String> {
+        Arc::new(s.to_string())
+    }
+
+    /// A name has one id, whichever kind of entity introduced it.
+    ///
+    /// This is the invariant behind #2457. With a dictionary per store, `since` was
+    /// registered only in the relationship table, so it got relationship-local id 0 —
+    /// colliding with the *node* attribute already holding node-local id 0. Effects put a
+    /// bare id on the wire, so a replica whose dictionary came from an RDB (one unified
+    /// table) resolved that 0 to the wrong attribute.
+    #[test]
+    fn one_id_per_name_across_entity_kinds() {
+        ensure_init();
+        let mut g = Graph::new(16, 16, 1, 0, "attr_id_space");
+
+        // Node attributes first, so a per-store numbering would start relationships back
+        // at 0 and collide with `a`.
+        let a = g.get_or_create_node_attr_id(&attr("a"));
+        let b = g.get_or_create_node_attr_id(&attr("b"));
+        // Then a relationship-only attribute.
+        let since = g.get_or_create_rel_attr_id(&attr("since"));
+
+        assert_eq!(a, 0);
+        assert_eq!(b, 1);
+        // The bug: this was 0 — the relationship table's first slot.
+        assert_eq!(
+            since, 2,
+            "a relationship attribute must not restart numbering"
+        );
+
+        // Every accessor agrees, because there is only one dictionary to disagree about.
+        for (name, expected) in [("a", 0usize), ("b", 1), ("since", 2)] {
+            let n = attr(name);
+            assert_eq!(g.get_node_attribute_id(&n), Some(expected));
+            assert_eq!(g.get_relationship_attribute_id(&n), Some(expected));
+            assert_eq!(g.get_global_attribute_id(&n), Some(expected));
+        }
+
+        // Re-registering under the other entity kind must not mint a second id.
+        assert_eq!(g.get_or_create_rel_attr_id(&attr("a")), 0);
+        assert_eq!(g.get_or_create_node_attr_id(&attr("since")), 2);
+        assert_eq!(g.build_global_attrs().len(), 3);
+    }
+
+    /// The RDB's flat list and the live dictionary are the same numbering.
+    ///
+    /// A full sync seeds a replica from `build_global_attrs()`. If that list disagreed
+    /// with the ids the master stamps into effects, the replica would misresolve them —
+    /// which is exactly how #2457 manifested.
+    #[test]
+    fn rdb_attr_list_matches_live_ids() {
+        ensure_init();
+        let mut g = Graph::new(16, 16, 1, 0, "attr_id_rdb");
+        g.get_or_create_node_attr_id(&attr("a"));
+        let since = g.get_or_create_rel_attr_id(&attr("since"));
+        g.get_or_create_node_attr_id(&attr("b"));
+
+        let list = g.build_global_attrs();
+
+        // The load-bearing one: an id the master stamps into an effect has to index the
+        // same name in the list a replica is seeded from. Split numbering broke exactly
+        // this — `since` was relationship-local 0, and position 0 of the list is `a`.
+        assert_eq!(
+            list.get(since as usize).map(|s| s.as_str()),
+            Some("since"),
+            "the id put on the wire does not index its own name in the RDB list"
+        );
+
+        for (id, name) in list.iter().enumerate() {
+            assert_eq!(
+                g.get_global_attribute_id(name),
+                Some(id),
+                "RDB position {id} disagrees with the live id for {name}"
+            );
+        }
+    }
+}

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -944,16 +944,14 @@ impl Graph {
     }
 
     /// Number of distinct property keys across nodes and relationships.
+    ///
+    /// Just the dictionary's length: there is one table per graph and it is keyed
+    /// by name, so entries are distinct by construction. This used to union two
+    /// per-store tables through a `HashSet`; after they were merged the union
+    /// became the same table twice.
     #[must_use]
-    pub fn property_key_count(&self) -> usize {
-        let mut seen = std::collections::HashSet::new();
-        for name in &self.attrs_name {
-            seen.insert(name.as_str());
-        }
-        for name in &self.attrs_name {
-            seen.insert(name.as_str());
-        }
-        seen.len()
+    pub const fn property_key_count(&self) -> usize {
+        self.attrs_name.len()
     }
 
     #[must_use]

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -86,7 +86,7 @@ use roaring::RoaringTreemap;
 use crate::{
     entity_type::EntityType,
     graph::{
-        attribute_store::AttributeStore,
+        attribute_store::{AttrNameMap, AttributeStore},
         constraint::{Constraint, ConstraintStatus, ConstraintType},
         graphblas::{
             matrix::{Descriptor, Dup, Matrix},
@@ -296,6 +296,16 @@ pub struct Graph {
     /// version pays one `Arc::make_mut` deep clone, node-only writes pay
     /// nothing. Empty/deleted slots hold [`EDGE_NO_ENDPOINT`].
     edge_endpoints: Arc<Vec<u64>>,
+    /// The graph's one attribute-name dictionary: name → id and id → name, shared by
+    /// both stores below so an id means the same attribute everywhere it appears — in a
+    /// span, the RDB, a `GRAPH.EFFECT`, or a compact reply.
+    ///
+    /// Deliberately *not* per store. Two dictionaries numbered the same name
+    /// differently for nodes and relationships, and because effects put a bare id on
+    /// the wire, an RDB-seeded replica resolved it against different numbering and wrote
+    /// to the wrong attribute (#2457). C has the same shape: one `attributes` array on
+    /// `GraphContext`, two `DataBlock`s.
+    attrs_name: AttrNameMap,
     /// Node property storage
     node_attrs: AttributeStore,
     /// Relationship property storage
@@ -697,6 +707,7 @@ impl Graph {
             labels_matices: Vec::new(),
             relationship_matrices: Vec::new(),
             edge_endpoints: Arc::new(Vec::new()),
+            attrs_name: AttrNameMap::default(),
             node_attrs: AttributeStore::new(),
             relationship_attrs: AttributeStore::new(),
             node_indexer: Indexer::default(),
@@ -733,6 +744,7 @@ impl Graph {
         relationship_matrices: Vec<Tensor>,
         node_labels: Vec<Arc<String>>,
         relationship_types: Vec<Arc<String>>,
+        attrs_name: AttrNameMap,
         node_attrs: AttributeStore,
         relationship_attrs: AttributeStore,
     ) -> Self {
@@ -773,6 +785,7 @@ impl Graph {
             labels_matices,
             relationship_matrices,
             edge_endpoints: Arc::new(edge_endpoints),
+            attrs_name,
             node_attrs,
             relationship_attrs,
             node_indexer: Indexer::default(),
@@ -838,6 +851,8 @@ impl Graph {
     pub fn new_version(&self) -> Self {
         debug_assert_eq!(self.reserved_node_count, 0);
         debug_assert_eq!(self.reserved_relationship_count, 0);
+        // One dictionary clone per version instead of the two the split tables cost.
+        let attrs_name = self.attrs_name.clone();
         let node_attrs = self.node_attrs.new_version();
         let relationship_attrs = self.relationship_attrs.new_version();
 
@@ -869,6 +884,7 @@ impl Graph {
                 .collect(),
             relationship_matrices,
             edge_endpoints: self.edge_endpoints.clone(),
+            attrs_name,
             node_attrs,
             relationship_attrs,
             node_indexer: self.node_indexer.clone(),
@@ -931,10 +947,10 @@ impl Graph {
     #[must_use]
     pub fn property_key_count(&self) -> usize {
         let mut seen = std::collections::HashSet::new();
-        for name in &self.node_attrs.attrs_name {
+        for name in &self.attrs_name {
             seen.insert(name.as_str());
         }
-        for name in &self.relationship_attrs.attrs_name {
+        for name in &self.attrs_name {
             seen.insert(name.as_str());
         }
         seen.len()
@@ -976,18 +992,13 @@ impl Graph {
         self.relationship_types.get(id.0).cloned()
     }
 
+    /// The graph's attribute names in id order; position is the id.
+    ///
+    /// Was a deduplicated union of two per-store tables, walked once per property on the
+    /// relationship reply path. With one dictionary it is a plain iteration and the
+    /// per-call `HashSet` is gone.
     pub fn get_attrs(&self) -> impl Iterator<Item = &Arc<String>> + '_ {
-        // Deduplicate by borrowed `&str` rather than owned `String`: this
-        // iterator is walked once per property on the relationship reply path
-        // (via `get_global_attribute_id` / `rel_attr_id_to_global`), so a
-        // per-attribute heap allocation here shows up as O(props * attrs)
-        // allocations when serializing results.
-        let mut seen = std::collections::HashSet::<&str>::new();
-        self.node_attrs
-            .attrs_name
-            .iter()
-            .chain(self.relationship_attrs.attrs_name.iter())
-            .filter(move |a| seen.insert(a.as_str()))
+        self.attrs_name.iter()
     }
 
     pub fn get_label_id_mut(
@@ -1230,12 +1241,12 @@ impl Graph {
         &self,
         attr: &Arc<String>,
     ) -> Option<usize> {
-        self.node_attrs.get_attr_id(attr)
+        self.attrs_name.get_index_of(attr)
     }
 
     #[must_use]
     pub const fn node_attribute_count(&self) -> usize {
-        self.node_attrs.attrs_name.len()
+        self.attrs_name.len()
     }
 
     #[must_use]
@@ -1243,27 +1254,20 @@ impl Graph {
         &self,
         attr: &Arc<String>,
     ) -> Option<usize> {
-        self.relationship_attrs.get_attr_id(attr)
+        self.attrs_name.get_index_of(attr)
     }
 
-    /// Return the global property ID for `attr`, matching the index in `get_attrs()`.
-    /// Node attrs come first; relationship-only attrs follow.
+    /// The id for `attr`, or `None` if this graph has never seen the name.
+    ///
+    /// Was an O(N) scan over a union of two per-store tables, per property serialized.
+    /// There is one dictionary now, so it is the dictionary's own lookup — and node,
+    /// relationship and "global" ids are the same thing.
     #[must_use]
     pub fn get_global_attribute_id(
         &self,
         attr: &Arc<String>,
     ) -> Option<usize> {
-        self.get_attrs().position(|a| a == attr)
-    }
-
-    /// Convert a relationship-local attribute ID to the global property ID.
-    #[must_use]
-    pub fn rel_attr_id_to_global(
-        &self,
-        local_id: u16,
-    ) -> Option<usize> {
-        let name = self.relationship_attrs.attrs_name.get(local_id as usize)?;
-        self.get_attrs().position(|a| a == name)
+        self.attrs_name.get_index_of(attr)
     }
 
     pub fn return_node_id(
@@ -1396,7 +1400,7 @@ impl Graph {
                 for (_, label_id) in self.node_labels_matrix.iter(*id, *id) {
                     let label = &self.node_labels[label_id as usize];
                     for (attr_id, _) in attrs {
-                        let Some(key) = self.node_attrs.attrs_name.get(*attr_id as usize) else {
+                        let Some(key) = self.attrs_name.get(*attr_id as usize) else {
                             continue;
                         };
                         if self.node_indexer.has_indexed_attr(label, key) {
@@ -1432,7 +1436,7 @@ impl Graph {
                 for &label_id in label_ids {
                     let label = &self.node_labels[label_id as usize];
                     for (attr_id, _) in attrs {
-                        let Some(key) = self.node_attrs.attrs_name.get(*attr_id as usize) else {
+                        let Some(key) = self.attrs_name.get(*attr_id as usize) else {
                             continue;
                         };
                         if self.node_indexer.has_indexed_attr(label, key) {
@@ -1470,7 +1474,7 @@ impl Graph {
                 for label_id in label_ids {
                     let label = &self.node_labels[label_id.0];
                     for (attr_id, _) in attrs {
-                        let Some(key) = self.node_attrs.attrs_name.get(*attr_id as usize) else {
+                        let Some(key) = self.attrs_name.get(*attr_id as usize) else {
                             continue;
                         };
                         if self.node_indexer.has_indexed_attr(label, key) {
@@ -1491,7 +1495,7 @@ impl Graph {
         &mut self,
         attr: &Arc<String>,
     ) -> u16 {
-        self.node_attrs.get_or_create_attr_id(attr)
+        self.attrs_name.get_or_create(attr)
     }
 
     /// Resolve a node attribute name to its index, if it exists.
@@ -1500,10 +1504,7 @@ impl Graph {
         &self,
         attr: &Arc<String>,
     ) -> Option<u16> {
-        self.node_attrs
-            .attrs_name
-            .get_index_of(attr)
-            .map(|i| i as u16)
+        self.attrs_name.get_index_of(attr).map(|i| i as u16)
     }
 
     /// Node attribute name for an index.
@@ -1512,7 +1513,7 @@ impl Graph {
         &self,
         attr_id: u16,
     ) -> Option<Arc<String>> {
-        self.node_attrs.attrs_name.get(attr_id as usize).cloned()
+        self.attrs_name.get(attr_id as usize).cloned()
     }
 
     /// Resolve a relationship attribute name to its index, if it exists.
@@ -1521,10 +1522,7 @@ impl Graph {
         &self,
         attr: &Arc<String>,
     ) -> Option<u16> {
-        self.relationship_attrs
-            .attrs_name
-            .get_index_of(attr)
-            .map(|i| i as u16)
+        self.attrs_name.get_index_of(attr).map(|i| i as u16)
     }
 
     /// Relationship attribute name for an index.
@@ -1533,10 +1531,7 @@ impl Graph {
         &self,
         attr_id: u16,
     ) -> Option<Arc<String>> {
-        self.relationship_attrs
-            .attrs_name
-            .get(attr_id as usize)
-            .cloned()
+        self.attrs_name.get(attr_id as usize).cloned()
     }
 
     /// Import pre-resolved relationship attributes directly into the cache.
@@ -1564,7 +1559,7 @@ impl Graph {
         &mut self,
         attr: &Arc<String>,
     ) -> u16 {
-        self.relationship_attrs.get_or_create_attr_id(attr)
+        self.attrs_name.get_or_create(attr)
     }
 
     pub fn import_relationship_attrs(
@@ -1599,7 +1594,7 @@ impl Graph {
         let type_name = &self.relationship_types[type_id.0];
         for (id, attrs) in attrs {
             for (attr_id, _) in attrs {
-                let Some(key) = self.relationship_attrs.attrs_name.get(*attr_id as usize) else {
+                let Some(key) = self.attrs_name.get(*attr_id as usize) else {
                     continue;
                 };
                 if self.edge_indexer.has_indexed_attr(type_name, key) {
@@ -1624,7 +1619,7 @@ impl Graph {
             let type_id = self.get_relationship_type_id(RelationshipId(*id));
             let type_name = &self.relationship_types[type_id.0];
             for (attr_id, _) in attrs {
-                let Some(key) = self.relationship_attrs.attrs_name.get(*attr_id as usize) else {
+                let Some(key) = self.attrs_name.get(*attr_id as usize) else {
                     continue;
                 };
                 if self.edge_indexer.has_indexed_attr(type_name, key) {
@@ -1762,7 +1757,7 @@ impl Graph {
 
             let label = &self.node_labels[lid];
             if self.node_indexer.has_index(label) {
-                for attr in self.node_attrs.get_attrs(node_id) {
+                for attr in self.node_attrs.get_attrs(&self.attrs_name, node_id) {
                     if self.node_indexer.has_indexed_attr(label, &attr) {
                         remove_docs.entry(label_id).or_default().insert(node_id);
                         break;
@@ -1978,7 +1973,7 @@ impl Graph {
         id: NodeId,
         attr: &Arc<String>,
     ) -> Option<Value> {
-        self.node_attrs.get_attr(id.0, attr)
+        self.node_attrs.get_attr(&self.attrs_name, id.0, attr)
     }
 
     /// Fetches a node attribute using a pre-resolved attribute index.
@@ -2719,7 +2714,8 @@ impl Graph {
         id: RelationshipId,
         attr: &Arc<String>,
     ) -> Option<Value> {
-        self.relationship_attrs.get_attr(id.0, attr)
+        self.relationship_attrs
+            .get_attr(&self.attrs_name, id.0, attr)
     }
 
     /// Fetches a relationship attribute using a pre-resolved attribute
@@ -2805,7 +2801,7 @@ impl Graph {
         &self,
         id: NodeId,
     ) -> impl Iterator<Item = Arc<String>> + '_ {
-        self.node_attrs.get_attrs(id.0)
+        self.node_attrs.get_attrs(&self.attrs_name, id.0)
     }
 
     /// Get all attribute names and values for a node in a single storage pass.
@@ -2813,7 +2809,7 @@ impl Graph {
         &self,
         id: NodeId,
     ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
-        self.node_attrs.get_all_attrs(id.0)
+        self.node_attrs.get_all_attrs(&self.attrs_name, id.0)
     }
 
     pub fn get_node_all_attrs_by_id(
@@ -2836,7 +2832,7 @@ impl Graph {
         &self,
         id: RelationshipId,
     ) -> impl Iterator<Item = Arc<String>> + '_ {
-        self.relationship_attrs.get_attrs(id.0)
+        self.relationship_attrs.get_attrs(&self.attrs_name, id.0)
     }
 
     /// Get all attribute names and values for a relationship in a single storage pass.
@@ -2844,7 +2840,8 @@ impl Graph {
         &self,
         id: RelationshipId,
     ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
-        self.relationship_attrs.get_all_attrs(id.0)
+        self.relationship_attrs
+            .get_all_attrs(&self.attrs_name, id.0)
     }
 
     pub fn get_relationship_all_attrs_by_id(
@@ -3003,7 +3000,10 @@ impl Graph {
                     // create+free churn).
                     let mut doc: Option<Document> = None;
                     for (attr, fields) in &attrs {
-                        if let Some(value) = self.relationship_attrs.get_attr(eid, attr) {
+                        if let Some(value) =
+                            self.relationship_attrs
+                                .get_attr(&self.attrs_name, eid, attr)
+                        {
                             let doc = doc.get_or_insert_with(|| Document::new_edge(src, dst, eid));
                             for field in fields {
                                 doc.set(field, &value);
@@ -3124,7 +3124,8 @@ impl Graph {
                 };
                 let mut doc = Document::new_edge(src, dst, id);
                 for (key, fields) in &fields {
-                    if let Some(value) = self.relationship_attrs.get_attr(id, key) {
+                    if let Some(value) = self.relationship_attrs.get_attr(&self.attrs_name, id, key)
+                    {
                         for field in fields {
                             doc.set(field, &value);
                         }
@@ -3176,7 +3177,7 @@ impl Graph {
             for id in ids {
                 let mut doc = Document::new(id);
                 for (key, fields) in &fields {
-                    if let Some(value) = attr_store.get_attr(id, key) {
+                    if let Some(value) = attr_store.get_attr(&self.attrs_name, id, key) {
                         for field in fields {
                             doc.set(field, &value);
                         }
@@ -4071,7 +4072,6 @@ impl Graph {
         &self,
         w: &mut dyn Writer,
         p: &PayloadEntry,
-        global_attrs: &[Arc<String>],
     ) {
         match p.state {
             EncodeState::Nodes => {
@@ -4079,7 +4079,6 @@ impl Graph {
                     w,
                     &self.deleted_nodes,
                     self.max_node_id(),
-                    global_attrs,
                     p.count,
                     p.offset,
                 );
@@ -4092,7 +4091,6 @@ impl Graph {
                     w,
                     &self.deleted_relationships,
                     self.max_relationship_id(),
-                    global_attrs,
                     p.count,
                     p.offset,
                 );
@@ -4125,13 +4123,13 @@ impl Graph {
     /// Get node attribute names.
     #[must_use]
     pub fn get_node_attribute_names(&self) -> Vec<Arc<String>> {
-        self.node_attrs.attrs_name.iter().cloned().collect()
+        self.attrs_name.iter().cloned().collect()
     }
 
     /// Get relationship attribute names.
     #[must_use]
     pub fn get_relationship_attribute_names(&self) -> Vec<Arc<String>> {
-        self.relationship_attrs.attrs_name.iter().cloned().collect()
+        self.attrs_name.iter().cloned().collect()
     }
 
     /// Register a node attribute name (get-or-create). Used by effect
@@ -4141,8 +4139,8 @@ impl Graph {
         name: &str,
     ) {
         let arc = Arc::new(name.to_string());
-        if self.node_attrs.attrs_name.get_index_of(&arc).is_none() {
-            self.node_attrs.attrs_name.insert(arc);
+        if self.attrs_name.get_index_of(&arc).is_none() {
+            self.attrs_name.insert(arc);
         }
     }
 
@@ -4152,32 +4150,19 @@ impl Graph {
         &mut self,
         name: &str,
     ) {
-        let arc = Arc::new(name.to_string());
-        if self
-            .relationship_attrs
-            .attrs_name
-            .get_index_of(&arc)
-            .is_none()
-        {
-            self.relationship_attrs.attrs_name.insert(arc);
-        }
+        // Identical to `add_node_attribute_name` now that there is one dictionary. Both
+        // are kept because the effects wire still carries an ATTR_NODE/ATTR_REL
+        // discriminator, which is vestigial from here on and is removed with the
+        // `EFFECTS_VERSION` bump in #2419.
+        self.attrs_name.insert(Arc::new(name.to_string()));
     }
 
-    /// Build the unified global attribute list (node attrs ∪ relationship attrs, in order).
+    /// The graph's attribute names, in id order — index *is* the id.
+    ///
+    /// Was a node ∪ relationship union over two dictionaries; with one dictionary it is
+    /// simply that dictionary's contents, and the RDB's flat table is the same list.
     #[must_use]
     pub fn build_global_attrs(&self) -> Vec<Arc<String>> {
-        let mut attrs = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        for name in &self.node_attrs.attrs_name {
-            if seen.insert(name.clone()) {
-                attrs.push(name.clone());
-            }
-        }
-        for name in &self.relationship_attrs.attrs_name {
-            if seen.insert(name.clone()) {
-                attrs.push(name.clone());
-            }
-        }
-        attrs
+        self.attrs_name.iter().cloned().collect()
     }
 }

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1757,7 +1757,7 @@ impl Graph {
 
             let label = &self.node_labels[lid];
             if self.node_indexer.has_index(label) {
-                for attr in self.node_attrs.get_attrs(&self.attrs_name, node_id) {
+                for attr in self.attr_names(&self.node_attrs, node_id) {
                     if self.node_indexer.has_indexed_attr(label, &attr) {
                         remove_docs.entry(label_id).or_default().insert(node_id);
                         break;
@@ -1973,7 +1973,7 @@ impl Graph {
         id: NodeId,
         attr: &Arc<String>,
     ) -> Option<Value> {
-        self.node_attrs.get_attr(&self.attrs_name, id.0, attr)
+        self.attr_by_name(&self.node_attrs, id.0, attr)
     }
 
     /// Fetches a node attribute using a pre-resolved attribute index.
@@ -2714,8 +2714,7 @@ impl Graph {
         id: RelationshipId,
         attr: &Arc<String>,
     ) -> Option<Value> {
-        self.relationship_attrs
-            .get_attr(&self.attrs_name, id.0, attr)
+        self.attr_by_name(&self.relationship_attrs, id.0, attr)
     }
 
     /// Fetches a relationship attribute using a pre-resolved attribute
@@ -2797,11 +2796,53 @@ impl Graph {
         }
     }
 
+    // ---- attribute name resolution ----------------------------------------
+    //
+    // `AttributeStore` is an id-keyed structure and does not own the name table;
+    // the graph does. These three resolve between the two, so the store's API stays
+    // honest about what it can answer on its own and no caller has to pass the
+    // graph's dictionary back into it.
+
+    /// Value of a named attribute on an entity in `store`.
+    fn attr_by_name(
+        &self,
+        store: &AttributeStore,
+        key: u64,
+        attr: &Arc<String>,
+    ) -> Option<Value> {
+        let idx = self.attrs_name.get_index_of(attr)? as u16;
+        store.get_attr_by_idx(key, idx)
+    }
+
+    /// Names of the attributes an entity in `store` carries.
+    fn attr_names<'a>(
+        &'a self,
+        store: &'a AttributeStore,
+        key: u64,
+    ) -> impl Iterator<Item = Arc<String>> + 'a {
+        store
+            .get_attr_ids(key)
+            .filter_map(move |id| self.attrs_name.get(id as usize).cloned())
+    }
+
+    /// Name/value pairs for an entity in `store`, in one storage pass.
+    fn attr_pairs<'a>(
+        &'a self,
+        store: &'a AttributeStore,
+        key: u64,
+    ) -> impl Iterator<Item = (Arc<String>, Value)> + 'a {
+        store
+            .get_all_attrs_by_id(key)
+            .filter_map(move |(id, value)| {
+                self.attrs_name.get(id as usize).map(|n| (n.clone(), value))
+            })
+    }
+
     pub fn get_node_attrs(
         &self,
         id: NodeId,
     ) -> impl Iterator<Item = Arc<String>> + '_ {
-        self.node_attrs.get_attrs(&self.attrs_name, id.0)
+        self.attr_names(&self.node_attrs, id.0)
     }
 
     /// Get all attribute names and values for a node in a single storage pass.
@@ -2809,7 +2850,7 @@ impl Graph {
         &self,
         id: NodeId,
     ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
-        self.node_attrs.get_all_attrs(&self.attrs_name, id.0)
+        self.attr_pairs(&self.node_attrs, id.0)
     }
 
     pub fn get_node_all_attrs_by_id(
@@ -2832,7 +2873,7 @@ impl Graph {
         &self,
         id: RelationshipId,
     ) -> impl Iterator<Item = Arc<String>> + '_ {
-        self.relationship_attrs.get_attrs(&self.attrs_name, id.0)
+        self.attr_names(&self.relationship_attrs, id.0)
     }
 
     /// Get all attribute names and values for a relationship in a single storage pass.
@@ -2840,8 +2881,7 @@ impl Graph {
         &self,
         id: RelationshipId,
     ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
-        self.relationship_attrs
-            .get_all_attrs(&self.attrs_name, id.0)
+        self.attr_pairs(&self.relationship_attrs, id.0)
     }
 
     pub fn get_relationship_all_attrs_by_id(
@@ -3000,9 +3040,7 @@ impl Graph {
                     // create+free churn).
                     let mut doc: Option<Document> = None;
                     for (attr, fields) in &attrs {
-                        if let Some(value) =
-                            self.relationship_attrs
-                                .get_attr(&self.attrs_name, eid, attr)
+                        if let Some(value) = self.attr_by_name(&self.relationship_attrs, eid, attr)
                         {
                             let doc = doc.get_or_insert_with(|| Document::new_edge(src, dst, eid));
                             for field in fields {
@@ -3124,8 +3162,7 @@ impl Graph {
                 };
                 let mut doc = Document::new_edge(src, dst, id);
                 for (key, fields) in &fields {
-                    if let Some(value) = self.relationship_attrs.get_attr(&self.attrs_name, id, key)
-                    {
+                    if let Some(value) = self.attr_by_name(&self.relationship_attrs, id, key) {
                         for field in fields {
                             doc.set(field, &value);
                         }
@@ -3177,7 +3214,7 @@ impl Graph {
             for id in ids {
                 let mut doc = Document::new(id);
                 for (key, fields) in &fields {
-                    if let Some(value) = attr_store.get_attr(&self.attrs_name, id, key) {
+                    if let Some(value) = self.attr_by_name(attr_store, id, key) {
                         for field in fields {
                             doc.set(field, &value);
                         }

--- a/graph/src/graph/graphblas/serialization.rs
+++ b/graph/src/graph/graphblas/serialization.rs
@@ -64,12 +64,22 @@ pub trait Decode<const VERSION: u64>: Sized {
     fn decode(r: &mut dyn Reader) -> Result<Self, String>;
 
     /// Decode `count` entities from the reader into `self`.
+    ///
+    /// `attr_limit` is the length of the graph's attribute dictionary: any
+    /// attribute id at or above it names nothing and must be dropped. It rides on
+    /// the trait rather than on an inherent method so the bound cannot be skipped
+    /// — an earlier revision had `AttributeStore` satisfy this signature by
+    /// assuming `usize::MAX`, which silently disabled the check on two of the
+    /// three load paths, including the multi-key one (every graph large enough to
+    /// be split across virtual keys). Implementors that decode no attributes
+    /// ignore it.
     fn decode_with_count(
         &mut self,
         r: &mut dyn Reader,
         count: u64,
+        attr_limit: usize,
     ) -> Result<(), String> {
-        let _ = (r, count);
+        let _ = (r, count, attr_limit);
         unimplemented!()
     }
 }
@@ -196,6 +206,7 @@ impl Decode<19> for RoaringTreemap {
         &mut self,
         r: &mut dyn Reader,
         count: u64,
+        _attr_limit: usize,
     ) -> Result<(), String> {
         let bytes = r.read_buffer()?;
         let expected_len = count as usize * 8;

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -205,19 +205,51 @@ unsafe extern "C" fn graph_rdb_save(
 // aux_save / aux_load
 // ---------------------------------------------------------------------------
 
+/// Write a NUL-terminated string, matching C's
+/// `RedisModule_SaveStringBuffer(io, s, strlen(s) + 1)`.
+///
+/// `save_string` writes exactly `s.len()` bytes. C reads these buffers back as C
+/// strings, so one arriving without its terminator leaves C reading whatever
+/// follows it in the RDB: a library saved here as `XLib` loaded there as
+/// `XLibte`, and none of its functions could be found afterwards. The listing
+/// still showed a library, so it failed quietly.
+fn save_string_nul(
+    rdb: *mut RedisModuleIO,
+    s: &str,
+) {
+    let mut buf = String::with_capacity(s.len() + 1);
+    buf.push_str(s);
+    buf.push('\0');
+    save_string(rdb, &buf);
+}
+
+/// Drop the trailing NUL that both engines now write.
+///
+/// Without this a name read back from C is `"XLib\0"`, which registers nothing
+/// findable and makes `deserialize` fail — and a failed aux load is not a
+/// degraded load, it aborts the whole RDB: Redis reported
+/// `Short read or OOM loading DB. Unrecoverable error, aborting now.` and the
+/// server refused to start. One NUL is stripped rather than all trailing ones, so
+/// a name that legitimately ends in NUL bytes is not silently altered further.
+fn strip_trailing_nul(buf: &[u8]) -> String {
+    let end = buf.strip_suffix(b"\0").unwrap_or(buf);
+    String::from_utf8_lossy(end).to_string()
+}
+
 #[unsafe(no_mangle)]
 unsafe extern "C" fn graph_aux_save(
     rdb: *mut RedisModuleIO,
     when: i32,
 ) {
     if when == raw::Aux::Before as i32 {
-        // BEFORE_RDB: Save UDF libraries.
+        // BEFORE_RDB: Save UDF libraries. C's `AUXSave` writes exactly this —
+        // count, then a NUL-terminated (name, script) per library.
         let repo = get_udf_repo();
         let libs = repo.serialize();
         save_unsigned(rdb, libs.len() as u64);
         for (name, code) in &libs {
-            save_string(rdb, name);
-            save_string(rdb, code);
+            save_string_nul(rdb, name);
+            save_string_nul(rdb, code);
         }
     } else {
         // AFTER_RDB: Write placeholder so aux_load(AFTER_RDB) has something to read.
@@ -241,11 +273,11 @@ unsafe extern "C" fn graph_aux_load(
         let mut libs = Vec::with_capacity(count as usize);
         for _ in 0..count {
             let name = match load_string_buffer(rdb) {
-                Ok(buf) => String::from_utf8_lossy(buf.as_ref()).to_string(),
+                Ok(buf) => strip_trailing_nul(buf.as_ref()),
                 Err(_) => return 1,
             };
             let code = match load_string_buffer(rdb) {
-                Ok(buf) => String::from_utf8_lossy(buf.as_ref()).to_string(),
+                Ok(buf) => strip_trailing_nul(buf.as_ref()),
                 Err(_) => return 1,
             };
             libs.push((name, code));

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -145,7 +145,11 @@ unsafe extern "C" fn graph_rdb_load(
             Box::into_raw(boxed).cast()
         }
         Err(e) => {
-            eprintln!("graph rdb_load error: {e}");
+            // Must go to the *Redis* log, not stderr: Redis answers a failed module load
+            // with "Check for modules log above for additional clues", and a daemonized
+            // server with --logfile discards stderr entirely — so an `eprintln!` here left
+            // every rejected RDB unattributable.
+            log_warning(format!("graph rdb_load rejected the payload: {e}"));
             null_mut()
         }
     }
@@ -863,7 +867,7 @@ unsafe extern "C" fn graphmeta_rdb_load(
             Box::into_raw(Box::new(0u8)).cast()
         }
         Err(e) => {
-            eprintln!("graphmeta rdb_load error: {e}");
+            log_warning(format!("graphmeta rdb_load rejected the payload: {e}"));
             null_mut()
         }
     }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -272,10 +272,10 @@ pub fn reply_compact_value(
                 raw::reply_with_array(ctx.ctx, bg.get_relationship_attr_count(*rel) as _);
                 for (key, value) in attrs {
                     raw::reply_with_array(ctx.ctx, 3);
-                    raw::reply_with_long_long(
-                        ctx.ctx,
-                        bg.rel_attr_id_to_global(key).unwrap_or(0) as _,
-                    );
+                    // The span's id is already the graph-wide id — one dictionary, shared
+                    // by both stores — so there is nothing to translate. This used to call
+                    // `rel_attr_id_to_global`, an O(N) scan per property.
+                    raw::reply_with_long_long(ctx.ctx, key as _);
                     reply_compact_value(ctx, runtime, &value);
                 }
                 drop(bg);

--- a/src/serializers/decoder/mod.rs
+++ b/src/serializers/decoder/mod.rs
@@ -235,13 +235,15 @@ fn decode_payloads_into_pending(
     for (state, count) in payloads {
         match *state {
             EncodeState::Nodes => {
-                pg.node_attrs.decode_with_count(r, *count)?;
+                let attr_limit = pg.attrs_name.len();
+                pg.node_attrs.decode_entities(r, *count, attr_limit)?;
             }
             EncodeState::DeletedNodes => {
                 pg.deleted_nodes.decode_with_count(r, *count)?;
             }
             EncodeState::Edges => {
-                pg.rel_attrs.decode_with_count(r, *count)?;
+                let attr_limit = pg.attrs_name.len();
+                pg.rel_attrs.decode_entities(r, *count, attr_limit)?;
             }
             EncodeState::DeletedEdges => {
                 pg.deleted_rels.decode_with_count(r, *count)?;
@@ -439,13 +441,13 @@ fn load_graph_from_reader(
     for (state, count) in &payloads {
         match *state {
             EncodeState::Nodes => {
-                node_attrs.decode_with_count(r, *count)?;
+                node_attrs.decode_entities(r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedNodes => {
                 deleted_nodes.decode_with_count(r, *count)?;
             }
             EncodeState::Edges => {
-                rel_attrs.decode_with_count(r, *count)?;
+                rel_attrs.decode_entities(r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedEdges => {
                 deleted_rels.decode_with_count(r, *count)?;

--- a/src/serializers/decoder/mod.rs
+++ b/src/serializers/decoder/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use graph::entity_type::EntityType;
-use graph::graph::attribute_store::AttributeStore;
+use graph::graph::attribute_store::{AttrNameMap, AttributeStore};
 use graph::graph::graph::Graph;
 use graph::graph::graphblas::serialization::{Decode, Reader};
 use graph::graph::graphblas::tensor::Tensor;
@@ -52,14 +52,16 @@ pub fn rdb_load_graph(
 
         if is_first_key {
             // First key: initialize the pending graph.
-            let node_attrs = AttributeStore::new();
-            let mut rel_attrs = AttributeStore::new();
+            let node_attrs_init = AttributeStore::new();
+            let rel_attrs = AttributeStore::new();
 
-            // Set attribute names on the stores now -- they are the same across all keys.
-            let mut node_attrs_init = node_attrs;
+            // The RDB's flat `attribute_names` list *is* the graph's dictionary: index is
+            // the id. Previously this seeded a copy into each store, which is what gave an
+            // RDB-loaded replica different numbering from a master that had never been
+            // reloaded (#2457).
+            let mut attrs_name = AttrNameMap::default();
             for name in &schema.attribute_names {
-                node_attrs_init.attrs_name.insert(name.clone());
-                rel_attrs.attrs_name.insert(name.clone());
+                attrs_name.insert(name.clone());
             }
 
             let pg = PendingGraph {
@@ -83,6 +85,7 @@ pub fn rdb_load_graph(
                     indexes: schema.indexes,
                     constraints: schema.constraints,
                 },
+                attrs_name,
                 node_attrs: node_attrs_init,
                 rel_attrs,
                 deleted_nodes: RoaringTreemap::new(),
@@ -142,9 +145,10 @@ pub fn rdb_load_graph(
     let mut node_attrs = AttributeStore::new();
     let mut rel_attrs = AttributeStore::new();
 
+    // One dictionary, shared by both stores — see the multi-key path above.
+    let mut attrs_name = AttrNameMap::default();
     for name in &schema.attribute_names {
-        node_attrs.attrs_name.insert(name.clone());
-        rel_attrs.attrs_name.insert(name.clone());
+        attrs_name.insert(name.clone());
     }
 
     let mut deleted_nodes = RoaringTreemap::new();
@@ -157,13 +161,13 @@ pub fn rdb_load_graph(
     for (state, count) in &payloads {
         match *state {
             EncodeState::Nodes => {
-                node_attrs.decode_with_count(&mut r, *count)?;
+                node_attrs.decode_entities(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedNodes => {
                 deleted_nodes.decode_with_count(&mut r, *count)?;
             }
             EncodeState::Edges => {
-                rel_attrs.decode_with_count(&mut r, *count)?;
+                rel_attrs.decode_entities(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedEdges => {
                 deleted_rels.decode_with_count(&mut r, *count)?;
@@ -206,6 +210,7 @@ pub fn rdb_load_graph(
         relationship_tensors,
         schema.node_labels,
         schema.relationship_types,
+        attrs_name,
         node_attrs,
         rel_attrs,
     );
@@ -268,6 +273,7 @@ fn decode_payloads_into_pending(
 
 /// Finalize a pending multi-key graph: build Graph, rebuild derived matrices.
 pub fn finalize_pending_graph(pg: PendingGraph) -> Graph {
+    let attrs_name = pg.attrs_name;
     let node_attrs = pg.node_attrs;
     let rel_attrs = pg.rel_attrs;
 
@@ -286,6 +292,7 @@ pub fn finalize_pending_graph(pg: PendingGraph) -> Graph {
         pg.relationship_tensors,
         pg.schema.node_labels,
         pg.schema.relationship_types,
+        attrs_name,
         node_attrs,
         rel_attrs,
     );
@@ -416,9 +423,10 @@ fn load_graph_from_reader(
     let mut node_attrs = AttributeStore::new();
     let mut rel_attrs = AttributeStore::new();
 
+    // One dictionary, shared by both stores — see the other decode paths above.
+    let mut attrs_name = AttrNameMap::default();
     for name in &schema.attribute_names {
-        node_attrs.attrs_name.insert(name.clone());
-        rel_attrs.attrs_name.insert(name.clone());
+        attrs_name.insert(name.clone());
     }
 
     let mut deleted_nodes = RoaringTreemap::new();
@@ -480,6 +488,7 @@ fn load_graph_from_reader(
         relationship_tensors,
         schema.node_labels,
         schema.relationship_types,
+        attrs_name,
         node_attrs,
         rel_attrs,
     );

--- a/src/serializers/decoder/mod.rs
+++ b/src/serializers/decoder/mod.rs
@@ -161,16 +161,16 @@ pub fn rdb_load_graph(
     for (state, count) in &payloads {
         match *state {
             EncodeState::Nodes => {
-                node_attrs.decode_entities(&mut r, *count, attrs_name.len())?;
+                node_attrs.decode_with_count(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedNodes => {
-                deleted_nodes.decode_with_count(&mut r, *count)?;
+                deleted_nodes.decode_with_count(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::Edges => {
-                rel_attrs.decode_entities(&mut r, *count, attrs_name.len())?;
+                rel_attrs.decode_with_count(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedEdges => {
-                deleted_rels.decode_with_count(&mut r, *count)?;
+                deleted_rels.decode_with_count(&mut r, *count, attrs_name.len())?;
             }
             EncodeState::LabelsMatrices => {
                 let count = r.read_unsigned()?;
@@ -236,17 +236,19 @@ fn decode_payloads_into_pending(
         match *state {
             EncodeState::Nodes => {
                 let attr_limit = pg.attrs_name.len();
-                pg.node_attrs.decode_entities(r, *count, attr_limit)?;
+                pg.node_attrs.decode_with_count(r, *count, attr_limit)?;
             }
             EncodeState::DeletedNodes => {
-                pg.deleted_nodes.decode_with_count(r, *count)?;
+                pg.deleted_nodes
+                    .decode_with_count(r, *count, pg.attrs_name.len())?;
             }
             EncodeState::Edges => {
                 let attr_limit = pg.attrs_name.len();
-                pg.rel_attrs.decode_entities(r, *count, attr_limit)?;
+                pg.rel_attrs.decode_with_count(r, *count, attr_limit)?;
             }
             EncodeState::DeletedEdges => {
-                pg.deleted_rels.decode_with_count(r, *count)?;
+                pg.deleted_rels
+                    .decode_with_count(r, *count, pg.attrs_name.len())?;
             }
             EncodeState::LabelsMatrices => {
                 let count = r.read_unsigned()?;
@@ -441,16 +443,16 @@ fn load_graph_from_reader(
     for (state, count) in &payloads {
         match *state {
             EncodeState::Nodes => {
-                node_attrs.decode_entities(r, *count, attrs_name.len())?;
+                node_attrs.decode_with_count(r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedNodes => {
-                deleted_nodes.decode_with_count(r, *count)?;
+                deleted_nodes.decode_with_count(r, *count, attrs_name.len())?;
             }
             EncodeState::Edges => {
-                rel_attrs.decode_entities(r, *count, attrs_name.len())?;
+                rel_attrs.decode_with_count(r, *count, attrs_name.len())?;
             }
             EncodeState::DeletedEdges => {
-                deleted_rels.decode_with_count(r, *count)?;
+                deleted_rels.decode_with_count(r, *count, attrs_name.len())?;
             }
             EncodeState::LabelsMatrices => {
                 let count = r.read_unsigned()?;

--- a/src/serializers/encoder/mod.rs
+++ b/src/serializers/encoder/mod.rs
@@ -73,7 +73,7 @@ fn encode_graph(
     }
 
     for p in payloads {
-        graph.encode_payload(w, p, global_attrs);
+        graph.encode_payload(w, p);
     }
 }
 

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -333,19 +333,27 @@ fn encode_schema_index_block(
         w.write_buffer(&null_terminated(sw));
     }
 
+    // Pair each field with the attribute name it indexes. `f.name` is the
+    // *RediSearch* field name, which carries a type prefix (`range:age`,
+    // `vector:embedding`); C writes the bare attribute name and encodes the type
+    // in the separate word below. Writing the prefixed name crashed C on load:
+    // its `_RdbLoadConstraint` asks for the exact-match index supporting a UNIQUE
+    // constraint, found none under `name` because ours was called `range:name`,
+    // and dereferenced the NULL that `Constraint_New` returned.
     let all_fields: Vec<_> = infos
         .iter()
         .flat_map(|info| {
-            info.field_order
-                .iter()
-                .filter_map(move |attr| info.fields.get(attr))
-                .flatten()
+            info.field_order.iter().filter_map(move |attr| {
+                info.fields
+                    .get(attr)
+                    .map(|fields| fields.iter().map(move |f| (attr, f)))
+            })
         })
+        .flatten()
         .collect();
     w.write_unsigned(all_fields.len() as u64);
-    for f in &all_fields {
-        let name = f.name.to_str().unwrap_or("");
-        w.write_buffer(&null_terminated(name));
+    for (attr, f) in &all_fields {
+        w.write_buffer(&null_terminated(attr));
 
         let field_type = match f.ty {
             IndexType::Fulltext => index_field_type::INDEX_FLD_FULLTEXT,
@@ -389,26 +397,37 @@ fn encode_schema_index_block(
     }
 }
 
-/// Write the constraint block for a schema entry.
-/// Format per constraint: constraint_type (u64), status (u64), field_count (u64), then attr_id (u64) per field.
+/// Write the constraint block for a schema entry, in C's v19 layout.
+///
+/// Per constraint: `constraint_type` (u64), `field_count` (u64), then one `attr_id` (u64) per
+/// field — matching `_RdbSaveConstraint` in `src/serializers/encoder/v19/encode_schema.c` on
+/// `master`.
+///
+/// Two things this deliberately does *not* do, both of which it used to:
+///
+/// * **No status word.** C never writes one, so a reader expecting it runs one field out of
+///   step for the rest of the block. A single constraint could still parse by luck; two could
+///   not, so a C-written RDB carrying two constraints was refused outright.
+/// * **Only active constraints.** C filters to `CT_ACTIVE` and writes the *filtered* count,
+///   which is what makes the status word redundant rather than merely absent: an RDB cannot
+///   contain an unfinished constraint. Writing all of them would hand C one we still consider
+///   under construction, with no field left to say so.
 fn encode_constraint_block(
     w: &mut dyn Writer,
     constraints: &[&Constraint],
     attribute_names: &[Arc<String>],
 ) {
-    w.write_unsigned(constraints.len() as u64);
-    for c in constraints {
+    let active = constraints
+        .iter()
+        .filter(|c| matches!(c.status, ConstraintStatus::Operational));
+
+    w.write_unsigned(active.clone().count() as u64);
+    for c in active {
         let ct = match c.ct {
             ConstraintType::Unique => 0u64,
             ConstraintType::Mandatory => 1u64,
         };
         w.write_unsigned(ct);
-        let status = match c.status {
-            ConstraintStatus::Operational => 0u64,
-            ConstraintStatus::UnderConstruction => 1u64,
-            ConstraintStatus::Failed => 2u64,
-        };
-        w.write_unsigned(status);
         w.write_unsigned(c.properties.len() as u64);
         for prop in &c.properties {
             let attr_id = attribute_names
@@ -546,12 +565,8 @@ fn decode_schema_entry(
             0 => ConstraintType::Unique,
             _ => ConstraintType::Mandatory,
         };
-        let status_id = r.read_unsigned()?;
-        let status = match status_id {
-            1 => ConstraintStatus::UnderConstruction,
-            2 => ConstraintStatus::Failed,
-            _ => ConstraintStatus::Operational,
-        };
+        // No status field: see `encode_constraint_block`. Both engines write only active
+        // constraints, so anything present here is operational by construction.
         let fields_count = r.read_unsigned()?;
         let mut properties = Vec::with_capacity(fields_count as usize);
         for _ in 0..fields_count {
@@ -569,7 +584,10 @@ fn decode_schema_entry(
             Arc::new(schema_name.clone()),
             properties,
         );
-        c.status = status;
+        // `Constraint::new` starts at `UnderConstruction`, which is right for a constraint
+        // being created but wrong for one being loaded — it is already enforced on the data
+        // we are reading. C's `_RdbLoadConstraint` does the same thing explicitly.
+        c.status = ConstraintStatus::Operational;
         constraints.push(c);
     }
 

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -7,7 +7,7 @@ use std::ffi::CString;
 use std::sync::{Arc, LazyLock};
 
 use graph::entity_type::EntityType;
-use graph::graph::attribute_store::AttributeStore;
+use graph::graph::attribute_store::{AttrNameMap, AttributeStore};
 use graph::graph::constraint::{Constraint, ConstraintStatus, ConstraintType};
 use graph::graph::graph::Graph;
 use graph::graph::graphblas::serialization::{Decode, Encode, Reader, Writer, index_field_type};
@@ -69,6 +69,9 @@ pub struct PendingGraph {
     pub cache_size: usize,
     pub header: Header,
     pub schema: Schema,
+    /// The graph's one attribute dictionary, carried across keys so every key's spans
+    /// are decoded against the same numbering.
+    pub attrs_name: AttrNameMap,
     pub node_attrs: AttributeStore,
     pub rel_attrs: AttributeStore,
     pub deleted_nodes: RoaringTreemap,

--- a/tests/flow/test_attr_id_space.py
+++ b/tests/flow/test_attr_id_space.py
@@ -1,0 +1,114 @@
+import os
+
+from common import *
+from time import sleep
+
+GRAPH_ID = "attr_id_space"
+
+
+class testAttributeIdSpace(FlowTestsBase):
+    def __init__(self):
+        # replication timing doesn't play well with sanitizers
+        if SANITIZER:
+            Environment.skip(None)
+
+        # This test repoints the replica with REPLICAOF and forces EFFECTS_THRESHOLD to 0,
+        # both of which are process-wide. On CI's shared services container that would
+        # reconfigure replication and effect routing for every other class in the cell, so
+        # skip there rather than corrupt them.
+        #
+        # The classifier cannot route this for us on `main`: `useSlaves` is explicitly not
+        # spawn-forcing, and the behavioural opt-out (`SPAWN_ONLY_FILES` in
+        # tests/flow/test_matrix_split.py) arrives with #2450. Once that lands, add this
+        # file there and drop the skip.
+        if os.getenv("FALKORDB_USE_SERVICE"):
+            Environment.skip(None)
+
+        self.env, self.db = Env(env='oss', useSlaves=True)
+
+    def test01_effect_after_full_sync_lands_on_the_right_attribute(self):
+        # Regression for #2457.
+        #
+        # A property effect carries a bare attribute id with no name beside it. The id is
+        # only meaningful against a dictionary, and the two sides used to build theirs
+        # differently: a master that had never been reloaded numbered node and
+        # relationship attributes in separate spaces, while a replica seeded by full sync
+        # got the single unified list the RDB carries. The same id then meant a different
+        # attribute on each side, so the value landed on the wrong one and the intended
+        # one stayed stale — silently, and healed by any resync.
+        #
+        # Three things have to line up for it to bite, and all three are arranged here:
+        #
+        #   1. node attributes exist *before* the relationship attribute, so a per-store
+        #      numbering would restart and collide;
+        #   2. the replica is attached afterwards, so its dictionary comes from an RDB
+        #      full sync rather than from replayed ADD_ATTRIBUTE effects;
+        #   3. the write is replicated as an effect, not verbatim.
+        env = self.env
+        master = env.getConnection()
+        replica_con = env.getSlaveConnection()
+        graph = self.db.select_graph(GRAPH_ID)
+        # Read the replica through the same parsed client the master uses, or the two
+        # sides come back in different shapes (a dict vs the raw reply string) and any
+        # comparison between them is meaningless.
+        replica = Graph(replica_con, GRAPH_ID)
+
+        # (3): force the effect path. At the 300us default, whether a write replicates
+        # verbatim or as an effect depends on timing — and the verbatim path re-resolves
+        # by name on the replica, which masks this entirely.
+        self.db.config_set("EFFECTS_THRESHOLD", 0)
+
+        # (1) node attributes first, then a relationship-only one.
+        graph.query("CREATE (:N {a: 1, b: 2})")
+        graph.query("CREATE (:N)-[:R {since: 1900}]->(:N)")
+
+        # (2) attach now, so the replica is seeded by a full sync.
+        replica_con.execute_command("REPLICAOF", "localhost", str(env.port))
+        self._wait_for_sync(replica_con)
+
+        # Sanity: the full sync itself is consistent. If this fails the test is not
+        # exercising what it claims — the divergence below would predate the effect.
+        synced = replica.ro_query("MATCH ()-[r:R]->() RETURN r.since").result_set[0][0]
+        env.assertEquals(synced, 1900,
+            message="full sync did not carry the edge property; the rest of this "
+                    "test would be measuring the wrong thing")
+
+        # The write whose effect the replica must interpret with the same numbering.
+        graph.query("MATCH ()-[r:R]->() SET r.since = 9999")
+        sleep(1)
+
+        master_props = graph.query(
+            "MATCH ()-[r:R]->() RETURN properties(r)").result_set[0][0]
+        replica_props = replica.ro_query(
+            "MATCH ()-[r:R]->() RETURN properties(r)").result_set[0][0]
+
+        env.assertEquals(replica_props, master_props,
+            message=f"replica diverged: master {master_props}, replica {replica_props} "
+                    f"— an effect's attribute id resolved to a different attribute")
+
+        # State the failure directly too, so a regression names itself rather than
+        # showing up as a dict comparison.
+        stale = replica.ro_query(
+            "MATCH ()-[r:R]->() WHERE r.since = 9999 RETURN count(r)").result_set[0][0]
+        env.assertEquals(stale, 1,
+            message="the replica's edge did not receive the new `since` value")
+
+        wrong = replica.ro_query(
+            "MATCH ()-[r:R]->() WHERE r.a IS NOT NULL RETURN count(r)").result_set[0][0]
+        env.assertEquals(wrong, 0,
+            message="the value landed on `a` — a node attribute that should not exist "
+                    "on an edge — which is the #2457 id-space collision")
+
+    def _wait_for_sync(self, replica, timeout=30):
+        while timeout > 0:
+            info = replica.execute_command("INFO", "replication")
+            if isinstance(info, dict):
+                up = info.get("master_link_status") == "up"
+            else:
+                up = "master_link_status:up" in str(info)
+            if up:
+                sleep(0.5)
+                return
+            sleep(0.5)
+            timeout -= 0.5
+        raise RuntimeError("replica never reached master_link_status:up")

--- a/tests/flow/test_attr_id_space.py
+++ b/tests/flow/test_attr_id_space.py
@@ -24,7 +24,9 @@ class testAttributeIdSpace(FlowTestsBase):
         if os.getenv("FALKORDB_USE_SERVICE"):
             Environment.skip(None)
 
-        self.env, self.db = Env(env='oss', useSlaves=True)
+        # enableDebugCommand: test02 reloads via DEBUG RELOAD, which redis refuses
+        # by default.
+        self.env, self.db = Env(env='oss', useSlaves=True, enableDebugCommand=True)
 
     def test01_effect_after_full_sync_lands_on_the_right_attribute(self):
         # Regression for #2457.
@@ -112,3 +114,141 @@ class testAttributeIdSpace(FlowTestsBase):
             sleep(0.5)
             timeout -= 0.5
         raise RuntimeError("replica never reached master_link_status:up")
+
+    # ── schema id stability ──────────────────────────────────────────────────
+    #
+    # Attribute, label and relationship-type ids all travel as bare integers in a
+    # GRAPH.EFFECT — there is no name beside them to check against. So an id has to
+    # mean the same thing after a reload, and on a replica seeded by full sync, as it
+    # did on the master that stamped it. #2457 was the case where that stopped being
+    # true for attributes; labels and types ride the same way ("label id N out of
+    # range" is what a replica reports when it isn't true for them).
+    #
+    # The ids are not directly observable from a client, but they are exactly the row
+    # order of these three procedures: each iterates its id-ordered vector.
+
+    # Deliberately not alphabetical, and not creation-sorted by name. If any of the
+    # three procedures ever started sorting its output, the order assertion in
+    # `_schema_order` would stop reflecting ids — these names make that visible
+    # instead of silently weakening the test.
+    LABELS = ["Zeta", "Alpha", "Mid"]
+    TYPES = ["ZLINK", "ALINK", "MLINK"]
+    ATTRS = ["zprop", "aprop", "mprop"]
+
+    def _schema_order(self, graph, expect_creation_order=False):
+        """The three schema vectors in id order, as the procedures report them."""
+        def col(proc, field):
+            return [r[0] for r in graph.ro_query(
+                f"CALL {proc}() YIELD {field} RETURN {field}").result_set]
+
+        order = {
+            "labels": col("db.labels", "label"),
+            "types": col("db.relationshipTypes", "relationshipType"),
+            "attrs": col("db.propertyKeys", "propertyKey"),
+        }
+
+        if expect_creation_order:
+            # Proves the row order really is id order rather than something sorted:
+            # these names were created in an order alphabetical sorting would not
+            # reproduce.
+            self.env.assertEquals(order["labels"], self.LABELS,
+                message=f"db.labels() must report ids in creation order, not sorted; "
+                        f"got {order['labels']}")
+            self.env.assertEquals(order["types"], self.TYPES,
+                message=f"db.relationshipTypes() must report ids in creation order; "
+                        f"got {order['types']}")
+            # Attributes include the ones the edges carry, appended after the node
+            # ones, so compare only the prefix this test controls.
+            self.env.assertEquals(order["attrs"][:len(self.ATTRS)], self.ATTRS,
+                message=f"db.propertyKeys() must report ids in creation order; "
+                        f"got {order['attrs']}")
+        return order
+
+    def _build_schema(self, graph):
+        """Register labels, types and attributes in a known, non-alphabetical order."""
+        for i, label in enumerate(self.LABELS):
+            graph.query(f"CREATE (:{label} {{{self.ATTRS[i]}: {i}}})")
+        for i, rel in enumerate(self.TYPES):
+            graph.query(f"MATCH (a:{self.LABELS[0]}), (b:{self.LABELS[1]}) "
+                        f"CREATE (a)-[:{rel} {{w: {i}}}]->(b)")
+
+    def test02_schema_ids_survive_a_reload(self):
+        # The RDB carries names as flat, ordered lists and the loader rebuilds the
+        # numbering by reading them in order. If the encoder and decoder ever
+        # disagreed on that order, every id already stamped into an effect — or into
+        # an entity's stored span — would resolve to a different name after a reload.
+        graph = self.db.select_graph(GRAPH_ID + "_reload")
+        self._build_schema(graph)
+        before = self._schema_order(graph, expect_creation_order=True)
+
+        self.env.dumpAndReload()
+
+        after = self._schema_order(graph)
+        self.env.assertEquals(after, before,
+            message=f"schema ids shifted across a reload: before {before}, after "
+                    f"{after}. An id is meaningless on its own, so a shift silently "
+                    f"repoints every effect and every stored span")
+        # And the data still reads back through those ids.
+        for i, label in enumerate(self.LABELS):
+            self.env.assertEquals(
+                graph.ro_query(f"MATCH (n:{label}) RETURN n.{self.ATTRS[i]}")
+                    .result_set[0][0], i,
+                message=f"{label}.{self.ATTRS[i]} did not survive the reload")
+        graph.delete()
+
+    def test03_schema_ids_match_on_a_replica_after_full_sync(self):
+        # Same invariant across the wire rather than across a restart: a replica
+        # builds its tables from the RDB the master sends, so master and replica must
+        # agree on the numbering before any effect referencing an id arrives.
+        #
+        # Detaching and emptying the replica first is what makes this a full-sync
+        # test. Written the obvious way it is not one: test01 leaves the replica
+        # attached, so the schema created below reaches it through the live
+        # replication stream — where the numbering is rebuilt by replaying
+        # ADD_ATTRIBUTE in order and the RDB decoder never runs. Ablating the
+        # decoder's ordering left that version of this test passing.
+        graph = self.db.select_graph(GRAPH_ID + "_sync")
+        replica_con = self.env.getSlaveConnection()
+
+        replica_con.execute_command("REPLICAOF", "NO", "ONE")
+        replica_con.execute_command("FLUSHALL")
+        # `sync_full` counts syncs a server has *served*, so it lives on the master.
+        master_con = self.env.getConnection()
+        syncs_before = self._full_sync_count(master_con)
+
+        self._build_schema(graph)
+        master = self._schema_order(graph, expect_creation_order=True)
+
+        # Nothing on the replica yet, so whatever it reports afterwards came from the
+        # sync rather than from having been there all along.
+        self.env.assertEquals(replica_con.execute_command("KEYS", "*"), [],
+            message="replica must start empty for this to be a full-sync test")
+
+        replica_con.execute_command("REPLICAOF", "localhost", str(self.env.port))
+        self._wait_for_sync(replica_con)
+
+        self.env.assertGreater(self._full_sync_count(master_con), syncs_before,
+            message="no full sync was performed, so this test would be measuring the "
+                    "effect-replay path instead of the RDB decoder")
+
+        replica = self._schema_order(Graph(replica_con, GRAPH_ID + "_sync"))
+        self.env.assertEquals(replica, master,
+            message=f"replica disagrees with master on schema ids after full sync: "
+                    f"master {master}, replica {replica}. Every subsequent effect "
+                    f"carries these ids with no name to verify against")
+        graph.delete()
+
+    @staticmethod
+    def _full_sync_count(con):
+        """`sync_full` from INFO stats — how many full syncs this server has served.
+
+        Master-side: a replica serves none of its own, so reading this off the replica
+        always returns 0 and the assertion below would be vacuous.
+        """
+        info = con.execute_command("INFO", "stats")
+        if isinstance(info, dict):
+            return int(info.get("sync_full", 0))
+        for line in str(info).splitlines():
+            if line.startswith("sync_full:"):
+                return int(line.split(":", 1)[1])
+        return 0

--- a/tests/flow/test_attr_id_space.py
+++ b/tests/flow/test_attr_id_space.py
@@ -47,7 +47,6 @@ class testAttributeIdSpace(FlowTestsBase):
         #      full sync rather than from replayed ADD_ATTRIBUTE effects;
         #   3. the write is replicated as an effect, not verbatim.
         env = self.env
-        master = env.getConnection()
         replica_con = env.getSlaveConnection()
         graph = self.db.select_graph(GRAPH_ID)
         # Read the replica through the same parsed client the master uses, or the two
@@ -86,7 +85,7 @@ class testAttributeIdSpace(FlowTestsBase):
 
         env.assertEquals(replica_props, master_props,
             message=f"replica diverged: master {master_props}, replica {replica_props} "
-                    f"— an effect's attribute id resolved to a different attribute")
+                    "— an effect's attribute id resolved to a different attribute")
 
         # State the failure directly too, so a regression names itself rather than
         # showing up as a dict comparison.
@@ -152,15 +151,15 @@ class testAttributeIdSpace(FlowTestsBase):
             # these names were created in an order alphabetical sorting would not
             # reproduce.
             self.env.assertEquals(order["labels"], self.LABELS,
-                message=f"db.labels() must report ids in creation order, not sorted; "
+                message="db.labels() must report ids in creation order, not sorted; "
                         f"got {order['labels']}")
             self.env.assertEquals(order["types"], self.TYPES,
-                message=f"db.relationshipTypes() must report ids in creation order; "
+                message="db.relationshipTypes() must report ids in creation order; "
                         f"got {order['types']}")
             # Attributes include the ones the edges carry, appended after the node
             # ones, so compare only the prefix this test controls.
             self.env.assertEquals(order["attrs"][:len(self.ATTRS)], self.ATTRS,
-                message=f"db.propertyKeys() must report ids in creation order; "
+                message="db.propertyKeys() must report ids in creation order; "
                         f"got {order['attrs']}")
         return order
 
@@ -187,7 +186,7 @@ class testAttributeIdSpace(FlowTestsBase):
         self.env.assertEquals(after, before,
             message=f"schema ids shifted across a reload: before {before}, after "
                     f"{after}. An id is meaningless on its own, so a shift silently "
-                    f"repoints every effect and every stored span")
+                    "repoints every effect and every stored span")
         # And the data still reads back through those ids.
         for i, label in enumerate(self.LABELS):
             self.env.assertEquals(
@@ -233,9 +232,9 @@ class testAttributeIdSpace(FlowTestsBase):
 
         replica = self._schema_order(Graph(replica_con, GRAPH_ID + "_sync"))
         self.env.assertEquals(replica, master,
-            message=f"replica disagrees with master on schema ids after full sync: "
+            message="replica disagrees with master on schema ids after full sync: "
                     f"master {master}, replica {replica}. Every subsequent effect "
-                    f"carries these ids with no name to verify against")
+                    "carries these ids with no name to verify against")
         graph.delete()
 
     @staticmethod

--- a/tests/flow/test_rdb_c_layout.py
+++ b/tests/flow/test_rdb_c_layout.py
@@ -204,3 +204,31 @@ class testRdbCLayout():
                     f"would load it as active because its format has no field to "
                     f"say otherwise")
         graph.delete()
+
+    def test04_udf_strings_are_nul_terminated(self):
+        # UDF libraries are not in the graph key at all -- they are a module-level
+        # AUX field written with raw RedisModule_Save* calls rather than the tagged
+        # writer everything above uses, so nothing else here covers them.
+        #
+        # C writes `strlen(s) + 1`, including the terminator, and reads the buffers
+        # back as C strings. The Rust helper writes `s.len()`. A library saved
+        # without its terminator loaded on C as `XLibte` -- the name ran into
+        # whatever followed it in the RDB -- and none of its functions could be
+        # found. `GRAPH.UDF LIST` still reported a library, so it failed quietly.
+        #
+        # Only the *writing* half needs asserting here. The reading half cannot
+        # regress unnoticed: since we now write the terminator, a reader that stops
+        # stripping it cannot load its own output, and the whole of test_udf fails
+        # to run. Ablating each half separately is what established that.
+        self._reset()
+        lib = "NulTermLib"
+        self.db.udf_load(lib, "function double (x) { return x * 2; }\n"
+                              f"falkor.register ('double', double);", True)
+        # A graph must exist for the keyspace to be worth saving.
+        self.db.select_graph(GRAPH_ID + "_udf").query("RETURN 1")
+
+        blob = self._dump_bytes()
+        self.env.assertTrue(lib.encode() + b"\x00" in blob,
+            message=f"the UDF library name must be written NUL-terminated, as C's "
+                    f"`AUXSaveUDF_latest` does; found {lib!r} without a terminator, "
+                    f"which C reads as that name plus whatever bytes follow it")

--- a/tests/flow/test_rdb_c_layout.py
+++ b/tests/flow/test_rdb_c_layout.py
@@ -1,0 +1,206 @@
+import os
+
+from common import *
+from constraint_utils import *
+
+GRAPH_ID = "rdb_c_layout"
+
+# BufferedWriter frames every unsigned word as a 1-byte type tag plus eight
+# little-endian bytes.
+TYPE_UNSIGNED = 4
+WORD_BYTES = 9
+
+# Constraint type discriminators, as written to the RDB.
+CT_MANDATORY = 1
+
+LABEL = "Person"
+CONSTRAINT_FIELDS = ["p1", "p2", "p3", "p4", "p5"]
+
+
+class testRdbCLayout():
+    """Guard the RDB schema layout against C's v19 encoder.
+
+    These assert the bytes of a real saved RDB, which is unusual for a flow test
+    and is the whole point: **a Rust-to-Rust reload cannot fail on either defect
+    they cover.** Our decoder strips an optional `range:` field-name prefix with
+    `unwrap_or`, so it accepts either spelling; and the constraint status word it
+    used to read was one it also wrote, so reader and writer agreed with each
+    other while both disagreed with C. Every persistency test in this suite passed
+    with both bugs present.
+
+    What they protect is cross-engine loading, verified by hand against
+    `falkordb/falkordb-server:edge-c` in both directions. Neither failure was
+    graceful on the C side -- a two-constraint RDB written by C was refused
+    outright, and C segfaulted in `Constraint_SetStatus` loading ours -- so there
+    is no error message to assert on instead of the layout.
+
+    Reference: `_RdbSaveConstraint` and `_RdbSaveIndexField` in
+    `src/serializers/encoder/v19/encode_schema.c` on the `master` branch.
+    """
+
+    def __init__(self):
+        self.env, self.db = Env()
+        # These read the RDB off disk, which the shared services container does not
+        # expose to the test process.
+        if os.getenv("FALKORDB_USE_SERVICE"):
+            Environment.skip(None)
+        self.con = self.env.getConnection()
+        # LZF would defeat every assertion here: a compressed payload contains
+        # none of the literals or word framing being looked for.
+        self.con.execute_command("CONFIG", "SET", "rdbcompression", "no")
+
+    def _reset(self):
+        """Start from an empty keyspace.
+
+        Not just tidiness: a dump.rdb these tests wrote is loaded by the next run
+        of the suite, so without this a test inherits graphs from the previous run
+        -- including, during a bisect, ones written by a differently-behaving
+        build.
+        """
+        self.con.execute_command("FLUSHALL")
+
+    def _dump_bytes(self, label=None):
+        """SAVE and return the RDB as raw bytes.
+
+        The dump covers the whole keyspace, so any other graph carrying the same
+        label would land in it and be indistinguishable from the one under test.
+        These tests also leave a dump.rdb behind that the *next* run loads at
+        startup, so isolation has to be asserted, not assumed -- an earlier run's
+        stale graph is what made the anchored lookups below find two schema
+        entries and fail.
+        """
+        if label is not None:
+            # The engine keeps its own `telemetry{...}` graph beside each user
+            # graph; it carries none of these labels, so it is not a confounder.
+            keys = [k for k in self.con.execute_command("KEYS", "*")
+                    if not str(k).startswith("telemetry")]
+            self.env.assertEquals(len(keys), 1,
+                message=f"exactly one user graph should exist while dumping; found "
+                        f"{keys}. Another graph with the same label would be "
+                        f"anchored on too")
+        self.con.execute_command("SAVE")
+        directory = self.con.execute_command("CONFIG", "GET", "dir")[1]
+        filename = self.con.execute_command("CONFIG", "GET", "dbfilename")[1]
+        with open(os.path.join(directory, filename), "rb") as f:
+            return f.read()
+
+    def _schema_words(self, blob, label, count=12):
+        """The words following each occurrence of `label` in the RDB.
+
+        A schema entry is the label name, then the index block, then the
+        constraint block, so anchoring on the name gives a known offset into the
+        part under test. Every occurrence is returned rather than the first,
+        because the name is not guaranteed to appear only once -- searching the
+        whole RDB for a word pattern instead is what this replaced, and it produced
+        false failures from `[1][0][5]` occurring by chance elsewhere.
+        """
+        out = []
+        needle = label.encode() + b"\x00"
+        i = blob.find(needle)
+        while i >= 0:
+            tail = blob[i + len(needle):]
+            ws, j = [], 0
+            while len(ws) < count and j + WORD_BYTES <= len(tail) \
+                    and tail[j] == TYPE_UNSIGNED:
+                ws.append(int.from_bytes(tail[j + 1:j + WORD_BYTES], "little"))
+                j += WORD_BYTES
+            out.append(ws)
+            i = blob.find(needle, i + 1)
+        return out
+
+    def test01_index_field_names_are_bare_attribute_names(self):
+        # C writes an index field's bare attribute name and puts the field type in
+        # a separate word. We hold the RediSearch field name internally, which
+        # carries a type prefix, and used to write that instead.
+        #
+        # The consequence on C is not a cosmetically odd index name: loading such
+        # an RDB, C looks for the exact-match index supporting a UNIQUE constraint
+        # on `name`, finds ours filed under `range:name`, and dereferences the NULL
+        # that `Constraint_New` hands back.
+        self._reset()
+        graph = self.db.select_graph(GRAPH_ID + "_idx")
+        graph.query("CREATE (:Person {name:'a', age:1, embedding:vecf32([1,2,3,4])})")
+        graph.query("CREATE INDEX FOR (n:Person) ON (n.age)")
+        graph.query("CREATE VECTOR INDEX FOR (n:Person) ON (n.embedding) "
+                    "OPTIONS {dimension: 4, similarityFunction: 'euclidean'}")
+
+        blob = self._dump_bytes()
+
+        self.env.assertTrue(b"age\x00" in blob,
+            message="the bare attribute name must be written")
+        self.env.assertFalse(b"range:age\x00" in blob,
+            message="a `range:`-prefixed field name reached the RDB; C reads that "
+                    "name literally and can then no longer match a constraint to "
+                    "its supporting index")
+        self.env.assertFalse(b"vector:embedding\x00" in blob,
+            message="a `vector:`-prefixed field name reached the RDB")
+        graph.delete()
+
+    def test02_constraint_block_matches_c_layout(self):
+        # The status word is invisible from inside this engine -- we stopped writing
+        # it and stopped reading it in the same change -- so the only way to notice
+        # its return is to look at the wire.
+        #
+        # No index is created here, which keeps the index block a single `false`
+        # word and puts the constraint block at a known offset from the label name.
+        self._reset()
+        graph = self.db.select_graph(GRAPH_ID + "_cons")
+        props = ", ".join(f"{p}:{i}" for i, p in enumerate(CONSTRAINT_FIELDS))
+        graph.query(f"CREATE (:{LABEL} {{{props}}})")
+        create_mandatory_node_constraint(graph, LABEL, *CONSTRAINT_FIELDS, sync=True)
+
+        n = len(CONSTRAINT_FIELDS)
+        # has_index=false, one constraint, MANDATORY, n fields -- then n attribute
+        # ids. C's layout is `type, field_count, ids...` with no status word; the
+        # status word would sit where field_count is and push everything along.
+        expected = [0, 1, CT_MANDATORY, n]
+        found = self._schema_words(self._dump_bytes(LABEL), LABEL)
+
+        matches = [ws for ws in found if ws[:len(expected)] == expected]
+        self.env.assertEquals(len(matches), 1,
+            message=f"expected exactly one schema entry reading "
+                    f"{expected} (has_index, constraint count, type, field count); "
+                    f"got {found}. A zero word between the type and the field count "
+                    f"is the status field, which C never writes -- it leaves C's "
+                    f"reader one field out of step for the rest of the block, which "
+                    f"is why C refused a two-constraint RDB outright while a "
+                    f"one-constraint RDB parsed by luck")
+        if matches:
+            ids = matches[0][len(expected):len(expected) + n]
+            self.env.assertEquals(sorted(ids), list(range(n)),
+                message=f"the {n} words after the field count must be the "
+                        f"constraint's attribute ids; got {ids}")
+        graph.delete()
+
+    def test03_only_active_constraints_are_encoded(self):
+        # C encodes only CT_ACTIVE constraints and writes the *filtered* count. That
+        # is what makes the status word unnecessary rather than merely absent: an RDB
+        # cannot describe an unfinished constraint, so there is nothing for a status
+        # field to say. Encoding a FAILED one would hand C a constraint it then marks
+        # active.
+        #
+        # The second node lacks `p1`, so the constraint cannot be satisfied.
+        # MANDATORY is deliberate: UNIQUE pulls in a supporting exact-match index,
+        # which would fill the index block and move the constraint block.
+        self._reset()
+        graph = self.db.select_graph(GRAPH_ID + "_failed")
+        props = ", ".join(f"{p}:{i}" for i, p in enumerate(CONSTRAINT_FIELDS))
+        graph.query(f"CREATE (:{LABEL} {{{props}}}), (:{LABEL} {{other:1}})")
+        create_mandatory_node_constraint(graph, LABEL, *CONSTRAINT_FIELDS, sync=True)
+
+        statuses = [r[0] for r in graph.query(
+            "CALL db.constraints() YIELD status RETURN status").result_set]
+        self.env.assertEquals(statuses, ["FAILED"],
+            message=f"this test needs a FAILED constraint to be meaningful; "
+                    f"got {statuses}")
+
+        found = self._schema_words(self._dump_bytes(LABEL), LABEL)
+        # has_index=false, then a constraint count of zero.
+        matches = [ws for ws in found if ws[:2] == [0, 0]]
+        self.env.assertEquals(len(matches), 1,
+            message=f"expected the schema to encode zero constraints, reading "
+                    f"[0, 0] for (has_index, constraint count); got {found}. A "
+                    f"count of 1 means the FAILED constraint was encoded, and C "
+                    f"would load it as active because its format has no field to "
+                    f"say otherwise")
+        graph.delete()

--- a/tests/flow/test_rdb_c_layout.py
+++ b/tests/flow/test_rdb_c_layout.py
@@ -75,9 +75,9 @@ class testRdbCLayout():
             keys = [k for k in self.con.execute_command("KEYS", "*")
                     if not str(k).startswith("telemetry")]
             self.env.assertEquals(len(keys), 1,
-                message=f"exactly one user graph should exist while dumping; found "
+                message="exactly one user graph should exist while dumping; found "
                         f"{keys}. Another graph with the same label would be "
-                        f"anchored on too")
+                        "anchored on too")
         self.con.execute_command("SAVE")
         directory = self.con.execute_command("CONFIG", "GET", "dir")[1]
         filename = self.con.execute_command("CONFIG", "GET", "dbfilename")[1]
@@ -132,6 +132,10 @@ class testRdbCLayout():
             message="a `range:`-prefixed field name reached the RDB; C reads that "
                     "name literally and can then no longer match a constraint to "
                     "its supporting index")
+        self.env.assertTrue(b"embedding\x00" in blob,
+            message="the bare vector field name must be written — asserting only the "
+                    "absence of the prefixed form would also pass if the encoder "
+                    "dropped the field altogether")
         self.env.assertFalse(b"vector:embedding\x00" in blob,
             message="a `vector:`-prefixed field name reached the RDB")
         graph.delete()
@@ -158,13 +162,13 @@ class testRdbCLayout():
 
         matches = [ws for ws in found if ws[:len(expected)] == expected]
         self.env.assertEquals(len(matches), 1,
-            message=f"expected exactly one schema entry reading "
+            message="expected exactly one schema entry reading "
                     f"{expected} (has_index, constraint count, type, field count); "
                     f"got {found}. A zero word between the type and the field count "
-                    f"is the status field, which C never writes -- it leaves C's "
-                    f"reader one field out of step for the rest of the block, which "
-                    f"is why C refused a two-constraint RDB outright while a "
-                    f"one-constraint RDB parsed by luck")
+                    "is the status field, which C never writes -- it leaves C's "
+                    "reader one field out of step for the rest of the block, which "
+                    "is why C refused a two-constraint RDB outright while a "
+                    "one-constraint RDB parsed by luck")
         if matches:
             ids = matches[0][len(expected):len(expected) + n]
             self.env.assertEquals(sorted(ids), list(range(n)),
@@ -191,18 +195,18 @@ class testRdbCLayout():
         statuses = [r[0] for r in graph.query(
             "CALL db.constraints() YIELD status RETURN status").result_set]
         self.env.assertEquals(statuses, ["FAILED"],
-            message=f"this test needs a FAILED constraint to be meaningful; "
+            message="this test needs a FAILED constraint to be meaningful; "
                     f"got {statuses}")
 
         found = self._schema_words(self._dump_bytes(LABEL), LABEL)
         # has_index=false, then a constraint count of zero.
         matches = [ws for ws in found if ws[:2] == [0, 0]]
         self.env.assertEquals(len(matches), 1,
-            message=f"expected the schema to encode zero constraints, reading "
+            message="expected the schema to encode zero constraints, reading "
                     f"[0, 0] for (has_index, constraint count); got {found}. A "
-                    f"count of 1 means the FAILED constraint was encoded, and C "
-                    f"would load it as active because its format has no field to "
-                    f"say otherwise")
+                    "count of 1 means the FAILED constraint was encoded, and C "
+                    "would load it as active because its format has no field to "
+                    "say otherwise")
         graph.delete()
 
     def test04_udf_strings_are_nul_terminated(self):
@@ -222,13 +226,30 @@ class testRdbCLayout():
         # to run. Ablating each half separately is what established that.
         self._reset()
         lib = "NulTermLib"
-        self.db.udf_load(lib, "function double (x) { return x * 2; }\n"
-                              f"falkor.register ('double', double);", True)
+        # Kept under 64 bytes *including* the terminator on purpose: redis encodes a
+        # string that short with a single-byte length, which the assertion below reads
+        # directly. Longer strings switch to a multi-byte encoding.
+        script = "function d (x) { return x*2; } falkor.register('d', d);"
+        assert len(script) + 1 < 64, "script must stay in redis' 6-bit length encoding"
+        self.db.udf_load(lib, script, True)
         # A graph must exist for the keyspace to be worth saving.
         self.db.select_graph(GRAPH_ID + "_udf").query("RETURN 1")
 
         blob = self._dump_bytes()
         self.env.assertTrue(lib.encode() + b"\x00" in blob,
-            message=f"the UDF library name must be written NUL-terminated, as C's "
+            message="the UDF library name must be written NUL-terminated, as C's "
                     f"`AUXSaveUDF_latest` does; found {lib!r} without a terminator, "
-                    f"which C reads as that name plus whatever bytes follow it")
+                    "which C reads as that name plus whatever bytes follow it")
+        # The script needs the same treatment — C reads it as a C string too — but
+        # searching for `script + NUL` does not test it: whatever follows the script in
+        # the RDB is often a zero byte anyway, so that assertion passes with the
+        # terminator removed (confirmed by ablation). What does distinguish the two is
+        # the *length prefix* redis writes before the bytes: it must count the
+        # terminator.
+        idx = blob.find(script.encode())
+        self.env.assertNotEqual(idx, -1, message="the UDF script must be in the RDB")
+        self.env.assertEquals(blob[idx - 1], len(script) + 1,
+            message=f"the UDF script's length prefix must count its NUL terminator: "
+                    f"expected {len(script) + 1}, found {blob[idx - 1]}. A prefix of "
+                    f"{len(script)} means the script was written unterminated, and C "
+                    f"reads it as a C string")


### PR DESCRIPTION
Closes #2457

Two engines that cannot load each other's RDB cannot be swapped by failover, in
either direction. This makes them able to, and the attribute-id fix #2457 asks for
is what made the comparison possible in the first place.

## 1. One attribute dictionary per graph, not one per store

`AttributeStore` owned its own name → id table, so node and relationship
attributes were numbered **independently**. The RDB, however, carries a single flat
`attribute_names` list and seeds *both* stores from it. So a master that had never
been reloaded kept split numbering while a replica seeded by full sync had the
unified one — and property effects put a **bare `u16` id on the wire with no name
to verify against**.

Same id, different attribute on each side:

```
master   {since: 9999}
replica  {a: 9999, since: 2026}
```

The value lands on `a` — a node attribute that should not exist on an edge — and
the intended one stays stale. No error, no log line. **Any resync heals it**, so it
presents as a replica that intermittently disagrees and then fixes itself.

Reachability is counter-intuitive: `should_use_effects` picks effects when *average
per-effect time > `EFFECTS_THRESHOLD`* (default 300µs), so a 20 000-edge bulk `SET`
replicates correctly via the verbatim path while a **single-edge `SET` behind an
expensive match** diverges.

### It was a violated invariant, not merely a mismatch

Bare ids are not an oversight — `pending.rs` states the contract above the
`CREATE_NODE` emission:

> the `EFFECT_ADD_SCHEMA` / `EFFECT_ADD_ATTRIBUTE` records above (and by in-order
> replay of earlier queries), which **mirror the master's registration order
> exactly**

The replica is meant to build its tables by replaying `ADD_ATTRIBUTE` in the
master's order, which makes the numbering agree by construction. **RDB full sync
violates that**: it replays nothing and seeds both tables from the merged list.
Which is also why a from-scratch effects-only pair looks fine, and every real
replica — beginning with a full sync — does not.

Worth noting for #2419: C reached the same conclusion from the other side. Its
effect stream carries **(id, name) pairs** and verifies them (`VerifySchema` /
`VerifyAttribute` in `effects_internal.h`), treating a mismatch as replica
divergence. With a name beside the id this bug would have been caught rather than
silently written to the wrong attribute.

### The fix

The dictionary lives **once on `Graph`** and is passed to the store methods that
need it. This is C's shape: one `attributes` array on `GraphContext` serving two
`DataBlock`s. Note what does *not* change — **storage stays split**. Both stores
remain; nodes and edges keep separate `DataBlock`s in both engines. Only the
dictionary moves.

No storage rewrite and no RDB migration were needed, for three reasons worth
stating because they are what makes this small:

* spans are **sparse and binary-searched on the id** (`SpanRef::get`), not
  columnar, so ids need no density and any numbering works;
* the **RDB format was already unified** — one flat list, and the loader already
  seeded both stores identically, so no per-entity remap;
* `AttributeID` stays `u16`.

### What falls out of having one id space

Three separate local→global translation implementations existed, and effects were
the surface that had been missed. All three go:

| before | after |
| --- | --- |
| `get_global_attribute_id` — O(N) scan over a deduplicated union of the two tables, **per property serialized** (`reply.rs:256`) | the dictionary's own lookup |
| `rel_attr_id_to_global` — same scan (`reply.rs:277`) | **deleted** — a span's id is already the id the client sees |
| `get_attrs()` — built an `FxHashSet<&str>` **per call** to dedupe the union | plain iteration |
| `encode_with_range` — built a local→global remap **per call**, and took the global list as a parameter | ids written as stored; parameter gone |
| `build_global_attrs` | the dictionary's contents |

The RDB id bounds check moves to a new inherent `decode_entities`, because
`Decode::decode_with_count`'s signature cannot carry the dictionary length. Without
a real bound a malformed RDB would store an id resolving to no name, which reads
back as a **silently absent** attribute rather than an error.

That parameter is a seam, and the first revision of this PR left it open: only one
of the three load paths actually received the bound. The other two called
`decode_with_count`, which satisfied itself with `usize::MAX` — silently disabling
the check on `load_graph_from_reader` and on the **multi-key** path, i.e. every
graph large enough to be split across virtual keys. Both now pass
`attrs_name.len()` (the dictionary was already in scope at each, carried on
`PendingGraph` for the multi-key case so every key decodes against one numbering).

Making the omission unreachable matters more than fixing the two call sites, because
nothing at those call sites looked wrong. So `AttributeStore` no longer implements
`Decode` at all: the trait's signature has nowhere to put the dictionary length, and
nothing needed the impl — no generic bound, no `dyn Decode`, no caller. Forgetting
the bound is now a compile error (`E0599: no method named decode_with_count`), and
removing the impl also removed an `unimplemented!` panic that was reachable in
principle from the load path — a panic unwinding across the module's FFI boundary
mid-load being a good deal worse than a returned error.

`EFFECT_ADD_ATTRIBUTE` keeps its `ATTR_NODE`/`ATTR_REL` discriminator. It is
vestigial from here — and C has no such field, for exactly this reason — but
removing it is a wire change, so it belongs with #2419 rather than here.

### Where name resolution lives

Moving the dictionary left the store's `get_attr` / `get_attrs` / `get_all_attrs`
taking a `&AttrNameMap` they had never needed. All eleven production callers were
`Graph` methods handing the store the graph's own dictionary straight back — a
method on the wrong type, not a missing shared reference.

The resolution therefore moved to `Graph`, and the store keeps only what it can
answer alone, which is what it is — id-keyed:

    get_attr_by_idx   get_attrs_by_idx_batch_into   get_attr_ids   get_all_attrs_by_id

`get_attr` is gone outright; `get_attr_by_idx` already existed and was all it
delegated to. `get_attr_ids` is new, so a name lookup that wants no values still
reads only the span's ids.

A shared handle was considered and rejected. `Arc<RwLock<AttrNameMap>>` puts a lock
on the property-serialization read path — the hottest path this touches. A bare
`Arc` needs `make_mut` per registration, and with the graph plus two stores holding
handles the refcount is never 1, so every registration would deep-copy the map:
worse than the one clone per MVCC version paid today. Both also hide the dependency,
and hiding it is what let the RDB id bound go missing above.

Measured on the three bench queries that reach this path, single rep against a
~1–2% instruction noise floor — `rel entity return` 36,911,657 → 36,905,497
(−0.02%), `multi-edge read` 728,565 → 726,306 (−0.31%), `SET edge prop` 975,086 →
971,858 (−0.33%). Neutral, not an improvement.

### Performance: measured flat

I initially argued this was also a performance win. **It is not, and the
measurement is the disproof.** Attribution first, on the pre-change build:

| query | instructions |
| --- | --- |
| `rel traverse only` — `RETURN count(r)` | 344,565 |
| `rel scalar int only` — `RETURN r.weight` | 34,825,615 |
| `rel props as scalars` — same values, no entity framing, no translation | 35,750,146 |
| `rel entity return` — `RETURN r`, entity framing **+ 200 translations** | 36,942,792 |

Entity framing plus every translation is **1.19M of 36.9M (~3%)**, and the
translation is only a fraction of that — at or under the ~1–2% noise floor. Before
vs after:

| query | before | after | delta |
| --- | --- | --- | --- |
| `rel entity return` | 36,906,880 | 36,922,843 | +0.04% |
| `multi-edge read` | 718,741 | 722,275 | +0.49% |
| `SET edge prop` | 979,321 | 974,658 | −0.48% |

So: **a correctness fix that is performance-neutral.** Adds a `rel entity return`
bench query — returning whole relationship entities is the only shape that reaches
the relationship property-map reply path, and nothing in the set covered it.

## 2. The RDB schema block, encoded C's way

Fixing the id space made the two engines' RDBs comparable, and they turned out not
to be loadable at all. Three divergences from C's v19 encoder, all in the schema
block:

* **A constraint status word we invented.** C writes `type, field_count, ids...`;
  we wrote `type, status, field_count, ids...`. A reader expecting the extra word
  runs one field out of step for the rest of the block, so one constraint could
  still parse by luck and two could not — a C-written RDB carrying two constraints
  was refused outright.

* **All constraints, not only active ones.** C filters to `CT_ACTIVE` and writes
  the filtered count, which is what makes the status word redundant rather than
  merely absent: an RDB cannot describe an unfinished constraint. Its loader then
  sets `CT_ACTIVE` unconditionally, so shipping a FAILED constraint would have C
  enforce one we had given up on.

* **RediSearch field names in place of attribute names.** We wrote `range:age`
  where C writes `age` and puts the type in a separate word. Not cosmetic: loading
  such an RDB, C looks for the exact-match index supporting a UNIQUE constraint on
  `name`, finds ours filed under `range:name`, and **segfaults** dereferencing the
  NULL `Constraint_New` returns.

C's format is the reference and Rust is not in production, so this changes our
encoding rather than adding a version. `ENCODING_VERSION` stays **19** — what
shipped as 19 could not be read by the engine whose format 19 names. Consequence
worth stating: an existing Rust-written RDB carrying a constraint will no longer
load.

## 3. UDF library strings, NUL-terminated

UDF libraries live in a module-level AUX field rather than a graph key, written
with raw `RedisModule_Save*` calls, so the schema-block work did not touch them —
and they broke in both directions. C writes `strlen(s) + 1` and reads the buffers
back as C strings; our helper wrote `s.len()`.

* **Writing.** A library saved as `XLib` loaded on C as `XLibte` — the name ran
  into whatever followed it — and none of its functions could be found.
  `GRAPH.UDF LIST` still reported a library, so it failed quietly.
* **Reading.** A name written by C arrived as `"XLib\0"`, which registers nothing
  findable and makes `deserialize` fail. A failed aux load is not a degraded load,
  it aborts the whole RDB: `Short read or OOM loading DB. Unrecoverable error,
  aborting now.` and the server refused to start.

## Cross-engine verification

Against `falkordb/falkordb-server:edge-c`, in **both** directions. A dump.rdb is
moved between engines rather than replication being configured, because a full-sync
failure and a decode failure are indistinguishable from a replica's INFO, whereas
the decoder names the field. Live `REPLICAOF` was then run as well.

| | before | after |
| --- | --- | --- |
| C writes → Rust reads | refused: `expected type tag 4, got 0 at pos 484` | **identical** |
| Rust writes → C reads | **segfault, exit 139**, `Constraint_SetStatus` | **identical** |
| Rust master → C replica (live full sync) | — | **identical**, replica healthy |
| C master → Rust replica (live full sync) | — | **identical**, replica healthy |

Compared over: 500 nodes / 200 edges, multi-label nodes, a multi-edge tensor,
deleted-entity bitmaps, string/int/float/bool/list/point/vector properties, four
range indexes, a fulltext index, a vector index with non-default options
(dimension/similarity/M/efConstruction/efRuntime), and four constraints including a
multi-property one and an edge one — plus a KNN query, so the vector index is shown
*usable* and not merely present. Enforcement is asserted behaviourally, since a
constraint that loads without being enforced is the silent failure here.

Also verified: **multi-key RDBs** (8 virtual keys each side at
`VKEY_MAX_ENTITY_COUNT=100`), and **scale** — 300,000 nodes / 50,000 edges / 4
virtual keys at the default threshold, identical both ways. That last one also
shows the size gap is not per-entity: 9,102,936 bytes (Rust) vs 9,095,038 (C),
0.09% apart, where a per-entity overhead would have shown ~400 KB.

## Tests

**Every test was verified by ablation** — reintroducing the bug and watching it
fail — because a regression test that has only ever seen the fix proves nothing.

`tests/flow/test_rdb_c_layout.py` asserts the saved RDB's **bytes**, which is not
over-specification: **our own reader is blind to two of the three defects.** It
strips the `range:` prefix with `unwrap_or`, and the status word it read was one it
also wrote — writer and reader agreed with each other while both disagreed with C.
All 190 flow tests in the persistency, index, constraint, effect and replication
suites passed with the bugs present.

| ablation | result |
| --- | --- |
| status word restored | `test02` fails, and only it |
| active-only filter dropped | `test03` fails, and only it |
| prefixed field name restored | `test01` fails, and only it |
| UDF writer stops terminating | `test04` fails; **all 44 `test_udf` tests still pass** |
| UDF reader stops stripping | `test_udf` cannot run at all — the engine can no longer load its own output |
| an unbounded `decode_with_count` call reintroduced | **does not compile** — `E0599`, no such method |

That UDF-reader row is why only the UDF *writer* needed a new assertion.

Unit (`graph.rs`), no server:

* `one_id_per_name_across_entity_kinds` — a name gets one id whichever entity kind
  introduces it, and every accessor agrees. Fails ablated with *"a relationship
  attribute must not restart numbering"*.
* `rdb_attr_list_matches_live_ids` — the id a master stamps into an effect indexes
  its own name in the list a replica is seeded from. **This one initially passed
  ablated**, because it only checked the dictionary against itself; asserting the
  wire id against the RDB list is what makes it bite.

* `decode_entities_drops_ids_beyond_the_dictionary` — the id bound above. It drives
  a recording `Writer` replayed into a `Reader`, so it asserts the bound without
  encoding assumptions about `Value`'s own format.

Flow (`test_attr_id_space.py`) covers what a unit test cannot: the trigger is an
**RDB full sync**, and a unit test would only encode our belief about how one seeds
the dictionary. It arranges all three conditions — node attributes before the
relationship one, replica attached afterwards, `EFFECTS_THRESHOLD 0` — and asserts
convergence, including the *intermediate* state so it fails loudly rather than
vacuously if the full sync ever stops carrying the property.

| check | result |
| --- | --- |
| #2457 repro, end to end | master and replica both `{since: 9999}`, **0** edges carrying `a` |
| `cargo test -p graph` | **156 passed**, 0 failed |
| flow suites (rdb_c_layout, udf ×2, attr_id_space, persistency, graph_copy, index ×6, fulltext, vecsim, constraint, effects, replication, aof) | **239 passed**, 0 failed |
| `cargo fmt --all -- --check`, `clippy --all-targets` | clean; the 3 remaining clippy warnings are pre-existing and in files this does not touch |

## Scope note

Items 2 and 3 go beyond #2457, which describes only the split attribute id space.
They are here because unifying the dictionary is what made the RDBs comparable, and
because the index-name defect **crashes** C rather than degrading it — leaving it
in place would mean shipping a fix for silent replica corruption while a hard crash
sat one layer down.

## Known gaps

* **Effects remain incompatible in both directions** and are out of scope here.
  Measured: C segfaults in `AttributeSet_Update` on our first property `SET`; we
  reject C's with `unknown effect type: 0` / `label id N out of range`, and on AOF
  replay come up with an **empty graph** while logging each rejection. Root cause
  is the record framing (4-byte `EffectType` vs 1, per-attribute vs batched
  updates, `SIType` bitmask vs sequential tags) plus C's implicit entity ids on
  create. #2419.
* **Byte parity is not claimed** — only mutual loadability. Virtual key names embed
  a fresh UUID, so two saves of one graph differ; that has to change before byte
  parity is coherent.
* `test_attr_id_space.py` and `test_rdb_c_layout.py` **skip under
  `FALKORDB_USE_SERVICE`**: one drives `REPLICAOF` and rewrites
  `EFFECTS_THRESHOLD`, the other reads the dump off disk. The behavioural opt-out
  (`SPAWN_ONLY_FILES`) arrives with #2450; list both there once it lands and drop
  the skips. The unit tests run everywhere.
* C-side robustness bugs found while doing this, not filed yet pending your
  review: `_RdbLoadConstraint` never NULL-checks `Constraint_New`, so a foreign or
  malformed RDB crashes the server rather than erroring; and two effect-apply
  segfaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unified node and relationship property identifiers to prevent collisions and ensure consistent access.
  - Improved graph restoration, replication synchronization, and relationship-property serialization.
  - Enhanced handling of invalid keys, persistence failures, and out-of-range property identifiers.
  - Updated RDB serialization for compatibility with schema fields, constraints, and UDF data.

- **Tests**
  - Added regression coverage for replica synchronization and property-ID collisions.
  - Added validation for RDB layout compatibility.
  - Added benchmarking for relationship-property serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->