### PR TITLE
bench(studies): publish the edge-storage boundary harness

### DIFF
--- a/bench/studies/edge_storage/.gitignore
+++ b/bench/studies/edge_storage/.gitignore
@@ -1,0 +1,3 @@
+obj/
+tensor_bench
+calib

--- a/bench/studies/edge_storage/README.md
+++ b/bench/studies/edge_storage/README.md
@@ -1,0 +1,65 @@
+# Edge storage at the data-structure boundary
+
+Measures the two multi-edge storage designs **as structures**, not as engines:
+
+- **(A) container per cell** — the C engine's tensor, a tagged `GrB_Vector`
+  handle in the matrix cell. Measured here.
+- **(C) inline-first with sentinel promotion** — the Rust engine's tensor.
+  Measured by `graph/src/graph/graphblas/tensor_cost_bench.rs`, which builds the
+  *same* fixture (`tensor_cost_c_comparable`) so the two are comparable.
+
+Why the boundary and not whole queries: a query-level ratio is a ratio between
+two engines, and the tensor is one component of each. Every time we checked, that
+difference mattered — engine-level differencing overstated the multi-edge entry
+charge by 1.6x for (C) and 5.1x for (A), and overstated the per-identifier slope
+by 3.6x and 26x, which is enough to *invert* the ordering of the two slopes. See
+`docs/papers/tensor.tex` §evalboundary and §evalfanout.
+
+## Building
+
+Two inputs live outside this repo's tree and are overridable:
+
+| | |
+| --- | --- |
+| `SRC` | a checkout of `master` (the C engine's sources) |
+| `BIN` | a C build tree, for `libfalkordb_static.a` and its GraphBLAS |
+
+```sh
+git worktree add /tmp/cmaster master          # SRC
+make                                          # BIN, if not already built
+SRC=/tmp/cmaster BIN=$PWD/bin/macos-arm64v8-release ./build.sh
+OMP_NUM_THREADS=1 ./tensor_bench
+```
+
+`build.sh` compiles **only** `tensor_bench.c`. `tensor.c`, `tensor_iterator.c`
+and `delta_matrix/*.c` come out of `libfalkordb_static.a`, so what is measured is
+the shipped implementation rather than a recompilation of it — 323 of the
+archive's 392 members link in, with no stubbed symbols.
+
+`OMP_NUM_THREADS=1` matters: the C side is measured single-threaded, and the Rust
+side uses GraphBLAS's default thread count. That asymmetry is why the comparison
+is stated in *instructions* and why the bulk-build rows are the ones to trust
+least.
+
+## What each file is
+
+| file | what it does |
+| --- | --- |
+| `tensor_bench.c` | the harness: point reads, iteration (forward and transposed), fan-out to `k = 16`, promote/demote, build paths, space |
+| `calib.c` | measures the instruction-counter overhead the harness subtracts |
+| `engine_space_and_transition.py` | the *engine-level* companion: `relation_matrices_sz_mb` across `k`, and the build-order gap that isolates a transition |
+| `build.sh` | compiles and links the above against `$BIN` |
+
+## Caveats that belong with the numbers
+
+- **Separate processes, separate allocators.** The C harness and the Rust
+  measurement tests do not share a process, so absolute wall clock is not
+  comparable across them; instructions are.
+- **GraphBLAS versions are not aligned.** The shipped archive here is built
+  against whatever `$BIN` was built against — 10.4.0 on the machine these were
+  last run on, where the Rust side is on 10.5.0. The `k <= 2` rows reproduce the
+  paper's table to within 1%, so the minor version is not what moves them, but
+  any cross-version claim needs both sides rebuilt on one.
+- **Warm and sequential.** Every read here walks pairs in ascending order with
+  the data hot. The Rust side measures a scattered-order variant; cold-cache
+  behaviour is measured nowhere yet.

--- a/bench/studies/edge_storage/build.sh
+++ b/bench/studies/edge_storage/build.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Build the standalone Tensor micro-benchmark.
+#
+# Sources come from the read-only master worktree ($SRC); everything else is
+# linked out of the pre-existing C build tree ($BIN) - nothing there is written.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Both inputs are overridable, because neither lives in this repo's tree:
+#
+#   SRC  a checkout of `master` (the C engine's sources). A git worktree is the
+#        cheapest way to get one:  git worktree add /tmp/cmaster master
+#   BIN  a C build tree, for `libfalkordb_static.a` and its GraphBLAS. The
+#        harness links the *shipped* archive rather than recompiling tensor.c,
+#        so what it measures is what ships.
+#
+# Defaults suit a macOS arm64 checkout with `make` already run.
+SRC="${SRC:-$(cd "$HERE/../../.." && pwd)/../cmaster}"
+BIN="${BIN:-$(cd "$HERE/../../.." && pwd)/bin/macos-arm64v8-release}"
+CC="${CC:-/opt/homebrew/opt/llvm/bin/clang}"
+
+if [ ! -d "$SRC/src/graph/tensor" ]; then
+	echo "SRC=$SRC is not a master checkout (no src/graph/tensor)." >&2
+	echo "Point SRC at one:  git worktree add /tmp/cmaster master" >&2
+	exit 1
+fi
+if [ ! -f "$BIN/libfalkordb_static.a" ]; then
+	echo "BIN=$BIN has no libfalkordb_static.a — build the C engine first." >&2
+	exit 1
+fi
+OBJ="$HERE/obj"
+mkdir -p "$OBJ"
+
+# NOTE: deps/xxHash and deps/RediSearch are git submodules and are NOT populated
+# in this worktree. xxhash.h is taken from the copy vendored inside
+# deps/GraphBLAS (only needed to compile value.h's hashing decls; the harness
+# never calls XXH*).
+INC="-I$SRC -I$SRC/src -I$SRC/deps -I$SRC/deps/rax -I$SRC/deps/GraphBLAS/xxHash \
+-I$SRC/deps/quickjs -I$SRC/deps/utf8proc -I$SRC/deps/oniguruma \
+-I$SRC/deps/RediSearch/src -I$SRC/deps/LAGraph/include \
+-I$SRC/deps/GraphBLAS/Include -I$SRC/deps/libcurl/include/curl \
+-I$SRC/deps/libcypher-parser/lib/src -I$BIN/libcypher-parser/lib/src \
+-isystem /opt/homebrew/opt/openssl@3/include"
+
+DEFS="-DREDISMODULE_EXPERIMENTAL_API -DREDIS_MODULE_TARGET -DXXH_STATIC_LINKING_ONLY -D_GNU_SOURCE"
+CFLAGS="-Wno-gnu-zero-variadic-macro-arguments -Wno-error=incompatible-pointer-types -fopenmp=libomp -O3 -g -DNDEBUG \
+-std=gnu11 -arch arm64 -mmacosx-version-min=12.0 -fno-strict-aliasing -UNDEBUG"
+
+# Only the harness is compiled from source. tensor.c / tensor_iterator.c /
+# delta_matrix/*.c come out of $BIN/libfalkordb_static.a, which was built from
+# the same commit-era sources against the same GraphBLAS 10.3.1 that
+# $BIN/GraphBLAS/libgraphblas.a provides -- so struct layouts agree.
+# (Compiling delta_matrix/*.c here is not possible in this worktree: several of
+# them include globals.h -> graphcontext.h -> index/index_field.h ->
+# redisearch_api.h, and deps/RediSearch is an unpopulated submodule.)
+SOURCES=("$HERE/tensor_bench.c")
+
+OBJS=()
+for f in "${SOURCES[@]}"; do
+  o="$OBJ/$(basename "$f" .c).o"
+  echo "CC $(basename "$f")"
+  $CC $DEFS $INC $CFLAGS -c "$f" -o "$o"
+  OBJS+=("$o")
+done
+
+echo "LD tensor_bench"
+$CC -arch arm64 -mmacosx-version-min=12.0 -fopenmp=libomp \
+  "${OBJS[@]}" \
+  "$@" \
+  "$BIN/libfalkordb_static.a" \
+  "$BIN/GraphBLAS/libgraphblas.a" \
+  "$BIN/LAGraph/src/liblagraph.a" \
+  "$BIN/LAGraph/experimental/liblagraphx.a" \
+  "$BIN/xxHash/libxxhash.a" \
+  "$BIN/rax/librax.a" \
+  "$BIN/utf8proc/libutf8proc.a" \
+  "$BIN/oniguruma/libonig.a" \
+  "$BIN/quickjs/libquickjs.a" \
+  "$BIN/libcsv/.libs/libcsv.a" \
+  "$BIN/libcurl/lib/.libs/libcurl.a" \
+  "$BIN/libcypher-parser/lib/src/.libs/libcypher-parser.a" \
+  "$BIN/search-static/libredisearch-static.a" \
+  "$BIN/search-static/deps/VectorSimilarity/src/VecSim/libVectorSimilarity.a" \
+  "$BIN/search-static/deps/VectorSimilarity/src/VecSim/spaces/libVectorSimilaritySpaces.a" \
+  "$BIN/search-static/deps/VectorSimilarity/src/VecSim/spaces/libVectorSimilaritySpaces_no_optimization.a" \
+  -L/opt/homebrew/opt/openssl@3/lib -lssl -lcrypto \
+  -framework CoreFoundation -framework SystemConfiguration \
+  -lc++ -lomp -L/opt/homebrew/opt/llvm/lib \
+  -o "$HERE/tensor_bench"
+echo "built $HERE/tensor_bench"

--- a/bench/studies/edge_storage/calib.c
+++ b/bench/studies/edge_storage/calib.c
@@ -1,0 +1,30 @@
+// Calibration for the ri_instructions offset used by tensor_bench.c:
+// a loop whose per-iteration instruction count is known from its disassembly.
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <libproc.h>
+#include <unistd.h>
+
+static uint64_t ins(void) {
+	static uint8_t b[1024];
+	proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)b);
+	uint64_t v;
+	memcpy(&v, b + 16 + 29 * 8, 8);
+	return v;
+}
+
+volatile uint64_t sink;
+
+int main(void) {
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t n = 1000000000ULL, a = 0;
+		uint64_t i0 = ins();
+		for(uint64_t i = 0; i < n; i++) a += i;
+		uint64_t i1 = ins();
+		sink = a;
+		printf("rep%d: %.4f instr/iter (total %llu)\n", rep,
+		       (double)(i1 - i0) / n, (unsigned long long)(i1 - i0));
+	}
+	return 0;
+}

