### PR TITLE
fix(bench): read jemalloc stats by column, not by whitespace

### DIFF
--- a/bench/src/falkorbench/client.py
+++ b/bench/src/falkorbench/client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -45,6 +46,77 @@ _DEATH_MARKERS = (
     "signal:",
     "=== REDIS BUG REPORT",
 )
+
+
+def _jemalloc_table_columns(header: str) -> dict[str, tuple[int, int]]:
+    """Map each column label in a jemalloc `bins:`/`large:` header to the
+    `(start, end)` character range of its field.
+
+    **jemalloc's stats tables cannot be split on whitespace.** Every value is
+    right-aligned in a fixed-width field, and the `(#/sec)` rate fields are only
+    8 characters wide, so a rate of 10,000,000/sec or more fills its field
+    exactly and no space is left between it and the `nmalloc` before it:
+
+    ```text
+    nmalloc (#/sec)      ndalloc (#/sec)     <- header
+        1379247  689623      1355704  677852 <- fine, rates are 6 digits
+    21949879 10974939 21947904 10973952      <- fused: 8-digit rates
+    ```
+
+    `line.split()` turns that second row into `['21949879109749392194790410973952']`
+    -- a 16-digit garbage `nmalloc` -- and shifts every later column left by
+    one, so `ndalloc` reads the fused ndalloc+rate too. The parsed cumulative
+    total jumps by ~7e16 bytes the moment a hot size class crosses 10M
+    allocations/sec, and drops back when it cools. Because `measure` reports
+    *deltas* between two snapshots, that surfaced as per-query allocation
+    figures in the petabytes and, when the fusion cleared between snapshots,
+    as negative ones. It read as a 30,000x memory regression in whichever
+    queries happened to straddle the transition.
+
+    Slicing by the header's own column ranges is immune: overflow in a
+    right-aligned field spills *left*, so a field read up to its own end column
+    is still correct, and only its left neighbour (a rate we do not use) is
+    damaged.
+
+    A field therefore runs from the *previous* column's end to its own, not from
+    its own label's start -- values are commonly wider than their label
+    (`size` labels a 5-digit 49152), and anchoring on the label's start would
+    shear the leading digits off.
+    """
+    cols: dict[str, tuple[int, int]] = {}
+    prev_end = 0
+    for m in re.finditer(r"\S+", header):
+        label = m.group()
+        # `(#/sec)` repeats after every counter, and the leading `bins:`/`large:`
+        # is a row label rather than a column; both still advance the boundary.
+        # First occurrence wins, which is all we need for named counters.
+        if label not in ("bins:", "large:") and label not in cols:
+            cols[label] = (prev_end, m.end())
+        prev_end = m.end()
+    return cols
+
+
+def _jemalloc_row(
+    line: str,
+    cols: dict[str, tuple[int, int]],
+    wanted: Sequence[str],
+) -> dict[str, int] | None:
+    """Read `wanted` integer fields out of one jemalloc table row, or None if
+    this is not a data row (a `total:`/`---` separator, or a short line).
+
+    Fields are located by the header's column ranges rather than by whitespace
+    position; see [`_jemalloc_table_columns`].
+    """
+    out: dict[str, int] = {}
+    for name in wanted:
+        span = cols.get(name)
+        if span is None:
+            return None
+        text = line[span[0] : span[1]].strip()
+        if not text.isdigit():
+            return None
+        out[name] = int(text)
+    return out
 
 
 class SetupFailed(RuntimeError):
@@ -130,13 +202,9 @@ class BenchClient:
         stats, or (None, None) if the server is not jemalloc-built.
 
         Sums size*nmalloc / size*ndalloc over the `bins:` and `large:`
