### PR TITLE
fix(planner): anchor a variable-length traverse on an endpoint bound below the scan

### DIFF
--- a/graph/src/planner/optimizer/select_scan_node.rs
+++ b/graph/src/planner/optimizer/select_scan_node.rs
@@ -262,6 +262,25 @@ fn planner_scan_alias(
     }
 }
 
+/// Returns the index of the scan at the bottom of a planner-added scan subtree
+/// (the shape [`is_planner_scan_subtree`] accepts), or `None` when `idx` does
+/// not root such a subtree.
+fn planner_scan_idx(
+    plan: &DynTree<IR>,
+    idx: NodeIdx<Dyn<IR>>,
+) -> Option<NodeIdx<Dyn<IR>>> {
+    let mut node = plan.node(idx);
+    loop {
+        match node.data() {
+            IR::AllNodeScan(_) | IR::NodeByLabelScan { .. } => return Some(node.idx()),
+            IR::Filter(_) | IR::IncludePending { .. } if node.num_children() == 1 => {
+                node = node.child(0);
+            }
+            _ => return None,
+        }
+    }
+}
+
 /// Creates a new `QueryRelationship` with from and to swapped.
 fn swap_relationship(
     rel: &Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>,
@@ -371,17 +390,23 @@ fn resolve_path(
 fn child_subtree_binds(
     plan: &DynTree<IR>,
     scan_idx: NodeIdx<Dyn<IR>>,
-    alias: u32,
+    alias: &Variable,
 ) -> bool {
+    use crate::runtime::runtime::GetVariables;
     let mut binds = false;
     for child in plan.node(scan_idx).children() {
-        let sub: DynTree<IR> = child.clone_as_tree();
-        for i in sub.root().indices::<Bfs>() {
-            if matches!(sub.node(i).data(), IR::Argument(None)) {
+        for ir in child.walk::<Bfs>() {
+            if matches!(ir, IR::Argument(None)) {
                 return false;
             }
         }
-        if collect_subtree_variables(&sub.root()).contains(&alias) {
+        // `id` alone is ambiguous: it is an index into its own scope's env, so
+        // the same number names different variables in different scopes.
+        if child
+            .get_variables()
+            .iter()
+            .any(|v| v.id == alias.id && v.scope_id == alias.scope_id)
+        {
             binds = true;
         }
     }
@@ -460,9 +485,33 @@ fn select_var_len_scan_node(
         // chains via `bound_vars`, except the binding here sits *below* the
         // planner's scan rather than being the immediate child, so it has to be
         // looked for one level deeper.
-        if child_subtree_binds(optimized_plan, child_idx, to.alias.id) {
+        let filtered_vars = collect_filtered_vars(optimized_plan, idx);
+
+        // `planner_scan_alias` looks through `Filter` (inline attrs) and
+        // `IncludePending` (MERGE) wrappers, so the scan to drop is not
+        // necessarily `child_idx`. The whole wrapper chain goes with it:
+        //  - a `Filter` there carries `from`'s inline attrs, which the planner
+        //    also emitted above this traverse — assert that duplicate is
+        //    present rather than assume it;
+        //  - `IncludePending` carries MERGE pending-node visibility that has
+        //    nowhere else to live, so bail out instead.
+        let scan_idx = planner_scan_idx(optimized_plan, child_idx)
+            .expect("planner_scan_alias matched, so a scan is there");
+        let wrapper_ok = {
+            let mut node = optimized_plan.node(child_idx);
+            let mut ok = true;
+            while node.idx() != scan_idx {
+                if matches!(node.data(), IR::IncludePending { .. }) {
+                    ok = false;
+                    break;
+                }
+                node = node.child(0);
+            }
+            ok && (from.attrs.root().num_children() == 0 || filtered_vars.contains(&from.alias.id))
+        };
+        if wrapper_ok && child_subtree_binds(optimized_plan, scan_idx, &to.alias) {
             let kept: Vec<DynTree<IR>> = optimized_plan
-                .node(child_idx)
+                .node(scan_idx)
                 .children()
                 .map(|c| c.clone_as_tree())
                 .collect();
@@ -491,7 +540,6 @@ fn select_var_len_scan_node(
             _ => {}
         }
 
-        let filtered_vars = collect_filtered_vars(optimized_plan, idx);
         // Both endpoints' inline attributes are enforced by Filters the planner
         // placed above this traverse, so replacing the scan subtree cannot lose
         // them — but only reverse once those Filters are confirmed present.

--- a/graph/src/planner/optimizer/select_scan_node.rs
+++ b/graph/src/planner/optimizer/select_scan_node.rs
@@ -363,6 +363,31 @@ fn resolve_path(
     Some(node.idx())
 }
 
+/// Does the subtree *beneath* `scan_idx` provably bind `alias`?
+///
+/// `Argument(None)` is opaque about which variables it carries, so its presence
+/// anywhere below makes the answer unknown and this reports `false` — the
+/// caller then leaves the plan alone.
+fn child_subtree_binds(
+    plan: &DynTree<IR>,
+    scan_idx: NodeIdx<Dyn<IR>>,
+    alias: u32,
+) -> bool {
+    let mut binds = false;
+    for child in plan.node(scan_idx).children() {
+        let sub: DynTree<IR> = child.clone_as_tree();
+        for i in sub.root().indices::<Bfs>() {
+            if matches!(sub.node(i).data(), IR::Argument(None)) {
+                return false;
+            }
+        }
+        if collect_subtree_variables(&sub.root()).contains(&alias) {
+            binds = true;
+        }
+    }
+    binds
+}
+
 /// Picks which endpoint of a leaf `CondVarLenTraverse` to scan.
 ///
 /// The planner always scans the pattern's `from` endpoint. When `to` is the
@@ -422,6 +447,37 @@ fn select_var_len_scan_node(
         }
         let from = relationship.from.clone();
         let to = relationship.to.clone();
+
+        // Non-leaf case: something below the planner's `from` scan may already
+        // bind `to`. Then no scan is needed on either endpoint — dropping the
+        // planner's scan leaves `to` bound and `from` free, and
+        // `CondVarLenTraverseOp` walks the relationship backwards from that one
+        // bound endpoint (`reversed`), enforcing `from`'s labels as the
+        // destination filter. Keeping the scan instead seeds the DFS with every
+        // node carrying `from`'s label, once per input row.
+        //
+        // This is the same decision `select_scan_node` makes for `CondTraverse`
+        // chains via `bound_vars`, except the binding here sits *below* the
+        // planner's scan rather than being the immediate child, so it has to be
+        // looked for one level deeper.
+        if child_subtree_binds(optimized_plan, child_idx, to.alias.id) {
+            let kept: Vec<DynTree<IR>> = optimized_plan
+                .node(child_idx)
+                .children()
+                .map(|c| c.clone_as_tree())
+                .collect();
+            // Only rewrite when the scan actually has something under it; a
+            // childless planner scan is the leaf case handled below.
+            if !kept.is_empty() {
+                optimized_plan.node_mut(child_idx).prune();
+                let idx = resolve_path(optimized_plan, &path)
+                    .expect("pruning a child never changes the parent's path");
+                for t in kept {
+                    optimized_plan.node_mut(idx).push_child_tree(t);
+                }
+                continue;
+            }
+        }
 
         // A correlated sub-plan may already bind `to` from its outer context;
         // scanning it here would rebind it. `Argument(None)` is opaque about

--- a/graph/src/planner/optimizer/select_scan_node.rs
+++ b/graph/src/planner/optimizer/select_scan_node.rs
@@ -88,7 +88,7 @@ use super::{collect_expr_variables, collect_subtree_variables};
 /// When scores are equal, the endpoint with fewer label nodes is preferred.
 fn score_endpoint(
     node: &Arc<QueryNode<Arc<String>, Variable>>,
-    filtered_vars: &HashSet<u32>,
+    filtered_vars: &HashSet<(u32, u32)>,
     bound_vars: &HashSet<u32>,
     graph: &Graph,
 ) -> (u32, u64) {
@@ -96,7 +96,7 @@ fn score_endpoint(
     if bound_vars.contains(&node.alias.id) {
         score += 3;
     }
-    if filtered_vars.contains(&node.alias.id) {
+    if filtered_vars.contains(&(node.alias.id, node.alias.scope_id)) {
         score += 2;
     }
     // Node attribute filters (e.g. {name: "Nicolas Cage"}) also count as filters.
@@ -120,12 +120,21 @@ fn score_endpoint(
     (score, cardinality)
 }
 
-/// Collects variable IDs referenced by Filter nodes that are ancestors of
-/// the given node index, up to the first non-Filter/non-CondTraverse ancestor.
+/// Collects the variables referenced by Filter nodes that are ancestors of the
+/// given node index, up to the first non-Filter/non-CondTraverse ancestor.
+///
+/// Keyed on the full `(id, scope_id)` pair. Today the walk cannot leave the
+/// traverse's own scope — every scope boundary (`Project` for `WITH`, `Apply`
+/// for `CALL {}`, `Unwind`, `Aggregate`) falls into the `_ => break` arm below,
+/// so bare ids would be unambiguous in practice. The pair is kept because two
+/// callers use this set to prove an endpoint's inline attributes are still
+/// enforced above before removing a scan that carried them, and `Variable::id`
+/// is only an index into its own scope's env: that proof should not silently
+/// rest on the walk never being widened.
 fn collect_filtered_vars(
     plan: &DynTree<IR>,
     start_idx: NodeIdx<Dyn<IR>>,
-) -> HashSet<u32> {
+) -> HashSet<(u32, u32)> {
     let mut vars = HashSet::new();
     let mut current = start_idx;
     while let Some(parent) = plan.node(current).parent() {
@@ -133,7 +142,7 @@ fn collect_filtered_vars(
             IR::Filter(filter) => {
                 for idx in filter.root().indices::<Bfs>() {
                     if let ExprIR::Variable(v) = filter.node(idx).data() {
-                        vars.insert(v.id);
+                        vars.insert((v.id, v.scope_id));
                     }
                 }
             }
@@ -338,10 +347,10 @@ fn collect_output_aliases(ir: &IR) -> HashSet<u32> {
         }
         // Argument with known bound vars: the incoming rows bind exactly
         // these variables. `Argument(None)` stays opaque (conservative).
-        // Only the id is kept: this set feeds `score_endpoint`, which is a
-        // preference heuristic over bare ids (as `filtered_vars` already is)
-        // and never decides plan validity. The scope-sensitive decision —
-        // whether the Argument is transparent — compares full pairs.
+        // Only the id is kept: this set feeds `score_endpoint`'s `bound_vars`,
+        // a preference heuristic that never decides plan validity. The
+        // scope-sensitive decision — whether the Argument is transparent —
+        // compares full pairs.
         IR::Argument(Some(vars)) => {
             aliases.extend(vars.iter().map(|(id, _)| *id));
         }
@@ -507,7 +516,8 @@ fn select_var_len_scan_node(
                 }
                 node = node.child(0);
             }
-            ok && (from.attrs.root().num_children() == 0 || filtered_vars.contains(&from.alias.id))
+            ok && (from.attrs.root().num_children() == 0
+                || filtered_vars.contains(&(from.alias.id, from.alias.scope_id)))
         };
         if wrapper_ok && child_subtree_binds(optimized_plan, scan_idx, &to.alias) {
             let kept: Vec<DynTree<IR>> = optimized_plan
@@ -544,10 +554,10 @@ fn select_var_len_scan_node(
         // placed above this traverse, so replacing the scan subtree cannot lose
         // them — but only reverse once those Filters are confirmed present.
         // `push_filters_down` then lands the `to` one back onto the new scan.
-        if [&from, &to]
-            .iter()
-            .any(|n| n.attrs.root().num_children() > 0 && !filtered_vars.contains(&n.alias.id))
-        {
+        if [&from, &to].iter().any(|n| {
+            n.attrs.root().num_children() > 0
+                && !filtered_vars.contains(&(n.alias.id, n.alias.scope_id))
+        }) {
             continue;
         }
 

--- a/tests/flow/test_traversal_construction.py
+++ b/tests/flow/test_traversal_construction.py
@@ -523,7 +523,7 @@ class testTraversalConstruction():
         barrier_plan = str(g.explain(barrier))
         self.env.assertNotContains("Node By Label Scan | (p:P)", barrier_plan)
         self.env.assertContains("Conditional Variable Length Traverse", barrier_plan)
-        self.env.assertTrue(g.query(barrier).result_set == expected)
+        self.env.assertEqual(g.query(barrier).result_set, expected)
 
         # `u` arriving through an UNWIND chain.
         unwound = """UNWIND [3] AS wanted
@@ -531,7 +531,7 @@ class testTraversalConstruction():
                      MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)"""
         unwound_plan = str(g.explain(unwound))
         self.env.assertNotContains("Node By Label Scan | (p:P)", unwound_plan)
-        self.env.assertTrue(g.query(unwound).result_set == expected)
+        self.env.assertEqual(g.query(unwound).result_set, expected)
 
         # The free endpoint's label is still enforced — by the traverse itself,
         # as its destination filter — so an unlabeled `p` must match strictly
@@ -542,5 +542,32 @@ class testTraversalConstruction():
                              MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)""").result_set
         unlabeled = g.query("""MATCH (u:P) WHERE u.id=3 WITH u LIMIT 1
                                MATCH path=(p)-[:E*0..]->(u) RETURN count(path)""").result_set
-        self.env.assertTrue(unlabeled[0][0] > labeled[0][0])
+        self.env.assertGreater(unlabeled[0][0], labeled[0][0])
+
+        # An inline attribute on the free endpoint puts a Filter between the
+        # traverse and the planner's scan. The scan must still go — and the
+        # Filter must not go with it, or `p` loses its predicate.
+        attrs = """MATCH (u:P) WHERE u.id=3 WITH u LIMIT 1
+                    MATCH path=(p:P {id:1})-[:E*0..]->(u) RETURN count(path)"""
+        attrs_plan = str(g.explain(attrs))
+        self.env.assertNotContains("Node By Label Scan | (p:P)", attrs_plan)
+        self.env.assertContains("Filter", attrs_plan)
+        self.env.assertEqual(g.query(attrs).result_set, [[1]])
+        g.delete()
+
+    # `Argument(None)` is opaque about which variables it carries, so a scan
+    # with one anywhere below it cannot be proven redundant and the plan must
+    # be left alone — even though the outer `u` is in fact bound.
+    def test_var_len_anchor_opaque_argument(self):
+        g = self.db.select_graph("VarLenAnchorOpaqueArgument")
+        g.query("CREATE (a:P {id:0})-[:E]->(b:P {id:1})-[:E]->(c:P {id:2})")
+
+        for q in ["MATCH (u:P) WHERE u.id=2 OPTIONAL MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)",
+                  """MATCH (u:P) WHERE u.id=2
+                     CALL { WITH u MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path) AS c }
+                     RETURN c"""]:
+            plan = str(g.explain(q))
+            self.env.assertContains("Argument", plan)
+            self.env.assertContains("Node By Label Scan | (p:P)", plan)
+            self.env.assertEqual(g.query(q).result_set, [[3]])
         g.delete()

--- a/tests/flow/test_traversal_construction.py
+++ b/tests/flow/test_traversal_construction.py
@@ -500,3 +500,47 @@ class testTraversalConstruction():
         result = self.graph.query(q).result_set
         self.env.assertTrue(result == expected)
 
+
+    # A variable-length traverse whose bound endpoint is supplied by an operator
+    # other than a directly selectable scan — a WITH barrier or an UNWIND —
+    # must still anchor on that bound endpoint. Before this was handled, the
+    # planner inserted a scan on the *free* endpoint and the runtime seeded its
+    # DFS with every node carrying that endpoint's label, once per input row.
+    def test_var_len_anchor_with_non_leaf_child(self):
+        g = self.db.select_graph("VarLenAnchorNonLeaf")
+        g.query("""CREATE (a:P {id:0})-[:E]->(b:P {id:1})-[:E]->(c:P {id:2})
+                          -[:E]->(d:P {id:3})-[:E]->(e:P {id:4})""")
+
+        # Baseline: the leaf form already anchors on the bound `u`.
+        leaf = """MATCH path=(p:P)-[:E*0..]->(u:P) WHERE u.id=3 RETURN count(path)"""
+        leaf_plan = str(g.explain(leaf))
+        self.env.assertNotContains("Node By Label Scan | (p:P)", leaf_plan)
+        expected = g.query(leaf).result_set
+
+        # A WITH/LIMIT barrier between the scan and the traverse.
+        barrier = """MATCH (u:P) WHERE u.id=3 WITH u LIMIT 1
+                     MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)"""
+        barrier_plan = str(g.explain(barrier))
+        self.env.assertNotContains("Node By Label Scan | (p:P)", barrier_plan)
+        self.env.assertContains("Conditional Variable Length Traverse", barrier_plan)
+        self.env.assertTrue(g.query(barrier).result_set == expected)
+
+        # `u` arriving through an UNWIND chain.
+        unwound = """UNWIND [3] AS wanted
+                     MATCH (u:P) WHERE u.id = wanted
+                     MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)"""
+        unwound_plan = str(g.explain(unwound))
+        self.env.assertNotContains("Node By Label Scan | (p:P)", unwound_plan)
+        self.env.assertTrue(g.query(unwound).result_set == expected)
+
+        # The free endpoint's label is still enforced — by the traverse itself,
+        # as its destination filter — so an unlabeled `p` must match strictly
+        # more rows once a non-P node can reach the same `u`. Attach to the
+        # existing id=3 node so `WITH u LIMIT 1` stays deterministic.
+        g.query("MATCH (d:P {id:3}) CREATE (:Q {id:99})-[:E]->(d)")
+        labeled = g.query("""MATCH (u:P) WHERE u.id=3 WITH u LIMIT 1
+                             MATCH path=(p:P)-[:E*0..]->(u) RETURN count(path)""").result_set
+        unlabeled = g.query("""MATCH (u:P) WHERE u.id=3 WITH u LIMIT 1
+                               MATCH path=(p)-[:E*0..]->(u) RETURN count(path)""").result_set
+        self.env.assertTrue(unlabeled[0][0] > labeled[0][0])
+        g.delete()


### PR DESCRIPTION
Fixes #2561

`select_var_len_scan_node` only rewrote when the planner's own scan for `from`
was the traverse's child and nothing below it mattered — the leaf case #2491
addressed. When the other endpoint is already bound by an operator further down
(a `WITH`/`Project` barrier, or an `UNWIND` chain), the pass left the plan alone
and the scan on the free endpoint stayed:

```
Conditional Variable Length Traverse | (p)-[:E*0..INF]->(u)
    Node By Label Scan | (p:P)          <-- spurious
        Limit / Project / Filter
            Node By Index Scan | (u:P)
```

`CondVarLenTraverseOp` then took the non-reversed path and seeded its DFS with
every node carrying `from`'s label, once per input row.

## The change

Look one level deeper for the binding and, when it is provably there, **drop**
the scan instead of replacing it. `to` bound with `from` free is the shape the
runtime already handles:

```rust
let reversed = from_id.is_none() && to_id.is_some() && !bidirectional;
let dest_labels = if reversed { &rp.from.labels } else { &rp.to.labels };
```

`reversed` walks the relationship backwards from the single bound endpoint and
enforces `from`'s labels as its destination filter, so the label predicate the
scan carried is not lost — the new test asserts exactly that by adding a
non-`:P` node that reaches the same `u` and checking the unlabeled pattern
matches strictly more paths. No runtime change is needed.

`Argument(None)` is opaque about what it binds, so its presence anywhere below
leaves the plan alone.

## Measurements

Engine-internal time, median of 3, same host. Row counts identical across C,
pre-fix and post-fix in every case.

| case | C | before | after | after/C | speedup |
|---|---|---|---|---|---|
| chain-800, bound target | 1.47 | 98.61 | **0.74** | 0.50x | 134x |
| chain-800, 10 bound targets | 0.64 | 977.37 | **0.52** | 0.81x | **1872x** |
| 101-edge MIR fixture | 3.2 | 30.5 | **2.4** | 0.76x | 12.6x |
| 220-edge MIR fixture | 132.3 | 732.1 | **91.3** | 0.69x | 8.0x |
| 288-edge MIR fixture | 112.5 | 775.3 | **76.7** | 0.68x | 10.1x |

The 5.6–5.9x deficit against the C engine on the real fixtures is gone and
reversed — Rust now runs these at 0.68–0.76x of C.

## Tests

Full flow suite: **1435 run, 1434 passed**. The single failure,
`test01_load_remote_csv`, fails identically on `main` and needs network access.

The added test is two-way: it **fails on a pre-fix binary**, printing the exact
spurious `Node By Label Scan | (p:P)` for both the barrier and `UNWIND` shapes,
and passes with the fix.

## Scope

This does **not** fix #2558, which is a different decision — which pattern of a
multi-pattern `MATCH` becomes the leaf. Verified: the plans for #2558's
reproducer are byte-identical before and after this change. Diagnosis for that
one is in a comment on the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable-length traversal planning across nested query operations and wrapped scans.
  * Preserved inline endpoint filters and descendant bindings during traversal optimization.
  * Prevented incorrect scan removal when bindings cannot be safely determined, including opaque optional matches and subqueries.
  * Maintained correct behavior for reverse traversal, endpoint labels, and pending results.

* **Tests**
  * Added coverage for scoped variable bindings, inline endpoint attributes, opaque query arguments, preserved filters, and traversal results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->