--- a/bench/studies/edge_storage/engine_space_and_transition.py
+++ b/bench/studies/edge_storage/engine_space_and_transition.py
@@ -1,0 +1,380 @@
+"""Gap 1: the auxiliary structure's SPACE, and the ABSENCE of a transition.
+
+Two properties the existing read-differencing bound says nothing about,
+measured on both engines: (A) container-per-cell (the C module) and (C)
+inline-first with lazy overflow (the Rust module).
+
+(a) SPACE
+    The always-materialised design (B) holds every edge id in the auxiliary
+    structure, including for single-edge pairs; (C) holds only multi-edge ids
+    there and (A) allocates a container only for multi-edge pairs. So the
+    quantity (B)'s space penalty is made of is *bytes per id in the auxiliary
+    structure*.
+
+    Method: hold PAIR COUNT (500,000) and NODE COUNT (2,500) fixed and vary ids
+    per pair k in {1, 2, 4, 8}; |E| = 500,000 * k. Metric is
+    `relation_matrices_sz_mb` from GRAPH.MEMORY, which is the engines' own
+    accounting of exactly the relationship-storage matrices — it excludes the
+    edge blocks and attribute stores that scale with |E| for reasons unrelated
+    to edge identity, which is why it is preferred here to total resident size.
+    Resident deltas (jemalloc live bytes, RSS after MEMORY PURGE) are recorded
+    alongside as a cross-check.
+
+    The slope over k >= 2, where every id is in the auxiliary structure, is its
+    marginal bytes per id. k = 1 is the all-inline point.
+
+    That slope AMORTISES the auxiliary structure's per-pair (per-row/per-
+    container) overhead over k ids, so as an estimate of what (B) would pay per
+    id at one id per pair it is a LOWER BOUND, not (B)'s number.
+
+    `reference` = 1,000,000 pairs x 1 edge: the same |E| as k=2 with no
+    multi-edge pair anywhere. Different pair count, so it is context, not a
+    controlled comparison.
+
+    Edges are deliberately property-free (`CREATE (a)-[:R]->(b)`) so nothing in
+    the attribute store moves with k.
+
+(b) NO TRANSITION
+    (B) never promotes or demotes because it has no state change. (C) promotes a
+    pair when it gains a second edge; (A) allocates a container. A pair built
+    multi-edge in a single batch does not pay the same transition as one built
+    incrementally — in (C), `set_all_from_slices` resolves within-batch
+    duplicates through its own map and promotes the pending inline slot without
+    probing the committed matrix. The gap between the two build orders isolates
+    the transition cost that (B) would not pay at all.
+
+    Method: build the SAME final graph (500,000 pairs x 2 edges) two ways and
+    count server-side instructions for the whole build:
+      incremental = one statement per source row creating edge 1, then a second
+                    pass creating edge 2 on the same pairs;
+      batch       = one statement per source row creating both edges at once.
+    `single` builds 1,000,000 single-edge pairs for the same |E| with no
+    promotion anywhere. 3 repetitions, each on a fresh server.
+
+Instructions come from `proc_pid_rusage` on the SERVER pid, so this driver's
+work is not in the numbers. Ports 6600-6699.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, "/Users/aviavni/repos/FalkorDB/bench/src")
+
+from falkorbench import client as client_mod
+from falkorbench.counters import select_backend, rss
+
+SRCS = 500  # :S nodes; the multi configs use the first MULTI_SRCS
+DSTS = 2_000  # :D nodes
+MULTI_SRCS = 250
+PAIRS = MULTI_SRCS * DSTS  # 500,000
+PORT = 6613
+REPS = 3
+
+WORK = Path(
+    "/private/tmp/claude-501/-Users-aviavni-repos-FalkorDB/"
+    "315a73ee-413e-4bd9-9431-31a67ffd04de/scratchpad/gap1work"
+)
+
+
+def fresh(module: Path):
+    shutil.rmtree(WORK, ignore_errors=True)
+    WORK.mkdir(parents=True, exist_ok=True)
+    server = client_mod.start_server(module, PORT, WORK / "srv", WORK / "imp")
+    bench = client_mod.connect(server)
+    bench.run(f"UNWIND range(0, {SRCS - 1}) AS i CREATE (:S {{id: i}})")
+    bench.run(f"UNWIND range(0, {DSTS - 1}) AS i CREATE (:D {{id: i}})")
+    bench.run("CREATE INDEX FOR (n:S) ON (n.id)")
+    return server, bench
+
+
+def build_rows(bench, src_lo, src_hi, k):
+    """One statement per source row: k property-free edges to every :D node."""
+    for s in range(src_lo, src_hi):
+        if k == 1:
+            bench.run(f"MATCH (a:S {{id: {s}}}) MATCH (b:D) CREATE (a)-[:R]->(b)")
+        else:
+            bench.run(
+                f"MATCH (a:S {{id: {s}}}) MATCH (b:D) "
+                f"UNWIND range(1, {k}) AS j CREATE (a)-[:R]->(b)"
+            )
+
+
+def edge_count(bench):
+    return bench.graph.query("MATCH ()-[r:R]->() RETURN count(r)").result_set[0][0]
+
+
+def memory(bench):
+    """GRAPH.MEMORY USAGE as a dict (values are integer MB)."""
+    try:
+        raw = bench.command("GRAPH.MEMORY", "USAGE", bench.graph_name)
+        return dict(zip(raw[0::2], raw[1::2]))
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)}
+
+
+# --- (a) space ----------------------------------------------------------------
+
+
+def space(engine: str, module: Path, out: dict) -> None:
+    # (label, src_lo, src_hi, k)
+    configs = [
+        ("k=1", 0, MULTI_SRCS, 1),
+        ("k=2", 0, MULTI_SRCS, 2),
+        ("k=4", 0, MULTI_SRCS, 4),
+        ("k=8", 0, MULTI_SRCS, 8),
+        ("reference", 0, SRCS, 1),
+    ]
+    for rep in range(REPS):
+        for label, lo, hi, k in configs:
+            server, bench = fresh(module)
+            try:
+                a0, d0 = bench.jemalloc_totals()
+                base_live = (a0 - d0) if a0 is not None else None
+                try:
+                    bench.command("MEMORY", "PURGE")
+                except Exception:  # noqa: BLE001
+                    pass
+                base_rss = rss(server.proc.pid)
+                build_rows(bench, lo, hi, k)
+                edges = edge_count(bench)
+                pairs = (hi - lo) * DSTS
+                assert edges == pairs * k, f"{label}: {edges} != {pairs} * {k}"
+                a1, d1 = bench.jemalloc_totals()
+                live = ((a1 - d1) - base_live) if a1 is not None else None
+                mem = memory(bench)
+                try:
+                    bench.command("MEMORY", "PURGE")
+                except Exception:  # noqa: BLE001
+                    pass
+                row = {
+                    "k": k,
+                    "pairs": pairs,
+                    "edges": edges,
+                    "rel_matrices_mb": mem.get("relation_matrices_sz_mb"),
+                    "total_graph_mb": mem.get("total_graph_sz_mb"),
+                    "edge_block_mb": mem.get("amortized_edge_block_sz_mb"),
+                    "live_bytes": live,
+                    "rss_delta": (rss(server.proc.pid) - base_rss) if base_rss else None,
+                }
+                out.setdefault(engine, {}).setdefault("space", {}).setdefault(
+                    label, []
+                ).append(row)
+                print(
+                    f"{engine:>5} space r{rep} {label:>10}  pairs={pairs:>7} "
+                    f"edges={edges:>8} rel_mb={row['rel_matrices_mb']} "
+                    f"total_mb={row['total_graph_mb']} live={live} rss={row['rss_delta']}",
+                    flush=True,
+                )
+            finally:
+                server.stop()
+
+
+# --- (b) transition -----------------------------------------------------------
+
+
+def transition(engine: str, module: Path, out: dict) -> None:
+    backend = select_backend(None)
+    for rep in range(REPS):
+        res: dict = {}
+
+        # incremental: edge 1 for every pair, then edge 2 for every pair.
+        server, bench = fresh(module)
+        try:
+            pid = server.proc.pid
+            with backend.count_window(pid) as w:
+                t0 = time.time()
+                build_rows(bench, 0, MULTI_SRCS, 1)
+                pass1_s = time.time() - t0
+            pass1 = w.reading.instr
+            with backend.count_window(pid) as w:
+                t0 = time.time()
+                build_rows(bench, 0, MULTI_SRCS, 1)  # a 2nd edge on the same pairs
+                pass2_s = time.time() - t0
+            pass2 = w.reading.instr
+            res["incremental"] = {
+                "pass1_instr": pass1,
+                "pass2_instr": pass2,
+                "total_instr": pass1 + pass2,
+                "seconds": pass1_s + pass2_s,
+                "edges": edge_count(bench),
+                "pairs": PAIRS,
+            }
+        finally:
+            server.stop()
+
+        # batch: both edges of every pair in one statement per source row.
+        server, bench = fresh(module)
+        try:
+            pid = server.proc.pid
+            with backend.count_window(pid) as w:
+                t0 = time.time()
+                build_rows(bench, 0, MULTI_SRCS, 2)
+                secs = time.time() - t0
+            res["batch"] = {
+                "total_instr": w.reading.instr,
+                "seconds": secs,
+                "edges": edge_count(bench),
+                "pairs": PAIRS,
+            }
+        finally:
+            server.stop()
+
+        # single: the same |E| as 1,000,000 single-edge pairs, no promotion.
+        server, bench = fresh(module)
+        try:
+            pid = server.proc.pid
+            with backend.count_window(pid) as w:
+                t0 = time.time()
+                build_rows(bench, 0, SRCS, 1)
+                secs = time.time() - t0
+            res["single"] = {
+                "total_instr": w.reading.instr,
+                "seconds": secs,
+                "edges": edge_count(bench),
+                "pairs": SRCS * DSTS,
+            }
+        finally:
+            server.stop()
+
+        out.setdefault(engine, {}).setdefault("transition", []).append(res)
+        for k, v in res.items():
+            print(
+                f"{engine:>5} trans r{rep} {k:>12}  edges={v['edges']:>8} "
+                f"pairs={v['pairs']:>7} instr={v['total_instr']:,.0f} ({v['seconds']:.2f}s)",
+                flush=True,
+            )
+
+
+def transition_controlled(engine: str, module: Path, out: dict) -> None:
+    """Promotion cost per pair with statement count and edge count held fixed.
+
+    `incremental` vs `batch` above answers "what does it cost to build this graph
+    two ways", but the incremental build runs the MATCH pipeline twice, so its
+    excess is promotion *plus* a second pass of parse/plan/scan. This isolates
+    the promotion instead:
+
+      pass1     250 statements, 1 edge to each of 500,000 pairs (setup, not
+                measured as the comparison).
+      promote   250 statements adding a 2nd edge to those SAME 500,000 pairs.
+      control   250 statements adding a 1st edge to 500,000 FRESH pairs
+                (source band 250..499), so the same number of statements, the
+                same number of created edges and the same plan shape — but no
+                promotion.
+
+    Promotion cost per pair = (promote - control) / 500,000. Not held fixed: the
+    control grows the pair count to 1,000,000 while the promote pass leaves it at
+    500,000, so the control does its work against a slightly larger adjacency.
+    """
+    backend = select_backend(None)
+    for rep in range(REPS):
+        row = {}
+        for label, lo, hi in (("promote", 0, MULTI_SRCS), ("control", MULTI_SRCS, SRCS)):
+            server, bench = fresh(module)
+            try:
+                pid = server.proc.pid
+                build_rows(bench, 0, MULTI_SRCS, 1)  # setup: 500,000 single-edge pairs
+                assert edge_count(bench) == PAIRS
+                with backend.count_window(pid) as w:
+                    t0 = time.time()
+                    build_rows(bench, lo, hi, 1)
+                    secs = time.time() - t0
+                row[label] = {
+                    "instr": w.reading.instr,
+                    "seconds": secs,
+                    "edges_after": edge_count(bench),
+                }
+            finally:
+                server.stop()
+        diff = row["promote"]["instr"] - row["control"]["instr"]
+        row["promote_instr_per_pair"] = diff / PAIRS
+        out.setdefault(engine, {}).setdefault("transition_controlled", []).append(row)
+        print(
+            f"{engine:>5} ctrl  r{rep}  promote={row['promote']['instr']:,.0f} "
+            f"control={row['control']['instr']:,.0f} "
+            f"promote_per_pair={diff / PAIRS:,.0f} instr",
+            flush=True,
+        )
+
+
+def transition_controlled2(engine: str, module: Path, out: dict) -> None:
+    """Promotion cost per pair, controlled against an insert that does NOT promote.
+
+    `transition_controlled` used fresh pairs as its control and came out negative
+    on the C engine: creating 500,000 new pairs grows the adjacency from 500,000
+    to 1,000,000 entries, and that growth costs more than a promotion, so the
+    control was measuring matrix growth rather than a plain insert.
+
+    The control here adds an edge to a pair that is ALREADY multi-edge, so the
+    auxiliary container/row already exists and no state changes:
+
+      promote   setup 500,000 pairs x 1 edge; measure 250 statements adding a
+                2nd edge to every pair. Every pair transitions.
+      control   setup 500,000 pairs x 2 edges; measure 250 statements adding a
+                3rd edge to every pair. No pair transitions.
+
+    Held fixed: pair count (500,000), statement count (250), edges created by the
+    measured pass (500,000), plan shape. Not held fixed, and it biases against the
+    control: the control's auxiliary structure already holds 1,000,000 ids when
+    the measured pass runs, while the promote pass starts with an empty one. So
+    (promote - control) is a LOWER BOUND on the transition cost.
+    """
+    backend = select_backend(None)
+    for rep in range(REPS):
+        row = {}
+        for label, setup_k in (("promote", 1), ("control", 2)):
+            server, bench = fresh(module)
+            try:
+                pid = server.proc.pid
+                build_rows(bench, 0, MULTI_SRCS, setup_k)
+                assert edge_count(bench) == PAIRS * setup_k
+                with backend.count_window(pid) as w:
+                    t0 = time.time()
+                    build_rows(bench, 0, MULTI_SRCS, 1)  # +1 edge on every pair
+                    secs = time.time() - t0
+                after = edge_count(bench)
+                assert after == PAIRS * (setup_k + 1), after
+                row[label] = {"instr": w.reading.instr, "seconds": secs, "edges_after": after}
+            finally:
+                server.stop()
+        diff = row["promote"]["instr"] - row["control"]["instr"]
+        row["promote_instr_per_pair"] = diff / PAIRS
+        out.setdefault(engine, {}).setdefault("transition_controlled2", []).append(row)
+        print(
+            f"{engine:>5} ctrl2 r{rep}  promote={row['promote']['instr']:,.0f} "
+            f"control={row['control']['instr']:,.0f} "
+            f"promote_per_pair={diff / PAIRS:,.0f} instr",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    root = Path("/Users/aviavni/repos/FalkorDB")
+    engines = {
+        "C": root / "bin/macos-arm64v8-release/falkordb.so",
+        "Rust": root / ".claude/worktrees/agent-aaba21650d1efbb58/target/release/libfalkordb.dylib",
+    }
+    results: dict = {}
+    for name, mod in engines.items():
+        if not mod.exists():
+            print(f"skip {name}: {mod} missing", flush=True)
+            continue
+        stages = {
+            "space": space,
+            "transition": transition,
+            "controlled": transition_controlled,
+            "controlled2": transition_controlled2,
+        }
+        want = sys.argv[1:] or list(stages)
+        for fn in [stages[s] for s in want]:
+            try:
+                fn(name, mod, results)
+            except Exception as e:  # noqa: BLE001
+                print(f"{name} {fn.__name__} FAILED: {type(e).__name__}: {e}", flush=True)
+    outp = WORK.parent / ("gap1_" + "_".join(sys.argv[1:] or ["all"]) + ".json")
+    outp.write_text(json.dumps(results, indent=2, default=str))
+    print(f"\nwrote {outp}")

--- a/bench/studies/edge_storage/tensor_bench.c
+++ b/bench/studies/edge_storage/tensor_bench.c
@@ -1,0 +1,775 @@
+// Standalone micro-benchmark harness for the C FalkorDB Tensor.
+//
+// Measures per-operation instruction counts using proc_pid_rusage(
+// RUSAGE_INFO_V4).ri_instructions (macOS), amortised over many repetitions.
+//
+// Build: see build.sh next to this file.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <malloc/malloc.h>
+#include <libproc.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "RG.h"
+#include "util/rmalloc.h"
+#include "configuration/config.h"
+#include "graph/tensor/tensor.h"
+#include "graph/delta_matrix/delta_matrix.h"
+#include "graph/delta_matrix/delta_matrix_iter.h"
+
+// ---------------------------------------------------------------------------
+// instruction counter
+// ---------------------------------------------------------------------------
+
+// rusage_info_v4: 16-byte ri_uuid followed by u64 fields.
+// ri_instructions is u64 index 29 counting from byte 16 (see
+// bench/src/falkorbench/counters.py read_rusage).
+#define RI_INSTRUCTIONS_OFF (16 + 29 * 8)
+#define RI_CYCLES_OFF       (16 + 30 * 8)
+
+static uint64_t read_instructions(void) {
+	static uint8_t buf[1024];
+	if(proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)buf) != 0) {
+		fprintf(stderr, "proc_pid_rusage failed\n");
+		exit(1);
+	}
+	uint64_t v;
+	memcpy(&v, buf + RI_INSTRUCTIONS_OFF, sizeof(v));
+	return v;
+}
+
+static double now_sec(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+
+// keep the optimiser from deleting the measured work
+static volatile uint64_t g_sink = 0;
+
+// ---------------------------------------------------------------------------
+// tensor construction helpers
+// ---------------------------------------------------------------------------
+
+// number of (src,dst) pairs
+static uint64_t N = 200000;
+
+// build a tensor with `edges_per_pair` edges on the diagonal-ish pairs
+// pair k is (k, k) ; edge ids are dense and unique
+// uses the batch entry point: one-at-a-time Tensor_SetElement is O(pending)
+// per call (see the note on the 1-at-a-time benchmark) and would make setup
+// quadratic.
+static Tensor build(uint64_t n, int edges_per_pair) {
+	Tensor T = Tensor_new(n + 1, n + 1);
+	uint64_t m = n * edges_per_pair;
+	GrB_Index *rows = malloc(m * sizeof(GrB_Index));
+	GrB_Index *cols = malloc(m * sizeof(GrB_Index));
+	uint64_t  *vals = malloc(m * sizeof(uint64_t));
+	uint64_t k = 0;
+	for(uint64_t i = 0; i < n; i++) {
+		for(int e = 0; e < edges_per_pair; e++) {
+			rows[k] = i; cols[k] = i; vals[k] = k; k++;
+		}
+	}
+	Tensor_SetElements(T, rows, cols, vals, m);
+	free(rows); free(cols); free(vals);
+	// flush pending changes so reads hit M, not delta-plus
+	GrB_Info info = Delta_Matrix_wait(T, true);
+	if(info != GrB_SUCCESS) { fprintf(stderr, "wait failed %d\n", info); exit(1); }
+	return T;
+}
+
+// ---------------------------------------------------------------------------
+// measurements
+// ---------------------------------------------------------------------------
+
+typedef struct {
+	const char *name;
+	double instr_per_op[3];
+	double sec_per_op[3];
+	uint64_t ops;
+} Result;
+
+static void report(const Result *r) {
+	double mn = r->instr_per_op[0], mx = r->instr_per_op[0], sum = 0;
+	for(int i = 0; i < 3; i++) {
+		if(r->instr_per_op[i] < mn) mn = r->instr_per_op[i];
+		if(r->instr_per_op[i] > mx) mx = r->instr_per_op[i];
+		sum += r->instr_per_op[i];
+	}
+	double avg = sum / 3.0;
+	printf("%-46s ops=%-9llu instr/op: %8.1f %8.1f %8.1f  (mean %8.1f, spread %+.2f%%)  ns/op %.1f\n",
+	       r->name, (unsigned long long)r->ops,
+	       r->instr_per_op[0], r->instr_per_op[1], r->instr_per_op[2],
+	       avg, 100.0 * (mx - mn) / avg,
+	       1e9 * (r->sec_per_op[0] + r->sec_per_op[1] + r->sec_per_op[2]) / 3.0);
+	fflush(stdout);
+}
+
+// ---- point read -----------------------------------------------------------
+
+// point read: extract the cell value at T[i,i].  This is what
+// Tensor_SetElement / Tensor_RemoveElements / traversal all do first.
+static void bench_point_read(Tensor T, const char *name, uint64_t reps) {
+	Result r = { .name = name, .ops = reps };
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		uint64_t acc = 0;
+		for(uint64_t k = 0; k < reps; k++) {
+			uint64_t x;
+			GrB_Index p = k % N;
+			GrB_Info info = Delta_Matrix_extractElement_UINT64(&x, T, p, p);
+			if(info != GrB_SUCCESS) { fprintf(stderr, "%s: miss at %llu\n", name, (unsigned long long)p); exit(1); }
+			acc += x;
+		}
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		g_sink += acc;
+		r.instr_per_op[rep] = (double)(i1 - i0) / reps;
+		r.sec_per_op[rep]   = (t1 - t0) / reps;
+	}
+	report(&r);
+}
+
+// point read that also materialises the edge id list, i.e. what a traversal
+// actually pays: read the cell, then walk the cell's edges.
+static void bench_point_read_edges(Tensor T, const char *name, uint64_t reps) {
+	Result r = { .name = name, .ops = reps };
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		uint64_t acc = 0;
+		for(uint64_t k = 0; k < reps; k++) {
+			GrB_Index p = k % N;
+			TensorIterator it;
+			TensorIterator_ScanEntry(&it, T, p, p);
+			uint64_t x;
+			while(TensorIterator_next(&it, NULL, NULL, &x, NULL)) acc += x;
+		}
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		g_sink += acc;
+		r.instr_per_op[rep] = (double)(i1 - i0) / reps;
+		r.sec_per_op[rep]   = (t1 - t0) / reps;
+	}
+	report(&r);
+}
+
+// baseline: the same point read straight against the underlying GrB_Matrix M,
+// i.e. without the delta layer's DP / DM probes.
+static void bench_raw_read(Tensor T, const char *name, uint64_t reps) {
+	GrB_Matrix M = Delta_Matrix_M(T);
+	Result r = { .name = name, .ops = reps };
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		uint64_t acc = 0;
+		for(uint64_t k = 0; k < reps; k++) {
+			uint64_t x;
+			GrB_Index p = k % N;
+			GrB_Info info = GrB_Matrix_extractElement_UINT64(&x, M, p, p);
+			if(info != GrB_SUCCESS) { fprintf(stderr, "%s: miss\n", name); exit(1); }
+			acc += x;
+		}
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		g_sink += acc;
+		r.instr_per_op[rep] = (double)(i1 - i0) / reps;
+		r.sec_per_op[rep]   = (t1 - t0) / reps;
+	}
+	report(&r);
+}
+
+// count how many cells are inline scalars vs tagged container pointers
+static void verify_cells(Tensor T, const char *name) {
+	Delta_MatrixTupleIter it;
+	Delta_MatrixTupleIter_attach(&it, T);
+	uint64_t x, scalars = 0, vectors = 0, edges = 0;
+	while(Delta_MatrixTupleIter_next_UINT64(&it, NULL, NULL, &x) == GrB_SUCCESS) {
+		if(SCALAR_ENTRY(x)) { scalars++; edges++; }
+		else {
+			vectors++;
+			GrB_Index nv;
+			GrB_Vector_nvals(&nv, AS_VECTOR(x));
+			edges += nv;
+		}
+	}
+	Delta_MatrixTupleIter_detach(&it);
+	printf("%-46s cells: %llu inline scalar, %llu container, %llu edges total\n",
+	       name, (unsigned long long)scalars, (unsigned long long)vectors,
+	       (unsigned long long)edges);
+	fflush(stdout);
+}
+
+// same census, printed once (first rep only), used to prove which build path
+// ends up with containers
+static void verify_containers_once(Tensor T, int rep, const char *tag) {
+	if(rep != 0) return;
+	char name[80];
+	snprintf(name, sizeof(name), "  [%s result]", tag);
+	verify_cells(T, name);
+}
+
+// ---- full iteration -------------------------------------------------------
+
+static void bench_iterate(Tensor T, const char *name, uint64_t expect_edges,
+                          uint64_t passes) {
+	Result r = { .name = name, .ops = expect_edges * passes };
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		uint64_t seen = 0, acc = 0;
+		for(uint64_t p = 0; p < passes; p++) {
+			TensorIterator it;
+			TensorIterator_ScanRange(&it, T, 0, N, false);
+			uint64_t x;
+			while(TensorIterator_next(&it, NULL, NULL, &x, NULL)) { acc += x; seen++; }
+		}
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		g_sink += acc;
+		if(seen != expect_edges * passes) {
+			fprintf(stderr, "%s: saw %llu edges, expected %llu\n", name,
+			        (unsigned long long)seen, (unsigned long long)(expect_edges * passes));
+			exit(1);
+		}
+		r.instr_per_op[rep] = (double)(i1 - i0) / (expect_edges * passes);
+		r.sec_per_op[rep]   = (t1 - t0) / (expect_edges * passes);
+	}
+	report(&r);
+}
+
+// transposed iteration: TensorIterator_ScanRange with transposed = true walks
+// the backward matrix, so its range selects by destination. The Rust side pays
+// a forward eff_get per incoming pair here (it stores no ids in `mt`); the C
+// side stores the same tagged cells both ways, so this is the row that says
+// what that trade costs relative to a design that duplicates.
+static void bench_iterate_t(Tensor T, const char *name, uint64_t expect_edges,
+                            uint64_t passes) {
+	Result r = { .name = name, .ops = expect_edges * passes };
+	for(int rep = 0; rep < 3; rep++) {
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		uint64_t seen = 0, acc = 0;
+		for(uint64_t p = 0; p < passes; p++) {
+			TensorIterator it;
+			TensorIterator_ScanRange(&it, T, 0, N, true);
+			uint64_t x;
+			while(TensorIterator_next(&it, NULL, NULL, &x, NULL)) { acc += x; seen++; }
+		}
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		g_sink += acc;
+		if(seen != expect_edges * passes) {
+			fprintf(stderr, "%s: saw %llu edges, expected %llu\n", name,
+			        (unsigned long long)seen, (unsigned long long)(expect_edges * passes));
+			exit(1);
+		}
+		r.instr_per_op[rep] = (double)(i1 - i0) / (expect_edges * passes);
+		r.sec_per_op[rep]   = (t1 - t0) / (expect_edges * passes);
+	}
+	report(&r);
+}
+
+// ---- promotion / demotion -------------------------------------------------
+
+// promotion: each measured op inserts a 2nd edge into a single-edge pair,
+// which allocates a GrB_Vector container.  Demotion: removing that edge again
+// frees the container and writes the surviving edge id back inline.
+//
+// promotion and demotion must alternate to keep the tensor in a steady state,
+// so we measure a promote+demote pair and also measure them separately by
+// building fresh single-edge tensors per rep.
+static void bench_promote_demote(uint64_t n) {
+	// --- container cost in isolation: what promotion pays on top of the
+	//     delta-matrix work -- allocate a GrB_Vector, put 2 edge ids in it,
+	//     materialise it, free it
+	{
+		Result rc = { .name = "container only: new+2 set+wait+free", .ops = n };
+		for(int rep = 0; rep < 3; rep++) {
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < n; i++) {
+				GrB_Vector V;
+				GrB_Vector_new(&V, GrB_BOOL, GrB_INDEX_MAX);
+				GrB_Vector_setElement_BOOL(V, true, 2 * i);
+				GrB_Vector_setElement_BOOL(V, true, 2 * i + 1);
+				GrB_wait(V, GrB_MATERIALIZE);
+				GrB_free(&V);
+			}
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rc.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rc.sec_per_op[rep]   = (t1 - t0) / n;
+		}
+		report(&rc);
+	}
+
+	// --- appending one more id to an ALREADY-MATERIALISED container, in
+	//     isolation from any delta-matrix work. This is the GraphBLAS-level
+	//     explanation for why the "add an edge to an already-multi-edge pair"
+	//     control comes out MORE expensive than the promotion it controls for:
+	//     GrB_wait on a vector that already holds entries rebuilds the whole
+	//     vector, whereas a fresh vector's first wait only builds the pendings.
+	for(int have = 2; have <= 4; have += 2) {
+		char name[80];
+		snprintf(name, sizeof(name), "container only: append 1 id to %d-id cntnr", have);
+		Result ra = { .name = name, .ops = n };
+		for(int rep = 0; rep < 3; rep++) {
+			// pre-build the containers so the measured region is only the append
+			GrB_Vector *vs = malloc(n * sizeof(GrB_Vector));
+			for(uint64_t i = 0; i < n; i++) {
+				GrB_Vector_new(&vs[i], GrB_BOOL, GrB_INDEX_MAX);
+				for(int e = 0; e < have; e++)
+					GrB_Vector_setElement_BOOL(vs[i], true, 10 * i + e);
+				GrB_wait(vs[i], GrB_MATERIALIZE);
+			}
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < n; i++) {
+				GrB_Vector_setElement_BOOL(vs[i], true, 10 * i + have);
+				GrB_wait(vs[i], GrB_MATERIALIZE);
+			}
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			ra.instr_per_op[rep] = (double)(i1 - i0) / n;
+			ra.sec_per_op[rep]   = (t1 - t0) / n;
+			for(uint64_t i = 0; i < n; i++) GrB_free(&vs[i]);
+			free(vs);
+		}
+		report(&ra);
+	}
+
+	// --- batch insert of n brand-new inline (single-edge) pairs, the path the
+	//     engine actually uses for bulk creation
+	{
+		Result rb = { .name = "batch insert n new inline pairs (per edge)", .ops = n };
+		GrB_Index *rows = malloc(n * sizeof(GrB_Index));
+		GrB_Index *cols = malloc(n * sizeof(GrB_Index));
+		uint64_t  *vals = malloc(n * sizeof(uint64_t));
+		for(uint64_t i = 0; i < n; i++) { rows[i] = cols[i] = i; vals[i] = i; }
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = Tensor_new(n + 1, n + 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			Tensor_SetElements(T, rows, cols, vals, n);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rb.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rb.sec_per_op[rep]   = (t1 - t0) / n;
+			Tensor_free(&T);
+		}
+		report(&rb);
+		free(rows); free(cols); free(vals);
+	}
+
+	// --- batch promotion: add a 2nd edge to every one of n single-edge pairs
+	{
+		Result rb = { .name = "batch promote n pairs (per promotion)", .ops = n };
+		GrB_Index *rows = malloc(n * sizeof(GrB_Index));
+		GrB_Index *cols = malloc(n * sizeof(GrB_Index));
+		uint64_t  *vals = malloc(n * sizeof(uint64_t));
+		for(uint64_t i = 0; i < n; i++) { rows[i] = cols[i] = i; vals[i] = n + i; }
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = build(n, 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			Tensor_SetElements(T, rows, cols, vals, n);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rb.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rb.sec_per_op[rep]   = (t1 - t0) / n;
+			Tensor_free(&T);
+		}
+		report(&rb);
+		free(rows); free(cols); free(vals);
+	}
+
+	// --- batch demotion: remove the 2nd edge of every one of n 2-edge pairs
+	{
+		Result rb = { .name = "batch demote n pairs (per demotion)", .ops = n };
+		Edge *es = calloc(n, sizeof(Edge));
+		for(uint64_t i = 0; i < n; i++) {
+			es[i].src_id = i; es[i].dest_id = i; es[i].id = 2 * i + 1;
+		}
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = build(n, 2);
+			// Tensor_RemoveElements sorts the range in place; restore each rep
+			for(uint64_t i = 0; i < n; i++) {
+				es[i].src_id = i; es[i].dest_id = i; es[i].id = 2 * i + 1;
+			}
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			Tensor_RemoveElements(T, es, n, NULL);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rb.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rb.sec_per_op[rep]   = (t1 - t0) / n;
+			Tensor_free(&T);
+		}
+		report(&rb);
+		free(es);
+	}
+
+	// --- reference point: inserting brand-new inline edges ONE AT A TIME.
+	//     NOTE: this is O(pending) per call, not constant -- Tensor_SetElement
+	//     reads T[row,col] first, and that read forces GraphBLAS to materialise
+	//     delta-plus's pending tuples, so the i-th insert flushes i tuples.
+	//     Reported per-op numbers therefore grow linearly with n.
+	//     measured at two sizes to expose the linear growth
+	for(uint64_t nn = 1000; nn <= 4000; nn *= 4) {
+		char name[80];
+		snprintf(name, sizeof(name), "insert 1-at-a-time, n=%-5llu (O(n)/op!)",
+		         (unsigned long long)nn);
+		Result ri = { .name = name, .ops = nn };
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = Tensor_new(nn + 1, nn + 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < nn; i++) Tensor_SetElement(T, i, i, i);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			ri.instr_per_op[rep] = (double)(i1 - i0) / nn;
+			ri.sec_per_op[rep]   = (t1 - t0) / nn;
+			Tensor_free(&T);
+		}
+		report(&ri);
+	}
+
+	// --- promotion: fresh all-single-edge tensor per rep, promote every pair
+	{
+		Result rp = { .name = "promote  single->2-edge (alloc container)", .ops = n };
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = build(n, 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < n; i++) Tensor_SetElement(T, i, i, n + i);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rp.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rp.sec_per_op[rep]   = (t1 - t0) / n;
+			Tensor_free(&T);
+		}
+		report(&rp);
+	}
+
+	// --- demotion: fresh all-2-edge tensor per rep, demote every pair
+	{
+		Result rd = { .name = "demote   2-edge->single (free container)", .ops = n };
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = build(n, 2);
+			// remove the 2nd edge of every pair; ids are 2*i and 2*i+1
+			Edge *e = malloc(sizeof(Edge));
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < n; i++) {
+				memset(e, 0, sizeof(Edge));
+				e->src_id  = i;
+				e->dest_id = i;
+				e->id      = 2 * i + 1;
+				Tensor_RemoveElements(T, e, 1, NULL);
+			}
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			rd.instr_per_op[rep] = (double)(i1 - i0) / n;
+			rd.sec_per_op[rep]   = (t1 - t0) / n;
+			free(e);
+			Tensor_free(&T);
+		}
+		report(&rd);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// transition cost vs non-transitioning control on the same code path
+// ---------------------------------------------------------------------------
+
+// helper: one Tensor_SetElements call adding one edge to every pair of a
+// tensor that already has `existing` edges per pair.
+// existing == 1 -> every pair promotes (inline scalar -> container)
+// existing >= 2 -> every pair already has a container, nothing transitions
+static double mean3(const Result *r) {
+	return (r->instr_per_op[0] + r->instr_per_op[1] + r->instr_per_op[2]) / 3.0;
+}
+
+static double bench_add_one_edge(uint64_t n, int existing, const char *name) {
+	Result r = { .name = name, .ops = n };
+	GrB_Index *rows = malloc(n * sizeof(GrB_Index));
+	GrB_Index *cols = malloc(n * sizeof(GrB_Index));
+	uint64_t  *vals = malloc(n * sizeof(uint64_t));
+	for(uint64_t i = 0; i < n; i++) {
+		rows[i] = cols[i] = i;
+		// fresh id, above every id build() handed out
+		vals[i] = (uint64_t)existing * n + i;
+	}
+	for(int rep = 0; rep < 3; rep++) {
+		Tensor T = build(n, existing);
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		Tensor_SetElements(T, rows, cols, vals, n);
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		r.instr_per_op[rep] = (double)(i1 - i0) / n;
+		r.sec_per_op[rep]   = (t1 - t0) / n;
+		Tensor_free(&T);
+	}
+	report(&r);
+	free(rows); free(cols); free(vals);
+	return mean3(&r);
+}
+
+// helper: one Tensor_RemoveElements call removing one edge from every pair of a
+// tensor that has `existing` edges per pair.
+// existing == 2 -> every pair demotes (container -> inline scalar, container freed)
+// existing >= 3 -> id is removed from the container, nothing transitions
+static double bench_remove_one_edge(uint64_t n, int existing, const char *name) {
+	Result r = { .name = name, .ops = n };
+	Edge *es = calloc(n, sizeof(Edge));
+	for(int rep = 0; rep < 3; rep++) {
+		Tensor T = build(n, existing);
+		// build() gives pair i the ids existing*i .. existing*i+existing-1;
+		// drop the last one. Tensor_RemoveElements sorts in place, so refill.
+		for(uint64_t i = 0; i < n; i++) {
+			memset(&es[i], 0, sizeof(Edge));
+			es[i].src_id  = i;
+			es[i].dest_id = i;
+			es[i].id      = (uint64_t)existing * i + (existing - 1);
+		}
+		uint64_t i0 = read_instructions();
+		double  t0  = now_sec();
+		Tensor_RemoveElements(T, es, n, NULL);
+		double t1 = now_sec();
+		uint64_t i1 = read_instructions();
+		r.instr_per_op[rep] = (double)(i1 - i0) / n;
+		r.sec_per_op[rep]   = (t1 - t0) / n;
+		Tensor_free(&T);
+	}
+	report(&r);
+	free(es);
+	return mean3(&r);
+}
+
+// ---------------------------------------------------------------------------
+// batch vs incremental construction of the same final tensor
+// ---------------------------------------------------------------------------
+
+// both variants end with N pairs x 2 edges; the difference is whether the two
+// edges of a pair arrive in the same Tensor_SetElements call.
+static void bench_build_paths(uint64_t n) {
+	GrB_Index *rows = malloc(2 * n * sizeof(GrB_Index));
+	GrB_Index *cols = malloc(2 * n * sizeof(GrB_Index));
+	uint64_t  *vals = malloc(2 * n * sizeof(uint64_t));
+
+	// --- incremental: pass 1 = first edge of every pair, pass 2 = second
+	{
+		Result r = { .name = "build incremental (2 calls) per pair", .ops = n };
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = Tensor_new(n + 1, n + 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			for(uint64_t i = 0; i < n; i++) { rows[i] = cols[i] = i; vals[i] = 2 * i; }
+			Tensor_SetElements(T, rows, cols, vals, n);
+			for(uint64_t i = 0; i < n; i++) { rows[i] = cols[i] = i; vals[i] = 2 * i + 1; }
+			Tensor_SetElements(T, rows, cols, vals, n);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			r.instr_per_op[rep] = (double)(i1 - i0) / n;
+			r.sec_per_op[rep]   = (t1 - t0) / n;
+			verify_containers_once(T, rep, "incremental");
+			Tensor_free(&T);
+		}
+		report(&r);
+	}
+
+	// --- batch: both edges of a pair in one call, adjacent in the array
+	{
+		Result r = { .name = "build batch (1 call, 2N tuples) per pair", .ops = n };
+		for(uint64_t i = 0; i < n; i++) {
+			rows[2*i] = cols[2*i] = i;         vals[2*i]   = 2 * i;
+			rows[2*i+1] = cols[2*i+1] = i;     vals[2*i+1] = 2 * i + 1;
+		}
+		for(int rep = 0; rep < 3; rep++) {
+			Tensor T = Tensor_new(n + 1, n + 1);
+			uint64_t i0 = read_instructions();
+			double  t0  = now_sec();
+			Tensor_SetElements(T, rows, cols, vals, 2 * n);
+			double t1 = now_sec();
+			uint64_t i1 = read_instructions();
+			r.instr_per_op[rep] = (double)(i1 - i0) / n;
+			r.sec_per_op[rep]   = (t1 - t0) / n;
+			verify_containers_once(T, rep, "batch");
+			Tensor_free(&T);
+		}
+		report(&r);
+	}
+
+	free(rows); free(cols); free(vals);
+}
+
+// ---- container size -------------------------------------------------------
+
+// a standalone container holding exactly k edge ids, as the always-materialised
+// design would hold them (including k == 1, which the C tensor never stores)
+static void report_container_size(void) {
+	printf("container: GrB_Vector (struct GB_Vector_opaque), GrB_BOOL, "
+	       "dim GrB_INDEX_MAX, edge id == vector index\n");
+	printf("  %-4s %-16s %-16s %s\n", "ids", "malloc_size(h)", "memoryUsage", "marginal vs k-1");
+	size_t prev = 0;
+	int ks[] = { 0, 1, 2, 4, 8, 16 };
+	for(unsigned t = 0; t < sizeof(ks) / sizeof(ks[0]); t++) {
+		int k = ks[t];
+		GrB_Vector V;
+		GrB_Info info = GrB_Vector_new(&V, GrB_BOOL, GrB_INDEX_MAX);
+		if(info != GrB_SUCCESS) { fprintf(stderr, "vector new failed\n"); exit(1); }
+		for(int i = 0; i < k; i++) GrB_Vector_setElement_BOOL(V, true, 1000 + i);
+		if(k > 0) GrB_wait(V, GrB_MATERIALIZE);
+		size_t mem = 0;
+		GxB_Vector_memoryUsage(&mem, V);
+		printf("  %-4d %-16zu %-16zu %s%zd\n", k, malloc_size(V), mem,
+		       t ? "+" : " ", t ? (ssize_t)(mem - prev) : (ssize_t)0);
+		prev = mem;
+		GrB_free(&V);
+	}
+	fflush(stdout);
+}
+
+// Tensor_memoryUsage for N pairs at k ids per pair.
+// NOTE: k == 1 is stored INLINE by the C tensor (no container at all), so the
+// k == 1 row is not "a container holding one id" -- see the standalone table.
+static void report_space_vs_k(uint64_t n) {
+	printf("\ntensor space, %llu pairs, k edge ids per pair:\n",
+	       (unsigned long long)n);
+	printf("  %-3s %-8s %-14s %-12s %-12s %s\n", "k", "cells", "Tensor_memUsage",
+	       "B/pair", "B/edge", "delta vs k-1 per pair");
+	double prev_per_pair = 0;
+	int ks[] = { 1, 2, 4, 8 };
+	for(unsigned t = 0; t < sizeof(ks) / sizeof(ks[0]); t++) {
+		int k = ks[t];
+		Tensor T = build(n, k);
+		size_t sz = 0;
+		Tensor_memoryUsage(&sz, T);
+		double per_pair = (double)sz / n;
+		printf("  %-3d %-8s %-14zu %-12.2f %-12.2f %s\n", k,
+		       k == 1 ? "inline" : "cntnr", sz, per_pair, (double)sz / (n * k),
+		       t == 0 ? "-" : "");
+		if(t > 0) {
+			printf("      %+.2f B/pair vs k=%d  (%+.2f B per added id)\n",
+			       per_pair - prev_per_pair, ks[t-1],
+			       (per_pair - prev_per_pair) / (k - ks[t-1]));
+		}
+		prev_per_pair = per_pair;
+		Tensor_free(&T);
+	}
+	fflush(stdout);
+}
+
+int main(int argc, char **argv) {
+	if(argc > 1) N = strtoull(argv[1], NULL, 10);
+	uint64_t reps = 1000000;
+	if(argc > 2) reps = strtoull(argv[2], NULL, 10);
+
+	// same init sequence as tests/unit/test_delta_matrix.c setup()
+	Alloc_Reset();  // route rm_malloc & friends to libc malloc
+
+	GrB_Info info = GrB_init(GrB_NONBLOCKING);
+	if(info != GrB_SUCCESS) { fprintf(stderr, "GrB_init failed %d\n", info); return 1; }
+	GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW);
+	Config_Option_set(Config_DELTA_MAX_PENDING_CHANGES, "10000", NULL);
+
+	printf("GraphBLAS %d.%d.%d, N=%llu pairs, reps=%llu\n",
+	       GxB_IMPLEMENTATION_MAJOR, GxB_IMPLEMENTATION_MINOR,
+	       GxB_IMPLEMENTATION_SUB, (unsigned long long)N,
+	       (unsigned long long)reps);
+
+	report_container_size();
+
+	Tensor T1 = build(N, 1);
+	Tensor T2 = build(N, 2);
+
+	size_t sz1 = 0, sz2 = 0;
+	Tensor_memoryUsage(&sz1, T1);
+	Tensor_memoryUsage(&sz2, T2);
+	printf("tensor memoryUsage: %llu single-edge pairs = %zu bytes (%.1f B/edge)\n",
+	       (unsigned long long)N, sz1, (double)sz1 / N);
+	printf("tensor memoryUsage: %llu 2-edge pairs      = %zu bytes (%.1f B/edge)\n",
+	       (unsigned long long)N, sz2, (double)sz2 / (2 * N));
+	verify_cells(T1, "T1 (1 edge/pair)");
+	verify_cells(T2, "T2 (2 edges/pair)");
+	printf("\n");
+
+	bench_raw_read(T1, "raw GrB_Matrix read of M, single-edge", reps);
+	bench_point_read(T1, "point read cell, single-edge (inline)", reps);
+	bench_point_read(T2, "point read cell, 2-edge (tagged ptr)", reps);
+	bench_point_read_edges(T1, "point read + edge ids, single-edge", reps);
+	bench_point_read_edges(T2, "point read + edge ids, 2-edge", reps);
+
+	uint64_t passes = (reps / N) ? (reps / N) : 1;
+	bench_iterate(T1, "full iteration, all single-edge  (per edge)", N, passes);
+	bench_iterate(T2, "full iteration, all 2-edge       (per edge)", 2 * N, passes);
+
+	bench_iterate_t(T1, "transposed iteration, single-edge (per edge)", N, passes);
+	bench_iterate_t(T2, "transposed iteration, 2-edge     (per edge)", 2 * N, passes);
+
+	Tensor_free(&T1);
+	Tensor_free(&T2);
+
+	//--------------------------------------------------------------------------
+	// fan-out: how reads and iteration scale past k = 2, which the paper listed
+	// as unmeasured on this side.
+	//--------------------------------------------------------------------------
+	printf("\n-- fan-out: k edge ids per pair --\n");
+	for(uint64_t k = 1; k <= 16; k *= 2) {
+		Tensor Tk = build(N, k);
+		char nm1[128], nm2[128], nm3[128];
+		snprintf(nm1, sizeof nm1, "point read + all ids, k=%-2llu", (unsigned long long)k);
+		snprintf(nm2, sizeof nm2, "full iteration (per edge), k=%-2llu", (unsigned long long)k);
+		snprintf(nm3, sizeof nm3, "transposed iteration (per edge), k=%-2llu", (unsigned long long)k);
+		bench_point_read_edges(Tk, nm1, reps);
+		uint64_t pk = (reps / (N * k)) ? (reps / (N * k)) : 1;
+		bench_iterate(Tk, nm2, N * k, pk);
+		bench_iterate_t(Tk, nm3, N * k, pk);
+		Tensor_free(&Tk);
+	}
+
+	bench_promote_demote(N);
+
+	//--------------------------------------------------------------------------
+	// transition vs non-transitioning control on the same code path
+	//--------------------------------------------------------------------------
+	printf("\n-- transition vs non-transitioning control (same entry point) --\n");
+	double promote = bench_add_one_edge(N, 1,
+			"promote   +1 edge on 1-edge pairs (transitions)");
+	double add3    = bench_add_one_edge(N, 2,
+			"control   +1 edge on 2-edge pairs (no transition)");
+	printf("  => promotion cost = %.1f - %.1f = %+.1f instr/pair (LOWER BOUND:\n"
+	       "     the control's containers already hold 2N ids when measured,\n"
+	       "     while the promote pass starts with none)\n",
+	       promote, add3, promote - add3);
+
+	double demote = bench_remove_one_edge(N, 2,
+			"demote    -1 edge on 2-edge pairs (transitions)");
+	double rem3   = bench_remove_one_edge(N, 3,
+			"control   -1 edge on 3-edge pairs (no transition)");
+	printf("  => demotion cost = %.1f - %.1f = %+.1f instr/pair (same lower-bound\n"
+	       "     caveat: the control's containers are larger when measured)\n",
+	       demote, rem3, demote - rem3);
+
+	//--------------------------------------------------------------------------
+	// batch vs incremental construction of the same final tensor
+	//--------------------------------------------------------------------------
+	printf("\n-- building the same N x 2-edge tensor two ways --\n");
+	bench_build_paths(N);
+
+	//--------------------------------------------------------------------------
+	// space as a function of ids per pair
+	//--------------------------------------------------------------------------
+	report_space_vs_k(N);
+
+	printf("\nsink=%llu\n", (unsigned long long)g_sink);
+	return 0;
+}


### PR DESCRIPTION
Closes #2564.

**Stacked on #2565** — review that first; this PR's own diff is the `bench/studies/edge_storage/` directory.

The paper measures the two multi-edge storage designs as *structures* rather than as engines, and only half of that was reproducible: (C)'s side is `tensor_cost_bench.rs` in the tree, while (A)'s was a standalone C harness living on a local branch. So every (A) column in §evalboundary and §evalfanout was measured but not checkable by a reader.

## What it does

`build.sh` compiles **only** `tensor_bench.c` and links `libfalkordb_static.a`, so what is measured is the shipped implementation rather than a recompilation of it — 323 of the archive's 392 members link in, with no stubbed symbols.

Both inputs that live outside this tree are overridable rather than hardcoded to one machine's scratch paths:

```sh
git worktree add /tmp/cmaster master
SRC=/tmp/cmaster BIN=$PWD/bin/macos-arm64v8-release ./build.sh
OMP_NUM_THREADS=1 ./tensor_bench
```

with defaults for a macOS arm64 checkout, and an explicit failure naming the missing input when either is wrong. Verified from clean env vars.

## Why it should not live on one laptop

Every time the two grains were compared, the engine-level one was wrong in the same direction. It overstated the multi-edge entry charge by 1.6× for (C) and 5.1× for (A), and the per-identifier slope by 3.6× and 26× — the latter by enough to **invert** which design walks a multi-edge row more cheaply. The harness that measures the structure is what caught that.

## Caveats, carried in the README

Separate processes so wall clock is not comparable across sides; GraphBLAS versions not aligned (10.4.0 here against the Rust side's 10.5.0, with the `k ≤ 2` rows reproducing the paper to 1%, so the minor version is not what moves them); every read warm and sequential.

Build artifacts are gitignored. Nothing here runs in CI.