-        size-class tables. Column positions are read from each table's own
-        header rather than hardcoded: they *were* hardcoded, and the dealloc
-        index was wrong — jemalloc 5.x emits
-        `size ind allocated nmalloc ndalloc nrequests ...`, so index 5 is
-        *nrequests*, not ndalloc. That inflated deallocated bytes and made the
-        per-query deltas meaningless (absurd ratios, negative values). Reading
-        the header also survives column changes between jemalloc versions.
+        size-class tables, reading each field by the character columns of its
+        own table header — see [`_jemalloc_table_columns`] for why splitting
+        those rows on whitespace does not work.
         """
         try:
             out = str(self.command("MEMORY", "MALLOC-STATS"))
@@ -146,34 +214,30 @@ class BenchClient:
             return None, None
 
         alloc = dealloc = 0
-        in_merged = in_table = False
-        i_nmalloc = i_ndalloc = None
+        in_merged = False
+        cols: dict[str, tuple[int, int]] | None = None
         for line in out.splitlines():
             if line.startswith("Merged arenas stats:"):
                 in_merged = True
             elif line.startswith("arenas["):
                 break
             elif in_merged:
-                s = line.split()
-                if not s:
+                head = line.split(maxsplit=1)
+                if not head:
                     continue
-                if s[0] in ("bins:", "large:") and "size" in s:
-                    in_table = True
-                    # Header tokens include the leading "bins:"/"large:" label,
-                    # which data rows do not, hence the -1.
-                    try:
-                        i_nmalloc = s.index("nmalloc") - 1
-                        i_ndalloc = s.index("ndalloc") - 1
-                    except ValueError:
-                        i_nmalloc = i_ndalloc = None
-                elif s[0] == "extents:":
-                    in_table = False
-                elif in_table and s[0].isdigit() and i_nmalloc is not None:
-                    if len(s) <= max(i_nmalloc, i_ndalloc):
+                label = head[0]
+                if label in ("bins:", "large:") and " size " in line:
+                    cols = _jemalloc_table_columns(line)
+                elif label == "extents:":
+                    # A different table with different columns, and no
+                    # nmalloc/ndalloc to contribute.
+                    cols = None
+                elif cols is not None:
+                    row = _jemalloc_row(line, cols, ("size", "nmalloc", "ndalloc"))
+                    if row is None:
                         continue
-                    size = int(s[0])
-                    alloc += size * int(s[i_nmalloc])
-                    dealloc += size * int(s[i_ndalloc])
+                    alloc += row["size"] * row["nmalloc"]
+                    dealloc += row["size"] * row["ndalloc"]
         return alloc, dealloc
 
     def shutdown(self) -> None:

--- a/bench/tests/test_jemalloc_stats.py
+++ b/bench/tests/test_jemalloc_stats.py
@@ -1,0 +1,111 @@
+"""Guards on the jemalloc MALLOC-STATS parse behind `alloc_bytes`.
+
+Every row below is verbatim from a real `MEMORY MALLOC-STATS` reply captured
+mid-benchmark, including the fused row that made the metric lie. The parse used
+to split these lines on whitespace, which silently fails once a `(#/sec)` rate
+reaches 8 digits and fills its fixed-width field: the rate runs into the
+`nmalloc` before it, and `nmalloc` reads as a 16-digit number. The parsed
+cumulative total jumped ~7e16 bytes when a hot size class crossed 10M
+allocs/sec and fell back when it cooled, so `measure`'s per-query *deltas* came
+out in the petabytes -- or negative -- and the compare gate read that as a
+30,000x memory regression on whatever queries straddled the transition.
+"""
+
+from falkorbench.client import _jemalloc_row
+from falkorbench.client import _jemalloc_table_columns
+
+BINS_HEADER = (
+    "bins:           size ind    allocated      nmalloc (#/sec)      "
+    "ndalloc (#/sec)    nrequests   (#/sec)  nshards      curregs     c"
+)
+# Rates of 6 digits: whitespace-separated, so both parses agree.
+BINS_ROW_SEPARATED = (
+    "                   8   0       188344      1379247  689623      "
+    "1355704  677852     64650963  32325481        1        23543      "
+)
+# The pathological one: rates are 10,974,939 and 10,973,952 -- 8 digits, which
+# exactly fills the `(#/sec)` field, leaving no space before it.
+BINS_ROW_FUSED = (
+    "                  32   3        63200     2194987910974939     "
+    "2194790410973952     69572003  34786001        1         1975      "
+)
+LARGE_HEADER = (
+    "large:          size ind    allocated      nmalloc (#/sec)      "
+    "ndalloc (#/sec)    nrequests (#/sec)  curlextents"
+)
+LARGE_ROW = (
+    "               49152  45       933888        24209   12104        "
+    "24190   12095        24209     12104        1           19      "
+)
+
+WANTED = ("size", "nmalloc", "ndalloc")
+
+
+def test_separated_row_reads_its_counters():
+    cols = _jemalloc_table_columns(BINS_HEADER)
+    assert _jemalloc_row(BINS_ROW_SEPARATED, cols, WANTED) == {
+        "size": 8,
+        "nmalloc": 1_379_247,
+        "ndalloc": 1_355_704,
+    }
+
+
+def test_fused_rate_column_does_not_corrupt_nmalloc():
+    """The regression this file exists for.
+
+    `BINS_ROW_FUSED.split()` yields `2194987910974939` in the nmalloc position;
+    the real value is 21,949,879 with a 10,974,939/sec rate glued to it.
+    """
+    cols = _jemalloc_table_columns(BINS_HEADER)
+    row = _jemalloc_row(BINS_ROW_FUSED, cols, WANTED)
+    assert row == {"size": 32, "nmalloc": 21_949_879, "ndalloc": 21_947_904}
+    # And the contribution stays a believable number of bytes, not 7e16.
+    assert row["size"] * row["nmalloc"] < 10**10
+    # Guard the premise, so this test still means something if jemalloc's
+    # formatting changes: whitespace splitting really does fuse the fields.
+    assert BINS_ROW_FUSED.split()[3] == "2194987910974939"
+
+
+def test_ndalloc_never_exceeds_nmalloc_on_a_fused_row():
+    """A size class cannot be freed more times than it was allocated. The old
+    parse broke this (it read `nrequests` as ndalloc at one point), and it is
+    the cheapest invariant that catches a column mix-up."""
+    cols = _jemalloc_table_columns(BINS_HEADER)
+    for line in (BINS_ROW_SEPARATED, BINS_ROW_FUSED):
+        row = _jemalloc_row(line, cols, WANTED)
+        assert row is not None
+        assert row["ndalloc"] <= row["nmalloc"]
+
+
+def test_large_table_has_its_own_column_layout():
+    """`large:` drops `nshards`/`curregs` and ends in `curlextents`, so its
+    columns must come from its own header rather than the `bins:` one."""
+    cols = _jemalloc_table_columns(LARGE_HEADER)
+    assert _jemalloc_row(LARGE_ROW, cols, WANTED) == {
+        "size": 49_152,
+        "nmalloc": 24_209,
+        "ndalloc": 24_190,
+    }
+
+
+def test_non_data_lines_are_rejected():
+    cols = _jemalloc_table_columns(BINS_HEADER)
+    for line in (
+        "total:                        7191648           23524     23524  ",
+        "                     ---",
+        "",
+        "active:                       9830400",
+    ):
+        assert _jemalloc_row(line, cols, WANTED) is None
+
+
+def test_missing_counter_column_yields_no_row():
+    """An `extents:`-shaped header has no nmalloc/ndalloc; asking for them must
+    fail closed rather than pick up whatever sits at that offset."""
+    extents = (
+        "extents:        size ind       ndirty        dirty       nmuzzy    "
+        "    muzzy    nretained     retained       ntotal"
+    )
+    cols = _jemalloc_table_columns(extents)
+    assert "nmalloc" not in cols
+    assert _jemalloc_row("               8   0            1         4096", cols, WANTED) is None


### PR DESCRIPTION
## The bug

`jemalloc_totals` splits the `bins:`/`large:` rows of `MEMORY MALLOC-STATS` on whitespace. Those tables are fixed-width and right-aligned, and the `(#/sec)` rate fields are 8 characters wide — so a rate ≥ 10,000,000/sec fills its field exactly and leaves no space before the `nmalloc` next to it:

```text
nmalloc (#/sec)      ndalloc (#/sec)
    1379247  689623      1355704  677852     <- fine, 6-digit rates
21949879 10974939 21947904 10973952          <- fused, 8-digit rates
```

`line.split()` reads that `nmalloc` as one 16-digit number and shifts every later column left, so `ndalloc` picks up a fused value too. The cumulative total jumps ~7e16 bytes when a hot size class crosses 10M allocs/sec and drops back when it cools — and since `measure` reports **deltas** between two snapshots, that lands as per-query allocation in the petabytes, or negative when the fusion clears between snapshots.

## Not hypothetical

Three full 317-query runs on one host, each producing exactly 8 physically impossible rows, consistently:

| query | rep 1 | rep 2 | rep 3 | with this fix |
|---|---:|---:|---:|---:|
| `MSF nodes yield` | 351,207,481,011,826 | 351,207,097,013,232 | 351,210,249,012,702 | **10,649,197** |
| `write 1m` | −39,655,479,199,115,760 | −39,656,013,599,155,096 | −39,656,194,399,073,920 | — |
| `write 100k` | 320,185,648,034,151 | 320,142,448,020,056 | 320,139,888,012,900 | — |
| `write 1k` | 3,182,176,503,580 | — | — | **485,442** |

`alloc_bytes` is the column the `benchmark-cov` CI comment uses **against the C engine** (callgrind can't measure that engine reliably), so this breaks the one vs-C reading CI has. It needs a full run to trigger — a handful of queries never gets a size class hot enough — which is why it survived.

## The fix

Slice each field by the character range of its own table's header. Overflow in a right-aligned field spills *left*, so a field read up to its own end column stays correct and only its left neighbour (a rate nothing here uses) is damaged. A field runs from the previous column's end rather than its own label's start, because values are routinely wider than their labels (`size` labels a 5-digit 49152).

`bench/tests/test_jemalloc_stats.py` guards it with real captured rows — the fused one included — and asserts both parses agree where the rates are narrow enough to be unambiguous. 95 bench tests pass.

Found while producing a full Rust-vs-C benchmark report; this was lead #5 of 5. The fix itself was already sitting in a local working tree, unlanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved jemalloc statistics parsing across standard and large allocation tables.
  * Correctly reads allocation and deallocation counts when columns are separated or combined.
  * Prevents malformed, unsupported, or incomplete rows from producing inaccurate statistics.
  * Ensures reported allocation counts remain consistent and reliable across supported table layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2496
