### PR TITLE
fix: bare GRAPH.INFO, and C-parity for the run-time config surface

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -15,12 +15,11 @@
 //!   TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX, RESULTSET_SIZE,
 //!   MAX_QUEUED_QUERIES, QUERY_MEM_CAPACITY, DELTA_MAX_PENDING_CHANGES,
 //!   VKEY_MAX_ENTITY_COUNT, JS_HEAP_SIZE, JS_STACK_SIZE, EFFECTS_THRESHOLD,
-//!   CMD_INFO
+//!   CMD_INFO, MAX_INFO_QUERIES, DELAY_INDEXING
 //!
 //! Read-only (SET returns an error):
 //!   THREAD_COUNT, OMP_THREAD_COUNT, CACHE_SIZE, ASYNC_DELETE,
-//!   NODE_CREATION_BUFFER, MAX_INFO_QUERIES,
-//!   BOLT_PORT, DELAY_INDEXING, IMPORT_FOLDER, TEMP_FOLDER
+//!   NODE_CREATION_BUFFER, BOLT_PORT, IMPORT_FOLDER, TEMP_FOLDER
 //!
 //! ## Multi-SET semantics
 //! When multiple name-value pairs are provided in a single SET, all pairs are
@@ -34,9 +33,9 @@ use crate::config::{
     CONFIGURATION_DELAY_INDEXING, CONFIGURATION_IMPORT_FOLDER, CONFIGURATION_INDEX_WORKER_THREADS,
     CONFIGURATION_JS_HEAP_SIZE, CONFIGURATION_JS_STACK_SIZE, CONFIGURATION_NODE_CREATION_BUFFER,
     CONFIGURATION_TEMP_FOLDER, CONFIGURATION_VKEY_MAX_ENTITY_COUNT, DELTA_MAX_PENDING_CHANGES,
-    EFFECTS_THRESHOLD, MAX_INFO_QUERIES, MAX_QUEUED_QUERIES, OMP_THREAD_COUNT, QUERY_MEM_CAPACITY,
-    RESULTSET_SIZE, TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX, get_thread_count,
-    normalize_node_creation_buffer,
+    EFFECTS_THRESHOLD, MAX_INFO_QUERIES, MAX_INFO_QUERIES_CAP, MAX_QUEUED_QUERIES,
+    OMP_THREAD_COUNT, QUERY_MEM_CAPACITY, RESULTSET_SIZE, TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX,
+    get_thread_count, normalize_node_creation_buffer,
 };
 use redis_module::{Context, NextArg, RedisResult, RedisString, RedisValue};
 use std::sync::atomic::Ordering;
@@ -116,7 +115,7 @@ fn validate_config_set(
             Ok(ConfigValue::Int(v))
         }
         // Runtime-settable boolean configs
