### PR TITLE
serializers: export Graph_EncodingVersion and Graph_GetDecoder

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -38,6 +38,8 @@
 #include "arithmetic/arithmetic_expression.h"
 #include "serializers/encoder/v19/encode_v19.h"
 #include "serializers/decoders/current/v19/decode_v19.h"
+#include "serializers/encoder/encode_graph.h"
+#include "serializers/decoders/decode_graph.h"
 
 // minimal supported Redis version
 #define MIN_REDIS_VERSION_MAJOR 8
@@ -82,6 +84,8 @@ static int _ExportAPIs
 	EXPORT_API ("RdbLoadGraphContext_latest",     RdbLoadGraphContext_latest)
 	EXPORT_API ("GraphContext_DecreaseRefCount",  GraphContext_DecreaseRefCount)
 	EXPORT_API ("GraphContextRedisModuleType_Get", GraphContextRedisModuleType_Get)
+	EXPORT_API ("Graph_EncodingVersion",          Graph_EncodingVersion)
+	EXPORT_API ("Graph_GetDecoder",               Graph_GetDecoder)
 
 #undef EXPORT_API
 

--- a/src/serializers/decoders/decode_graph.c
+++ b/src/serializers/decoders/decode_graph.c
@@ -5,6 +5,7 @@
 
 #include "decode_graph.h"
 #include "current/v19/decode_v19.h"
+#include "../encoding_version.h"
 
 GraphContext *RdbLoadGraph
 (
@@ -17,5 +18,23 @@ GraphContext *RdbLoadGraph
 	SerializerIO_Free (&io) ;
 
 	return gc ;
+}
+
+RdbLoadGraphContext_t Graph_GetDecoder
+(
+	uint32_t version
+) {
+	// expose only SerializerIO-based decoders that match the canonical
+	// RdbLoadGraphContext_latest signature. offload dumps are never older than
+	// the version offloading shipped in, so the latest decoder covers all
+	// current dumps. when a newer encoding version becomes latest, map each
+	// aging version to its decoder here — wrapping any prev-version decoder that
+	// omits the `detached` parameter in a small adapter with this signature.
+	switch(version) {
+		case GRAPH_ENCODING_LATEST_V:
+			return RdbLoadGraphContext_latest ;
+		default:
+			return NULL ;  // no SerializerIO decoder for this version
+	}
 }
 

--- a/src/serializers/decoders/decode_graph.h
+++ b/src/serializers/decoders/decode_graph.h
@@ -6,7 +6,23 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "../serializers_include.h"
 
 // load RDB
 GraphContext *RdbLoadGraph(RedisModuleIO *rdb);
+
+// decoder for a graph encoding version, matching RdbLoadGraphContext_latest
+typedef GraphContext *(*RdbLoadGraphContext_t)
+(
+	SerializerIO rdb,
+	const RedisModuleString *rm_key_name,
+	bool detached
+);
+
+// resolve the SerializerIO-based decoder for a given encoding version, or NULL
+// when this build ships no such decoder for it
+// the graph-offloading module records the encoding version in every dump and
+// asks for the matching decoder on load
+RdbLoadGraphContext_t Graph_GetDecoder(uint32_t version);

--- a/src/serializers/encoder/encode_graph.c
+++ b/src/serializers/encoder/encode_graph.c
@@ -6,6 +6,7 @@
 #include "encode_graph.h"
 #include "v19/encode_v19.h"
 #include "../serializer_io.h"
+#include "../encoding_version.h"
 
 void RdbSaveGraph
 (
@@ -15,5 +16,9 @@ void RdbSaveGraph
 	SerializerIO io = SerializerIOv2_FromBufferedRedisModuleIO(rdb, true);
 	RdbSaveGraph_latest(io, value);
 	SerializerIO_Free(&io);
+}
+
+uint32_t Graph_EncodingVersion(void) {
+	return GRAPH_ENCODING_LATEST_V;
 }
 

--- a/src/serializers/encoder/encode_graph.h
+++ b/src/serializers/encoder/encode_graph.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "../serializers_include.h"
 
 void RdbSaveGraph
@@ -12,4 +14,9 @@ void RdbSaveGraph
 	RedisModuleIO *rdb,
 	void *value
 );
+
+// return the graph encoding version RdbSaveGraph_latest writes
+// the graph-offloading module records this in every dump so the matching
+// decoder can be selected on load (see Graph_GetDecoder)
+uint32_t Graph_EncodingVersion(void);
 


### PR DESCRIPTION
Resolve: #2553
Expose the current graph encoding version and a per-version decoder resolver as shared APIs so the graph-offloading module can stamp each dump with the encoding version used and pick the matching decoder on load. Graph_GetDecoder returns the SerializerIO-based decoder for a given version, or NULL when this build ships none; it grows a case per version as encodings age out of latest.