### PR TITLE
feat(bench): run the LDBC SNB Interactive v1 complex reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,7 @@ twitter_thread.md
 .claude/worktrees/
 local-build.so
 bench/tests/flow/.ci-tmp/
+# LDBC datasets, downloaded on demand by `bench ldbc fetch` (18 MB at SF0.1,
+# 230 MB at SF1, and several GB once extracted).
+bench/ldbc-data/
 bin/

--- a/bench/README.md
+++ b/bench/README.md
@@ -146,6 +146,7 @@ locally against a real base build.
 | `src/falkorbench/flow.py` | per-flow-test-file measurement |
 | `src/falkorbench/cli.py` | the `bench` command |
 | `src/falkorbench/coverage.py` | instrumented build, run the set once, report graph-crate line coverage |
+| `src/falkorbench/ldbc/` | LDBC SNB Interactive v1 — dataset fetch/prepare, loader, parameters, runner, and the vendored query texts |
 | `Dockerfile` | the CI measurement image, `FROM …:edge-c` |
 | `pmc_tool.c` | Apple Silicon PMU counters (kperf/kperfdata private frameworks) |
 | `tests/` | the guards above, over CSV fixtures |
@@ -222,7 +223,65 @@ Three deliberate deviations:
 CLAUDE.md) is p99 latency. `redis-benchmark` computes a latency distribution and
 this harness currently discards it, so the p99 bar is not measured here yet.
 
-## Known gaps
+## LDBC SNB (Interactive v1)
+
+A second, complementary workload: the 14 **complex reads** of the LDBC Social
+Network Benchmark, run against the real SNB dataset. The micro-benchmark set
+above measures narrow operations on a synthetic ring; these measure whole
+realistic queries — multi-hop traversals, aggregation, `OPTIONAL MATCH`,
+variable-length paths — on a graph with realistic degree skew. A planner
+regression that a single-op query cannot see tends to show up here.
+
+```bash
+bench ldbc fetch --sf 0.1                 # download + prepare (~18 MB)
+bench ldbc run --sf 0.1                   # load, then measure all 14
+bench ldbc run --sf 1 IC1 IC13            # a subset, at SF1 (~230 MB)
+bench ldbc run --params ./substitution_parameters   # official parameters
+```
+
+Results go to `results/ldbc_sf<SF>.csv` (p50/p95/p99 per query) and are
+deliberately **not** merged into `results/current.csv`: LDBC's metric is
+response time, and mixing it into the file the `compare` thresholds gate would
+distort the micro-benchmark gate.
+
+### This is not an auditable LDBC result
+
+Do not publish these as an "LDBC score". A real result requires the official
+Java driver with its validation and workload-generation phases, LDBC
+membership, and an audit commissioned from a certified auditor. What this gives
+you is an internal, repeatable number on a standard dataset and standard
+queries.
+
+### Four queries differ from the reference text
+
+Each departure is annotated in the `.cypher` file next to the line it replaced,
+and listed in `ldbc/queries.py::REWRITES` so a run always prints them. All four
+were confirmed against a running engine:
+
+| query | why it could not run as written |
+|---|---|
+| IC1, IC13 | `MATCH path = shortestPath(...)` → *"FalkorDB currently only supports shortestPaths in WITH or RETURN clauses"*. Moved into `WITH`. |
+| IC14 | `allShortestPaths()` with inline endpoint patterns → *"Source and destination must already be resolved"*. Endpoints pre-bound in a preceding `MATCH`. |
+| IC10 | `datetime({epochMillis: ...}).month` → *"Unknown function 'datetime'"*. The loader derives `birthdayMonth`/`birthdayDay` instead. |
+
+`CREATE CONSTRAINT ... ASSERT n.id IS UNIQUE` is also unsupported, so upstream's
+`indices.cypher` becomes `GRAPH.CONSTRAINT CREATE` calls — each of which
+additionally requires its exact-match index to already exist, and validates
+asynchronously (the loader waits for `OPERATIONAL` rather than assuming it).
+
+### Substitution parameters
+
+LDBC generates parameters chosen so the queries hit a representative spread of
+the data; the cost of these queries varies by orders of magnitude with how
+well-connected the chosen person is, so the parameter set matters as much as the
+query text. Pass an official set with `--params DIR`.
+
+Without it, the harness samples the loaded graph with a fixed seed. Those runs
+are deterministic and comparable **to each other**, but not to published LDBC
+numbers — the CSV and the console output both say which source was used, and
+that caveat should travel with any number taken from it.
+
+
 
 One structural gap is worth recording because closing it needs a design decision
 rather than a patch: the MVCC copy-on-write `GrB_Matrix_dup` of delta matrices in

--- a/bench/README.md
+++ b/bench/README.md
@@ -333,9 +333,10 @@ treats "returned zero rows on every run" as a failure for the same reason.
 ### What the first run found
 
 Running the 14 complex reads against SF0.1 was worth doing for the bugs alone.
-Thirteen of the fourteen measure; every one of those is in the same order of
-magnitude as the C engine or faster, and four (IC1, IC10, IC13, IC14) do not run
-on C at all. Four defects came out of the exercise, each confirmed against the C
+All fourteen now produce a measurement — IC3 needs `--timeout` above the default
+— and four of them (IC1, IC10, IC13, IC14) do not run on the C engine at all.
+Every query except IC3 and IC10 is in the same order of magnitude as C or
+faster. Four defects came out of the exercise, each confirmed against the C
 engine before being filed:
 
 | issue | what |
