### PR TITLE
fix(runtime): reject bad arity/type on temporal constructors

### DIFF
--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -878,13 +878,18 @@ impl<'a> ExprEval<'a> {
                     // child values into a stack array and dispatch the
                     // slice-based struct_fn directly. Bypasses the per-row
                     // ThinVec<Value> heap alloc, the validate_args_type walk,
-                    // and the Arc<RuntimeFn> dispatch hop. The
-                    // `num_children > 1` guard distinguishes the rewritten
-                    // positional form from the regular `duration({...})` call
-                    // with a single Map argument. Max 10 slots
+                    // and the Arc<RuntimeFn> dispatch hop. Max 10 slots
                     // (matches `localdatetime`).
+                    //
+                    // The rewrite always emits exactly one child per slot, so
+                    // matching that count is what identifies the rewritten
+                    // form. A looser "more than one child" test would also
+                    // catch a user-written `date(a, b)` — the constructors are
+                    // registered `var_arg` to allow the zero-arg "now" form,
+                    // so arity validation does not reject it — and hand
+                    // `struct_fn` fewer values than it indexes.
                     if let Some(struct_fn) = func.struct_fn
-                        && node.num_children() > 1
+                        && node.num_children() == func.struct_slots.len()
                     {
                         let n = node.num_children();
                         debug_assert!(n <= 10);

--- a/graph/src/runtime/functions/mod.rs
+++ b/graph/src/runtime/functions/mod.rs
@@ -841,7 +841,22 @@ impl GraphFn {
                     }
                 }
             }
-            FnArguments::VarLength(_) => {}
+            // A var-length signature still declares the type each argument
+            // must have. Leaving it unchecked made the declared type purely
+            // decorative and let values the function never expects reach it —
+            // the constructors (`date`, `localtime`, `localdatetime`) narrow
+            // to Map/String/Null and then `unreachable!()` on anything else,
+            // so an unvalidated argument aborted the process rather than
+            // returning an error.
+            FnArguments::VarLength(arg_type) => {
+                for arg in args {
+                    if let Some((actual, expected)) = arg.borrow().value_of_type(arg_type) {
+                        return Err(format!(
+                            "Type mismatch: expected {expected} but was {actual}"
+                        ));
+                    }
+                }
+            }
         }
         Ok(())
     }

