### PR TITLE
test(functions): cover crash-inducing arguments to range() and exists()

### DIFF
--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2068,6 +2068,20 @@ class testFunctionCallsFlow(FlowTestsBase):
         }
         for query, expected_result in query_to_expected_result.items():
             self.get_res_and_assertEquals(query, expected_result)
+
+        # a range whose bounds sit at the i64 limits must be rejected
+        # cleanly, negating i64::MIN used to crash the server
+        queries_with_errors = [
+            "RETURN range(0, -9223372036854775808, -1)",
+            "RETURN range(0, -9223372036854775807, -1)",
+            "RETURN range(-9223372036854775808, 0, 1)",
+        ]
+        for query in queries_with_errors:
+            self.expect_error(query, "Range too large")
+
+        # a zero step is a distinct, equally clean error
+        self.expect_error("RETURN range(0, 10, 0)",
+                          "step argument to range() can't be 0")
     
     def test80_IN(self):
         query_to_expected_result = {
@@ -2804,3 +2818,23 @@ class testFunctionCallsFlow(FlowTestsBase):
     #
     #     res = self.graph.query("UNWIND range(1, 5) AS x RETURN prev(tostring(x) + tostring(x))")
     #     self.env.assertEqual(res.result_set, [[None], ['11'], ['22'], ['33'], ['44']])
+
+    def test96_exists_unbound_variables(self):
+        # exists() over a traversal pattern referencing unbound variables,
+        # reusing the same relationship variable in both patterns, used to
+        # dereference unresolved entities and crash the server
+        q = "RETURN exists( (n0)-[r1]-(n1), (n1)-[r1]-(n0) ) AS has_path"
+        self.expect_error(q, "'n0' not defined")
+
+        # a traversal pattern is not a valid exists() argument at all,
+        # whether or not its variables resolve
+        q = "RETURN exists( (n0)-[r1]-(n1) )"
+        self.expect_error(q,
+            "traversal patterns are not allowed as arguments to exists()")
+
+        q = "MATCH (a) RETURN exists( (a)-[r1]-(n1) )"
+        self.expect_error(q,
+            "traversal patterns are not allowed as arguments to exists()")
+
+        # the server is still responsive
+        self.env.assertEqual(self.graph.query("RETURN 1").result_set, [[1]])


### PR DESCRIPTION
## Summary

Regression tests for two `fixed-rust` crashes in which hostile arguments took the **whole server down** (SIGSEGV/SIGFPE, `ExitCode=139`) instead of producing a query error. Both are fixed by the Rust engine; neither had a test.

## Changes

**Extended `test79_Range`** (#385) — `range()` negated `i64::MIN` while computing its span, which is undefined at the 64-bit boundary:

- `range(0, -9223372036854775808, -1)` — the original report
- `range(0, -9223372036854775807, -1)` — the adjacent value, which used to OOM instead
- `range(-9223372036854775808, 0, 1)` — the same limit as the *start* bound

All must raise `Range too large`. Also pinned the neighbouring `step = 0` error so the two failure modes stay distinct.

**Added `test96_exists_unbound_variables`** (#2264) — `exists()` dereferenced unresolved entities when its traversal pattern referenced unbound variables and reused a relationship variable:

- `RETURN exists( (n0)-[r1]-(n1), (n1)-[r1]-(n0) )` → `'n0' not defined`
- `RETURN exists( (n0)-[r1]-(n1) )` and the bound-source variant → `traversal patterns are not allowed as arguments to exists()`
- a trailing `RETURN 1` asserts the **server is still responsive**, which is the property that actually regressed

## Testing

`RELEASE=1 VERBOSE=0 TEST=tests/flow/test_function_calls ./flow.sh` → **94/94 pass**.

Both crashes were reproduced on the era image before writing the tests:

| issue | query | `v4.20.1` | `main` |
|---|---|---|---|
| #385 | `range(0, -9223372036854775808, -1)` | `Server closed the connection` 💥 | `Range too large` |
| #2264 | `exists( (n0)-[r1]-(n1), (n1)-[r1]-(n0) )` | `Server closed the connection` 💥 | `'n0' not defined` |

In both cases the container died and the follow-up `PING` returned `Connection reset by peer`.

## Memory / Performance Impact

N/A — tests only.

## Related Issues

Closes #385
Closes #2264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for invalid `range()` inputs, including boundary values and zero steps.
  * Improved handling of invalid traversal patterns in `exists()`, returning clear validation errors without disrupting later queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->