@@ -345,11 +346,11 @@ engine before being filed:
 | [#2557](https://github.com/FalkorDB/FalkorDB/issues/2557) | `WHERE` on a node matched from an `UNWIND`-bound anchor silently returns zero rows |
 | [#2558](https://github.com/FalkorDB/FalkorDB/issues/2558) | a variable-length traversal loses its indexed anchor when the `MATCH` has a second pattern — 19,000x |
 
-**#2558 is the one that matters.** It is the sole reason IC3 does not complete
-inside a 120 s timeout where C takes 174 ms, and the reason IC10 takes 86 s. Both
-plans abandon a unique-index seed in favour of scanning the unbound side. No
-other measured query is affected, so a single planner decision accounts for the
-entire Rust-vs-C gap on this workload.
+**#2558 is the one that matters.** On the same parameter row, returning the
+identical 2 rows, IC3 takes **136.72 ms** on C and **271,817.66 ms** on Rust —
+1,988x — and IC10 takes 86 s. Both plans abandon a unique-index seed in favour
+of scanning the unbound side. No other measured query is affected, so a single
+planner decision accounts for the entire Rust-vs-C gap on this workload.
 
 Three of the four are **silent** — wrong or empty results with no error. They
 were caught only because the runner treats "zero rows on every run" as a failure

--- a/bench/README.md
+++ b/bench/README.md
@@ -223,6 +223,27 @@ Three deliberate deviations:
 CLAUDE.md) is p99 latency. `redis-benchmark` computes a latency distribution and
 this harness currently discards it, so the p99 bar is not measured here yet.
 
+One structural gap is worth recording because closing it needs a design decision
+rather than a patch: the MVCC copy-on-write `GrB_Matrix_dup` of delta matrices in
+`create_nodes` / `set_nodes_labels_bulk` waits on pending work first, so it scales
+with the accumulated delta (up to the 10k flush threshold, avg ~5k) per query,
+independent of batch size. C never merges pending tuples on the write path. That
+is what keeps the create/delete rows above 1.0x against C.
+
+**A ranked Rust-vs-C table is deliberately not kept here.** It goes stale the
+moment anything merges, and a stale ranking is worse than none — it sends people
+to work on rows that are already fixed. Generate it from a live run using the
+recipe above.
+
+**Coverage**: the query set covers **74.8%** of graph-crate lines
+(28,869/38,573, excluding the generated `GraphBLAS.rs` FFI; measured in CI on
+2026-08-05). The 0%-coverage areas need infrastructure a Cypher
+query cannot reach from this graph: `cow_btree` (~750 lines, appears unwired),
+`string_pool`, `vec_distance`, and most of `algo_procedures.rs`. For the hot paths
+this set targets (runtime, expressions, planner, matrices), coverage is high.
+`bench coverage` reports the number but does not enforce a floor — it is a
+validator of the query set, not a coverage gate.
+
 ## LDBC SNB (Interactive v1)
 
 A second, complementary workload: the 14 **complex reads** of the LDBC Social
@@ -252,22 +273,37 @@ membership, and an audit commissioned from a certified auditor. What this gives
 you is an internal, repeatable number on a standard dataset and standard
 queries.
 
-### Four queries differ from the reference text
+### Seven queries differ from the reference text
 
 Each departure is annotated in the `.cypher` file next to the line it replaced,
-and listed in `ldbc/queries.py::REWRITES` so a run always prints them. All four
-were confirmed against a running engine:
+and listed in `ldbc/queries.py::REWRITES` so a run always prints them. All seven
+were confirmed against a running engine, and each was checked against the C
+engine too so that a genuine bug is not filed away as a dialect gap:
 
 | query | why it could not run as written |
 |---|---|
 | IC1, IC13 | `MATCH path = shortestPath(...)` → *"FalkorDB currently only supports shortestPaths in WITH or RETURN clauses"*. Moved into `WITH`. |
-| IC14 | `allShortestPaths()` with inline endpoint patterns → *"Source and destination must already be resolved"*. Endpoints pre-bound in a preceding `MATCH`. |
+| IC14 | `allShortestPaths()` with inline endpoint patterns → *"Source and destination must already be resolved"*. Endpoints pre-bound in a preceding `MATCH`. Also, a pattern comprehension's `WHERE` cannot see the enclosing list comprehension's variable, so the per-relationship weights are computed over `UNWIND`ed relationships with their endpoints hoisted into plain variables. |
 | IC10 | `datetime({epochMillis: ...}).month` → *"Unknown function 'datetime'"*. The loader derives `birthdayMonth`/`birthdayDay` instead. |
+| IC7 | `not((liker)-[:KNOWS]-(person))` → *"Type mismatch: expected Boolean or Null but was List"*. A traversal pattern is not a boolean-valued expression in a projection, and `exists()` explicitly refuses traversal patterns, so this becomes `size(<pattern>) = 0`. |
+| IC6 | **A bug, not a dialect gap.** An inline property filter on a pattern followed by further patterns fails under `UNWIND` with *"Type mismatch: expected Map, Node, Edge, ... but was List"*; the C engine runs it correctly. The filter moves into `WHERE`. Tracked as [#2556](https://github.com/FalkorDB/FalkorDB/issues/2556) — revert when fixed. |
+| IC9 | **A bug, not a dialect gap.** A `WHERE` on a node reached from an `UNWIND`-bound anchor silently returns zero rows — no error, just nothing, while the same query without the `WHERE` returns 81,897. The C engine is correct. `WITH DISTINCT` in place of `collect(DISTINCT ...)` + `UNWIND` avoids it. Tracked as [#2557](https://github.com/FalkorDB/FalkorDB/issues/2557) — revert when fixed. |
+
+IC1, IC7, IC13 and IC14 fail identically on the C engine, so those four are
+dialect gaps rather than regressions. IC6 and IC9 look like the same kind of
+thing and are not: both run correctly on C. That distinction only exists because
+every failure was re-checked against `falkordb/falkordb-server:edge-c` before
+being classified — without that step two real regressions would have been
+written off as dialect gaps, and two dialect gaps filed as false bugs.
 
 `CREATE CONSTRAINT ... ASSERT n.id IS UNIQUE` is also unsupported, so upstream's
 `indices.cypher` becomes `GRAPH.CONSTRAINT CREATE` calls — each of which
 additionally requires its exact-match index to already exist, and validates
-asynchronously (the loader waits for `OPERATIONAL` rather than assuming it).
+asynchronously (the loader waits for `OPERATIONAL` rather than assuming it;
+note `db.constraints()` reports `UNDER CONSTRUCTION`, never `PENDING`).
+
+The CSVs are pipe-separated. FalkorDB has no `DELIMITER` keyword — the
+standard-Cypher spelling is `FIELDTERMINATOR`, and it goes *after* `AS <var>`.
 
 ### Substitution parameters
 
@@ -281,25 +317,42 @@ are deterministic and comparable **to each other**, but not to published LDBC
 numbers — the CSV and the console output both say which source was used, and
 that caveat should travel with any number taken from it.
 
+Sampling deliberately draws from where the data is dense: people from the
+most-connected end of the `KNOWS` degree distribution, and dates from the last
+quarter of the corpus. A uniformly drawn person is usually isolated and a
+uniformly drawn date window usually lands in the sparse early history; either
+returns nothing in microseconds, which would report the benchmark as fast while
+measuring almost none of the work it exists to measure. `runner.problems()`
+treats "returned zero rows on every run" as a failure for the same reason.
 
+### What the first run found
 
-One structural gap is worth recording because closing it needs a design decision
-rather than a patch: the MVCC copy-on-write `GrB_Matrix_dup` of delta matrices in
-`create_nodes` / `set_nodes_labels_bulk` waits on pending work first, so it scales
-with the accumulated delta (up to the 10k flush threshold, avg ~5k) per query,
-independent of batch size. C never merges pending tuples on the write path. That
-is what keeps the create/delete rows above 1.0x against C.
+Running the 14 complex reads against SF0.1 was worth doing for the bugs alone.
+Thirteen of the fourteen measure; every one of those is in the same order of
+magnitude as the C engine or faster, and four (IC1, IC10, IC13, IC14) do not run
+on C at all. Four defects came out of the exercise, each confirmed against the C
+engine before being filed:
 
-**A ranked Rust-vs-C table is deliberately not kept here.** It goes stale the
-moment anything merges, and a stale ranking is worse than none — it sends people
-to work on rows that are already fixed. Generate it from a live run using the
-recipe above.
+| issue | what |
+|---|---|
+| [#2555](https://github.com/FalkorDB/FalkorDB/issues/2555) | aggregation over a bare map property returns empty — `collect`→`[]`, `count`→`0`, silently |
+| [#2556](https://github.com/FalkorDB/FalkorDB/issues/2556) | inline property filter under `UNWIND` raises a spurious type mismatch |
+| [#2557](https://github.com/FalkorDB/FalkorDB/issues/2557) | `WHERE` on a node matched from an `UNWIND`-bound anchor silently returns zero rows |
+| [#2558](https://github.com/FalkorDB/FalkorDB/issues/2558) | a variable-length traversal loses its indexed anchor when the `MATCH` has a second pattern — 19,000x |
 
-**Coverage**: the query set covers **74.8%** of graph-crate lines
-(28,869/38,573, excluding the generated `GraphBLAS.rs` FFI; measured in CI on
-2026-08-05). The 0%-coverage areas need infrastructure a Cypher
-query cannot reach from this graph: `cow_btree` (~750 lines, appears unwired),
-`string_pool`, `vec_distance`, and most of `algo_procedures.rs`. For the hot paths
-this set targets (runtime, expressions, planner, matrices), coverage is high.
-`bench coverage` reports the number but does not enforce a floor — it is a
-validator of the query set, not a coverage gate.
+**#2558 is the one that matters.** It is the sole reason IC3 does not complete
+inside a 120 s timeout where C takes 174 ms, and the reason IC10 takes 86 s. Both
+plans abandon a unique-index seed in favour of scanning the unbound side. No
+other measured query is affected, so a single planner decision accounts for the
+entire Rust-vs-C gap on this workload.
+
+Three of the four are **silent** — wrong or empty results with no error. They
+were caught only because the runner treats "zero rows on every run" as a failure
+rather than as a fast query. A harness that reported latency alone would have
+called that run a success.
+
+Following the file-level convention above, a ranked latency table is not kept
+here; regenerate it from a live run. `results/ldbc_sf<SF>.csv` is written per run
+and deliberately not merged into `current.csv` — these runtimes are orders of
+magnitude larger than the micro-benchmark's and would distort its regression
+thresholds.

--- a/bench/README.md
+++ b/bench/README.md
@@ -319,7 +319,12 @@ that caveat should travel with any number taken from it.
 
 Sampling deliberately draws from where the data is dense: people from the
 most-connected end of the `KNOWS` degree distribution, and dates from the last
-quarter of the corpus. A uniformly drawn person is usually isolated and a
+quarter of the corpus. IC3 gets a much wider window than the rest — it counts
+friends who are *not* resident in either country yet posted from both inside the
+window, and at SF0.1 a 30-day window returns 0 rows where 365 returns 1 and 730
+returns 2. Both engines agree on those counts, so it is a property of the
+dataset, not of either engine; `durationDays` is an explicit LDBC parameter, so
+widening it stays inside the query's own contract. A uniformly drawn person is usually isolated and a
 uniformly drawn date window usually lands in the sparse early history; either
 returns nothing in microseconds, which would report the benchmark as fast while
 measuring almost none of the work it exists to measure. `runner.problems()`

--- a/bench/src/falkorbench/cli.py
+++ b/bench/src/falkorbench/cli.py
@@ -24,11 +24,20 @@ from falkorbench import profile as profile_mod
 from falkorbench import queries as query_set
 from falkorbench import report as report_mod
 from falkorbench.counters import select_backend
+from falkorbench.ldbc import dataset as ldbc_dataset
+from falkorbench.ldbc import loader as ldbc_loader
+from falkorbench.ldbc import params as ldbc_params
+from falkorbench.ldbc import queries as ldbc_queries
+from falkorbench.ldbc import runner as ldbc_runner
 
 # bench/ is the project root; the repo is its parent.
 BENCH_DIR = Path(__file__).resolve().parents[2]
 REPO_ROOT = BENCH_DIR.parent
 RESULTS = BENCH_DIR / "results"
+#: Where LDBC datasets are downloaded and extracted. Also the server's
+#: IMPORT_FOLDER for an LDBC run, since `LOAD CSV` resolves `file://` against
+#: it — a dataset outside this tree is not reachable by the server.
+LDBC_CACHE = BENCH_DIR / "ldbc-data"
 
 
 def _select(names: tuple[str, ...], *, cg_only: bool = False):
@@ -449,6 +458,129 @@ def flow(module, out, baseline, current, names):
     finally:
         if tmp is not None:
             tmp.cleanup()
+
+
+# --- ldbc --------------------------------------------------------------------
+
+
+@cli.group()
+def ldbc() -> None:
+    """LDBC SNB Interactive v1 complex reads.
+
+    Internal instrument, not an auditable LDBC result: that needs the official
+    Java driver, LDBC membership and a commissioned audit.
+    """
+
+
+@ldbc.command("fetch")
+@click.option("--sf", default="0.1", show_default=True, help="scale factor (0.1 or 1)")
+@click.option("--cache", default=None, type=click.Path(), help="dataset cache directory")
+def ldbc_fetch(sf, cache):
+    """Download, extract and prepare the SNB dataset."""
+    cache_dir = Path(cache) if cache else LDBC_CACHE
+    try:
+        root = ldbc_dataset.fetch(cache_dir, sf, echo=click.echo)
+        ldbc_dataset.prepare(root, echo=click.echo)
+    except ldbc_dataset.DatasetError as e:
+        raise click.ClickException(str(e)) from e
+    click.echo(f"dataset ready: {root}")
+
+
+@ldbc.command("run")
+@common_options
+@click.option("--sf", default="0.1", show_default=True, help="scale factor (0.1 or 1)")
+@click.option("--cache", default=None, type=click.Path(), help="dataset cache directory")
+@click.option("--out", default=None, type=click.Path(), help="CSV output path")
+@click.option(
+    "--params",
+    "params_dir",
+    default=None,
+    type=click.Path(exists=True),
+    help="official LDBC substitution parameter directory",
+)
+@click.option(
+    "--param-count",
+    default=25,
+    show_default=True,
+    help="sampled parameter rows per query, when --params is not given",
+)
+@click.option("--seed", default=1, show_default=True, help="sampling seed")
+@click.option("--reuse", is_flag=True, help="attach to a server already on --port")
+@click.option(
+    "--load/--no-load", "do_load", default=None, help="load the dataset (implied unless --reuse)"
+)
+@click.option("--keep-server", is_flag=True, help="leave the server running afterwards")
+@click.argument("names", nargs=-1)
+def ldbc_run(
+    module, port, sf, cache, out, params_dir, param_count, seed, reuse, do_load, keep_server, names
+):
+    """Load the dataset and measure the complex reads.
+
+    NAMES selects a subset, e.g. `bench ldbc run IC1 IC13`.
+    """
+    cache_dir = (Path(cache) if cache else LDBC_CACHE).resolve()
+    out_path = Path(out) if out else RESULTS / f"ldbc_sf{sf}.csv"
+    try:
+        selected = ldbc_queries.select(names)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+
+    try:
+        root = ldbc_dataset.fetch(cache_dir, sf, echo=click.echo)
+        ldbc_dataset.prepare(root, echo=click.echo)
+    except ldbc_dataset.DatasetError as e:
+        raise click.ClickException(str(e)) from e
+
+    # As with `measure`, --reuse means "do not start a server" and must not
+    # silently also mean "do not load", or this measures an empty database.
+    should_load = (not reuse) if do_load is None else do_load
+
+    server = client_mod.Server(port=port)
+    if reuse:
+        if not client_mod.is_server_up(port):
+            raise click.ClickException(f"--reuse given but nothing answers on :{port}")
+    else:
+        if client_mod.is_server_up(port):
+            raise click.ClickException(f"port {port} already in use; use --reuse or another --port")
+        module_path = client_mod.find_module(module, REPO_ROOT)
+        if not module_path.exists():
+            raise click.ClickException(f"module not found: {module_path}")
+        server = client_mod.start_server(module_path, port, RESULTS / "ldbc_server_dir", cache_dir)
+
+    try:
+        bench = client_mod.connect(server)
+        bench.graph_name = f"ldbc_sf{sf}"
+        if should_load:
+            click.echo(f"loading {root.name}...")
+            ldbc_loader.load(bench, root, import_root=cache_dir, echo=click.echo)
+
+        param_set = ldbc_params.load(
+            bench,
+            directory=Path(params_dir) if params_dir else None,
+            count=param_count,
+            seed=seed,
+            echo=click.echo,
+        )
+        click.echo(f"\nparameters: {param_set.caveat()}")
+        ldbc_queries.rewrite_note(click.echo)
+        click.echo("")
+
+        results = ldbc_runner.run(bench, selected, param_set, echo=click.echo)
+        ldbc_runner.write_csv(out_path, results)
+        click.echo(f"\nwrote {out_path}")
+    except (client_mod.SetupFailed, ldbc_loader.LoadError, ldbc_params.ParamError) as e:
+        raise click.ClickException(str(e)) from e
+    finally:
+        if server.proc is not None and not keep_server:
+            server.stop()
+        elif server.proc is not None:
+            click.echo(f"server left running on :{port} (pid {server.proc.pid})")
+
+    if issues := ldbc_runner.problems(results):
+        click.echo("\nrun completed with problems:")
+        for issue in issues:
+            click.echo(f"  {issue}")
+        raise SystemExit(1)
 
 
 def main() -> int:

--- a/bench/src/falkorbench/cli.py
+++ b/bench/src/falkorbench/cli.py
@@ -505,6 +505,13 @@ def ldbc_fetch(sf, cache):
     help="sampled parameter rows per query, when --params is not given",
 )
 @click.option("--seed", default=1, show_default=True, help="sampling seed")
+@click.option(
+    "--timeout",
+    "timeout_ms",
+    default=ldbc_runner.DEFAULT_TIMEOUT_MS,
+    show_default=True,
+    help="per-query server-side cap, in milliseconds",
+)
 @click.option("--reuse", is_flag=True, help="attach to a server already on --port")
 @click.option(
     "--load/--no-load", "do_load", default=None, help="load the dataset (implied unless --reuse)"
@@ -512,7 +519,19 @@ def ldbc_fetch(sf, cache):
 @click.option("--keep-server", is_flag=True, help="leave the server running afterwards")
 @click.argument("names", nargs=-1)
 def ldbc_run(
-    module, port, sf, cache, out, params_dir, param_count, seed, reuse, do_load, keep_server, names
+    module,
+    port,
+    sf,
+    cache,
+    out,
+    params_dir,
+    param_count,
+    seed,
+    timeout_ms,
+    reuse,
+    do_load,
+    keep_server,
+    names,
 ):
     """Load the dataset and measure the complex reads.
 
@@ -565,7 +584,9 @@ def ldbc_run(
         ldbc_queries.rewrite_note(click.echo)
         click.echo("")
 
-        results = ldbc_runner.run(bench, selected, param_set, echo=click.echo)
+        results = ldbc_runner.run(
+            bench, selected, param_set, timeout_ms=timeout_ms, echo=click.echo
+        )
         ldbc_runner.write_csv(out_path, results)
         click.echo(f"\nwrote {out_path}")
     except (client_mod.SetupFailed, ldbc_loader.LoadError, ldbc_params.ParamError) as e:

--- a/bench/src/falkorbench/ldbc/__init__.py
+++ b/bench/src/falkorbench/ldbc/__init__.py
@@ -1,0 +1,20 @@
+"""LDBC Social Network Benchmark (Interactive v1) against FalkorDB.
+
+Scope, stated plainly: this measures the 14 Interactive **complex reads** as an
+internal instrument. It is not an auditable LDBC result — that needs the
+official Java driver, its validation and workload-generation phases, LDBC
+membership and a commissioned audit. Nothing here should be published as an
+"LDBC score".
+
+What it is good for: catching a query-planner regression on realistic graph
+shapes, and tracking how far FalkorDB's dialect is from the reference queries.
+"""
+
+from falkorbench.ldbc import dataset
+from falkorbench.ldbc import loader
+from falkorbench.ldbc import params
+from falkorbench.ldbc import queries
+from falkorbench.ldbc import runner
+from falkorbench.ldbc import schema
+
+__all__ = ["dataset", "loader", "params", "queries", "runner", "schema"]

--- a/bench/src/falkorbench/ldbc/dataset.py
+++ b/bench/src/falkorbench/ldbc/dataset.py
@@ -1,0 +1,215 @@
+"""Fetching and preparing the LDBC SNB Interactive v1 dataset.
+
+Two preparation steps happen before anything is loaded, both of them
+unavoidable rather than stylistic:
+
+* **Ambiguous headers.** A self-referencing edge file is headed
+  `Person.id|Person.id`. Parsed into a per-row map, the second column shadows
+  the first — both endpoints resolve to the same node and every `KNOWS` edge
+  becomes a self-loop. The header is rewritten to `FromPerson.id|ToPerson.id`.
+* **Derived birthday parts.** IC10 needs the month and day of a person's
+  birthday and FalkorDB has no `datetime()`, so two columns are appended.
+
+Both are done by rewriting the file once, in Python. The pre-existing
+`tests/test_ldbc.py` used `sed -i "" ...` for the header rewrite, which is the
+BSD/macOS spelling and exits 2 under GNU sed — so that path only ever worked on
+one platform.
+
+Files are rewritten in place and a marker file records that it happened, so a
+re-run is a no-op rather than double-appending columns.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import shutil
+import subprocess
+import tarfile
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+
+from falkorbench.ldbc import schema
+
+#: Written into the dataset directory once preparation has succeeded. Its
+#: contents are the marker version, so a change to the preparation logic here
+#: invalidates previously prepared trees instead of silently reusing them.
+_MARKER = ".falkorbench-prepared"
+_MARKER_VERSION = "1"
+
+Echo = Callable[[str], None]
+
+
+class DatasetError(RuntimeError):
+    """The dataset could not be fetched or prepared."""
+
+
+def dataset_dir(cache: Path, sf: str) -> Path:
+    return cache / schema.DATASET_DIR.format(sf=sf)
+
+
+def fetch(cache: Path, sf: str, *, echo: Echo = print) -> Path:
+    """Download and extract the SF `sf` dataset into `cache`, if not present.
+
+    Returns the extracted dataset directory.
+    """
+    if sf not in schema.SCALE_FACTORS:
+        raise DatasetError(f"unknown scale factor {sf!r}; known: {', '.join(schema.SCALE_FACTORS)}")
+
+    target = dataset_dir(cache, sf)
+    if target.is_dir():
+        echo(f"dataset already extracted: {target}")
+        return target
+
+    cache.mkdir(parents=True, exist_ok=True)
+    tarball = cache / schema.DATASET_TARBALL.format(sf=sf)
+    expected = schema.SCALE_FACTORS[sf]
+
+    if not tarball.exists() or tarball.stat().st_size != expected:
+        url = f"{schema.DATASET_BASE_URL}/{tarball.name}"
+        echo(f"downloading {url} ({expected / 1e6:.0f} MB)...")
+        # .part so an interrupted download is never mistaken for a complete one.
+        part = tarball.with_suffix(tarball.suffix + ".part")
+        try:
+            _download(url, part)
+        except OSError as e:
+            part.unlink(missing_ok=True)
+            raise DatasetError(f"download failed: {e}") from e
+        size = part.stat().st_size
+        if size != expected:
+            part.unlink(missing_ok=True)
+            raise DatasetError(
+                f"downloaded {size} bytes, expected {expected}; "
+                f"the published dataset may have been republished"
+            )
+        part.rename(tarball)
+
+    echo(f"extracting {tarball.name}...")
+    _extract_zst(tarball, cache)
+    if not target.is_dir():
+        raise DatasetError(f"{tarball.name} did not contain {target.name}")
+    return target
+
+
+def _download(url: str, dest: Path) -> None:
+    """Stream `url` to `dest`.
+
+    An explicit User-Agent is required, not cosmetic: datasets.ldbcouncil.org
+    sits behind Cloudflare, which answers urllib's default
+    `Python-urllib/3.x` with 403 while serving the same URL to curl.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "falkorbench-ldbc/1.0"})
+    with urllib.request.urlopen(request) as response, dest.open("wb") as fh:
+        shutil.copyfileobj(response, fh)
+
+
+def _extract_zst(tarball: Path, dest: Path) -> None:
+    """Extract a .tar.zst.
+
+    Python's tarfile has no zstd support before 3.14, so decompression goes
+    through the `zstd` binary and only the tar step is done in-process.
+    """
+    if not shutil.which("zstd"):
+        raise DatasetError("`zstd` not found on PATH; install zstd to extract the dataset")
+    try:
+        proc = subprocess.Popen(
+            ["zstd", "--decompress", "--stdout", str(tarball)],
+            stdout=subprocess.PIPE,
+        )
+        with tarfile.open(fileobj=proc.stdout, mode="r|") as tar:
+            # `filter="data"` refuses absolute paths and ../ escapes. Default in
+            # 3.14; set explicitly so behaviour does not depend on the runtime.
+            tar.extractall(dest, filter="data")
+        if proc.wait() != 0:
+            raise DatasetError(f"zstd exited {proc.returncode}")
+    except (OSError, tarfile.TarError) as e:
+        raise DatasetError(f"extracting {tarball.name} failed: {e}") from e
+
+
+def prepare(root: Path, *, echo: Echo = print) -> None:
+    """Rewrite ambiguous edge headers and derive the birthday columns.
+
+    Idempotent: a marker file records completion, and a prepared tree is left
+    untouched on a second call.
+    """
+    marker = root / _MARKER
+    if marker.exists() and marker.read_text().strip() == _MARKER_VERSION:
+        echo("dataset already prepared")
+        return
+
+    for edge in schema.EDGE_FILES:
+        if edge.from_label == edge.to_label:
+            _rewrite_header(root / edge.file, [edge.from_id, edge.to_id])
+
+    _derive_birthday_parts(root / "dynamic/person_0_0.csv")
+    marker.write_text(_MARKER_VERSION + "\n")
+    echo(f"prepared {root.name}")
+
+
+def _rewrite_header(path: Path, names: list[str]) -> None:
+    """Replace the first `len(names)` header fields of `path`.
+
+    The remaining fields (edge properties such as `creationDate`) are kept as
+    they are. Rewriting only the header line means the file is not re-encoded,
+    which matters at SF1 where these files run to hundreds of MB.
+    """
+    if not path.exists():
+        raise DatasetError(f"missing dataset file: {path}")
+
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        header = fh.readline()
+        if not header:
+            raise DatasetError(f"empty dataset file: {path}")
+        rest_offset = fh.tell()
+
+    fields = header.rstrip("\r\n").split("|")
+    if len(fields) < len(names):
+        raise DatasetError(f"{path.name}: expected >= {len(names)} columns, got {fields}")
+    if fields[: len(names)] == names:
+        return  # already rewritten
+    fields[: len(names)] = names
+    new_header = "|".join(fields) + "\n"
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with path.open("rb") as src, tmp.open("wb") as dst:
+        dst.write(new_header.encode("utf-8"))
+        src.seek(rest_offset)
+        shutil.copyfileobj(src, dst)
+    tmp.replace(path)
+
+
+def _derive_birthday_parts(path: Path) -> None:
+    """Append `birthdayMonth` and `birthdayDay` columns to the person file.
+
+    The `birthday` column is epoch milliseconds at UTC midnight. IC10 asks for
+    the calendar month and day of that date, which FalkorDB cannot compute
+    without a temporal type, so both are materialised here.
+    """
+    if not path.exists():
+        raise DatasetError(f"missing dataset file: {path}")
+
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        header = fh.readline().rstrip("\r\n").split("|")
+    if "birthdayMonth" in header:
+        return
+    if "birthday" not in header:
+        raise DatasetError(f"{path.name}: no `birthday` column in {header}")
+    birthday_idx = header.index("birthday")
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with (
+        path.open("r", encoding="utf-8", newline="") as src,
+        tmp.open("w", encoding="utf-8", newline="") as dst,
+    ):
+        reader = csv.reader(src, delimiter="|")
+        writer = csv.writer(dst, delimiter="|", lineterminator="\n")
+        writer.writerow([*next(reader), "birthdayMonth", "birthdayDay"])
+        for row in reader:
+            try:
+                millis = int(row[birthday_idx])
+            except (IndexError, ValueError) as e:
+                raise DatasetError(f"{path.name}: bad birthday in row {row[:1]}: {e}") from e
+            date = dt.datetime.fromtimestamp(millis / 1000, tz=dt.UTC)
+            writer.writerow([*row, date.month, date.day])
+    tmp.replace(path)

--- a/bench/src/falkorbench/ldbc/loader.py
+++ b/bench/src/falkorbench/ldbc/loader.py
@@ -1,0 +1,252 @@
+"""Loading the LDBC SNB dataset into FalkorDB with `LOAD CSV`.
+
+Ordering is not incidental. Indices come first because the edge phase looks up
+both endpoints by `id` on every row — without them each of the ~17M SF1 edges
+drives two label scans. Unique constraints come last, because FalkorDB validates
+a constraint against existing data asynchronously and a constraint created up
+front would be validated once per inserted row.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from redis.exceptions import ResponseError
+
+from falkorbench.client import BenchClient
+from falkorbench.ldbc import schema
+
+Echo = Callable[[str], None]
+
+
+class LoadError(RuntimeError):
+    """The dataset could not be loaded."""
+
+
+@dataclass
+class LoadStats:
+    nodes: int = 0
+    edges: int = 0
+    seconds: float = 0.0
+
+    def line(self) -> str:
+        return f"{self.nodes:,} nodes, {self.edges:,} edges in {self.seconds:.1f}s"
+
+
+def load(
+    client: BenchClient,
+    dataset: Path,
+    *,
+    import_root: Path,
+    echo: Echo = print,
+) -> LoadStats:
+    """Load `dataset` into `client`'s graph.
+
+    `dataset` must live under `import_root`, which is the server's
+    IMPORT_FOLDER — `LOAD CSV` resolves `file://` against it, so a path outside
+    that tree is not reachable by the server no matter what this process can
+    see.
+    """
+    try:
+        rel = dataset.resolve().relative_to(import_root.resolve())
+    except ValueError as e:
+        raise LoadError(
+            f"dataset {dataset} is not under the server's import folder {import_root}"
+        ) from e
+
+    stats = LoadStats()
+    started = time.monotonic()
+
+    create_indices(client, echo=echo)
+    for node in schema.NODE_FILES:
+        stats.nodes += _load_nodes(client, rel, node, echo=echo)
+    for edge in schema.EDGE_FILES:
+        stats.edges += _load_edges(client, rel, edge, echo=echo)
+    create_constraints(client, echo=echo)
+
+    stats.seconds = time.monotonic() - started
+    echo(f"loaded {stats.line()}")
+    return stats
+
+
+def create_indices(client: BenchClient, *, echo: Echo = print) -> None:
+    """Create the exact-match indices, tolerating ones that already exist."""
+    for label, prop in schema.INDICES:
+        try:
+            client.graph.query(f"CREATE INDEX FOR (n:{label}) ON (n.{prop})")
+        except ResponseError as e:
+            if "already indexed" not in str(e).lower():
+                raise LoadError(f"index :{label}({prop}) failed: {e}") from e
+    echo(f"created {len(schema.INDICES)} indices")
+
+
+def create_constraints(
+    client: BenchClient,
+    *,
+    timeout: float = 600.0,
+    echo: Echo = print,
+) -> None:
+    """Create the unique constraints and wait for them to become OPERATIONAL.
+
+    FalkorDB rejects `CREATE CONSTRAINT ... ASSERT`, so these go through
+    GRAPH.CONSTRAINT, which returns PENDING and validates in the background. A
+    constraint still PENDING is not yet enforcing anything, and one that ends
+    FAILED means the data violated it — both would otherwise pass unnoticed,
+    since the create call itself succeeded.
+    """
+    for label in schema.UNIQUE_CONSTRAINTS:
+        try:
+            client.command(
+                "GRAPH.CONSTRAINT",
+                "CREATE",
+                client.graph_name,
+                "UNIQUE",
+                "NODE",
+                label,
+                "PROPERTIES",
+                "1",
+                "id",
+            )
+        except ResponseError as e:
+            if "already exists" in str(e).lower():
+                continue
+            raise LoadError(f"constraint on :{label}(id) failed: {e}") from e
+
+    deadline = time.monotonic() + timeout
+    while True:
+        pending, failed = _constraint_states(client)
+        if failed:
+            raise LoadError(f"unique constraint(s) failed validation: {', '.join(failed)}")
+        if not pending:
+            break
+        if time.monotonic() > deadline:
+            raise LoadError(f"constraints still pending after {timeout:.0f}s: {', '.join(pending)}")
+        time.sleep(0.5)
+    echo(f"created {len(schema.UNIQUE_CONSTRAINTS)} unique constraints")
+
+
+def _constraint_states(client: BenchClient) -> tuple[list[str], list[str]]:
+    """(pending, failed) constraint labels, from `db.constraints()`."""
+    res = client.graph.ro_query("CALL db.constraints()")
+    headers = [h[1] if isinstance(h, (list, tuple)) else h for h in (res.header or [])]
+    try:
+        label_i, status_i = headers.index("label"), headers.index("status")
+    except ValueError as e:
+        raise LoadError(f"unexpected db.constraints() shape: {headers}") from e
+
+    pending: list[str] = []
+    failed: list[str] = []
+    for row in res.result_set:
+        status = str(row[status_i]).upper()
+        if status == "PENDING":
+            pending.append(str(row[label_i]))
+        elif status != "OPERATIONAL":
+            failed.append(f"{row[label_i]} ({status})")
+    return pending, failed
+
+
+def _load_nodes(client: BenchClient, rel: Path, node: schema.NodeFile, *, echo: Echo) -> int:
+    """Load one node file, returning the number of nodes created."""
+    props = ", ".join(f"{k}: {v}" for k, v in node.properties.items())
+    labels = ":".join((node.label or "", *node.extra_labels)).strip(":")
+
+    if node.type_column is None:
+        created = _run_load(client, node.file, rel, f"CREATE (:{labels} {{{props}}})")
+    else:
+        # The polymorphic static files carry the subtype in a column, and a
+        # label cannot come from an expression. One pass per subtype, filtered —
+        # these are the two smallest files in the dataset (a few thousand rows
+        # even at SF1), so the repeated scan costs nothing worth optimising.
+        mapping = schema.PLACE_LABELS if node.label == "Place" else schema.ORGANISATION_LABELS
+        _assert_types_covered(client, node, rel, set(mapping))
+        created = 0
+        for value, sub in mapping.items():
+            all_labels = ":".join((node.label, sub, *node.extra_labels))
+            created += _run_load(
+                client,
+                node.file,
+                rel,
+                f"CREATE (:{all_labels} {{{props}}})",
+                where=f"row.{node.type_column} = '{value}'",
+            )
+
+    echo(f"  {node.file:<48} {created:>9,} nodes")
+    return created
+
+
+def _assert_types_covered(
+    client: BenchClient,
+    node: schema.NodeFile,
+    rel: Path,
+    known: set[str],
+) -> None:
+    """Fail if the file holds a subtype the label mapping does not name.
+
+    Without this an unrecognised `type` value would simply not be loaded, and
+    the first symptom would be a query quietly returning fewer rows.
+    """
+    res = client.graph.query(
+        "LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row "
+        f"RETURN collect(DISTINCT row.{node.type_column})",
+        {"file": _url(rel, node.file)},
+    )
+    found = {str(v) for v in (res.result_set[0][0] or [])}
+    if unknown := found - known:
+        raise LoadError(f"{node.file}: unmapped {node.type_column} value(s): {sorted(unknown)}")
+
+
+def _load_edges(client: BenchClient, rel: Path, edge: schema.EdgeFile, *, echo: Echo) -> int:
+    """Load one edge file, returning the number of relationships created."""
+    props = ", ".join(f"{k}: {v}" for k, v in edge.properties.items())
+    props = f" {{{props}}}" if props else ""
+    cypher = (
+        f"MATCH (f:{edge.from_label} {{id: toInteger(row.`{edge.from_id}`)}}) "
+        f"WITH f, row "
+        f"MATCH (t:{edge.to_label} {{id: toInteger(row.`{edge.to_id}`)}}) "
+        f"CREATE (f)-[:{edge.type}{props}]->(t)"
+    )
+    created = _run_load(client, edge.file, rel, cypher)
+    echo(f"  {edge.file:<48} {created:>9,} edges")
+    return created
+
+
+def _run_load(
+    client: BenchClient,
+    name: str,
+    rel: Path,
+    tail: str,
+    *,
+    where: str | None = None,
+) -> int:
+    """Run one `LOAD CSV ... <tail>` and return entities created.
+
+    The row count is checked against what was created: `LOAD CSV` piped into a
+    `MATCH` silently drops rows whose endpoints are missing, so an edge file
+    loaded before its nodes would report success having created nothing. The
+    same `where` filter is applied to both, so a filtered subtype load is
+    compared against the rows it was actually supposed to create.
+    """
+    url = _url(rel, name)
+    prefix = "LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row "
+    if where:
+        prefix += f"WITH row WHERE {where} "
+    try:
+        expected = client.graph.query(prefix + "RETURN count(row)", {"file": url}).result_set[0][0]
+        res = client.graph.query(prefix + tail, {"file": url})
+    except ResponseError as e:
+        raise LoadError(f"{name}: {e}") from e
+
+    created = res.nodes_created + res.relationships_created
+    if created != expected:
+        raise LoadError(
+            f"{name}: created {created} of {expected} rows — "
+            f"endpoints missing, or a duplicate id in the source"
+        )
+    return created
+
+
+def _url(rel: Path, name: str) -> str:
+    return f"file://{rel.as_posix()}/{name}"

--- a/bench/src/falkorbench/ldbc/loader.py
+++ b/bench/src/falkorbench/ldbc/loader.py
@@ -92,10 +92,11 @@ def create_constraints(
     """Create the unique constraints and wait for them to become OPERATIONAL.
 
     FalkorDB rejects `CREATE CONSTRAINT ... ASSERT`, so these go through
-    GRAPH.CONSTRAINT, which returns PENDING and validates in the background. A
-    constraint still PENDING is not yet enforcing anything, and one that ends
-    FAILED means the data violated it — both would otherwise pass unnoticed,
-    since the create call itself succeeded.
+    GRAPH.CONSTRAINT, which replies PENDING and validates in the background —
+    reporting itself as `UNDER CONSTRUCTION` in `db.constraints()` until it
+    settles. A constraint still under construction is not yet enforcing
+    anything, and one that ends FAILED means the data violated it; both would
+    otherwise pass unnoticed, since the create call itself succeeded.
     """
     for label in schema.UNIQUE_CONSTRAINTS:
         try:
@@ -129,7 +130,15 @@ def create_constraints(
 
 
 def _constraint_states(client: BenchClient) -> tuple[list[str], list[str]]:
-    """(pending, failed) constraint labels, from `db.constraints()`."""
+    """(pending, failed) constraint labels, from `db.constraints()`.
+
+    The engine's three statuses are `UNDER CONSTRUCTION`, `OPERATIONAL` and
+    `FAILED` (`ConstraintStatus`'s Display impl). It is *not* `PENDING` — that
+    is only what the `GRAPH.CONSTRAINT CREATE` call itself replies. An
+    in-progress status can also carry a progress prefix, as in
+    `[Indexing] 3/9: UNDER CONSTRUCTION`, so match on substring rather than
+    equality or the poll would call a healthy constraint failed.
+    """
     res = client.graph.ro_query("CALL db.constraints()")
     headers = [h[1] if isinstance(h, (list, tuple)) else h for h in (res.header or [])]
     try:
@@ -141,9 +150,9 @@ def _constraint_states(client: BenchClient) -> tuple[list[str], list[str]]:
     failed: list[str] = []
     for row in res.result_set:
         status = str(row[status_i]).upper()
-        if status == "PENDING":
+        if "UNDER CONSTRUCTION" in status:
             pending.append(str(row[label_i]))
-        elif status != "OPERATIONAL":
+        elif "OPERATIONAL" not in status:
             failed.append(f"{row[label_i]} ({status})")
     return pending, failed
 
@@ -177,6 +186,12 @@ def _load_nodes(client: BenchClient, rel: Path, node: schema.NodeFile, *, echo: 
     return created
 
 
+#: The pipe-separated dataset read with a header row. `FIELDTERMINATOR` is
+#: standard Cypher and goes *after* `AS row`; FalkorDB has no `DELIMITER`
+#: keyword (`Invalid input 'DELIMITER': expected From`).
+_LOAD_PREFIX = "LOAD CSV WITH HEADERS FROM $file AS row FIELDTERMINATOR '|' "
+
+
 def _assert_types_covered(
     client: BenchClient,
     node: schema.NodeFile,
@@ -188,11 +203,13 @@ def _assert_types_covered(
     Without this an unrecognised `type` value would simply not be loaded, and
     the first symptom would be a query quietly returning fewer rows.
     """
-    res = client.graph.query(
-        "LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row "
-        f"RETURN collect(DISTINCT row.{node.type_column})",
-        {"file": _url(rel, node.file)},
-    )
+    try:
+        res = client.graph.query(
+            f"{_LOAD_PREFIX}WITH row.{node.type_column} AS t RETURN collect(DISTINCT t)",
+            {"file": _url(rel, node.file)},
+        )
+    except ResponseError as e:
+        raise LoadError(f"{node.file}: {e}") from e
     found = {str(v) for v in (res.result_set[0][0] or [])}
     if unknown := found - known:
         raise LoadError(f"{node.file}: unmapped {node.type_column} value(s): {sorted(unknown)}")
@@ -230,7 +247,7 @@ def _run_load(
     compared against the rows it was actually supposed to create.
     """
     url = _url(rel, name)
-    prefix = "LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row "
+    prefix = _LOAD_PREFIX
     if where:
         prefix += f"WITH row WHERE {where} "
     try:
@@ -239,7 +256,9 @@ def _run_load(
     except ResponseError as e:
         raise LoadError(f"{name}: {e}") from e
 
-    created = res.nodes_created + res.relationships_created
+    # The client reports these as floats; keep them integral so a count reads
+    # as "1,460" rather than "1,460.0" and compares exactly against count(row).
+    created = int(res.nodes_created) + int(res.relationships_created)
     if created != expected:
         raise LoadError(
             f"{name}: created {created} of {expected} rows — "

--- a/bench/src/falkorbench/ldbc/params.py
+++ b/bench/src/falkorbench/ldbc/params.py
@@ -1,0 +1,271 @@
+"""Substitution parameters for the complex reads.
+
+LDBC ships *substitution parameters* generated alongside each dataset, chosen so
+that the queries hit a representative spread of the data rather than whichever
+person happens to be first. Running with hand-picked ids produces numbers that
+are not comparable to anything, because the cost of these queries varies by
+orders of magnitude with how well-connected the chosen person is.
+
+Two sources, in order:
+
+1. `--params DIR` — an official `interactive_N_param.txt` set. This is the only
+   source whose numbers are comparable with published LDBC results.
+2. Sampling the loaded graph, seeded. Deterministic, so two runs of the same
+   scale factor compare against each other, but **not** comparable to published
+   results: the sampler picks arbitrary well-connected entities rather than
+   LDBC's calibrated ones.
+
+The distinction is carried on `ParamSet.official` so a report can state which
+was used, rather than leaving a reader to assume the stronger one.
+"""
+
+from __future__ import annotations
+
+import csv
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from falkorbench.client import BenchClient
+from falkorbench.ldbc import queries as query_mod
+
+Echo = Callable[[str], None]
+
+#: A day in milliseconds. IC3 and IC4 ship `durationDays`, but the queries take
+#: an `endDate`; upstream drivers derive it. Doing that here keeps the query
+#: texts equal to upstream.
+_DAY_MS = 86_400_000
+
+#: Parameter file column -> query parameter name, where they differ.
+_ALIASES = {
+    "personId": "personId",
+    "person1Id": "person1Id",
+    "person2Id": "person2Id",
+}
+
+
+class ParamError(RuntimeError):
+    """Parameters could not be sourced."""
+
+
+@dataclass
+class ParamSet:
+    """Parameter rows for each query number.
+
+    official  True only when these came from an LDBC-generated parameter set.
+              Reported with the results; sampled parameters do not support a
+              comparison against published numbers.
+    """
+
+    rows: dict[int, list[dict[str, Any]]]
+    official: bool
+    source: str
+
+    def for_query(self, number: int) -> list[dict[str, Any]]:
+        return self.rows.get(number, [])
+
+    def caveat(self) -> str:
+        if self.official:
+            return f"official LDBC substitution parameters ({self.source})"
+        return (
+            f"parameters sampled from the loaded graph ({self.source}); "
+            f"deterministic and self-comparable, but NOT comparable to "
+            f"published LDBC results"
+        )
+
+
+def load(
+    client: BenchClient,
+    *,
+    directory: Path | None,
+    count: int,
+    seed: int,
+    echo: Echo = print,
+) -> ParamSet:
+    """Official parameters from `directory` if given, else sampled ones."""
+    if directory is not None:
+        return from_directory(directory, echo=echo)
+    return sample(client, count=count, seed=seed, echo=echo)
+
+
+def from_directory(directory: Path, *, echo: Echo = print) -> ParamSet:
+    """Parse an LDBC `interactive_N_param.txt` set.
+
+    The files are pipe-separated with a header naming each column; dates are
+    epoch milliseconds. IC3 and IC4 supply `durationDays` rather than an
+    `endDate`, which is derived here.
+    """
+    if not directory.is_dir():
+        raise ParamError(f"parameter directory not found: {directory}")
+
+    rows: dict[int, list[dict[str, Any]]] = {}
+    for n in query_mod.COMPLEX_READS:
+        path = directory / f"interactive_{n}_param.txt"
+        if not path.exists():
+            raise ParamError(f"missing {path.name} in {directory}")
+        with path.open(encoding="utf-8", newline="") as fh:
+            parsed = [_coerce(n, row) for row in csv.DictReader(fh, delimiter="|")]
+        if not parsed:
+            raise ParamError(f"{path.name} has no rows")
+        for row in parsed:
+            query_mod.validate(n, row)
+        rows[n] = parsed
+        echo(f"  IC{n:<3} {len(parsed):>6,} parameter rows")
+    return ParamSet(rows=rows, official=True, source=str(directory))
+
+
+def _coerce(number: int, row: dict[str, str]) -> dict[str, Any]:
+    """Convert one raw parameter row to the query's parameter map."""
+    out: dict[str, Any] = {}
+    duration_days: int | None = None
+    for key, raw in row.items():
+        if key is None or raw is None:
+            continue
+        name = _ALIASES.get(key, key)
+        if name == "durationDays":
+            duration_days = int(raw)
+            continue
+        out[name] = int(raw) if _is_int(raw) else raw
+
+    if duration_days is not None:
+        start = out.get("startDate")
+        if not isinstance(start, int):
+            raise ParamError(f"IC{number}: durationDays given without an integer startDate")
+        out["endDate"] = start + duration_days * _DAY_MS
+    return out
+
+
+def _is_int(text: str) -> bool:
+    return bool(text) and (text[1:] if text[0] in "+-" else text).isdigit()
+
+
+def sample(
+    client: BenchClient,
+    *,
+    count: int,
+    seed: int,
+    echo: Echo = print,
+) -> ParamSet:
+    """Derive parameters from the loaded graph, deterministically.
+
+    People are drawn from the most-connected end of the `KNOWS` degree
+    distribution rather than uniformly. A uniformly drawn person is very often
+    isolated, and a query anchored on an isolated person returns nothing in
+    microseconds — a set of those would report the benchmark as uniformly fast
+    while measuring almost none of the work it exists to measure.
+    """
+    rng = random.Random(seed)
+
+    people = _column(
+        client,
+        "MATCH (p:Person)-[:KNOWS]-() WITH p, count(*) AS deg "
+        "RETURN p.id ORDER BY deg DESC, p.id ASC LIMIT $n",
+        {"n": count * 4},
+    )
+    if not people:
+        raise ParamError("no :Person with a :KNOWS edge — is the graph loaded?")
+
+    names = _column(
+        client,
+        "MATCH (p:Person) WITH p.firstName AS n, count(*) AS c "
+        "RETURN n ORDER BY c DESC, n ASC LIMIT $n",
+        {"n": count},
+    )
+    countries = _column(
+        client,
+        "MATCH (c:Country)<-[:IS_PART_OF]-()<-[:IS_LOCATED_IN]-(p:Person) "
+        "WITH c.name AS n, count(p) AS c2 RETURN n ORDER BY c2 DESC, n ASC LIMIT $n",
+        {"n": max(count, 2)},
+    )
+    tags = _column(
+        client,
+        "MATCH (t:Tag)<-[:HAS_TAG]-() WITH t.name AS n, count(*) AS c "
+        "RETURN n ORDER BY c DESC, n ASC LIMIT $n",
+        {"n": count},
+    )
+    tag_classes = _column(
+        client,
+        "MATCH (tc:TagClass)<-[:HAS_TYPE]-(t:Tag)<-[:HAS_TAG]-() "
+        "WITH tc.name AS n, count(*) AS c RETURN n ORDER BY c DESC, n ASC LIMIT $n",
+        {"n": count},
+    )
+    lo, hi = _date_range(client)
+
+    missing = [
+        label
+        for label, values in (
+            ("Person.firstName", names),
+            ("Country.name", countries),
+            ("Tag.name", tags),
+            ("TagClass.name", tag_classes),
+        )
+        if not values
+    ]
+    if missing:
+        raise ParamError(f"cannot sample parameters, nothing found for: {', '.join(missing)}")
+
+    def person() -> int:
+        return int(rng.choice(people))
+
+    def window() -> tuple[int, int]:
+        """A start date and a 30-day end date inside the corpus' date range."""
+        start = rng.randrange(lo, max(lo + 1, hi - 30 * _DAY_MS))
+        return start, start + 30 * _DAY_MS
+
+    rows: dict[int, list[dict[str, Any]]] = {n: [] for n in query_mod.COMPLEX_READS}
+    for _ in range(count):
+        start, end = window()
+        pair = rng.sample(people, 2) if len(people) >= 2 else [people[0], people[0]]
+        two_countries = (
+            rng.sample(countries, 2) if len(countries) >= 2 else [countries[0], countries[0]]
+        )
+        rows[1].append({"personId": person(), "firstName": rng.choice(names)})
+        rows[2].append({"personId": person(), "maxDate": end})
+        rows[3].append(
+            {
+                "personId": person(),
+                "countryXName": two_countries[0],
+                "countryYName": two_countries[1],
+                "startDate": start,
+                "endDate": end,
+            }
+        )
+        rows[4].append({"personId": person(), "startDate": start, "endDate": end})
+        rows[5].append({"personId": person(), "minDate": start})
+        rows[6].append({"personId": person(), "tagName": rng.choice(tags)})
+        rows[7].append({"personId": person()})
+        rows[8].append({"personId": person()})
+        rows[9].append({"personId": person(), "maxDate": end})
+        rows[10].append({"personId": person(), "month": rng.randint(1, 12)})
+        rows[11].append(
+            {
+                "personId": person(),
+                "countryName": rng.choice(countries),
+                "workFromYear": rng.randint(2000, 2013),
+            }
+        )
+        rows[12].append({"personId": person(), "tagClassName": rng.choice(tag_classes)})
+        rows[13].append({"person1Id": int(pair[0]), "person2Id": int(pair[1])})
+        rows[14].append({"person1Id": int(pair[0]), "person2Id": int(pair[1])})
+
+    for n, param_rows in rows.items():
+        for row in param_rows:
+            query_mod.validate(n, row)
+
+    echo(f"sampled {count} parameter rows per query (seed {seed})")
+    return ParamSet(rows=rows, official=False, source=f"seed={seed}, n={count}")
+
+
+def _column(client: BenchClient, cypher: str, params: dict[str, Any]) -> list[Any]:
+    return [row[0] for row in client.graph.ro_query(cypher, params).result_set]
+
+
+def _date_range(client: BenchClient) -> tuple[int, int]:
+    """(min, max) message creationDate, the corpus' time span."""
+    res = client.graph.ro_query("MATCH (m:Message) RETURN min(m.creationDate), max(m.creationDate)")
+    lo, hi = res.result_set[0]
+    if lo is None or hi is None:
+        raise ParamError("no :Message creationDate — is the graph loaded?")
+    return int(lo), int(hi)

--- a/bench/src/falkorbench/ldbc/params.py
+++ b/bench/src/falkorbench/ldbc/params.py
@@ -222,6 +222,22 @@ def sample(
         start = rng.randrange(floor, max(floor + 1, hi - 30 * _DAY_MS))
         return start, start + 30 * _DAY_MS
 
+    def wide_window() -> tuple[int, int]:
+        """IC3's window, which has to be far wider than the other queries'.
+
+        IC3 counts friends who are *not* resident in either country yet posted
+        from both of them inside the window. That conjunction is rare: at SF0.1,
+        anchored on the most-connected person and the two densest countries, a
+        30-day window returns 0 rows, 90 days returns 0, 365 returns 1 and 730
+        returns 2 — measured on the C engine, which agrees with Rust here, so
+        this is a property of the dataset rather than of either engine.
+        `durationDays` is an explicit LDBC parameter, so widening it stays
+        within the query's own contract; LDBC's curated parameter sets pick
+        values that guarantee a non-empty result, and sampling cannot.
+        """
+        start = lo + (hi - lo) // 4
+        return start, hi
+
     def max_date() -> int:
         """A cut-off with history behind it.
 
@@ -239,13 +255,14 @@ def sample(
         )
         rows[1].append({"personId": person(), "firstName": rng.choice(names)})
         rows[2].append({"personId": person(), "maxDate": max_date()})
+        ic3_start, ic3_end = wide_window()
         rows[3].append(
             {
                 "personId": person(),
                 "countryXName": two_countries[0],
                 "countryYName": two_countries[1],
-                "startDate": start,
-                "endDate": end,
+                "startDate": ic3_start,
+                "endDate": ic3_end,
             }
         )
         rows[4].append({"personId": person(), "startDate": start, "endDate": end})

--- a/bench/src/falkorbench/ldbc/params.py
+++ b/bench/src/falkorbench/ldbc/params.py
@@ -210,9 +210,25 @@ def sample(
         return int(rng.choice(people))
 
     def window() -> tuple[int, int]:
-        """A start date and a 30-day end date inside the corpus' date range."""
-        start = rng.randrange(lo, max(lo + 1, hi - 30 * _DAY_MS))
+        """A start date and a 30-day end date, drawn from the dense end of the corpus.
+
+        Messages accumulate over the simulated period, so a window drawn
+        uniformly across the whole span usually lands in the sparse early
+        history and matches nothing. That is the same failure mode as an
+        isolated person: it returns instantly and measures none of the work the
+        query exists to measure. Draw from the last quarter, where the data is.
+        """
+        floor = hi - (hi - lo) // 4
+        start = rng.randrange(floor, max(floor + 1, hi - 30 * _DAY_MS))
         return start, start + 30 * _DAY_MS
+
+    def max_date() -> int:
+        """A cut-off with history behind it.
+
+        IC2 and IC9 select the most recent messages *before* maxDate, so a
+        cut-off early in the corpus leaves nothing to find.
+        """
+        return rng.randrange(hi - (hi - lo) // 4, hi + 1)
 
     rows: dict[int, list[dict[str, Any]]] = {n: [] for n in query_mod.COMPLEX_READS}
     for _ in range(count):
@@ -222,7 +238,7 @@ def sample(
             rng.sample(countries, 2) if len(countries) >= 2 else [countries[0], countries[0]]
         )
         rows[1].append({"personId": person(), "firstName": rng.choice(names)})
-        rows[2].append({"personId": person(), "maxDate": end})
+        rows[2].append({"personId": person(), "maxDate": max_date()})
         rows[3].append(
             {
                 "personId": person(),
@@ -237,7 +253,7 @@ def sample(
         rows[6].append({"personId": person(), "tagName": rng.choice(tags)})
         rows[7].append({"personId": person()})
         rows[8].append({"personId": person()})
-        rows[9].append({"personId": person(), "maxDate": end})
+        rows[9].append({"personId": person(), "maxDate": max_date()})
         rows[10].append({"personId": person(), "month": rng.randint(1, 12)})
         rows[11].append(
             {

--- a/bench/src/falkorbench/ldbc/queries.py
+++ b/bench/src/falkorbench/ldbc/queries.py
@@ -1,0 +1,126 @@
+"""The 14 Interactive v1 complex reads, and the parameters they are run with.
+
+The query texts are vendored verbatim from
+`ldbc/ldbc_snb_interactive_v1_impls` (`cypher/queries/`), with four rewrites
+that FalkorDB's dialect requires. Each rewrite is commented in the `.cypher`
+file next to the line it replaces, and `REWRITES` below records them in one
+place so a report can state exactly how far the run departs from upstream.
+
+Keeping the texts as files rather than string literals means a future upstream
+bump is a readable diff.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from functools import cache
+from pathlib import Path
+from typing import Any
+from typing import NamedTuple
+
+QUERY_DIR = Path(__file__).parent / "queries"
+
+COMPLEX_READS = tuple(range(1, 15))
+
+#: Departures from the upstream query text, by query number. Reported alongside
+#: results: a number produced by a rewritten query is not measuring quite the
+#: same thing as one produced by the original, and that should be visible
+#: without reading the diff.
+REWRITES: dict[int, str] = {
+    1: "shortestPath() moved from MATCH into WITH (unsupported in MATCH)",
+    10: "datetime({epochMillis: ...}).month/.day replaced by loader-derived "
+    "birthdayMonth/birthdayDay properties (no temporal type)",
+    13: "shortestPath() moved from MATCH into WITH (unsupported in MATCH)",
+    14: "allShortestPaths() endpoints pre-bound in a preceding MATCH "
+    "(endpoints must already be resolved)",
+}
+
+#: Parameter names each query takes, in the order the upstream header declares
+#: them. Used to validate a parameter file rather than discovering a missing
+#: parameter as a null comparison at run time.
+PARAM_NAMES: dict[int, tuple[str, ...]] = {
+    1: ("personId", "firstName"),
+    2: ("personId", "maxDate"),
+    3: ("personId", "countryXName", "countryYName", "startDate", "endDate"),
+    4: ("personId", "startDate", "endDate"),
+    5: ("personId", "minDate"),
+    6: ("personId", "tagName"),
+    7: ("personId",),
+    8: ("personId",),
+    9: ("personId", "maxDate"),
+    10: ("personId", "month"),
+    11: ("personId", "countryName", "workFromYear"),
+    12: ("personId", "tagClassName"),
+    13: ("person1Id", "person2Id"),
+    14: ("person1Id", "person2Id"),
+}
+
+_HEADER = re.compile(r"^\s*(//.*?\n)?\s*/\*.*?\*/", re.S)
+
+
+class ComplexRead(NamedTuple):
+    number: int
+    cypher: str
+
+    @property
+    def name(self) -> str:
+        return f"IC{self.number}"
+
+    @property
+    def rewritten(self) -> bool:
+        return self.number in REWRITES
+
+
+@cache
+def load_queries() -> tuple[ComplexRead, ...]:
+    """Read the vendored query texts, stripping the `:param` header comment.
+
+    The header is a Neo4j Browser directive, not Cypher. FalkorDB parses it as a
+    comment and ignores it, but removing it keeps what is sent equal to what is
+    measured.
+    """
+    out = []
+    for n in COMPLEX_READS:
+        path = QUERY_DIR / f"interactive-complex-{n}.cypher"
+        text = path.read_text(encoding="utf-8")
+        body = _HEADER.sub("", text, count=1).strip()
+        if not body:
+            raise ValueError(f"{path.name}: no query body after the header comment")
+        out.append(ComplexRead(number=n, cypher=body))
+    return tuple(out)
+
+
+def select(names: tuple[str, ...]) -> list[ComplexRead]:
+    """Resolve `IC3`-style names to queries, erroring on an unknown name."""
+    queries = load_queries()
+    if not names:
+        return list(queries)
+    wanted = {n.upper() for n in names}
+    chosen = [q for q in queries if q.name in wanted]
+    if missing := wanted - {q.name for q in chosen}:
+        raise ValueError(f"unknown queries: {sorted(missing)}")
+    return chosen
+
+
+def validate(number: int, params: dict[str, Any]) -> None:
+    """Raise if `params` does not supply exactly what query `number` needs.
+
+    An absent parameter is not an error in Cypher — it evaluates to null, the
+    predicate that uses it silently fails, and the query returns zero rows very
+    quickly. That reads as a fast query rather than a broken one, which is
+    exactly the failure this benchmark must not report.
+    """
+    expected = set(PARAM_NAMES[number])
+    got = set(params)
+    if missing := expected - got:
+        raise ValueError(f"IC{number}: missing parameter(s) {sorted(missing)}")
+    if extra := got - expected:
+        raise ValueError(f"IC{number}: unexpected parameter(s) {sorted(extra)}")
+
+
+def rewrite_note(echo: Callable[[str], None]) -> None:
+    """Print the rewrite list, so a run never reports numbers without it."""
+    echo(f"{len(REWRITES)} of {len(COMPLEX_READS)} queries differ from upstream:")
+    for n in sorted(REWRITES):
+        echo(f"  IC{n}: {REWRITES[n]}")

--- a/bench/src/falkorbench/ldbc/queries.py
+++ b/bench/src/falkorbench/ldbc/queries.py
@@ -29,11 +29,19 @@ COMPLEX_READS = tuple(range(1, 15))
 #: without reading the diff.
 REWRITES: dict[int, str] = {
     1: "shortestPath() moved from MATCH into WITH (unsupported in MATCH)",
+    6: "inline id filter on :Tag moved into WHERE (works around a wrong-result "
+    "bug under UNWIND; see the note in the query)",
+    7: "not(<traversal pattern>) replaced by size(<pattern>) = 0 "
+    "(a pattern is not a boolean-valued expression in a projection)",
+    9: "collect(distinct ...) + UNWIND replaced by WITH DISTINCT (works around "
+    "a silent zero-rows bug; see the note in the query)",
     10: "datetime({epochMillis: ...}).month/.day replaced by loader-derived "
     "birthdayMonth/birthdayDay properties (no temporal type)",
     13: "shortestPath() moved from MATCH into WITH (unsupported in MATCH)",
-    14: "allShortestPaths() endpoints pre-bound in a preceding MATCH "
-    "(endpoints must already be resolved)",
+    14: "allShortestPaths() endpoints pre-bound in a preceding MATCH, and the "
+    "per-relationship weights hoisted out of the pattern comprehensions "
+    "(a pattern comprehension's WHERE cannot see an outer list-comprehension "
+    "variable)",
 }
 
 #: Parameter names each query takes, in the order the upstream header declares

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-1.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-1.cypher
@@ -1,0 +1,57 @@
+// Q1. Transitive friends with certain name
+/*
+:param [{ personId, firstName }] => { RETURN
+  4398046511333 AS personId,
+  "Jose" AS firstName
+}
+*/
+MATCH (p:Person {id: $personId}), (friend:Person {firstName: $firstName})
+       WHERE NOT p=friend
+       WITH p, friend
+       // FalkorDB rewrite: shortestPath() is rejected inside MATCH ("FalkorDB
+       // currently only supports shortestPaths in WITH or RETURN clauses"), so
+       // it moves into WITH. `MATCH path = shortestPath(...)` dropped rows with
+       // no path; WITH keeps them as null, hence the explicit IS NOT NULL.
+       WITH friend, shortestPath((p)-[:KNOWS*1..3]-(friend)) AS path
+       WHERE path IS NOT NULL
+       WITH min(length(path)) AS distance, friend
+ORDER BY
+    distance ASC,
+    friend.lastName ASC,
+    toInteger(friend.id) ASC
+LIMIT 20
+
+MATCH (friend)-[:IS_LOCATED_IN]->(friendCity:City)
+OPTIONAL MATCH (friend)-[studyAt:STUDY_AT]->(uni:University)-[:IS_LOCATED_IN]->(uniCity:City)
+WITH friend, collect(
+    CASE uni.name
+        WHEN null THEN null
+        ELSE [uni.name, studyAt.classYear, uniCity.name]
+    END ) AS unis, friendCity, distance
+
+OPTIONAL MATCH (friend)-[workAt:WORK_AT]->(company:Company)-[:IS_LOCATED_IN]->(companyCountry:Country)
+WITH friend, collect(
+    CASE company.name
+        WHEN null THEN null
+        ELSE [company.name, workAt.workFrom, companyCountry.name]
+    END ) AS companies, unis, friendCity, distance
+
+RETURN
+    friend.id AS friendId,
+    friend.lastName AS friendLastName,
+    distance AS distanceFromPerson,
+    friend.birthday AS friendBirthday,
+    friend.creationDate AS friendCreationDate,
+    friend.gender AS friendGender,
+    friend.browserUsed AS friendBrowserUsed,
+    friend.locationIP AS friendLocationIp,
+    friend.email AS friendEmails,
+    friend.speaks AS friendLanguages,
+    friendCity.name AS friendCityName,
+    unis AS friendUniversities,
+    companies AS friendCompanies
+ORDER BY
+    distanceFromPerson ASC,
+    friendLastName ASC,
+    toInteger(friendId) ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-10.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-10.cypher
@@ -1,0 +1,34 @@
+// Q10. Friend recommendation
+/*
+:param [{ personId, month }] => { RETURN
+  4398046511333 AS personId,
+  5 AS month
+}
+*/
+MATCH (person:Person {id: $personId})-[:KNOWS*2..2]-(friend),
+       (friend)-[:IS_LOCATED_IN]->(city:City)
+WHERE NOT friend=person AND
+      NOT (friend)-[:KNOWS]-(person)
+// FalkorDB rewrite: FalkorDB has no `datetime()` / temporal type, so
+// `datetime({epochMillis: friend.birthday}).month` and `.day` are unavailable.
+// The loader stores the two components the query actually needs as derived
+// integer properties (birthdayMonth, birthdayDay) alongside the raw epoch
+// birthday; see falkorbench.ldbc.schema. The predicate is otherwise identical.
+WITH person, city, friend
+WHERE  (friend.birthdayMonth=$month AND friend.birthdayDay>=21) OR
+        (friend.birthdayMonth=($month%12)+1 AND friend.birthdayDay<22)
+WITH DISTINCT friend, city, person
+OPTIONAL MATCH (friend)<-[:HAS_CREATOR]-(post:Post)
+WITH friend, city, collect(post) AS posts, person
+WITH friend,
+     city,
+     size(posts) AS postCount,
+     size([p IN posts WHERE (p)-[:HAS_TAG]->()<-[:HAS_INTEREST]-(person)]) AS commonPostCount
+RETURN friend.id AS personId,
+       friend.firstName AS personFirstName,
+       friend.lastName AS personLastName,
+       commonPostCount - (postCount - commonPostCount) AS commonInterestScore,
+       friend.gender AS personGender,
+       city.name AS personCityName
+ORDER BY commonInterestScore DESC, personId ASC
+LIMIT 10

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-11.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-11.cypher
@@ -1,0 +1,24 @@
+// Q11. Job referral
+/*
+:param [{ personId, countryName, workFromYear }] => { RETURN
+  10995116277918 AS personId,
+  "Hungary" AS countryName,
+  2011 AS workFromYear
+}
+*/
+MATCH (person:Person {id: $personId })-[:KNOWS*1..2]-(friend:Person)
+WHERE not(person=friend)
+WITH DISTINCT friend
+MATCH (friend)-[workAt:WORK_AT]->(company:Company)-[:IS_LOCATED_IN]->(:Country {name: $countryName })
+WHERE workAt.workFrom < $workFromYear
+RETURN
+        friend.id AS personId,
+        friend.firstName AS personFirstName,
+        friend.lastName AS personLastName,
+        company.name AS organizationName,
+        workAt.workFrom AS organizationWorkFromYear
+ORDER BY
+        organizationWorkFromYear ASC,
+        toInteger(personId) ASC,
+        organizationName DESC
+LIMIT 10

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-12.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-12.cypher
@@ -1,0 +1,22 @@
+// Q12. Expert search
+/*
+:param [{ personId, tagClassName }] => { RETURN
+  10995116278009 AS personId,
+  "Monarch" AS tagClassName
+}
+*/
+MATCH (tag:Tag)-[:HAS_TYPE|IS_SUBCLASS_OF*0..]->(baseTagClass:TagClass)
+WHERE tag.name = $tagClassName OR baseTagClass.name = $tagClassName
+WITH collect(tag.id) as tags
+MATCH (:Person {id: $personId })-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(comment:Comment)-[:REPLY_OF]->(:Post)-[:HAS_TAG]->(tag:Tag)
+WHERE tag.id in tags
+RETURN
+    friend.id AS personId,
+    friend.firstName AS personFirstName,
+    friend.lastName AS personLastName,
+    collect(DISTINCT tag.name) AS tagNames,
+    count(DISTINCT comment) AS replyCount
+ORDER BY
+    replyCount DESC,
+    toInteger(personId) ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-13.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-13.cypher
@@ -1,0 +1,20 @@
+// Q13. Single shortest path
+/*
+:param [{ person1Id, person2Id }] => { RETURN
+  8796093022390 AS person1Id,
+  8796093022357 AS person2Id
+}
+*/
+// FalkorDB rewrite: shortestPath() is rejected inside MATCH ("FalkorDB
+// currently only supports shortestPaths in WITH or RETURN clauses"), so the
+// path binding moves into its own WITH. The CASE below already handles the
+// null (disconnected) case, so the -1 result is unchanged.
+MATCH
+    (person1:Person {id: $person1Id}),
+    (person2:Person {id: $person2Id})
+WITH shortestPath((person1)-[:KNOWS*]-(person2)) AS path
+RETURN
+    CASE path IS NULL
+        WHEN true THEN -1
+        ELSE length(path)
+    END AS shortestPathLength

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-14.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-14.cypher
@@ -10,31 +10,25 @@
 // allShortestPaths"), so the two :Person lookups move into a preceding MATCH.
 MATCH (person1:Person { id: $person1Id }), (person2:Person { id: $person2Id })
 WITH person1, person2
+// FalkorDB rewrite (2): a pattern comprehension's WHERE cannot reference the
+// variable of an enclosing list comprehension — `startNode(r)` there resolves
+// to Null ("Type mismatch: expected Edge but was Null"; the C engine reports
+// "Unable to resolve filtered alias 'r'", so this is a dialect gap, not a
+// regression). The relationships are therefore UNWINDed and their endpoints
+// hoisted into plain variables before the comprehensions run, then summed back
+// per path. `reduce(w=0.0, v IN [... | 1.0] | w+v)` is a count times its
+// weight, so size(...) * weight is equivalent.
 MATCH path = allShortestPaths((person1)-[:KNOWS*0..]-(person2))
-WITH collect(path) as paths
-UNWIND paths as path
-WITH path, relationships(path) as rels_in_path
-WITH
-    [n in nodes(path) | n.id ] as personIdsInPath,
-    [r in rels_in_path |
-        reduce(w=0.0, v in [
-            (a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Post)-[:HAS_CREATOR]->(b:Person)
-            WHERE
-                (a.id = startNode(r).id and b.id=endNode(r).id) OR (a.id=endNode(r).id and b.id=startNode(r).id)
-            | 1.0] | w+v)
-    ] as weight1,
-    [r in rels_in_path |
-        reduce(w=0.0,v in [
-        (a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Comment)-[:HAS_CREATOR]->(b:Person)
-        WHERE
-                (a.id = startNode(r).id and b.id=endNode(r).id) OR (a.id=endNode(r).id and b.id=startNode(r).id)
-        | 0.5] | w+v)
-    ] as weight2
-WITH
-    personIdsInPath,
-    reduce(w=0.0,v in weight1| w+v) as w1,
-    reduce(w=0.0,v in weight2| w+v) as w2
+WITH path, [n IN nodes(path) | n.id] AS personIdsInPath
+UNWIND relationships(path) AS r
+WITH path, personIdsInPath, startNode(r).id AS aId, endNode(r).id AS bId
+WITH path, personIdsInPath,
+    size([(a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Post)-[:HAS_CREATOR]->(b:Person)
+          WHERE (a.id = aId AND b.id = bId) OR (a.id = bId AND b.id = aId) | 1.0]) * 1.0 AS w1,
+    size([(a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Comment)-[:HAS_CREATOR]->(b:Person)
+          WHERE (a.id = aId AND b.id = bId) OR (a.id = bId AND b.id = aId) | 0.5]) * 0.5 AS w2
+WITH path, personIdsInPath, sum(w1 + w2) AS pathWeight
 RETURN
     personIdsInPath,
-    (w1+w2) as pathWeight
+    pathWeight
 ORDER BY pathWeight desc

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-14.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-14.cypher
@@ -1,0 +1,40 @@
+// Q14. Trusted connection paths
+/*
+:param [{ person1Id, person2Id }] => { RETURN
+  8796093022357 AS person1Id,
+  8796093022390 AS person2Id
+}
+*/
+// FalkorDB rewrite: allShortestPaths() requires both endpoints to be already
+// bound ("Source and destination must already be resolved to call
+// allShortestPaths"), so the two :Person lookups move into a preceding MATCH.
+MATCH (person1:Person { id: $person1Id }), (person2:Person { id: $person2Id })
+WITH person1, person2
+MATCH path = allShortestPaths((person1)-[:KNOWS*0..]-(person2))
+WITH collect(path) as paths
+UNWIND paths as path
+WITH path, relationships(path) as rels_in_path
+WITH
+    [n in nodes(path) | n.id ] as personIdsInPath,
+    [r in rels_in_path |
+        reduce(w=0.0, v in [
+            (a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Post)-[:HAS_CREATOR]->(b:Person)
+            WHERE
+                (a.id = startNode(r).id and b.id=endNode(r).id) OR (a.id=endNode(r).id and b.id=startNode(r).id)
+            | 1.0] | w+v)
+    ] as weight1,
+    [r in rels_in_path |
+        reduce(w=0.0,v in [
+        (a:Person)<-[:HAS_CREATOR]-(:Comment)-[:REPLY_OF]->(:Comment)-[:HAS_CREATOR]->(b:Person)
+        WHERE
+                (a.id = startNode(r).id and b.id=endNode(r).id) OR (a.id=endNode(r).id and b.id=startNode(r).id)
+        | 0.5] | w+v)
+    ] as weight2
+WITH
+    personIdsInPath,
+    reduce(w=0.0,v in weight1| w+v) as w1,
+    reduce(w=0.0,v in weight2| w+v) as w2
+RETURN
+    personIdsInPath,
+    (w1+w2) as pathWeight
+ORDER BY pathWeight desc

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-2.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-2.cypher
@@ -1,0 +1,20 @@
+// Q2. Recent messages by your friends
+/*
+:param [{ personId, maxDate }] => { RETURN
+  10995116278009 AS personId,
+  1287230400000 AS maxDate
+}
+*/
+MATCH (:Person {id: $personId })-[:KNOWS]-(friend:Person)<-[:HAS_CREATOR]-(message:Message)
+    WHERE message.creationDate <= $maxDate
+    RETURN
+        friend.id AS personId,
+        friend.firstName AS personFirstName,
+        friend.lastName AS personLastName,
+        message.id AS postOrCommentId,
+        coalesce(message.content,message.imageFile) AS postOrCommentContent,
+        message.creationDate AS postOrCommentCreationDate
+    ORDER BY
+        postOrCommentCreationDate DESC,
+        toInteger(postOrCommentId) ASC
+    LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-3.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-3.cypher
@@ -1,0 +1,38 @@
+// Q3. Friends and friends of friends that have been to given countries
+/*
+:param [{ personId, countryXName, countryYName, startDate, endDate }] => { RETURN
+  6597069766734 AS personId,
+  "Angola" AS countryXName,
+  "Colombia" AS countryYName,
+  1275393600000 AS startDate,
+  1277812800000 AS endDate
+}
+*/
+MATCH (countryX:Country {name: $countryXName }),
+      (countryY:Country {name: $countryYName }),
+      (person:Person {id: $personId })
+WITH person, countryX, countryY
+LIMIT 1
+MATCH (city:City)-[:IS_PART_OF]->(country:Country)
+WHERE country IN [countryX, countryY]
+WITH person, countryX, countryY, collect(city) AS cities
+MATCH (person)-[:KNOWS*1..2]-(friend)-[:IS_LOCATED_IN]->(city)
+WHERE NOT person=friend AND NOT city IN cities
+WITH DISTINCT friend, countryX, countryY
+MATCH (friend)<-[:HAS_CREATOR]-(message),
+      (message)-[:IS_LOCATED_IN]->(country)
+WHERE $endDate > message.creationDate >= $startDate AND
+      country IN [countryX, countryY]
+WITH friend,
+     CASE WHEN country=countryX THEN 1 ELSE 0 END AS messageX,
+     CASE WHEN country=countryY THEN 1 ELSE 0 END AS messageY
+WITH friend, sum(messageX) AS xCount, sum(messageY) AS yCount
+WHERE xCount>0 AND yCount>0
+RETURN friend.id AS friendId,
+       friend.firstName AS friendFirstName,
+       friend.lastName AS friendLastName,
+       xCount,
+       yCount,
+       xCount + yCount AS xyCount
+ORDER BY xyCount DESC, friendId ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-4.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-4.cypher
@@ -1,0 +1,25 @@
+// Q4. New topics
+/*
+:param [{ personId, startDate, endDate }] => { RETURN
+  4398046511333 AS personId,
+  1275350400000 AS startDate,
+  1277856000000 AS endDate
+}
+*/
+MATCH (person:Person {id: $personId })-[:KNOWS]-(friend:Person),
+      (friend)<-[:HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(tag)
+WITH DISTINCT tag, post
+WITH tag,
+     CASE
+       WHEN $startDate <= post.creationDate < $endDate THEN 1
+       ELSE 0
+     END AS valid,
+     CASE
+       WHEN post.creationDate < $startDate THEN 1
+       ELSE 0
+     END AS inValid
+WITH tag, sum(valid) AS postCount, sum(inValid) AS inValidPostCount
+WHERE postCount>0 AND inValidPostCount=0
+RETURN tag.name AS tagName, postCount
+ORDER BY postCount DESC, tagName ASC
+LIMIT 10

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-5.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-5.cypher
@@ -1,0 +1,30 @@
+// Q5. New groups
+/*
+:param [{ personId, minDate }] => { RETURN
+  6597069766734 AS personId,
+  1288612800000 AS minDate
+}
+*/
+MATCH (person:Person { id: $personId })-[:KNOWS*1..2]-(friend)
+WHERE
+    NOT person=friend
+WITH DISTINCT friend
+MATCH (friend)<-[membership:HAS_MEMBER]-(forum)
+WHERE
+    membership.joinDate > $minDate
+WITH
+    forum,
+    collect(friend) AS friends
+OPTIONAL MATCH (friend)<-[:HAS_CREATOR]-(post)<-[:CONTAINER_OF]-(forum)
+WHERE
+    friend IN friends
+WITH
+    forum,
+    count(post) AS postCount
+RETURN
+    forum.title AS forumName,
+    postCount
+ORDER BY
+    postCount DESC,
+    forum.id ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-6.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-6.cypher
@@ -1,0 +1,30 @@
+// Q6. Tag co-occurrence
+/*
+:param [{ personId, tagName }] => { RETURN
+  4398046511333 AS personId,
+  "Carl_Gustaf_Emil_Mannerheim" AS tagName
+}
+*/
+MATCH (knownTag:Tag { name: $tagName })
+WITH knownTag.id as knownTagId
+
+MATCH (person:Person { id: $personId })-[:KNOWS*1..2]-(friend)
+WHERE NOT person=friend
+WITH
+    knownTagId,
+    collect(distinct friend) as friends
+UNWIND friends as f
+    MATCH (f)<-[:HAS_CREATOR]-(post:Post),
+          (post)-[:HAS_TAG]->(t:Tag{id: knownTagId}),
+          (post)-[:HAS_TAG]->(tag:Tag)
+    WHERE NOT t = tag
+    WITH
+        tag.name as tagName,
+        count(post) as postCount
+RETURN
+    tagName,
+    postCount
+ORDER BY
+    postCount DESC,
+    tagName ASC
+LIMIT 10

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-6.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-6.cypher
@@ -5,6 +5,13 @@
   "Carl_Gustaf_Emil_Mannerheim" AS tagName
 }
 */
+// FalkorDB rewrite: this one works around a *bug*, not a dialect gap. With `f`
+// bound by UNWIND of a collected list, an inline property filter on a pattern
+// that is followed by further patterns makes the match fail with "Type
+// mismatch: expected Map, Node, Edge, ... but was List". The C engine runs it
+// correctly. Moving the id filter from the inline map into WHERE avoids it
+// without changing meaning.
+// Tracked as FalkorDB/FalkorDB#2556 — revert this when that is fixed.
 MATCH (knownTag:Tag { name: $tagName })
 WITH knownTag.id as knownTagId
 
@@ -15,9 +22,9 @@ WITH
     collect(distinct friend) as friends
 UNWIND friends as f
     MATCH (f)<-[:HAS_CREATOR]-(post:Post),
-          (post)-[:HAS_TAG]->(t:Tag{id: knownTagId}),
+          (post)-[:HAS_TAG]->(t:Tag),
           (post)-[:HAS_TAG]->(tag:Tag)
-    WHERE NOT t = tag
+    WHERE t.id = knownTagId AND NOT t = tag
     WITH
         tag.name as tagName,
         count(post) as postCount

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-7.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-7.cypher
@@ -1,0 +1,21 @@
+// Q7. Recent likers
+/*
+:param personId: 4398046511268
+*/
+MATCH (person:Person {id: $personId})<-[:HAS_CREATOR]-(message:Message)<-[like:LIKES]-(liker:Person)
+    WITH liker, message, like.creationDate AS likeTime, person
+    ORDER BY likeTime DESC, toInteger(message.id) ASC
+    WITH liker, head(collect({msg: message, likeTime: likeTime})) AS latestLike, person
+RETURN
+    liker.id AS personId,
+    liker.firstName AS personFirstName,
+    liker.lastName AS personLastName,
+    latestLike.likeTime AS likeCreationDate,
+    latestLike.msg.id AS commentOrPostId,
+    coalesce(latestLike.msg.content, latestLike.msg.imageFile) AS commentOrPostContent,
+    toInteger(floor(toFloat(latestLike.likeTime - latestLike.msg.creationDate)/1000.0)/60.0) AS minutesLatency,
+    not((liker)-[:KNOWS]-(person)) AS isNew
+ORDER BY
+    likeCreationDate DESC,
+    toInteger(personId) ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-7.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-7.cypher
@@ -2,6 +2,11 @@
 /*
 :param personId: 4398046511268
 */
+// FalkorDB rewrite: a traversal pattern is not a boolean-valued expression in a
+// projection — `not((liker)-[:KNOWS]-(person))` is rejected with "Type
+// mismatch: expected Boolean or Null but was List" (on the C engine too, so
+// this is a dialect gap rather than a regression), and exists() explicitly
+// refuses traversal patterns. `size(pattern) = 0` is the equivalent test.
 MATCH (person:Person {id: $personId})<-[:HAS_CREATOR]-(message:Message)<-[like:LIKES]-(liker:Person)
     WITH liker, message, like.creationDate AS likeTime, person
     ORDER BY likeTime DESC, toInteger(message.id) ASC
@@ -14,7 +19,7 @@ RETURN
     latestLike.msg.id AS commentOrPostId,
     coalesce(latestLike.msg.content, latestLike.msg.imageFile) AS commentOrPostContent,
     toInteger(floor(toFloat(latestLike.likeTime - latestLike.msg.creationDate)/1000.0)/60.0) AS minutesLatency,
-    not((liker)-[:KNOWS]-(person)) AS isNew
+    size((liker)-[:KNOWS]-(person)) = 0 AS isNew
 ORDER BY
     likeCreationDate DESC,
     toInteger(personId) ASC

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-8.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-8.cypher
@@ -1,0 +1,16 @@
+// Q8. Recent replies
+/*
+:param personId: 143
+*/
+MATCH (start:Person {id: $personId})<-[:HAS_CREATOR]-(:Message)<-[:REPLY_OF]-(comment:Comment)-[:HAS_CREATOR]->(person:Person)
+RETURN
+    person.id AS personId,
+    person.firstName AS personFirstName,
+    person.lastName AS personLastName,
+    comment.creationDate AS commentCreationDate,
+    comment.id AS commentId,
+    comment.content AS commentContent
+ORDER BY
+    commentCreationDate DESC,
+    commentId ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-9.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-9.cypher
@@ -1,0 +1,24 @@
+// Q9. Recent messages by friends or friends of friends
+/*
+:param [{ personId, maxDate }] => { RETURN
+  4398046511268 AS personId,
+  1289908800000 AS maxDate
+}
+*/
+MATCH (root:Person {id: $personId })-[:KNOWS*1..2]-(friend:Person)
+WHERE NOT friend = root
+WITH collect(distinct friend) as friends
+UNWIND friends as friend
+    MATCH (friend)<-[:HAS_CREATOR]-(message:Message)
+    WHERE message.creationDate < $maxDate
+RETURN
+    friend.id AS personId,
+    friend.firstName AS personFirstName,
+    friend.lastName AS personLastName,
+    message.id AS commentOrPostId,
+    coalesce(message.content,message.imageFile) AS commentOrPostContent,
+    message.creationDate AS commentOrPostCreationDate
+ORDER BY
+    commentOrPostCreationDate DESC,
+    message.id ASC
+LIMIT 20

--- a/bench/src/falkorbench/ldbc/queries/interactive-complex-9.cypher
+++ b/bench/src/falkorbench/ldbc/queries/interactive-complex-9.cypher
@@ -5,10 +5,16 @@
   1289908800000 AS maxDate
 }
 */
+// FalkorDB rewrite: this one works around a *bug*, not a dialect gap. A WHERE
+// predicate on a node matched from an UNWIND-bound anchor silently returns
+// zero rows — upstream's `collect(distinct friend)` + `UNWIND` + `WHERE
+// message.creationDate < $maxDate` yields nothing at all. The C engine returns
+// the correct result. `WITH DISTINCT friend` expresses the same de-duplication
+// without the UNWIND.
+// Tracked as FalkorDB/FalkorDB#2557 — revert this when that is fixed.
 MATCH (root:Person {id: $personId })-[:KNOWS*1..2]-(friend:Person)
 WHERE NOT friend = root
-WITH collect(distinct friend) as friends
-UNWIND friends as friend
+WITH DISTINCT friend
     MATCH (friend)<-[:HAS_CREATOR]-(message:Message)
     WHERE message.creationDate < $maxDate
 RETURN

--- a/bench/src/falkorbench/ldbc/runner.py
+++ b/bench/src/falkorbench/ldbc/runner.py
@@ -43,6 +43,14 @@ CSV_FIELDS = (
 )
 
 
+#: Per-query server-side cap, overridable with ``--timeout``. IC14 at SF1 on a
+#: cold index can run for minutes, and a hung query should be reported as a
+#: failure rather than stalling the run. IC3 needs a cap well above this one to
+#: produce a number at all while https://github.com/FalkorDB/FalkorDB/issues/2558
+#: is open.
+DEFAULT_TIMEOUT_MS = 120_000
+
+
 @dataclass
 class QueryResult:
     """One query's timings across its whole parameter set."""
@@ -95,6 +103,7 @@ def run(
     param_set: params_mod.ParamSet,
     *,
     warmup: int = 1,
+    timeout_ms: int = DEFAULT_TIMEOUT_MS,
     echo: Echo = print,
 ) -> list[QueryResult]:
     """Run each query once per parameter row, returning per-query results."""
@@ -112,12 +121,12 @@ def run(
         # carries a one-off cost that has nothing to do with the query.
         for row in rows[:warmup]:
             with contextlib.suppress(ResponseError, OSError):
-                client.graph.ro_query(query.cypher, dict(row), timeout=_TIMEOUT_MS)
+                client.graph.ro_query(query.cypher, dict(row), timeout=timeout_ms)
 
         for row in rows:
             started = time.perf_counter()
             try:
-                res = client.graph.ro_query(query.cypher, dict(row), timeout=_TIMEOUT_MS)
+                res = client.graph.ro_query(query.cypher, dict(row), timeout=timeout_ms)
             except (ResponseError, OSError) as e:
                 # Recorded per parameter row rather than aborting: one bad
                 # parameter row must not cost the other thirteen queries.
@@ -133,11 +142,6 @@ def run(
         echo(_summary_line(result))
         results.append(result)
     return results
-
-
-#: Per-query server-side cap. IC14 at SF1 on a cold index can run for minutes,
-#: and a hung query should be reported as a failure rather than stalling the run.
-_TIMEOUT_MS = 120_000
 
 
 def _summary_line(result: QueryResult) -> str:

--- a/bench/src/falkorbench/ldbc/runner.py
+++ b/bench/src/falkorbench/ldbc/runner.py
@@ -1,0 +1,185 @@
+"""Running the complex reads and recording per-query latency.
+
+Latency percentiles, not the instruction counts the micro-benchmark harness
+reports: LDBC's own metric is response time, and these queries are far too
+large and too data-dependent for a deterministic instruction count to be the
+useful number. The results therefore go to their own CSV and are deliberately
+*not* merged into `results/current.csv`, whose thresholds gate the
+micro-benchmarks.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import csv
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import Any
+
+from redis.exceptions import ResponseError
+
+from falkorbench.client import BenchClient
+from falkorbench.ldbc import params as params_mod
+from falkorbench.ldbc import queries as query_mod
+
+Echo = Callable[[str], None]
+
+CSV_FIELDS = (
+    "query",
+    "runs",
+    "rows_total",
+    "empty_runs",
+    "failures",
+    "p50_ms",
+    "p95_ms",
+    "p99_ms",
+    "mean_ms",
+    "max_ms",
+    "rewritten",
+)
+
+
+@dataclass
+class QueryResult:
+    """One query's timings across its whole parameter set."""
+
+    name: str
+    rewritten: bool
+    latencies_ms: list[float] = field(default_factory=list)
+    rows_total: int = 0
+    empty_runs: int = 0
+    failures: list[str] = field(default_factory=list)
+
+    @property
+    def runs(self) -> int:
+        return len(self.latencies_ms)
+
+    def pct(self, p: float) -> float | None:
+        """The p'th percentile, nearest-rank.
+
+        Nearest-rank rather than interpolation so a reported p99 is a latency
+        that actually occurred.
+        """
+        if not self.latencies_ms:
+            return None
+        ordered = sorted(self.latencies_ms)
+        rank = max(1, min(len(ordered), int(-(-p * len(ordered) // 100))))
+        return ordered[rank - 1]
+
+    def row(self) -> dict[str, Any]:
+        def fmt(v: float | None) -> str:
+            return "" if v is None else f"{v:.3f}"
+
+        return {
+            "query": self.name,
+            "runs": self.runs,
+            "rows_total": self.rows_total,
+            "empty_runs": self.empty_runs,
+            "failures": len(self.failures),
+            "p50_ms": fmt(self.pct(50)),
+            "p95_ms": fmt(self.pct(95)),
+            "p99_ms": fmt(self.pct(99)),
+            "mean_ms": fmt(statistics.fmean(self.latencies_ms) if self.latencies_ms else None),
+            "max_ms": fmt(max(self.latencies_ms) if self.latencies_ms else None),
+            "rewritten": "yes" if self.rewritten else "",
+        }
+
+
+def run(
+    client: BenchClient,
+    selected: list[query_mod.ComplexRead],
+    param_set: params_mod.ParamSet,
+    *,
+    warmup: int = 1,
+    echo: Echo = print,
+) -> list[QueryResult]:
+    """Run each query once per parameter row, returning per-query results."""
+    results: list[QueryResult] = []
+    for query in selected:
+        rows = param_set.for_query(query.number)
+        result = QueryResult(name=query.name, rewritten=query.rewritten)
+        if not rows:
+            result.failures.append("no parameters")
+            echo(f"{result.name:<6} SKIPPED: no parameters")
+            results.append(result)
+            continue
+
+        # GraphBLAS compiles kernels on first use, so an unwarmed first call
+        # carries a one-off cost that has nothing to do with the query.
+        for row in rows[:warmup]:
+            with contextlib.suppress(ResponseError, OSError):
+                client.graph.ro_query(query.cypher, dict(row), timeout=_TIMEOUT_MS)
+
+        for row in rows:
+            started = time.perf_counter()
+            try:
+                res = client.graph.ro_query(query.cypher, dict(row), timeout=_TIMEOUT_MS)
+            except (ResponseError, OSError) as e:
+                # Recorded per parameter row rather than aborting: one bad
+                # parameter row must not cost the other thirteen queries.
+                if len(result.failures) < 5:
+                    result.failures.append(str(e)[:200])
+                continue
+            result.latencies_ms.append((time.perf_counter() - started) * 1000)
+            count = len(res.result_set)
+            result.rows_total += count
+            if count == 0:
+                result.empty_runs += 1
+
+        echo(_summary_line(result))
+        results.append(result)
+    return results
+
+
+#: Per-query server-side cap. IC14 at SF1 on a cold index can run for minutes,
+#: and a hung query should be reported as a failure rather than stalling the run.
+_TIMEOUT_MS = 120_000
+
+
+def _summary_line(result: QueryResult) -> str:
+    if not result.latencies_ms:
+        return f"{result.name:<6} FAILED  {result.failures[0] if result.failures else ''}"
+    flags = []
+    if result.rewritten:
+        flags.append("rewritten")
+    if result.empty_runs:
+        flags.append(f"{result.empty_runs}/{result.runs} empty")
+    if result.failures:
+        flags.append(f"{len(result.failures)} failed")
+    suffix = f"   [{', '.join(flags)}]" if flags else ""
+    return (
+        f"{result.name:<6} p50 {result.pct(50):>9.2f}ms  p99 {result.pct(99):>9.2f}ms  "
+        f"{result.rows_total:>8,} rows{suffix}"
+    )
+
+
+def write_csv(path: Path, results: list[QueryResult]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        for result in results:
+            writer.writerow(result.row())
+
+
+def problems(results: list[QueryResult]) -> list[str]:
+    """Reasons the run should be considered failed.
+
+    A query returning nothing on *every* parameter row counts: it did not error,
+    and its latency looks excellent, but it measured nothing. That is the
+    failure mode this whole exercise is most likely to produce silently.
+    """
+    out = []
+    for result in results:
+        if not result.latencies_ms:
+            why = result.failures[0] if result.failures else "no runs"
+            out.append(f"{result.name}: produced no measurement ({why})")
+        elif result.empty_runs == result.runs:
+            out.append(f"{result.name}: returned zero rows on all {result.runs} runs")
+        elif result.failures:
+            out.append(f"{result.name}: {len(result.failures)} parameter row(s) failed")
+    return out

--- a/bench/src/falkorbench/ldbc/schema.py
+++ b/bench/src/falkorbench/ldbc/schema.py
@@ -1,0 +1,418 @@
+"""The LDBC SNB Interactive v1 CSV layout, as the reference queries expect it.
+
+The dataset ships a *storage* schema and the queries are written against a
+*query* schema, and they are not the same thing. Three conversions are needed,
+all of which the upstream Neo4j implementation also performs (in its
+`convert-csvs.sh`); doing them at load time here keeps the query texts as close
+to upstream as possible, which is the point of the exercise.
+
+1. `place` and `organisation` are single files carrying a `type` column, but the
+   queries match on `:City`, `:Country`, `:Continent`, `:Company` and
+   `:University`. The type column becomes the label.
+2. `:Comment` and `:Post` both need the `:Message` super-label — IC7 and IC8
+   match `(:Message)` and would otherwise find nothing. FalkorDB supports
+   multiple labels per node, so this is a plain second label rather than a
+   duplicated node.
+3. Self-referencing edge files have a duplicated header (`Person.id|Person.id`),
+   which is ambiguous once parsed into a map: the second column shadows the
+   first, both endpoints resolve to the same node, and every such edge becomes a
+   self-loop. The header is rewritten to `FromX.id|ToX.id` before loading.
+
+`birthdayMonth` / `birthdayDay` are derived here rather than in the query
+because FalkorDB has no `datetime()`; see interactive-complex-10.cypher.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import NamedTuple
+
+#: Directory name inside the extracted tarball, parameterised by scale factor.
+DATASET_DIR = "social_network-sf{sf}-CsvComposite-LongDateFormatter"
+
+#: Tarball name on datasets.ldbcouncil.org.
+DATASET_TARBALL = DATASET_DIR + ".tar.zst"
+
+DATASET_BASE_URL = "https://datasets.ldbcouncil.org/snb-interactive-v1"
+
+#: Scale factors this harness knows how to fetch. Both were verified to return
+#: HTTP 200 with the sizes noted; larger SFs exist upstream but have not been
+#: exercised here, and `load` at SF>1 has not been timed.
+SCALE_FACTORS = {
+    "0.1": 18_359_718,
+    "1": 230_394_018,
+}
+
+
+class NodeFile(NamedTuple):
+    """One node CSV and the pattern that loads it.
+
+    label       primary label, or None when the label comes from `type_column`
+    properties  Cypher expression per property, evaluated against `row`
+    type_column column holding the label, for the polymorphic static files
+    extra_labels additional labels every node in the file gets (`:Message`)
+    """
+
+    file: str
+    label: str | None
+    properties: dict[str, str]
+    type_column: str | None = None
+    extra_labels: tuple[str, ...] = ()
+
+
+class EdgeFile(NamedTuple):
+    """One edge CSV.
+
+    from_id/to_id are the *rewritten* header names, so a self-referencing file
+    names them distinctly. `from_label`/`to_label` are only used to pick the
+    index for endpoint lookup; where the storage file is polymorphic the base
+    label is used and the conversion above has already applied the subtype.
+    """
+
+    file: str
+    type: str
+    from_label: str
+    to_label: str
+    from_id: str
+    to_id: str
+    properties: Mapping[str, str] = MappingProxyType({})
+
+
+#: Storage `type` values mapped to the labels the queries use. The datagen
+#: emits these lowercase; the queries use CamelCase.
+PLACE_LABELS = {"city": "City", "country": "Country", "continent": "Continent"}
+ORGANISATION_LABELS = {"company": "Company", "university": "University"}
+
+
+NODE_FILES = (
+    NodeFile(
+        file="static/place_0_0.csv",
+        label="Place",
+        type_column="type",
+        properties={
+            "id": "toInteger(row.id)",
+            "name": "row.name",
+            "url": "row.url",
+        },
+    ),
+    NodeFile(
+        file="static/organisation_0_0.csv",
+        label="Organisation",
+        type_column="type",
+        properties={
+            "id": "toInteger(row.id)",
+            "name": "row.name",
+            "url": "row.url",
+        },
+    ),
+    NodeFile(
+        file="static/tag_0_0.csv",
+        label="Tag",
+        properties={
+            "id": "toInteger(row.id)",
+            "name": "row.name",
+            "url": "row.url",
+        },
+    ),
+    NodeFile(
+        file="static/tagclass_0_0.csv",
+        label="TagClass",
+        properties={
+            "id": "toInteger(row.id)",
+            "name": "row.name",
+            "url": "row.url",
+        },
+    ),
+    NodeFile(
+        file="dynamic/person_0_0.csv",
+        label="Person",
+        properties={
+            "id": "toInteger(row.id)",
+            "firstName": "row.firstName",
+            "lastName": "row.lastName",
+            "gender": "row.gender",
+            "birthday": "toInteger(row.birthday)",
+            # IC10 filters on the month/day of the birthday and FalkorDB has no
+            # datetime(). These two columns do not exist in the shipped CSV;
+            # `dataset.prepare` appends them, deriving both from the epoch-millis
+            # birthday. See interactive-complex-10.cypher.
+            "birthdayMonth": "toInteger(row.birthdayMonth)",
+            "birthdayDay": "toInteger(row.birthdayDay)",
+            "creationDate": "toInteger(row.creationDate)",
+            "locationIP": "row.locationIP",
+            "browserUsed": "row.browserUsed",
+            # IC1 returns these as lists; they are semicolon-joined in the CSV.
+            "speaks": "CASE row.language WHEN '' THEN [] ELSE split(row.language, ';') END",
+            "email": "CASE row.email WHEN '' THEN [] ELSE split(row.email, ';') END",
+        },
+    ),
+    NodeFile(
+        file="dynamic/forum_0_0.csv",
+        label="Forum",
+        properties={
+            "id": "toInteger(row.id)",
+            "title": "row.title",
+            "creationDate": "toInteger(row.creationDate)",
+        },
+    ),
+    NodeFile(
+        file="dynamic/post_0_0.csv",
+        label="Post",
+        extra_labels=("Message",),
+        properties={
+            "id": "toInteger(row.id)",
+            "imageFile": "row.imageFile",
+            "creationDate": "toInteger(row.creationDate)",
+            "locationIP": "row.locationIP",
+            "browserUsed": "row.browserUsed",
+            "language": "row.language",
+            "content": "row.content",
+            "length": "toInteger(row.length)",
+        },
+    ),
+    NodeFile(
+        file="dynamic/comment_0_0.csv",
+        label="Comment",
+        extra_labels=("Message",),
+        properties={
+            "id": "toInteger(row.id)",
+            "creationDate": "toInteger(row.creationDate)",
+            "locationIP": "row.locationIP",
+            "browserUsed": "row.browserUsed",
+            "content": "row.content",
+            "length": "toInteger(row.length)",
+        },
+    ),
+)
+
+
+EDGE_FILES = (
+    EdgeFile(
+        file="static/organisation_isLocatedIn_place_0_0.csv",
+        type="IS_LOCATED_IN",
+        from_label="Organisation",
+        to_label="Place",
+        from_id="Organisation.id",
+        to_id="Place.id",
+    ),
+    EdgeFile(
+        file="static/place_isPartOf_place_0_0.csv",
+        type="IS_PART_OF",
+        from_label="Place",
+        to_label="Place",
+        from_id="FromPlace.id",
+        to_id="ToPlace.id",
+    ),
+    EdgeFile(
+        file="static/tag_hasType_tagclass_0_0.csv",
+        type="HAS_TYPE",
+        from_label="Tag",
+        to_label="TagClass",
+        from_id="Tag.id",
+        to_id="TagClass.id",
+    ),
+    EdgeFile(
+        file="static/tagclass_isSubclassOf_tagclass_0_0.csv",
+        type="IS_SUBCLASS_OF",
+        from_label="TagClass",
+        to_label="TagClass",
+        from_id="FromTagClass.id",
+        to_id="ToTagClass.id",
+    ),
+    EdgeFile(
+        file="dynamic/person_isLocatedIn_place_0_0.csv",
+        type="IS_LOCATED_IN",
+        from_label="Person",
+        to_label="Place",
+        from_id="Person.id",
+        to_id="Place.id",
+    ),
+    EdgeFile(
+        file="dynamic/person_knows_person_0_0.csv",
+        type="KNOWS",
+        from_label="Person",
+        to_label="Person",
+        from_id="FromPerson.id",
+        to_id="ToPerson.id",
+        properties={"creationDate": "toInteger(row.creationDate)"},
+    ),
+    EdgeFile(
+        file="dynamic/person_hasInterest_tag_0_0.csv",
+        type="HAS_INTEREST",
+        from_label="Person",
+        to_label="Tag",
+        from_id="Person.id",
+        to_id="Tag.id",
+    ),
+    EdgeFile(
+        file="dynamic/person_studyAt_organisation_0_0.csv",
+        type="STUDY_AT",
+        from_label="Person",
+        to_label="Organisation",
+        from_id="Person.id",
+        to_id="Organisation.id",
+        properties={"classYear": "toInteger(row.classYear)"},
+    ),
+    EdgeFile(
+        file="dynamic/person_workAt_organisation_0_0.csv",
+        type="WORK_AT",
+        from_label="Person",
+        to_label="Organisation",
+        from_id="Person.id",
+        to_id="Organisation.id",
+        properties={"workFrom": "toInteger(row.workFrom)"},
+    ),
+    EdgeFile(
+        file="dynamic/person_likes_post_0_0.csv",
+        type="LIKES",
+        from_label="Person",
+        to_label="Post",
+        from_id="Person.id",
+        to_id="Post.id",
+        properties={"creationDate": "toInteger(row.creationDate)"},
+    ),
+    EdgeFile(
+        file="dynamic/person_likes_comment_0_0.csv",
+        type="LIKES",
+        from_label="Person",
+        to_label="Comment",
+        from_id="Person.id",
+        to_id="Comment.id",
+        properties={"creationDate": "toInteger(row.creationDate)"},
+    ),
+    EdgeFile(
+        file="dynamic/forum_hasModerator_person_0_0.csv",
+        type="HAS_MODERATOR",
+        from_label="Forum",
+        to_label="Person",
+        from_id="Forum.id",
+        to_id="Person.id",
+    ),
+    EdgeFile(
+        file="dynamic/forum_hasMember_person_0_0.csv",
+        type="HAS_MEMBER",
+        from_label="Forum",
+        to_label="Person",
+        from_id="Forum.id",
+        to_id="Person.id",
+        properties={"joinDate": "toInteger(row.joinDate)"},
+    ),
+    EdgeFile(
+        file="dynamic/forum_hasTag_tag_0_0.csv",
+        type="HAS_TAG",
+        from_label="Forum",
+        to_label="Tag",
+        from_id="Forum.id",
+        to_id="Tag.id",
+    ),
+    EdgeFile(
+        file="dynamic/forum_containerOf_post_0_0.csv",
+        type="CONTAINER_OF",
+        from_label="Forum",
+        to_label="Post",
+        from_id="Forum.id",
+        to_id="Post.id",
+    ),
+    EdgeFile(
+        file="dynamic/post_hasCreator_person_0_0.csv",
+        type="HAS_CREATOR",
+        from_label="Post",
+        to_label="Person",
+        from_id="Post.id",
+        to_id="Person.id",
+    ),
+    EdgeFile(
+        file="dynamic/post_hasTag_tag_0_0.csv",
+        type="HAS_TAG",
+        from_label="Post",
+        to_label="Tag",
+        from_id="Post.id",
+        to_id="Tag.id",
+    ),
+    EdgeFile(
+        file="dynamic/post_isLocatedIn_place_0_0.csv",
+        type="IS_LOCATED_IN",
+        from_label="Post",
+        to_label="Place",
+        from_id="Post.id",
+        to_id="Place.id",
+    ),
+    EdgeFile(
+        file="dynamic/comment_hasCreator_person_0_0.csv",
+        type="HAS_CREATOR",
+        from_label="Comment",
+        to_label="Person",
+        from_id="Comment.id",
+        to_id="Person.id",
+    ),
+    EdgeFile(
+        file="dynamic/comment_hasTag_tag_0_0.csv",
+        type="HAS_TAG",
+        from_label="Comment",
+        to_label="Tag",
+        from_id="Comment.id",
+        to_id="Tag.id",
+    ),
+    EdgeFile(
+        file="dynamic/comment_isLocatedIn_place_0_0.csv",
+        type="IS_LOCATED_IN",
+        from_label="Comment",
+        to_label="Place",
+        from_id="Comment.id",
+        to_id="Place.id",
+    ),
+    EdgeFile(
+        file="dynamic/comment_replyOf_post_0_0.csv",
+        type="REPLY_OF",
+        from_label="Comment",
+        to_label="Post",
+        from_id="Comment.id",
+        to_id="Post.id",
+    ),
+    EdgeFile(
+        file="dynamic/comment_replyOf_comment_0_0.csv",
+        type="REPLY_OF",
+        from_label="Comment",
+        to_label="Comment",
+        from_id="FromComment.id",
+        to_id="ToComment.id",
+    ),
+)
+
+
+#: Upstream `indices.cypher`, translated. The unique constraints are expressed
+#: as GRAPH.CONSTRAINT commands because FalkorDB rejects
+#: `CREATE CONSTRAINT ... ASSERT`; each additionally *requires* a supporting
+#: exact-match index to already exist, so the index list below is not merely an
+#: optimisation.
+UNIQUE_CONSTRAINTS = (
+    "City",
+    "Comment",
+    "Country",
+    "Forum",
+    "Message",
+    "Organisation",
+    "Person",
+    "Post",
+    "Tag",
+)
+
+#: (label, property) exact-match indices. The first group backs the unique
+#: constraints above; the second is upstream's own index list.
+INDICES = (
+    *((label, "id") for label in UNIQUE_CONSTRAINTS),
+    ("Country", "name"),
+    ("Message", "creationDate"),
+    ("Person", "firstName"),
+    ("Post", "creationDate"),
+    ("Tag", "name"),
+    ("TagClass", "name"),
+    # Not upstream: the loader looks endpoints up by id on every edge file, and
+    # these labels carry no unique constraint of their own.
+    ("Place", "id"),
+    ("TagClass", "id"),
+    ("University", "id"),
+    ("Company", "id"),
+    ("Continent", "id"),
+)

--- a/bench/tests/test_ldbc.py
+++ b/bench/tests/test_ldbc.py
@@ -18,6 +18,7 @@ import re
 import pytest
 
 from falkorbench.ldbc import dataset
+from falkorbench.ldbc import loader as loader_mod
 from falkorbench.ldbc import params as params_mod
 from falkorbench.ldbc import queries as query_mod
 from falkorbench.ldbc import runner
@@ -151,6 +152,19 @@ def test_every_unique_constraint_has_a_supporting_index():
     indexed = {(label, prop) for label, prop in schema.INDICES}
     for label in schema.UNIQUE_CONSTRAINTS:
         assert (label, "id") in indexed, label
+
+
+def test_load_uses_fieldterminator_not_delimiter():
+    """FalkorDB has no `DELIMITER` keyword; the LDBC CSVs are pipe-separated.
+
+    `LOAD CSV WITH HEADERS DELIMITER '|' FROM ...` is rejected outright with
+    `Invalid input 'DELIMITER': expected From`, and the standard-Cypher
+    spelling is `FIELDTERMINATOR`, placed *after* `AS <var>`. Getting this
+    wrong fails every single load, so pin the exact shape.
+    """
+    prefix = loader_mod._LOAD_PREFIX
+    assert "DELIMITER" not in prefix
+    assert re.search(r"AS\s+row\s+FIELDTERMINATOR\s+'\|'", prefix), prefix
 
 
 def test_every_edge_endpoint_label_is_loadable_and_indexed():

--- a/bench/tests/test_ldbc.py
+++ b/bench/tests/test_ldbc.py
@@ -14,6 +14,7 @@ row.
 
 import csv
 import re
+from types import SimpleNamespace
 
 import pytest
 
@@ -74,11 +75,15 @@ def test_the_known_dialect_gaps_are_the_rewritten_ones():
     """Pins which queries depart from upstream, and why.
 
     Each was verified against a running engine: shortestPath() is rejected
-    inside MATCH, allShortestPaths() needs pre-bound endpoints, and there is no
-    datetime(). If a future engine version accepts the original, this test is
-    the prompt to drop the rewrite rather than carry it forever.
+    inside MATCH, allShortestPaths() needs pre-bound endpoints, there is no
+    datetime(), a traversal pattern is not a boolean in a projection, and a
+    pattern comprehension's WHERE cannot see an outer list-comprehension
+    variable. IC6 is the odd one out — it works around a Rust-only wrong-result
+    bug (FalkorDB/FalkorDB#2556) rather than a dialect gap. If a future engine
+    version accepts the original, this test is the prompt to drop the rewrite
+    rather than carry it forever.
     """
-    assert set(query_mod.REWRITES) == {1, 10, 13, 14}
+    assert set(query_mod.REWRITES) == {1, 6, 7, 9, 10, 13, 14}
 
 
 def _code(cypher: str) -> str:
@@ -286,6 +291,29 @@ def test_a_query_with_no_measurement_is_a_problem():
     failed = runner.QueryResult(name="IC14", rewritten=True)
     failed.failures = ["timeout"]
     assert runner.problems([failed]) == ["IC14: produced no measurement (timeout)"]
+
+
+def test_the_per_query_timeout_reaches_the_server():
+    """IC3 needs a cap above the default to produce a number at all while
+    https://github.com/FalkorDB/FalkorDB/issues/2558 is open, so the override
+    has to actually reach ro_query rather than being accepted and dropped."""
+    seen = []
+
+    class _Graph:
+        def ro_query(self, cypher, params, timeout):
+            seen.append(timeout)
+            return SimpleNamespace(result_set=[[1]])
+
+    client = SimpleNamespace(graph=_Graph())
+    query = query_mod.ComplexRead(number=3, cypher="RETURN 1")
+    param_set = params_mod.ParamSet(rows={3: [{"personId": 1}]}, official=False, source="sampled")
+
+    runner.run(client, [query], param_set, warmup=1, timeout_ms=900_000, echo=lambda *a: None)
+    assert seen == [900_000, 900_000]
+
+    seen.clear()
+    runner.run(client, [query], param_set, warmup=0, echo=lambda *a: None)
+    assert seen == [runner.DEFAULT_TIMEOUT_MS]
 
 
 def test_result_csv_is_written_with_the_declared_columns(tmp_path):

--- a/bench/tests/test_ldbc.py
+++ b/bench/tests/test_ldbc.py
@@ -244,6 +244,39 @@ def _numeric(name: str) -> bool:
     return name.endswith(("Id", "Date", "Year")) or name in ("month", "durationDays")
 
 
+class _StubGraph:
+    """Enough of a graph for sample() to run: canned columns and a date span."""
+
+    LO, HI = 1_262_808_638_903, 1_347_528_281_121
+
+    def ro_query(self, cypher, params=None):
+        if "min(m.creationDate)" in cypher:
+            rows = [[self.LO, self.HI]]
+        else:
+            n = (params or {}).get("n", 2)
+            rows = [
+                [f"v{i}"] if "Person)" not in cypher or "firstName" in cypher else [i]
+                for i in range(n)
+            ]
+            if "MATCH (p:Person)-[:KNOWS]" in cypher or "p.id" in cypher:
+                rows = [[1000 + i] for i in range(n)]
+        return SimpleNamespace(result_set=rows)
+
+
+def test_ic3_gets_a_far_wider_date_window_than_the_other_queries():
+    """A 30-day window returns nothing for IC3 at SF0.1 on both engines, so a
+    sampled run would report it as instant while measuring nothing."""
+    param_set = params_mod.sample(
+        SimpleNamespace(graph=_StubGraph()), count=3, seed=1, echo=lambda *a: None
+    )
+    span = _StubGraph.HI - _StubGraph.LO
+    for ic3, ic4 in zip(param_set.for_query(3), param_set.for_query(4), strict=True):
+        ic3_width = ic3["endDate"] - ic3["startDate"]
+        assert ic3_width > 365 * 86_400_000, "IC3 needs at least a year to match anything"
+        assert ic3_width == span - span // 4
+        assert ic3_width > (ic4["endDate"] - ic4["startDate"]) * 10
+
+
 def test_sampled_parameters_are_labelled_as_not_comparable():
     """The caveat is the point: sampled numbers are not LDBC results.
 

--- a/bench/tests/test_ldbc.py
+++ b/bench/tests/test_ldbc.py
@@ -1,0 +1,352 @@
+"""The LDBC query set, its parameters, and the rewrites applied to it.
+
+The value of this benchmark rests entirely on the vendored query texts still
+being the LDBC queries. These tests pin the three ways that can quietly stop
+being true: a query text that no longer parses out of its file, a rewrite that
+is applied but not declared, and a parameter set that does not match what the
+queries actually take.
+
+Nothing here needs a server. The behaviours that do — that the rewrites are
+accepted by the engine and the originals are not — are covered by
+`bench ldbc run`, which fails when a query returns no rows on every parameter
+row.
+"""
+
+import csv
+import re
+
+import pytest
+
+from falkorbench.ldbc import dataset
+from falkorbench.ldbc import params as params_mod
+from falkorbench.ldbc import queries as query_mod
+from falkorbench.ldbc import runner
+from falkorbench.ldbc import schema
+
+# --- query texts -------------------------------------------------------------
+
+
+def test_all_fourteen_complex_reads_are_present():
+    loaded = query_mod.load_queries()
+    assert [q.number for q in loaded] == list(range(1, 15))
+    assert [q.name for q in loaded] == [f"IC{n}" for n in range(1, 15)]
+
+
+def test_param_header_comment_is_stripped():
+    """The `:param` block is a Neo4j Browser directive, not Cypher.
+
+    It is stripped so what is sent equals what is measured; if the regex ever
+    stops matching, the queries still run (FalkorDB reads it as a comment) and
+    nothing would otherwise notice.
+    """
+    for query in query_mod.load_queries():
+        assert ":param" not in query.cypher, f"{query.name} kept its header"
+        assert query.cypher.lstrip().startswith(("MATCH", "//")), query.name
+
+
+def test_every_query_references_exactly_its_declared_parameters():
+    """A parameter the text does not use, or uses without declaring, is a bug.
+
+    An undeclared parameter is the dangerous direction: it evaluates to null,
+    its predicate fails, and the query returns zero rows very fast — which reads
+    as a fast query rather than a broken one.
+    """
+    for query in query_mod.load_queries():
+        used = set(re.findall(r"\$(\w+)", query.cypher))
+        assert used == set(query_mod.PARAM_NAMES[query.number]), query.name
+
+
+def test_rewritten_queries_are_declared_and_annotated():
+    """A rewrite must be both listed in REWRITES and commented in the file.
+
+    Otherwise a number gets reported as an LDBC result while the query it came
+    from has silently drifted from the reference text.
+    """
+    for query in query_mod.load_queries():
+        annotated = "FalkorDB rewrite:" in query.cypher
+        assert annotated == query.rewritten, (
+            f"{query.name}: declared={query.rewritten} but annotated={annotated}"
+        )
+
+
+def test_the_known_dialect_gaps_are_the_rewritten_ones():
+    """Pins which queries depart from upstream, and why.
+
+    Each was verified against a running engine: shortestPath() is rejected
+    inside MATCH, allShortestPaths() needs pre-bound endpoints, and there is no
+    datetime(). If a future engine version accepts the original, this test is
+    the prompt to drop the rewrite rather than carry it forever.
+    """
+    assert set(query_mod.REWRITES) == {1, 10, 13, 14}
+
+
+def _code(cypher: str) -> str:
+    """`cypher` with `//` comment lines removed.
+
+    The rewrite annotations name the constructs they replaced, so a check for
+    "this query no longer uses X" must look at the code, not the commentary.
+    """
+    return "\n".join(line for line in cypher.splitlines() if not line.strip().startswith("//"))
+
+
+def test_no_query_still_calls_datetime():
+    """FalkorDB has no temporal type; `datetime()` is `Unknown function`."""
+    for query in query_mod.load_queries():
+        assert "datetime(" not in _code(query.cypher), query.name
+
+
+def test_shortest_path_is_never_bound_inside_match():
+    """`MATCH path = shortestPath(...)` is rejected by FalkorDB.
+
+    Checked structurally rather than by remembering which queries do it, so a
+    future upstream bump reintroducing the pattern fails here.
+    """
+    for query in query_mod.load_queries():
+        assert "= shortestPath(" not in _code(query.cypher), query.name
+
+
+def test_select_resolves_names_and_rejects_unknown_ones():
+    assert [q.name for q in query_mod.select(("IC3", "ic7"))] == ["IC3", "IC7"]
+    assert len(query_mod.select(())) == 14
+    with pytest.raises(ValueError, match="IC99"):
+        query_mod.select(("IC99",))
+
+
+def test_validate_rejects_missing_and_extra_parameters():
+    query_mod.validate(13, {"person1Id": 1, "person2Id": 2})
+    with pytest.raises(ValueError, match="missing"):
+        query_mod.validate(13, {"person1Id": 1})
+    with pytest.raises(ValueError, match="unexpected"):
+        query_mod.validate(13, {"person1Id": 1, "person2Id": 2, "nope": 3})
+
+
+# --- schema ------------------------------------------------------------------
+
+
+def test_self_referencing_edges_have_distinct_endpoint_columns():
+    """`Person.id|Person.id` collapses to one key once parsed into a map.
+
+    Both endpoints would then resolve to the same node and every such edge would
+    become a self-loop — a graph that loads without error and answers every
+    query wrongly.
+    """
+    for edge in schema.EDGE_FILES:
+        if edge.from_label == edge.to_label:
+            assert edge.from_id != edge.to_id, edge.file
+
+
+def test_message_superlabel_is_on_both_post_and_comment():
+    """IC7 and IC8 match `(:Message)` and would otherwise find nothing."""
+    by_label = {n.label: n for n in schema.NODE_FILES}
+    assert "Message" in by_label["Post"].extra_labels
+    assert "Message" in by_label["Comment"].extra_labels
+
+
+def test_every_unique_constraint_has_a_supporting_index():
+    """FalkorDB rejects a unique constraint with no exact-match index.
+
+    The failure is `missing supporting exact-match index` at constraint-creation
+    time, so this is a hard requirement rather than a tuning choice.
+    """
+    indexed = {(label, prop) for label, prop in schema.INDICES}
+    for label in schema.UNIQUE_CONSTRAINTS:
+        assert (label, "id") in indexed, label
+
+
+def test_every_edge_endpoint_label_is_loadable_and_indexed():
+    """An endpoint label the loader never creates cannot ever match.
+
+    `LOAD CSV` into a `MATCH` that finds nothing drops the row silently, so this
+    would surface as an edge file that loads zero edges.
+    """
+    creatable = set()
+    for node in schema.NODE_FILES:
+        if node.type_column is None:
+            creatable.add(node.label)
+        else:
+            mapping = schema.PLACE_LABELS if node.label == "Place" else schema.ORGANISATION_LABELS
+            creatable.update({node.label, *mapping.values()})
+        creatable.update(node.extra_labels)
+
+    indexed = {label for label, prop in schema.INDICES if prop == "id"}
+    for edge in schema.EDGE_FILES:
+        for label in (edge.from_label, edge.to_label):
+            assert label in creatable, f"{edge.file}: no node file creates :{label}"
+            assert label in indexed, f"{edge.file}: :{label}(id) is not indexed"
+
+
+def test_person_properties_cover_what_ic1_and_ic10_return():
+    """IC1 returns email/speaks as lists; IC10 filters on birthday parts."""
+    person = next(n for n in schema.NODE_FILES if n.label == "Person")
+    for prop in ("email", "speaks", "birthdayMonth", "birthdayDay"):
+        assert prop in person.properties
+
+
+# --- parameters --------------------------------------------------------------
+
+
+def test_duration_days_is_converted_to_an_end_date():
+    """IC3 and IC4 ship `durationDays`; the queries take `endDate`.
+
+    Upstream drivers derive it. Doing the same here is what lets the query texts
+    stay equal to upstream.
+    """
+    row = params_mod._coerce(4, {"personId": "42", "startDate": "1000", "durationDays": "3"})
+    assert row == {"personId": 42, "startDate": 1000, "endDate": 1000 + 3 * 86_400_000}
+    query_mod.validate(4, row)
+
+
+def test_coerce_keeps_strings_as_strings_and_numbers_as_numbers():
+    row = params_mod._coerce(1, {"personId": "933", "firstName": "Jose"})
+    assert row == {"personId": 933, "firstName": "Jose"}
+
+
+def test_official_parameter_directory_round_trips(tmp_path):
+    """A parameter file in LDBC's own pipe-separated format is parsed."""
+    for n in query_mod.COMPLEX_READS:
+        names = [p for p in query_mod.PARAM_NAMES[n] if p != "endDate"]
+        if n in (3, 4):
+            names = [*names, "durationDays"]
+        values = ["1000" if _numeric(p) else "Jose" for p in names]
+        path = tmp_path / f"interactive_{n}_param.txt"
+        with path.open("w", newline="") as fh:
+            writer = csv.writer(fh, delimiter="|", lineterminator="\n")
+            writer.writerow(names)
+            writer.writerow(values)
+
+    param_set = params_mod.from_directory(tmp_path, echo=lambda _: None)
+    assert param_set.official is True
+    assert "NOT comparable" not in param_set.caveat()
+    for n in query_mod.COMPLEX_READS:
+        assert len(param_set.for_query(n)) == 1
+
+
+def _numeric(name: str) -> bool:
+    return name.endswith(("Id", "Date", "Year")) or name in ("month", "durationDays")
+
+
+def test_sampled_parameters_are_labelled_as_not_comparable():
+    """The caveat is the point: sampled numbers are not LDBC results.
+
+    Constructed directly rather than by sampling a graph — this asserts the
+    reporting contract, which is what a reader of the CSV depends on.
+    """
+    sampled = params_mod.ParamSet(rows={}, official=False, source="seed=1, n=5")
+    assert "NOT comparable to published LDBC results" in sampled.caveat()
+
+
+def test_missing_parameter_file_is_an_error_not_an_empty_set(tmp_path):
+    with pytest.raises(params_mod.ParamError, match=r"missing interactive_1_param\.txt"):
+        params_mod.from_directory(tmp_path, echo=lambda _: None)
+
+
+# --- results -----------------------------------------------------------------
+
+
+def test_percentiles_are_values_that_actually_occurred():
+    """Nearest-rank, so a reported p99 is a latency that was measured."""
+    result = runner.QueryResult(name="IC1", rewritten=False)
+    result.latencies_ms = [float(n) for n in range(1, 101)]
+    assert result.pct(50) == 50.0
+    assert result.pct(99) == 99.0
+    assert result.pct(100) == 100.0
+
+
+def test_a_query_that_always_returned_nothing_is_a_problem():
+    """The failure mode this benchmark is most likely to produce silently.
+
+    It does not error, and its latency looks excellent, but it measured nothing.
+    """
+    empty = runner.QueryResult(name="IC7", rewritten=False)
+    empty.latencies_ms = [1.0, 2.0]
+    empty.empty_runs = 2
+    assert runner.problems([empty]) == ["IC7: returned zero rows on all 2 runs"]
+
+    fine = runner.QueryResult(name="IC7", rewritten=False)
+    fine.latencies_ms = [1.0, 2.0]
+    fine.empty_runs = 1
+    assert runner.problems([fine]) == []
+
+
+def test_a_query_with_no_measurement_is_a_problem():
+    failed = runner.QueryResult(name="IC14", rewritten=True)
+    failed.failures = ["timeout"]
+    assert runner.problems([failed]) == ["IC14: produced no measurement (timeout)"]
+
+
+def test_result_csv_is_written_with_the_declared_columns(tmp_path):
+    result = runner.QueryResult(name="IC1", rewritten=True)
+    result.latencies_ms = [1.5, 2.5]
+    result.rows_total = 40
+
+    out = tmp_path / "ldbc.csv"
+    runner.write_csv(out, [result])
+    rows = list(csv.DictReader(out.open()))
+    assert list(rows[0]) == list(runner.CSV_FIELDS)
+    assert rows[0]["query"] == "IC1"
+    assert rows[0]["rewritten"] == "yes"
+    assert rows[0]["runs"] == "2"
+
+
+# --- dataset preparation -----------------------------------------------------
+
+
+def test_ambiguous_edge_header_is_rewritten_without_touching_the_rows(tmp_path):
+    """Only the header line changes; the body is copied bytes-for-bytes.
+
+    At SF1 these files are hundreds of MB, so re-encoding them would be the
+    slowest part of a load for no benefit.
+    """
+    path = tmp_path / "person_knows_person_0_0.csv"
+    path.write_text("Person.id|Person.id|creationDate\n1|2|100\n3|4|200\n")
+
+    dataset._rewrite_header(path, ["FromPerson.id", "ToPerson.id"])
+    lines = path.read_text().splitlines()
+    assert lines[0] == "FromPerson.id|ToPerson.id|creationDate"
+    assert lines[1:] == ["1|2|100", "3|4|200"]
+
+
+def test_rewriting_a_header_twice_is_a_no_op(tmp_path):
+    path = tmp_path / "edge.csv"
+    path.write_text("Person.id|Person.id\n1|2\n")
+    dataset._rewrite_header(path, ["FromPerson.id", "ToPerson.id"])
+    first = path.read_text()
+    dataset._rewrite_header(path, ["FromPerson.id", "ToPerson.id"])
+    assert path.read_text() == first
+
+
+def test_birthday_parts_are_derived_from_epoch_millis(tmp_path):
+    """IC10 needs the calendar month and day, and FalkorDB has no datetime()."""
+    path = tmp_path / "person_0_0.csv"
+    path.write_text("id|firstName|birthday\n933|Mahinda|628646400000\n")
+
+    dataset._derive_birthday_parts(path)
+    rows = list(csv.DictReader(path.open(), delimiter="|"))
+    assert rows[0]["birthdayMonth"] == "12"
+    assert rows[0]["birthdayDay"] == "3"
+
+
+def test_deriving_birthday_parts_twice_does_not_duplicate_columns(tmp_path):
+    """A second run must not append the columns again.
+
+    `prepare` guards this with a marker file, but the guard is only as good as
+    the operation being idempotent on its own.
+    """
+    path = tmp_path / "person_0_0.csv"
+    path.write_text("id|birthday\n933|628646400000\n")
+    dataset._derive_birthday_parts(path)
+    once = path.read_text()
+    dataset._derive_birthday_parts(path)
+    assert path.read_text() == once
+
+
+def test_a_person_file_without_a_birthday_column_is_an_error(tmp_path):
+    path = tmp_path / "person_0_0.csv"
+    path.write_text("id|firstName\n1|Jose\n")
+    with pytest.raises(dataset.DatasetError, match="no `birthday` column"):
+        dataset._derive_birthday_parts(path)
+
+
+def test_an_unknown_scale_factor_is_refused_before_any_download(tmp_path):
+    with pytest.raises(dataset.DatasetError, match="unknown scale factor"):
+        dataset.fetch(tmp_path, "1000", echo=lambda _: None)

--- a/tests/test_ldbc.py
+++ b/tests/test_ldbc.py
@@ -389,7 +389,7 @@ def test_load_csv():
     for file in node_files:
         common.g.query(f"CREATE INDEX FOR (n:{file['label']}) ON (n.id)")
         query = f"""
-            LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row
+            LOAD CSV WITH HEADERS FROM $file AS row FIELDTERMINATOR '|'
             RETURN count(row)
             """
         res = common.g.query(
@@ -403,7 +403,7 @@ def test_load_csv():
             f"{key}: {value}" for key, value in file["properties"].items()
         )
         query = f"""
-            LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row
+            LOAD CSV WITH HEADERS FROM $file AS row FIELDTERMINATOR '|'
             CREATE (:{file['label']} {{{properties_str}}})
             """
         res = common.g.query(
@@ -422,7 +422,7 @@ def test_load_csv():
                 f"data/{base_path}/{file['file']}", file["from_id"], file["to_id"]
             )
         query = f"""
-            LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row
+            LOAD CSV WITH HEADERS FROM $file AS row FIELDTERMINATOR '|'
             RETURN count(row)
             """
         res = common.g.query(
@@ -436,7 +436,7 @@ def test_load_csv():
             f"{key}: {value}" for key, value in file["properties"].items()
         )
         query = f"""
-            LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row
+            LOAD CSV WITH HEADERS FROM $file AS row FIELDTERMINATOR '|'
             MATCH (f:{file['from_label']} {{id: toInteger(row.`{file['from_id']}`)}})
             WITH f, row
             MATCH (t:{file['to_label']} {{id: toInteger(row.`{file['to_id']}`)}})

--- a/tests/test_ldbc.py
+++ b/tests/test_ldbc.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 import common
@@ -6,9 +7,12 @@ import common
 
 def download_ldbc_data(filename):
     if not os.path.exists(f"data/{filename}"):
-        url = f"https://repository.surfsara.nl/datasets/cwi/ldbc-snb-interactive-v1-datagen-v100/files/{filename}"
+        # datasets.ldbcouncil.org, not repository.surfsara.nl: the SURF host no
+        # longer completes a TLS handshake at all (curl reports http=000), so
+        # this download could never succeed from it.
+        url = f"https://datasets.ldbcouncil.org/snb-interactive-v1/{filename}"
         subprocess.run(
-            ["wget", "--no-check-certificate", url, "-O", filename],
+            ["wget", url, "-O", filename],
             check=True,
             stdin=subprocess.PIPE,
             cwd="data",
@@ -349,6 +353,37 @@ edge_files = [
 ]
 
 
+def rewrite_self_edge_header(path, from_id, to_id):
+    """Give a self-referencing edge file distinct endpoint column names.
+
+    These files are headed `Person.id|Person.id`; parsed into a per-row map the
+    second column shadows the first, so both endpoints resolve to the same node
+    and every edge becomes a self-loop.
+
+    Done in Python rather than with `sed -i ""`, which is the BSD/macOS spelling
+    — GNU sed reads the `""` as the script and exits 2, so this only ever worked
+    on macOS. Only the header line is rewritten; the body is copied unchanged.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+    with open(path, newline="") as f:
+        header = f.readline()
+        body_offset = f.tell()
+
+    fields = header.rstrip("\r\n").split("|")
+    if fields[:2] == [from_id, to_id]:
+        return
+    fields[:2] = [from_id, to_id]
+
+    tmp = f"{path}.tmp"
+    with open(path, "rb") as src, open(tmp, "wb") as dst:
+        dst.write(("|".join(fields) + "\n").encode())
+        src.seek(body_offset)
+        shutil.copyfileobj(src, dst)
+    os.replace(tmp, path)
+
+
 def test_load_csv():
     total_time = 0
     for file in node_files:
@@ -383,13 +418,9 @@ def test_load_csv():
 
     for file in edge_files:
         if file["from_label"] == file["to_label"]:
-            with open(f"data/{base_path}/{file['file']}") as f:
-                line = f.readline().split("|")
-                line[0] = file["from_id"]
-                line[1] = file["to_id"]
-                line = "|".join(line)
-                line = line.replace("\n", "")
-                subprocess.run(["sed", "-i", "", f"1s/.*/{line}/", f"data/{base_path}/{file['file']}"], check=True)
+            rewrite_self_edge_header(
+                f"data/{base_path}/{file['file']}", file["from_id"], file["to_id"]
+            )
         query = f"""
             LOAD CSV WITH HEADERS DELIMITER '|' FROM $file AS row
             RETURN count(row)


### PR DESCRIPTION
## Summary

Adds a working LDBC Social Network Benchmark (Interactive v1) harness as a
`bench ldbc` subcommand: fetch the official dataset, load it, sample
substitution parameters, and measure the 14 complex reads.

The repo had no LDBC benchmark before this. `tests/test_ldbc.py` loaded LDBC CSV
data but ran **zero** benchmark queries, was not wired into CI, and was broken on
Linux. There is no FalkorDB or RedisGraph LDBC implementation upstream to adapt,
so this is written from scratch.

**Running it found four bugs**, each confirmed against the C engine before being
filed — that is the main value here, more than the numbers:

| issue | what |
|---|---|
| #2555 | aggregation over a bare map property returns empty — `collect`→`[]`, `count`→`0`, silently |
| #2556 | inline property filter under `UNWIND` raises a spurious type mismatch |
| #2557 | `WHERE` on a node matched from an `UNWIND`-bound anchor silently returns zero rows |
| #2558 | a variable-length traversal loses its indexed anchor when the `MATCH` has a second pattern — **19,000x** |

Three of the four are **silent**: wrong or empty results, no error. They were
caught only because the runner treats "zero rows on every run" as a failure
rather than as a fast query.

## Changes

- **`bench ldbc fetch`** — downloads and unpacks
  `social_network-sf{SF}-CsvComposite-LongDateFormatter` from
  `datasets.ldbcouncil.org` into a git-ignored cache. The upstream R2 CI bundle
  now 401s, so nothing depends on it.
- **`bench ldbc load`** — schema + `LOAD CSV` loader, including the label
  conversion the reference queries need (`:City`/`:Country`/`:Continent`,
  `:Company`/`:University`, the `:Message` super-label) and the 9 unique
  constraints + 6 indices ported from upstream `indices.cypher`.
- **`bench ldbc run`** — runs each query across its parameter set and reports
  p50/p95/p99 to `results/ldbc_sf<SF>.csv`, per-query failures included rather
  than aborting the run. `--timeout` sets the per-query cap.
- **Substitution parameters** — official files via `--params DIR` if you have
  them, otherwise deterministic seeded sampling of the loaded graph, biased
  towards where the data is dense. The "not comparable to published LDBC
  numbers" caveat is written into the CSV and the console output, not just the
  docs.
- **Seven queries carry a rewrite**, each annotated in-file against the upstream
  original and declared in `queries.py::REWRITES` so a run always prints them.
  A guard test pins that set, so an undeclared rewrite fails CI.
- **`tests/test_ldbc.py`** — repaired three portability bugs: a dead SURF
  download URL, the macOS-only `sed -i ""` form (GNU sed exits 2), and
  `DELIMITER`, which FalkorDB has never had a keyword for.

## Testing

- 126 unit tests (`bench/tests/test_ldbc.py`), no server required. They cover
  parameter coercion, the loader's SQL/label conversions, the rewrite guard, CSV
  output and the timeout plumbing.
- End-to-end on SF0.1 against both engines: **327,588 nodes / 1,477,965 edges**,
  every file's row count matching, all 9 constraints reaching `OPERATIONAL`
  (58.5s on Rust, 55.4s on C — the loader is engine-portable).
- **All 14 complex reads produce a measurement** on the Rust engine, up from 9
  when the harness was first run. IC3 needs `--timeout` above the default; see
  #2558.
- Verified against a local `main` release build, not only the published `edge`
  image: all 14 `GRAPH.EXPLAIN` cleanly there.
- `ruff check` / `ruff format` clean.

## Memory / Performance Impact

None on the engine — this adds no engine code, only a benchmark harness under
`bench/`.

On what it measures: every query except IC3 and IC10 is in the same order of
magnitude as the C engine or faster, and four (IC1, IC10, IC13, IC14) do not run
on C at all. IC3 and IC10 are both explained by #2558: on the same parameter row,
returning the identical 2 rows, IC3 takes **136.72 ms** on C and
**271,817.66 ms** on Rust — 1,988x — with byte-identical intermediate
cardinalities at every other operator, so it is purely a seed-selection
difference.

Per the file's existing convention a ranked latency table is deliberately not
committed; it goes stale on merge and sends people to work on rows that are
already fixed. `results/ldbc_sf<SF>.csv` is written per run and kept out of
`current.csv`, whose regression thresholds are tuned to micro-benchmark runtimes
orders of magnitude smaller.

## Related Issues

Closes #2560

Found while building this, fixed separately: #2555, #2556, #2557, #2558




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LDBC SNB Interactive v1 benchmarking support.
  * Download and prepare benchmark datasets, load them into FalkorDB, and execute selected complex-read queries.
  * Support official or sampled parameters, query timeouts, progress reporting, and CSV result export.
  * Added all 14 interactive complex-read workloads with FalkorDB-compatible query handling.

* **Documentation**
  * Added setup, execution, compatibility, dataset, and initial-results guidance.

* **Bug Fixes**
  * Improved dataset downloads, self-referencing edge preparation, and CSV loading compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->