--- a/graph/src/runtime/functions/temporal.rs
+++ b/graph/src/runtime/functions/temporal.rs
@@ -693,7 +693,11 @@ pub fn register(funcs: &mut Functions) {
 
     // ── date() ──
     cypher_fn!(funcs, "date",
-        var_arg: Type::union([Type::Map, Type::String, Type::Null]),
+        args: [Type::Optional(Box::new(Type::union([
+            Type::Map,
+            Type::String,
+            Type::Null,
+        ])))],
         ret: Type::union([Type::Date, Type::Null]),
         non_deterministic,
         fn date_fn(_, args) {
@@ -710,7 +714,11 @@ pub fn register(funcs: &mut Functions) {
 
     // ── localtime() ──
     cypher_fn!(funcs, "localtime",
-        var_arg: Type::union([Type::Map, Type::String, Type::Null]),
+        args: [Type::Optional(Box::new(Type::union([
+            Type::Map,
+            Type::String,
+            Type::Null,
+        ])))],
         ret: Type::union([Type::Time, Type::Null]),
         non_deterministic,
         fn localtime_fn(_, args) {
@@ -729,7 +737,11 @@ pub fn register(funcs: &mut Functions) {
 
     // ── localdatetime() ──
     cypher_fn!(funcs, "localdatetime",
-        var_arg: Type::union([Type::Map, Type::String, Type::Null]),
+        args: [Type::Optional(Box::new(Type::union([
+            Type::Map,
+            Type::String,
+            Type::Null,
+        ])))],
         ret: Type::union([Type::Datetime, Type::Null]),
         non_deterministic,
         fn localdatetime_fn(_, args) {

--- a/tests/flow/test_temporal.py
+++ b/tests/flow/test_temporal.py
@@ -646,3 +646,90 @@ class testTemporalDuration(FlowTestsBase):
             self.env.assertFalse(True)
         except Exception:
             pass
+
+class testTemporalConstructorArity(FlowTestsBase):
+    def __init__(self):
+        self.env, self.db = Env()
+        self.graph = self.db.select_graph(GRAPH_ID)
+
+    # The struct constructors are dispatched through a fast path that reads
+    # one value per named slot. `date`, `localtime` and `localdatetime` used
+    # to be registered with a var-length signature so that the zero-argument
+    # "now" form would bind, which meant a call carrying more arguments than
+    # the constructor accepts reached that fast path and read past the values
+    # it was given, killing the server.
+    def test_extra_arguments_are_rejected(self):
+        cases = [
+            ("RETURN date('2020-01-01', 'x')",                      "date",          2),
+            ("RETURN date({year: 2020}, 'x')",                      "date",          2),
+            ("RETURN date('2020-01-01', 'a', 'b', 'c', 'd', 'e')",  "date",          6),
+            ("RETURN localtime(1, 2)",                              "localtime",     2),
+            ("RETURN localtime('12:00', 'a', 'b')",                 "localtime",     3),
+            ("RETURN localdatetime(1, 2)",                          "localdatetime", 2),
+        ]
+
+        for query, name, count in cases:
+            try:
+                self.graph.query(query)
+                assert(False)
+            except redis.ResponseError as e:
+                self.env.assertContains(
+                    f"Received {count} arguments to function '{name}', expected at most 1",
+                    str(e))
+
+        # the server must still be answering: the read ran off the end of the
+        # slot array only once the reply had been handed back
+        self.env.assertEqual(self.graph.query("RETURN 1").result_set, [[1]])
+
+    # A var-length signature still names the type each argument must have.
+    # That type went unchecked, so a value the constructor never expects
+    # reached code that treats it as unreachable and aborts.
+    def test_wrongly_typed_argument_is_rejected(self):
+        for name in ["date", "localtime", "localdatetime"]:
+            for arg in ["1", "1.5", "true", "[1]"]:
+                try:
+                    self.graph.query(f"RETURN {name}({arg})")
+                    assert(False)
+                except redis.ResponseError as e:
+                    self.env.assertContains("Type mismatch", str(e))
+
+        self.env.assertEqual(self.graph.query("RETURN 1").result_set, [[1]])
+
+    # the forms that must keep working - the zero-argument "now" reading, the
+    # string form and the map form that the slot fast path exists to serve
+    def test_supported_arities_still_construct(self):
+        for query in ["RETURN date()", "RETURN localtime()", "RETURN localdatetime()"]:
+            self.env.assertEqual(len(self.graph.query(query).result_set), 1)
+
+        cases = [
+            ("RETURN date('2020-01-01')",                            '2020-01-01'),
+            ("RETURN date({year: 1984, month: 10, day: 11})",        '1984-10-11'),
+            ("RETURN localtime('12:31:14')",                         '12:31:14'),
+            ("RETURN localtime({hour: 12, minute: 31, second: 14})", '12:31:14'),
+            ("RETURN localdatetime({year: 1984, month: 10, day: 11, hour: 12, minute: 31, second: 14})",
+             '1984-10-11 12:31:14+00:00'),
+        ]
+        for query, expected in cases:
+            actual = str(self.graph.query(query).result_set[0][0])
+            self.env.assertEqual(actual, expected)
+
+        # null propagates rather than being treated as a missing argument
+        for name in ["date", "localtime", "localdatetime"]:
+            res = self.graph.query(f"RETURN {name}(null)")
+            self.env.assertEqual(res.result_set, [[None]])
+
+    # the fixed-arity constructors already refused a second argument - they
+    # are asserted here so the two groups cannot drift apart
+    def test_fixed_arity_constructors_are_unchanged(self):
+        for query, name in [("RETURN duration(1, 2)", "duration"),
+                            ("RETURN point(1, 2)",    "point")]:
+            try:
+                self.graph.query(query)
+                assert(False)
+            except redis.ResponseError as e:
+                self.env.assertContains(
+                    f"Received 2 arguments to function '{name}', expected at most 1",
+                    str(e))
+
+        res = self.graph.query("RETURN duration({months: 3, days: 2})")
+        self.env.assertEqual(res.result_set[0][0], relativedelta(months=3, days=2))


### PR DESCRIPTION
## Summary

`RETURN date('2020-01-01','x')` terminates the server process. So do `localtime(1,2)`, `localdatetime(1,2)` and `date(1)`. Any client able to run a query can take the database down with one malformed call, so this fixes that.

Found by the `fuzz` job on #2304, which panicked at `temporal.rs:635` with `left: 2, right: 7`.

## Changes

`date`, `localtime` and `localdatetime` are registered with a var-length signature so their zero-argument "now" form binds. That signature is looser than what they accept, and two separate things relied on it being accurate.

- **`eval.rs`** — the struct-constructor fast path identified the binder's rewritten positional form by testing `node.num_children() > 1`. `rewrite_struct_constructor` always emits exactly one child per slot, so the correct test is equality. For a fixed-arity constructor like `point` the loose test was still safe, because arity validation rejects a second argument before evaluation; for these three nothing did, so a user-written `date(a, b)` entered the fast path and handed `date_struct_pure` a 2-element slice that indexes `args[0..6]`. Match on `func.struct_slots.len()`.
- **`functions/mod.rs`** — `validate_args_type` had `FnArguments::VarLength(_) => {}`, so a var-length signature's declared element type was decorative. The three constructors declare `Map | String | Null` and their pure functions treat anything else as `unreachable!()`, which `date(1)` reached. Validate the declared type. Every other var-length function declares `Type::Any`, and `value_of_type` returns `None` for `Type::Any`, so none of them are affected.
- **`functions/temporal.rs`** — give the three their real arity, `args: [Type::Optional(...)]`. `validate` excludes `Optional` from the minimum count, so this is exactly "0 or 1" and is how `duration` and `point` already express the same thing. Using var-length to mean "may be empty" is what pulled the arity check out.

## Testing

`tests/flow/test_temporal.py::testTemporalConstructorArity`, four cases: extra arguments are rejected, wrongly-typed arguments are rejected, every supported form still constructs (0-arg, string, map, and `null` propagation), and the fixed-arity constructors are unchanged so the two groups cannot drift apart. Each rejection case also asserts the server is still answering afterwards.

- with the fix: `test_temporal` 26/26
- with the fix reverted, tests kept: **4 failures**, server killed — so the tests fail for the reason they are meant to
- `cargo test -p graph --lib` 148/148, `test_function_calls` 93/93, `cargo fmt --all --check` clean

Before and after:

| query | before | after |
|---|---|---|
| `RETURN date('2020-01-01','x')` | server killed | `Received 2 arguments to function 'date', expected at most 1` |
| `RETURN localtime(1,2)` | server killed | `Received 2 arguments to function 'localtime', expected at most 1` |
| `RETURN date(1)` | server killed | `Type mismatch: expected Map, String, or Null but was Integer` |
| `RETURN date()`, `date('2020-01-01')`, `date({year:2020})`, `date(null)` | ok | ok |

## Memory / Performance Impact

None. The fast-path guard swaps `> 1` for `== struct_slots.len()`, both constant comparisons on an already-loaded field. Type validation for var-length arguments happens once at plan time, not per row.

## Related Issues

Closes #2466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for temporal constructors such as `date`, `localtime`, and `localdatetime`.
  - Invalid argument counts and unsupported argument types are now rejected with clear errors.
  - Correctly supports optional map, string, or null arguments while preserving existing valid behavior.
  - Prevented malformed constructor calls from being incorrectly dispatched.
  - Fixed variable-length function validation so each supplied argument is checked against its declared type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->