### PR TITLE
ci(dependabot): cover Python, uv and Docker dependencies on main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,49 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+# Python test dependencies for the e2e / TCK / flow suites.
+#
+# `redis<8.1` in tests/requirements.txt is a deliberate pin with a documented
+# reason (falkordb-py 1.6.2 forwards `himport_registry` to the sync client).
+# Dependabot honours declared constraints and will not widen it, so the pin
+# holds until someone edits it by hand.
+- directory: /tests
+  package-ecosystem: pip
+  schedule:
+    interval: weekly
+  groups:
+    python-test-deps:
+      patterns:
+        - "*"
+
+# The benchmark harness is a separate uv project (bench/pyproject.toml +
+# bench/uv.lock) rather than part of the tests/ virtualenv, so it needs its
+# own entry; `pip` would not read the lockfile.
+- directory: /bench
+  package-ecosystem: uv
+  schedule:
+    interval: weekly
+  groups:
+    bench-deps:
+      patterns:
+        - "*"
+
+# Base images for the build, runtime and devcontainer images.
+#
+# /bench is deliberately absent: bench/Dockerfile is `FROM ${C_IMAGE}`, an
+# entirely ARG-driven base that Dependabot cannot resolve to a registry tag.
+# build/runtime/Dockerfile is included for its pinned stages (debian, node);
+# its $BUILD_IMAGE and $BROWSER_TAG stages are skipped for the same reason.
+- package-ecosystem: docker
+  directories:
+    - /build
+    - /build/runtime
+    - /.devcontainer
+  schedule:
+    interval: weekly
+  groups:
+    docker-base-images:
+      patterns:
+        - "*"
+
 version: 2


### PR DESCRIPTION
## Summary

Dependabot on `main` currently tracks only `github-actions` and `cargo`. Three dependency surfaces in the Rust tree receive no updates at all, so vulnerable versions there would go unflagged indefinitely.

This adds one entry per uncovered surface. The three existing entries — including the `target-branch: master` entry that keeps the C engine's Actions bumps alive (#2255) — are untouched.

## Changes

- **`pip` at `/tests`** — `tests/requirements.txt` (`behave`, `pytest`, `redis`, `RLTest`, `hypothesis`, `falkordb`, `textual`)
- **`uv` at `/bench`** — the benchmark harness is its own uv project with `pyproject.toml` + `uv.lock`; `pip` would not read the lockfile, so it needs the `uv` ecosystem
- **`docker` at `/build`, `/build/runtime`, `/.devcontainer`** — the `debian:trixie-slim`, `node:24-bookworm-slim` and `ubuntu:24.04` base images
- Each entry is **grouped** (`patterns: ["*"]`) so it opens one consolidated PR per week instead of one per dependency

### Two deliberate exclusions

- **`/bench` is not in the docker entry.** `bench/Dockerfile` is `FROM ${C_IMAGE}` — an entirely ARG-driven base that Dependabot cannot resolve to a registry tag. Including it would add a directory that yields nothing.
- **`gitsubmodule` is not added.** `main` has no `.gitmodules`; submodules exist only on `master`, where `submodule-update.yml` already handles them. Enabling it would produce duplicate, conflicting PRs pinned to unreleased upstream commits.

### Note on the `redis<8.1` pin

`tests/requirements.txt` pins `redis<8.1` with a documented reason (falkordb-py 1.6.2 forwards `himport_registry` to the sync constructor). Dependabot honours declared version constraints and will not widen them, so this pin holds until someone edits it by hand. The comment in the config records why.

## Testing

- `dependabot.yml` parses as valid YAML; all six entries enumerate correctly with `version: 2` preserved
- Every configured directory was confirmed to contain a manifest Dependabot can actually read: `tests/requirements.txt`, `bench/pyproject.toml` + `bench/uv.lock`, and a `Dockerfile` with at least one statically-resolvable `FROM` in each of the three docker directories
- `package-ecosystem: uv` and the plural `directories:` key are both currently supported per GitHub's Dependabot options reference
- Config-only change — no build, runtime or test behaviour is affected. GitHub validates the file on merge to the default branch; a syntax error would surface in the repo's Dependabot settings rather than at runtime

## Memory / Performance Impact

N/A — CI configuration only. No C, Rust or graph code paths touched.

## Related Issues

Closes #2465

References #2255 (the branch migration that made `main` the config's authoritative location).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update coverage for Python test and benchmark dependencies.
  * Added automated monitoring for Docker base image updates across development and runtime environments.
  * Grouped related dependency updates to simplify maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
