### PR TITLE
test(reduce): cover nested reduce with shadowed iterator names

### DIFF
--- a/tests/flow/test_reduce.py
+++ b/tests/flow/test_reduce.py
@@ -143,8 +143,18 @@ class testReduce():
         q = "RETURN [x IN [1] | reduce(s=0, x IN [1] | s + [x IN [1] | x][0])][0]"
         self.env.assertEqual(self.graph.query(q).result_set, [[1]])
 
-        # three levels deep, shadowing both the accumulator and the iterator
-        q = """RETURN reduce(s=0, x IN [0] | s + reduce(s=0, x IN [0] | s + 1))"""
+        # three reduce() scopes deep, shadowing both the accumulator and
+        # the iterator at every level
+        q = """RETURN reduce(s=0, x IN [0] |
+                      s + reduce(s=0, x IN [0] |
+                          s + reduce(s=0, x IN [0] | s + 1)))"""
+        self.env.assertEqual(self.graph.query(q).result_set, [[1]])
+
+        # the same depth wrapped in a list comprehension, which adds a
+        # fourth scope shadowing the iterator
+        q = """RETURN [x IN [0] | reduce(s=0, x IN [0] |
+                          s + reduce(s=0, x IN [0] |
+                              s + reduce(s=0, x IN [0] | s + 1)))][0]"""
         self.env.assertEqual(self.graph.query(q).result_set, [[1]])
 
         # the shadowed form is still a non-boolean expression in a WHERE

--- a/tests/flow/test_reduce.py
+++ b/tests/flow/test_reduce.py
@@ -137,6 +137,31 @@ class testReduce():
         actual = self.graph.query(q).result_set[0][0]
         self.env.assertEqual(actual, expected)
 
+        # nesting reduce() inside a list comprehension while shadowing the
+        # iterator names in the inner scopes used to corrupt the outer
+        # scope's references and crash the server
+        q = "RETURN [x IN [1] | reduce(s=0, x IN [1] | s + [x IN [1] | x][0])][0]"
+        self.env.assertEqual(self.graph.query(q).result_set, [[1]])
+
+        # three levels deep, shadowing both the accumulator and the iterator
+        q = """RETURN reduce(s=0, x IN [0] | s + reduce(s=0, x IN [0] | s + 1))"""
+        self.env.assertEqual(self.graph.query(q).result_set, [[1]])
+
+        # the shadowed form is still a non-boolean expression in a WHERE
+        # clause, so it must be rejected rather than evaluated
+        self.graph.query("CREATE (:Node)")
+        q = """MATCH (n)
+               WHERE [x IN [0] | reduce(s=0, x IN [0] | s + reduce(s=0, x IN [0] | s + 1))][0]
+               RETURN 1"""
+        try:
+            self.graph.query(q)
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("Expected boolean predicate", str(e))
+
+        # the server survived and the outer scope is uncorrupted
+        self.env.assertEqual(self.graph.query("RETURN 1").result_set, [[1]])
+
     def test_empty_reduction(self):
         # 1 + nothing is 1
         q = "RETURN reduce(sum=1, n in [] | sum + n)"


### PR DESCRIPTION
## Summary

Regression test for #1481, a memory-corruption crash: nesting `reduce()` inside a list comprehension while **shadowing** the accumulator and iterator names in the inner scopes took the server down with a SIGSEGV. Fixed by the Rust engine, untested until now.

## Changes

**Extended `test_nested_reduction`** — the file already had a nested-`reduce()` test, but it used *distinct* variable names in each scope, so the shadowing path was never exercised. The extension follows that test's narrative:

- the reporter's minimal PoC — `[x IN [1] | reduce(s=0, x IN [1] | s + [x IN [1] | x][0])][0]` → `1`
- three levels deep, shadowing **both** the accumulator `s` and the iterator `x` → `1`
- the original `WHERE`-clause form, which must be rejected with `Expected boolean predicate` (the projection yields an integer, not a boolean) rather than evaluated
- a trailing `RETURN 1` asserting the **server survived and the outer scope is uncorrupted** — the property that actually regressed

## Testing

`RELEASE=1 VERBOSE=0 TEST=tests/flow/test_reduce ./flow.sh` → **14/14 pass**.

Reproduced on the era image first:

| query | `v4.20.1` | `main` |
|---|---|---|
| `MATCH (n) WHERE [x IN [0] \| reduce(s=0, x IN [0] \| s + reduce(s=0, x IN [0] \| s + 1))][0] RETURN 1` | `Server closed the connection` 💥 | `Expected boolean predicate` |
| minimal PoC (`RETURN [x IN [1] \| ...][0]`) | `1` | `1` |

Worth noting the minimal PoC from the issue does **not** crash `v4.20.1` — only the deeper `WHERE`-clause form does, which is why that form is included rather than the minimal one alone.

`tests/flow/test_reduce.py` is already listed in `flow_tests_done.txt` (line 85), so this runs in CI.

## Memory / Performance Impact

N/A — tests only.

## Related Issues

Closes #1481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested reduction expressions when accumulator and iterator names overlap.
  * Prevented invalid reduction expressions from being accepted as filter conditions.
  * Confirmed subsequent queries continue to work correctly after invalid expressions are evaluated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->