-        "ASYNC_DELETE" | "CMD_INFO" => {
+        "ASYNC_DELETE" | "CMD_INFO" | "DELAY_INDEXING" => {
             let v = match value.to_lowercase().as_str() {
                 "yes" | "1" | "true" => 1i64,
                 "no" | "0" | "false" => 0i64,
@@ -146,6 +145,17 @@ fn validate_config_set(
                 .map_err(|_| format!("Failed to set config value {name} to {value}"))?;
             Ok(ConfigValue::Int(v))
         }
+        "MAX_INFO_QUERIES" => {
+            let v: i64 = value
+                .parse()
+                .map_err(|_| format!("Failed to set config value {name} to {value}"))?;
+            if v < 0 {
+                return Err(format!("Failed to set config value {name} to {value}"));
+            }
+            // C clamps to the cap instead of failing, so a too-large value is
+            // accepted and reported back as the cap
+            Ok(ConfigValue::Int(v.min(MAX_INFO_QUERIES_CAP)))
+        }
         "JS_HEAP_SIZE" | "JS_STACK_SIZE" => {
             let v: i64 = value
                 .parse()
@@ -163,9 +173,7 @@ fn validate_config_set(
         | "OMP_THREAD_COUNT"
         | "CACHE_SIZE"
         | "NODE_CREATION_BUFFER"
-        | "MAX_INFO_QUERIES"
         | "BOLT_PORT"
-        | "DELAY_INDEXING"
         | "IMPORT_FOLDER"
         | "TEMP_FOLDER" => {
             Err("This configuration parameter cannot be set at run-time".to_string())
@@ -239,6 +247,10 @@ fn apply_config_set(
         "EFFECTS_THRESHOLD" => EFFECTS_THRESHOLD.store(val.as_i64(), Ordering::Relaxed),
         "ASYNC_DELETE" => ASYNC_DELETE.store(val.as_i64(), Ordering::Relaxed),
         "CMD_INFO" => CONFIGURATION_CMD_INFO.store(val.as_i64() != 0, Ordering::Relaxed),
+        "MAX_INFO_QUERIES" => MAX_INFO_QUERIES.store(val.as_i64(), Ordering::Relaxed),
+        "DELAY_INDEXING" => {
+            *CONFIGURATION_DELAY_INDEXING.lock(ctx) = val.as_i64() != 0;
+        }
         "VKEY_MAX_ENTITY_COUNT" => {
             *CONFIGURATION_VKEY_MAX_ENTITY_COUNT.lock(ctx) = val.as_i64();
         }

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -14,11 +14,12 @@
 //! Runtime-settable (via SET):
 //!   TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX, RESULTSET_SIZE,
 //!   MAX_QUEUED_QUERIES, QUERY_MEM_CAPACITY, DELTA_MAX_PENDING_CHANGES,
-//!   VKEY_MAX_ENTITY_COUNT, JS_HEAP_SIZE, JS_STACK_SIZE, EFFECTS_THRESHOLD
+//!   VKEY_MAX_ENTITY_COUNT, JS_HEAP_SIZE, JS_STACK_SIZE, EFFECTS_THRESHOLD,
+//!   CMD_INFO
 //!
 //! Read-only (SET returns an error):
 //!   THREAD_COUNT, OMP_THREAD_COUNT, CACHE_SIZE, ASYNC_DELETE,
-//!   NODE_CREATION_BUFFER, CMD_INFO, MAX_INFO_QUERIES,
+//!   NODE_CREATION_BUFFER, MAX_INFO_QUERIES,
 //!   BOLT_PORT, DELAY_INDEXING, IMPORT_FOLDER, TEMP_FOLDER
 //!
 //! ## Multi-SET semantics
@@ -74,7 +75,9 @@ fn config_get_one(
         "NODE_CREATION_BUFFER" => RedisValue::Integer(normalize_node_creation_buffer(
             *CONFIGURATION_NODE_CREATION_BUFFER.lock(ctx),
         )),
-        "CMD_INFO" => RedisValue::Integer(i64::from(*CONFIGURATION_CMD_INFO.lock(ctx))),
+        "CMD_INFO" => {
+            RedisValue::Integer(i64::from(CONFIGURATION_CMD_INFO.load(Ordering::Relaxed)))
+        }
         "MAX_INFO_QUERIES" => RedisValue::Integer(MAX_INFO_QUERIES.load(Ordering::Relaxed)),
         "EFFECTS_THRESHOLD" => RedisValue::Integer(EFFECTS_THRESHOLD.load(Ordering::Relaxed)),
         "BOLT_PORT" => RedisValue::Integer(BOLT_PORT.load(Ordering::Relaxed)),
@@ -112,7 +115,8 @@ fn validate_config_set(
             }
             Ok(ConfigValue::Int(v))
         }
-        "ASYNC_DELETE" => {
+        // Runtime-settable boolean configs
+        "ASYNC_DELETE" | "CMD_INFO" => {
             let v = match value.to_lowercase().as_str() {
                 "yes" | "1" | "true" => 1i64,
                 "no" | "0" | "false" => 0i64,
@@ -159,7 +163,6 @@ fn validate_config_set(
         | "OMP_THREAD_COUNT"
         | "CACHE_SIZE"
         | "NODE_CREATION_BUFFER"
-        | "CMD_INFO"
         | "MAX_INFO_QUERIES"
         | "BOLT_PORT"
         | "DELAY_INDEXING"
@@ -235,6 +238,7 @@ fn apply_config_set(
         }
         "EFFECTS_THRESHOLD" => EFFECTS_THRESHOLD.store(val.as_i64(), Ordering::Relaxed),
         "ASYNC_DELETE" => ASYNC_DELETE.store(val.as_i64(), Ordering::Relaxed),
+        "CMD_INFO" => CONFIGURATION_CMD_INFO.store(val.as_i64() != 0, Ordering::Relaxed),
         "VKEY_MAX_ENTITY_COUNT" => {
             *CONFIGURATION_VKEY_MAX_ENTITY_COUNT.lock(ctx) = val.as_i64();
         }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -6,7 +6,8 @@
 //! ```
 //!
 //! Returns information about currently running and/or waiting queries
-//! across all graphs, plus string-pool stats.
+//! across all graphs, plus string-pool stats. With no section given, every
+//! section is reported, same as the C engine.
 
 use crate::telemetry;
 use graph::runtime::string_pool;
@@ -23,13 +24,13 @@ pub fn graph_info(
         .map(|a| a.to_string_lossy())
         .collect();
 
-    if args.is_empty() {
-        return Err(RedisError::WrongArity);
-    }
+    // no section asked for means all of them: clients such as the node
+    // client's `db.info()` send a bare GRAPH.INFO
+    let all = args.is_empty();
 
-    let mut want_running = false;
-    let mut want_waiting = false;
-    let mut want_object_pool = false;
+    let mut want_running = all;
+    let mut want_waiting = all;
+    let mut want_object_pool = all;
 
     for arg in &args {
         match arg.to_ascii_lowercase().as_str() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,8 @@
 //! | VKEY_MAX_ENTITY_COUNT         |    | RESULTSET_SIZE             |
 //! | IMPORT_FOLDER / TEMP_FOLDER   |    | QUERY_MEM_CAPACITY         |
 //! | JS_HEAP_SIZE / JS_STACK_SIZE  |    | DELTA_MAX_PENDING_CHANGES  |
-//! | CMD_INFO / DELAY_INDEXING     |    | OMP_THREAD_COUNT ...       |
+//! | DELAY_INDEXING                |    | CMD_INFO                   |
+//! |                               |    | OMP_THREAD_COUNT ...       |
 //! +-------------------------------+    +----------------------------+
 //!       |                                      |
 //!       | requires Redis GIL to read           | lock-free atomic reads
@@ -27,16 +28,17 @@
 //!   These are immutable after module load (flagged `IMMUTABLE` in the
 //!   `redis_module!` macro).
 //!
-//! - **Atomic configs** use `AtomicI64` / `AtomicU64` for lock-free
-//!   concurrent reads from worker threads. Some are runtime-configurable
-//!   through `GRAPH.CONFIG SET`; others are read-only after init.
+//! - **Atomic configs** use `AtomicI64` / `AtomicU64` / `AtomicBool` for
+//!   lock-free concurrent reads from worker threads. Some are
+//!   runtime-configurable through `GRAPH.CONFIG SET`; others are read-only
+//!   after init.
 //!
 //! `CONFIG_NAMES` provides the ordered list of all configuration keys,
 //! used by `GRAPH.CONFIG GET *` to enumerate settings.
 
 use lazy_static::lazy_static;
 use redis_module::RedisGILGuard;
-use std::sync::atomic::{AtomicI64, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64};
 
 // ── Redis module-level configurations (set via moduleArgs) ──
 
@@ -54,7 +56,6 @@ lazy_static! {
         RedisGILGuard::new(graph::graph::graph::DEFAULT_NODE_CREATION_BUFFER as i64);
     pub static ref CONFIGURATION_VKEY_MAX_ENTITY_COUNT: RedisGILGuard<i64> =
         RedisGILGuard::new(100_000.into());
-    pub static ref CONFIGURATION_CMD_INFO: RedisGILGuard<bool> = RedisGILGuard::new(true);
     pub static ref CONFIGURATION_DELAY_INDEXING: RedisGILGuard<bool> = RedisGILGuard::new(false);
     pub static ref CONFIGURATION_TEMP_FOLDER: RedisGILGuard<String> =
         RedisGILGuard::new("/tmp".into());
@@ -74,6 +75,10 @@ pub static RESULTSET_SIZE: AtomicI64 = AtomicI64::new(-1);
 pub static QUERY_MEM_CAPACITY: AtomicI64 = AtomicI64::new(0);
 pub static DELTA_MAX_PENDING_CHANGES: AtomicI64 = AtomicI64::new(10000);
 pub static EFFECTS_THRESHOLD: AtomicI64 = AtomicI64::new(300);
+/// Toggles the telemetry stream that backs `GRAPH.INFO`. Atomic rather than
+/// GIL-guarded because the query hot path reads it off the main thread, and
+/// because C lets `GRAPH.CONFIG SET CMD_INFO yes|no` flip it at runtime.
+pub static CONFIGURATION_CMD_INFO: AtomicBool = AtomicBool::new(true);
 
 // ── Read-only runtime configs ──
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,8 +25,9 @@
 //!
 //! - **GIL-guarded configs** are declared via `lazy_static` and wrapped in
 //!   `RedisGILGuard`, ensuring safe access from the Redis main thread.
-//!   These are immutable after module load (flagged `IMMUTABLE` in the
-//!   `redis_module!` macro).
+//!   Most are immutable after module load (flagged `IMMUTABLE` in the
+//!   `redis_module!` macro); the ones C also lets change at run-time are
+//!   flagged `DEFAULT` and accepted by `GRAPH.CONFIG SET`.
 //!
 //! - **Atomic configs** use `AtomicI64` / `AtomicU64` / `AtomicBool` for
 //!   lock-free concurrent reads from worker threads. Some are
@@ -79,13 +80,18 @@ pub static EFFECTS_THRESHOLD: AtomicI64 = AtomicI64::new(300);
 /// GIL-guarded because the query hot path reads it off the main thread, and
 /// because C lets `GRAPH.CONFIG SET CMD_INFO yes|no` flip it at runtime.
 pub static CONFIGURATION_CMD_INFO: AtomicBool = AtomicBool::new(true);
+/// Cap on the telemetry stream's length, used as the XADD `MAXLEN`.
+pub static MAX_INFO_QUERIES: AtomicI64 = AtomicI64::new(MAX_INFO_QUERIES_CAP);
 
 // ── Read-only runtime configs ──
 
 pub static OMP_THREAD_COUNT: AtomicI64 = AtomicI64::new(0);
 pub static ASYNC_DELETE: AtomicI64 = AtomicI64::new(0);
-pub static MAX_INFO_QUERIES: AtomicI64 = AtomicI64::new(1000);
 pub static BOLT_PORT: AtomicI64 = AtomicI64::new(65535);
+
+/// Highest accepted `MAX_INFO_QUERIES`, and its default. Larger values are
+/// clamped rather than rejected, matching C's `Config_cmd_info_max_queries_set`.
+pub const MAX_INFO_QUERIES_CAP: i64 = 1000;
 
 pub fn get_thread_count(ctx: &redis_module::Context) -> i64 {
     let val = *CONFIGURATION_THREAD_COUNT.lock(ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ redis_module! {
         ],
         bool: [
             ["CMD_INFO", &CONFIGURATION_CMD_INFO, true, ConfigurationFlags::DEFAULT, None],
-            ["DELAY_INDEXING", &*CONFIGURATION_DELAY_INDEXING, false, ConfigurationFlags::IMMUTABLE, None],
+            ["DELAY_INDEXING", &*CONFIGURATION_DELAY_INDEXING, false, ConfigurationFlags::DEFAULT, None],
         ],
         enum: [],
         module_args_as_configuration: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ redis_module! {
             ["TEMP_FOLDER", &*CONFIGURATION_TEMP_FOLDER, "/tmp", ConfigurationFlags::IMMUTABLE, None],
         ],
         bool: [
-            ["CMD_INFO", &*CONFIGURATION_CMD_INFO, true, ConfigurationFlags::IMMUTABLE, None],
+            ["CMD_INFO", &CONFIGURATION_CMD_INFO, true, ConfigurationFlags::DEFAULT, None],
             ["DELAY_INDEXING", &*CONFIGURATION_DELAY_INDEXING, false, ConfigurationFlags::IMMUTABLE, None],
         ],
         enum: [],

--- a/src/module_init.rs
+++ b/src/module_init.rs
@@ -25,8 +25,9 @@
 use crate::config::{
     CONFIGURATION_INDEX_WORKER_THREADS, CONFIGURATION_JS_HEAP_SIZE, CONFIGURATION_JS_STACK_SIZE,
     CONFIGURATION_NODE_CREATION_BUFFER, CONFIGURATION_TEMP_FOLDER, DELTA_MAX_PENDING_CHANGES,
-    EFFECTS_THRESHOLD, MAX_QUEUED_QUERIES, OMP_THREAD_COUNT, QUERY_MEM_CAPACITY, RESULTSET_SIZE,
-    TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX, get_thread_count, normalize_node_creation_buffer,
+    EFFECTS_THRESHOLD, MAX_INFO_QUERIES, MAX_INFO_QUERIES_CAP, MAX_QUEUED_QUERIES,
+    OMP_THREAD_COUNT, QUERY_MEM_CAPACITY, RESULTSET_SIZE, TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX,
+    get_thread_count, normalize_node_creation_buffer,
 };
 use crate::redis_type::on_persistence;
 use crate::telemetry;
@@ -182,6 +183,23 @@ pub fn graph_init(
                     continue;
                 }
                 ctx.log_warning(&format!("Invalid value for {name} module argument"));
+                return Status::Err;
+            }
+            if name == "MAX_INFO_QUERIES" {
+                // Clamped rather than rejected, the same way C's setter caps it
+                // and the same way GRAPH.CONFIG SET does at run-time.
+                if i + 1 < args_str.len()
+                    && let Ok(v) = args_str[i + 1].parse::<i64>()
+                    && v >= 0
+                {
+                    MAX_INFO_QUERIES.store(
+                        v.min(MAX_INFO_QUERIES_CAP),
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                    i += 2;
+                    continue;
+                }
+                ctx.log_warning("Invalid value for MAX_INFO_QUERIES module argument");
                 return Status::Err;
             }
             if name == "MAX_QUEUED_QUERIES" {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::config::MAX_INFO_QUERIES;
+use crate::config::{CONFIGURATION_CMD_INFO, MAX_INFO_QUERIES};
 
 /// Maximum stored string length for query/params in telemetry entries.
 const STR_MAX_LEN: usize = 2048;
@@ -463,6 +463,12 @@ pub fn enqueue_entry(
     graph_name: &Arc<str>,
     entry: TelemetryEntry,
 ) {
+    // Query logging is switched off. C gates the equivalent cron task on the
+    // same config, so flipping CMD_INFO back on resumes streaming — entries
+    // produced while off are dropped, not buffered.
+    if !CONFIGURATION_CMD_INFO.load(Ordering::Relaxed) {
+        return;
+    }
     // Skip on replicas: the master's XADDs are replicated to us, so writing
     // here would duplicate entries (and direct writes to a replica must not
     // create a stream).

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -344,6 +344,43 @@ class testConfig(FlowTestsBase):
         expected_response = 1024
         self.env.assertEqual(creation_buffer_size, expected_response)
 
+    def test12_set_get_runtime_booleans(self):
+        """CMD_INFO and DELAY_INDEXING are settable at run-time, as in C"""
+
+        for config_name in ["CMD_INFO", "DELAY_INDEXING"]:
+            for value, expected in [("no", 0), ("yes", 1), ("0", 0), ("1", 1)]:
+                self.env.assertEqual(self.db.config_set(config_name, value), "OK")
+                self.env.assertEqual(self.db.config_get(config_name), expected)
+
+            # a non-boolean value is rejected, leaving the config as it was
+            try:
+                self.db.config_set(config_name, "maybe")
+                assert(False)
+            except redis.ResponseError as e:
+                assert(("Failed to set config value %s to maybe" % config_name) in str(e))
+            self.env.assertEqual(self.db.config_get(config_name), 1)
+
+        # restore defaults for the tests that follow
+        self.db.config_set("DELAY_INDEXING", "no")
+
+    def test13_set_get_max_info_queries(self):
+        """MAX_INFO_QUERIES is settable at run-time, and clamped to its cap"""
+
+        self.env.assertEqual(self.db.config_set("MAX_INFO_QUERIES", 42), "OK")
+        self.env.assertEqual(self.db.config_get("MAX_INFO_QUERIES"), 42)
+
+        # above the cap the value is clamped, not rejected - as C's setter does
+        self.env.assertEqual(self.db.config_set("MAX_INFO_QUERIES", 99999), "OK")
+        self.env.assertEqual(self.db.config_get("MAX_INFO_QUERIES"), 1000)
+
+        for invalid in [-1, "invalid"]:
+            try:
+                self.db.config_set("MAX_INFO_QUERIES", invalid)
+                assert(False)
+            except redis.ResponseError as e:
+                assert(("Failed to set config value MAX_INFO_QUERIES to %s" % invalid) in str(e))
+        self.env.assertEqual(self.db.config_get("MAX_INFO_QUERIES"), 1000)
+
 import stat
 import shutil
 import tempfile
@@ -496,3 +533,13 @@ class testLoadTimeConfig(FlowTestsBase):
                 val = False
 
             env.assertEqual(db.config_get(name), val)
+
+    def test02_loadtime_max_info_queries(self):
+        """MAX_INFO_QUERIES honours its load-time argument, up to the cap"""
+
+        env, db = Env(moduleArgs="MAX_INFO_QUERIES 500")
+        env.assertEqual(db.config_get("MAX_INFO_QUERIES"), 500)
+
+        # over the cap the value is clamped rather than refused
+        env, db = Env(moduleArgs="MAX_INFO_QUERIES 99999")
+        env.assertEqual(db.config_get("MAX_INFO_QUERIES"), 1000)

--- a/tests/flow/test_graph_info.py
+++ b/tests/flow/test_graph_info.py
@@ -485,6 +485,30 @@ class testGraphInfo():
             for t in threads:
                 t.join()
 
+    def test08_no_sections_reports_everything(self):
+        """a bare GRAPH.INFO reports every section, as the C engine does"""
+
+        res = self.conn.execute_command("GRAPH.INFO")
+
+        # same sections, in the same order, as asking for all of them
+        self.env.assertEqual(res,
+                             self.conn.execute_command("GRAPH.INFO",
+                                                       "RunningQueries",
+                                                       "WaitingQueries",
+                                                       "ObjectPool"))
+
+        self.env.assertEqual(len(res), 6)
+        self.env.assertEqual(res[0], "# Running queries")
+        self.env.assertEqual(res[2], "# Waiting queries")
+        self.env.assertEqual(res[4], "Object Pool")
+
+        # an unknown section is still rejected
+        try:
+            self.conn.execute_command("GRAPH.INFO", "NoSuchSection")
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertContains("Unknown section", str(e))
+
 #class testGraphInfoReplication():
 #    def __init__(self):
 #        self.env, self.db = Env(env='oss', useSlaves=True)

--- a/tests/flow/test_graph_info.py
+++ b/tests/flow/test_graph_info.py
@@ -509,6 +509,50 @@ class testGraphInfo():
         except redis.exceptions.ResponseError as e:
             self.env.assertContains("Unknown section", str(e))
 
+    def test09_cmd_info_runtime_toggle(self):
+        """CMD_INFO is settable at run-time, and gates query logging"""
+
+        stream = StreamName(self.graph)
+        self.conn.delete(stream)
+
+        # on by default: a query shows up in the telemetry stream
+        self.graph.query("RETURN 1")
+        pollUntil(lambda: self.conn.xlen(stream), "a logged query")
+
+        #-----------------------------------------------------------------------
+        # turn logging off
+        #-----------------------------------------------------------------------
+
+        self.env.assertEqual(
+            self.conn.execute_command("GRAPH.CONFIG", "SET", "CMD_INFO", "no"), "OK")
+        self.env.assertEqual(self.db.config_get("CMD_INFO"), 0)
+
+        n = self.conn.xlen(stream)
+        self.graph.query("RETURN 2")
+        # the flusher wakes every 5ms; half a second is well past the point
+        # where an entry would have landed had logging still been on
+        time.sleep(0.5)
+        self.env.assertEqual(self.conn.xlen(stream), n)
+
+        #-----------------------------------------------------------------------
+        # and back on
+        #-----------------------------------------------------------------------
+
+        self.env.assertEqual(
+            self.conn.execute_command("GRAPH.CONFIG", "SET", "CMD_INFO", "yes"), "OK")
+        self.env.assertEqual(self.db.config_get("CMD_INFO"), 1)
+
+        self.graph.query("RETURN 3")
+        pollUntil(lambda: self.conn.xlen(stream) > n, "query logging to resume")
+
+        # a non-boolean value is rejected, leaving the config untouched
+        try:
+            self.conn.execute_command("GRAPH.CONFIG", "SET", "CMD_INFO", "maybe")
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertContains("Failed to set config value CMD_INFO to maybe", str(e))
+        self.env.assertEqual(self.db.config_get("CMD_INFO"), 1)
+
 #class testGraphInfoReplication():
 #    def __init__(self):
 #        self.env, self.db = Env(env='oss', useSlaves=True)


### PR DESCRIPTION
Fixes #2434.

## 1. Bare `GRAPH.INFO` returned an arity error

On the Rust engine a bare `GRAPH.INFO` returned `ERR wrong number of arguments for 'graph.INFO' command`. The C engine treats "no section given" as "all sections", so the node client's `db.info()` — which sends `GRAPH.INFO` with no section — fails against the Rust engine.

[src/commands/info.rs](src/commands/info.rs): default the three section flags to on when the argument list is empty, instead of returning `WrongArity`. Explicit section lists and the `ERR Unknown section: x` error are untouched, and the command's registered arity was already 1, so nothing changes at the module-registration level. Output for a bare call is now identical to `GRAPH.INFO RunningQueries WaitingQueries ObjectPool`, in that order — matching the C output quoted in the issue.

## 2. Three configs C sets at run-time, refused here

`CMD_INFO`, `MAX_INFO_QUERIES` and `DELAY_INDEXING` are all runtime-settable in C; `GRAPH.CONFIG SET` answered `This configuration parameter cannot be set at run-time` for each. Two of them were worse than read-only:

- `CMD_INFO` was never *read*. Telemetry streamed regardless, so even `CMD_INFO no` at load time did nothing.
- `MAX_INFO_QUERIES` ignored its load-time module argument too — it is not in the `redis_module!` config section and the manual arg loop never looked for it — so the telemetry stream was always trimmed at the 1000 default.

Changes:

- [src/config.rs](src/config.rs): `CONFIGURATION_CMD_INFO` moves from a GIL-guarded `bool` to an `AtomicBool` so the query hot path can read it off the main thread; `MAX_INFO_QUERIES_CAP` names the 1000 cap.
- [src/lib.rs](src/lib.rs): `CMD_INFO` and `DELAY_INDEXING` registered `DEFAULT` instead of `IMMUTABLE`, so `CONFIG SET graph.*` works too. Each shares one storage location with `GRAPH.CONFIG SET`, so the two surfaces cannot drift.
- [src/commands/config_cmd.rs](src/commands/config_cmd.rs): `CMD_INFO` and `DELAY_INDEXING` take `yes|no` (also `1/0/true/false`, as `ASYNC_DELETE` already does); `MAX_INFO_QUERIES` takes a non-negative integer and is clamped to the cap rather than rejected, matching C's `Config_cmd_info_max_queries_set`.
- [src/module_init.rs](src/module_init.rs): parse `MAX_INFO_QUERIES` as a load-time module argument, with the same clamp.
- [src/telemetry.rs](src/telemetry.rs): `enqueue_entry` returns early while `CMD_INFO` is off. C gates the equivalent finished-queries cron task on the same config, so entries produced while off are dropped rather than buffered, and turning it back on resumes streaming.

`DELAY_INDEXING` still has no consumer in the Rust engine — C reads it in the RDB decoders to defer index construction, and that is not implemented here. This PR only aligns the config surface; the flag remains inert.

Manual check of the surfaces staying in sync:

```
> config set graph.CMD_INFO no
OK
> graph.config get CMD_INFO
1) "CMD_INFO"
2) (integer) 0
> graph.config set CMD_INFO yes
OK
> config get graph.CMD_INFO
1) "graph.CMD_INFO"
2) "yes"
> graph.config set CMD_INFO maybe
(error) Failed to set config value CMD_INFO to maybe
> graph.config set MAX_INFO_QUERIES 99999    # clamped, not refused
OK
> graph.config get MAX_INFO_QUERIES
1) "MAX_INFO_QUERIES"
2) (integer) 1000
```

## Testing

The `GRAPH.INFO` fix was reproduced first with the new flow test against an unfixed build:

```
redis.exceptions.ResponseError: wrong number of arguments for 'graph.INFO' command
```

`MAX_INFO_QUERIES 500` as a load-time argument likewise reported `1000` before the fix, `500` after.

After all changes:

```
Total Tests Run: 9,  Failed: 0   # tests/flow/test_graph_info
Total Tests Run: 19, Failed: 0   # tests/flow/test_config
Total Tests Run: 11, Failed: 0   # tests/flow/test_intern_string (GRAPH.INFO ObjectPool)
```

`cargo fmt --all -- --check` clean; `cargo clippy --all-targets` shows only pre-existing warnings in unrelated files.

New tests:
- [test_graph_info.py](tests/flow/test_graph_info.py) `test08_no_sections_reports_everything` — bare call equals the all-sections call, three section headers present, unknown section still rejected.
- [test_graph_info.py](tests/flow/test_graph_info.py) `test09_cmd_info_runtime_toggle` — toggling `CMD_INFO` off stops entries reaching the telemetry stream, on resumes them, a non-boolean value is rejected without changing the config.
- [test_config.py](tests/flow/test_config.py) `test12_set_get_runtime_booleans` — `CMD_INFO` and `DELAY_INDEXING` accept yes/no/1/0 and reject anything else.
- [test_config.py](tests/flow/test_config.py) `test13_set_get_max_info_queries` — set, clamp at the cap, reject negative and non-numeric.
- [test_config.py](tests/flow/test_config.py) `test02_loadtime_max_info_queries` — load-time argument honoured, and clamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `GRAPH.INFO` can be called without specifying sections to return all available information.
  * `CMD_INFO` and `MAX_INFO_QUERIES` can now be changed at runtime.
  * Explicit `GRAPH.INFO` section selection remains supported.

* **Bug Fixes**
  * Bare `GRAPH.INFO` no longer returns an argument-count error.
  * Query telemetry is suppressed when `CMD_INFO` is disabled and resumes when re-enabled.
  * Invalid configuration values are rejected, and excessive query limits are capped.

* **Documentation**
  * Clarified `GRAPH.INFO` default behavior and runtime configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->