### PR TITLE
test(all-shortest-paths): cover aggregating WITH * over unresolved endpoints

### DIFF
--- a/tests/flow/test_all_shortest_paths.py
+++ b/tests/flow/test_all_shortest_paths.py
@@ -123,7 +123,24 @@ class testAllShortestPaths():
         except redis.ResponseError as e:
             self.env.assertContains("FalkorDB support allShortestPaths only in match clauses", str(e))
 
+        # unresolved endpoints followed by an aggregating WITH * used to
+        # crash the server: the error is raised while an aggregation is
+        # still pending, and unwinding it corrupted the execution plan
+        query = """MATCH p = allShortestPaths((a:Paper)-[*..2]-(b:Paper))
+                   WITH *, count(a) AS count_a
+                   RETURN p"""
+
+        try:
+            self.graph.query(query)
+            self.env.assertTrue(False)
+        except redis.ResponseError as e:
+            self.env.assertContains("Source and destination must already be resolved to call allShortestPaths", str(e))
+
+        # the server is still alive and serving queries
+        self.env.assertEqual(self.graph.query("RETURN 1").result_set, [[1]])
+
     def test02_all_shortest_paths(self):
+
         # running against following graph
         #
         # (v1)-[:E]->(v2)-[:E]->(v3)-[:E]->(v4)


### PR DESCRIPTION
## Summary

Regression test for #2127, a SIGSEGV: `allShortestPaths()` whose endpoints are declared **inline in its own pattern** correctly raises `Source and destination must already be resolved`, but when the clause was followed by an **aggregating `WITH *`**, raising that error with an aggregation still pending took the whole server down.

## Changes

**Extended `test01_invalid_shortest_paths`** — that test already enumerates the invalid `allShortestPaths` forms and asserts a clean error for each, so this is the same narrative rather than a new test. Added:

- `MATCH p = allShortestPaths((a:Paper)-[*..2]-(b:Paper)) WITH *, count(a) AS count_a RETURN p` → `Source and destination must already be resolved to call allShortestPaths`
- a trailing `RETURN 1` asserting the **server is still alive** — the property that actually regressed

## Testing

`RELEASE=1 VERBOSE=0 TEST=tests/flow/test_all_shortest_paths ./flow.sh` → **7/7 pass**.

I bisected the reported query on the era image to isolate what actually crashes, because the issue's own root-cause analysis (hashing `Path`/`Array` as `GROUP BY` keys) turns out not to be the trigger:

| query on `v4.18.10` | result |
|---|---|
| `MATCH p = allShortestPaths((a:Paper)-[*..2]-(b:Paper)) RETURN p` | clean error ✅ |
| the same **+ `WITH *, count(a)`** | `Server closed the connection` 💥 |
| `MATCH p = (a:Paper)-[*..2]-(b:Paper) WITH *, count(a) ...` | works ✅ |
| `MATCH (a:Paper) WITH *, [a.x, 1] AS arr, count(a) ...` | works ✅ |

So grouping by a `Path` or an `Array` was never the problem — the crash needs the **error path** and the **pending aggregation** together. The test asserts exactly that combination.

I also checked the case already covered by this test's first assertion (`MATCH (v1),(v4), p = allShortestPaths((v1)-[*]->(v4))`): it errors cleanly on `v4.18.10`, so it never covered this crash and the extension is not duplication.

## Memory / Performance Impact

N/A — tests only.

## Related Issues

Closes #2127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unresolved `allShortestPaths` endpoints followed by `WITH *` aggregation.
  * Confirmed the server remains operational after the expected error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->