### PR TITLE
fix(dependabot): stop widening the deliberate redis<8.1 test pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,14 +32,32 @@ updates:
     default-days: 7
 # Python test dependencies for the e2e / TCK / flow suites.
 #
-# `redis<8.1` in tests/requirements.txt is a deliberate pin with a documented
-# reason (falkordb-py 1.6.2 forwards `himport_registry` to the sync client).
-# Dependabot honours declared constraints and will not widen it, so the pin
-# holds until someone edits it by hand.
+# `redis` is ignored here deliberately. tests/requirements.txt pins `redis<8.1`
+# because redis-py 8.1.0 adds `himport_registry` to
+# ConnectionPool.connection_kwargs, which falkordb-py 1.6.2 forwards to the
+# sync Redis() constructor; every flow test that builds its own pool fails with
+# a TypeError. The identical pin is duplicated in build/Dockerfile and the two
+# are documented as having to move together.
+#
+# An earlier revision of this comment claimed Dependabot would not widen the
+# constraint. That is wrong: the pip ecosystem defaults to
+# `versioning-strategy: auto`, which raises a `<` ceiling rather than treating
+# it as a hard bound. It opened #2476 to move the ceiling to `<8.2`, which
+# would have re-admitted the broken redis-py release and desynced
+# tests/requirements.txt from build/Dockerfile. CI would not have caught it:
+# no workflow installs tests/requirements.txt -- the flow suites run inside
+# the ghcr.io/falkordb/falkordb-build image, which bakes its own copy of the
+# pin -- so the change is invisible to CI and only breaks local/non-container
+# runs.
+#
+# Remove this ignore when falkordb-py ships a fix and both pins are dropped
+# together.
 - directory: /tests
   package-ecosystem: pip
   schedule:
     interval: weekly
+  ignore:
+  - dependency-name: "redis"
   groups:
     python-test-deps:
       patterns:


### PR DESCRIPTION
## Summary

Follow-up to #2464. The `pip` entry I added for `/tests` carried no `ignore` rule, on the incorrect assumption — stated in a comment in that PR — that Dependabot treats a `<` ceiling as a hard constraint. It does not: the pip ecosystem defaults to `versioning-strategy: auto`, which widens ranges.

Dependabot then opened #2476, raising `redis<8.1` to `redis<8.2`.

## Why that is a problem

**It re-admits the exact release the pin excludes.** `<8.2` permits redis-py 8.1.0, which adds `himport_registry` to `ConnectionPool.connection_kwargs`; falkordb-py 1.6.2 forwards it to the sync `Redis()` constructor, and every flow test that builds its own pool fails with a `TypeError`.

**It desyncs two pins that must move together.** The identical pin lives at `build/Dockerfile:141`, and the comment above it says "Keep in sync with build/Dockerfile". #2476 touches only `tests/requirements.txt`.

**CI gives false assurance.** `tests/requirements.txt` is installed by *no* workflow — the flow suites run inside `ghcr.io/falkordb/falkordb-build`, which bakes its own copy of the pin. So `flow-test-matrix` passes on #2476 without ever exercising the changed file. The breakage surfaces only on local and non-container runs, which is why this needs a config guard rather than a test.

## Changes

- Add `ignore: [dependency-name: "redis"]` to the `/tests` pip entry
- Replace the comment that made the wrong claim, recording why the ignore exists, that CI cannot catch the regression, and the condition for removing it

## Testing

- `.github/dependabot.yml` parses under `yaml.safe_load`; all six update entries verified intact with the `ignore` attached to the `pip` `/tests` entry only
- Confirmed `tests/requirements.txt` matches no reference in `.github/workflows/`
- Confirmed the duplicate pin at `build/Dockerfile:141`
- No change to the other five ecosystems; the `target-branch: master` github-actions entry is untouched

## Memory / Performance Impact

N/A — CI configuration only.

## Related Issues

Closes #2483

Once merged, #2476 should be closed unmerged; Dependabot will not reopen it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to keep Redis below version 8.1 for test environments.
  * Added documentation explaining the compatibility constraint, CI limitations, and criteria for revisiting the restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->