### PR TITLE
diag(#2430): the two states are not edge storage — by magnitude and by shape

### DIFF
--- a/bench/studies/issue_2430/README.md
+++ b/bench/studies/issue_2430/README.md
@@ -1,0 +1,47 @@
+# Issue #2430: the two-state multi-edge point read
+
+A bound multi-edge point read lands in one of two cost states, selected by graph
+size. Three hypotheses are refuted in the issue itself (scaling with `|me|`, more
+ids walked, a latched-but-unflushed delta). This directory narrows what is left.
+
+Two measurements, deliberately at different grains:
+
+| | what it runs | result |
+| --- | --- | --- |
+| `engine_two_states.py` | the whole query, per pair | 8,725 → 9,943 instructions: a **step** of ~1,150 between 41k and 88k pairs |
+| `graph/.../issue_2430_bench.rs` | the same read with no pipeline around it | 2,771 → 2,879: a **smooth drift** of ~108 across the same range |
+
+**The fixture detail both depend on.** Node count is held at 1,000 while pairs
+grow, so a bigger graph means *longer adjacency rows*, not more of them. An
+earlier version of the Rust bench gave every pair its own row — holding row
+length at 1 at every size — and so measured a perfectly flat cost and wrongly
+cleared edge storage outright. Row length is exactly the variable a point read
+can be sensitive to, since `GrB_Matrix_extractElement` searches within a row.
+
+## What this establishes
+
+Edge storage is **not** where the two states come from, on two independent
+grounds:
+
+1. **Magnitude.** The tensor's contribution across the whole range is ~108
+   instructions; the engine-level effect is ~1,150. Edge storage accounts for at
+   most a tenth of it.
+2. **Shape.** The tensor's cost *drifts* smoothly and roughly logarithmically —
+   which is what a binary search inside a lengthening row should do. The
+   engine-level cost *steps*. A drift cannot produce a step.
+
+And the storage format is constant throughout — `m` sparse, `dp`/`dm`/`me`
+hypersparse at every size — so a GraphBLAS format switch is not the cause either.
+That was the leading remaining hypothesis and it is now refuted.
+
+## What is still open
+
+Which pipeline stage steps, and why the selection is not monotonic in graph size
+(the issue reports low/high/low/high/high; this fixture reproduces a single
+crossing, so the non-monotonicity is fixture-sensitive and worth pinning down).
+The tensor can be excluded from that search.
+
+Run both:
+
+    python3 bench/studies/issue_2430/engine_two_states.py target/release/libfalkordb.dylib 6650
+    cargo test --release -p graph issue_2430 -- --ignored --nocapture --test-threads=1

--- a/bench/studies/issue_2430/engine_two_states.py
+++ b/bench/studies/issue_2430/engine_two_states.py
@@ -1,0 +1,58 @@
+"""Reproduce #2430's two cost states at engine level.
+
+The issue reports a bound multi-edge point read landing in one of two cost
+states, selected by graph size. This is the engine-level half of the diagnosis;
+the structure-level half is `issue_2430_bench.rs`, and the point of running both
+is that they disagree about the *shape* of the effect.
+
+The fixture detail that matters: node count is held at 1,000 while the pair count
+grows, so a bigger graph means **longer adjacency rows**, not more of them. That
+is the variable a point read can be sensitive to, since
+`GrB_Matrix_extractElement` searches within a row.
+
+Usage:
+    python3 engine_two_states.py <path-to-module> <port>
+"""
+import sys, json
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from falkorbench import client as bc
+from falkorbench.counters import read_rusage
+
+MOD = Path(sys.argv[1]); PORT = int(sys.argv[2])
+work = Path("/tmp/i2430"); work.mkdir(parents=True, exist_ok=True)
+PROBE = 1000
+
+def build(cl, pairs):
+    cl.run("UNWIND range(0, 999) AS i CREATE (:N {id:i})")
+    # `PROBE` two-edge pairs, then single-edge pairs out to `pairs`
+    cl.run(f"MATCH (n:N) WITH collect(n) AS ns UNWIND range(0,{PROBE-1}) AS i "
+           f"WITH ns,i,ns[i%1000] AS a, ns[(i+1)%1000] AS b "
+           f"UNWIND [1,2] AS r CREATE (a)-[:R {{k:i}}]->(b)")
+    if pairs > PROBE:
+        for lo in range(PROBE, pairs, 20000):
+            hi = min(lo+20000, pairs)
+            cl.run(f"MATCH (n:N) WITH collect(n) AS ns UNWIND range({lo},{hi-1}) AS i "
+                   f"WITH ns,i,ns[i%1000] AS a, ns[(i*7+3)%1000] AS b "
+                   f"CREATE (a)-[:R {{k:i}}]->(b)")
+
+Q = (f"MATCH (n:N) WITH collect(n) AS ns UNWIND range(0,{PROBE-1}) AS i "
+     f"WITH ns,i,ns[i%1000] AS a, ns[(i+1)%1000] AS b "
+     f"MATCH (a)-[r:R]->(b) RETURN count(r)")
+
+out=[]
+for pairs in [1000, 11000, 41000, 88000, 121000]:
+    srv = bc.start_server(MOD, PORT, work/"srv", work/"imp")
+    try:
+        cl = bc.connect(srv)
+        build(cl, pairs)
+        for _ in range(3): cl.run(Q, write=False)
+        r0 = read_rusage(cl.pid)
+        for _ in range(20): cl.run(Q, write=False)
+        r1 = read_rusage(cl.pid)
+        per = (r1.instructions - r0.instructions)/(20*PROBE)
+        out.append({"pairs":pairs,"instr_per_pair":round(per,1)})
+        print(json.dumps(out[-1]), flush=True)
+        cl.shutdown()
+    finally:
+        srv.stop()

--- a/graph/src/graph/graphblas/issue_2430_bench.rs
+++ b/graph/src/graph/graphblas/issue_2430_bench.rs
@@ -1,0 +1,180 @@
+//! Diagnosis for FalkorDB issue #2430: the two-state multi-edge point read.
+//!
+//! A bound multi-edge point read lands in one of two cost states — about 4.35k
+//! or about 5.5k instructions per pair — selected *non-monotonically* by graph
+//! size, crossing at least twice between 1,000 and 121,000 populated pairs.
+//! Three hypotheses are refuted in the issue: it is not the sentinel charge
+//! scaling with `|me|` (flat across a 41x change), not walking more ids (`k` is
+//! pinned at 2), and not a lingering delta a read latches but never flushes.
+//!
+//! Two candidates remain, and this file is the cheap way to separate them.
+//!
+//! 1. **A GraphBLAS storage-format or capacity threshold.** Matrix dimensions
+//!    step with node capacity, and sparse/hypersparse selection depends on the
+//!    ratio of populated vectors to dimension, so the same logical read can land
+//!    on a different kernel either side of a switch. [`issue_2430_sparsity`]
+//!    prints the format of every matrix on the read path across the sizes where
+//!    the engine-level cost is known to flip.
+//!
+//! 2. **Something outside edge storage entirely.** The boundary measurements say
+//!    a sentinel read is a *flat* cost — 2,684 instructions at `k = 2` and the
+//!    same at `k = 16`, and flat across `|me|`. If the two states do not
+//!    reproduce with no query pipeline around the read, the defect is not in the
+//!    tensor and the issue belongs to whoever owns the pipeline.
+//!    [`issue_2430_boundary`] is that reproduction.
+//!
+//! Run with:
+//!   cargo test --release -p graph issue_2430 -- --ignored --nocapture --test-threads=1
+
+use std::time::Instant;
+
+use super::tensor::Tensor;
+use super::test_init::ensure_init;
+
+/// Instruction counter, same `proc_pid_rusage` backend as the other benches.
+#[cfg(target_os = "macos")]
+fn read_instr() -> Option<u64> {
+    use std::os::raw::{c_int, c_void};
+    unsafe extern "C" {
+        fn proc_pid_rusage(
+            pid: c_int,
+            flavor: c_int,
+            buffer: *mut c_void,
+        ) -> c_int;
+        fn getpid() -> c_int;
+    }
+    let mut buf = [0u8; 512];
+    let rc = unsafe { proc_pid_rusage(unsafe { getpid() }, 4, buf.as_mut_ptr().cast()) };
+    if rc != 0 {
+        return None;
+    }
+    let off = 16 + 29 * 8;
+    Some(u64::from_le_bytes(buf[off..off + 8].try_into().unwrap()))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_instr() -> Option<u64> {
+    None
+}
+
+/// The issue's fixture, and the detail that matters: **rows are held at
+/// `ROWS`** while the pair count grows, so a bigger graph means *longer rows*,
+/// not more of them. An earlier version of this file gave every pair its own row
+/// and so held row length at 1 at every size — which is why it saw a flat cost
+/// and wrongly cleared edge storage. `GrB_Matrix_extractElement` searches within
+/// a row, so row length is exactly the variable a point read can be sensitive
+/// to.
+///
+/// The first `multi` pairs of row 0.. are two-edge and are the ones read.
+const ROWS: u64 = 1_000;
+
+fn built(
+    pairs: u64,
+    multi: u64,
+) -> Tensor {
+    let mut t = Tensor::new(ROWS + 2, ROWS + 2);
+    let (mut srcs, mut dsts, mut ids) = (Vec::new(), Vec::new(), Vec::new());
+    let mut next = 0u64;
+    for i in 0..pairs {
+        // spread over ROWS rows: row length grows as `pairs` does
+        let (s, d) = if i < multi {
+            (i % ROWS, (i + 1) % ROWS)
+        } else {
+            (i % ROWS, (i * 7 + 3) % ROWS)
+        };
+        let k = if i < multi { 2 } else { 1 };
+        for _ in 0..k {
+            srcs.push(s);
+            dsts.push(d);
+            ids.push(next);
+            next += 1;
+        }
+    }
+    t.set_all_from_slices(&srcs, &dsts, &ids);
+    let mut t = t.dup();
+    t.flush();
+    t.wait();
+    t
+}
+
+const PROBES: u64 = 1_000;
+const REPS: u64 = 20;
+
+fn probe_cost(t: &Tensor) -> (f64, f64) {
+    // warm
+    for i in 0..PROBES {
+        std::hint::black_box(t.get(i % ROWS, (i + 1) % ROWS).count());
+    }
+    let i0 = read_instr();
+    let t0 = Instant::now();
+    let mut acc = 0usize;
+    for _ in 0..REPS {
+        for i in 0..PROBES {
+            acc += t.get(i % ROWS, (i + 1) % ROWS).count();
+        }
+    }
+    let el = t0.elapsed();
+    let i1 = read_instr();
+    std::hint::black_box(acc);
+    let n = (PROBES * REPS) as f64;
+    (
+        match (i0, i1) {
+            (Some(a), Some(b)) => (b - a) as f64 / n,
+            _ => f64::NAN,
+        },
+        el.as_secs_f64() * 1e9 / n,
+    )
+}
+
+/// **Candidate 1**: print every read-path matrix's storage format across the
+/// sizes where the engine-level cost is known to flip, alongside the cost.
+///
+/// If a format column changes exactly where the cost changes, that is the cause.
+/// If every format is constant while the cost flips, candidate 1 is refuted and
+/// the answer is candidate 2.
+#[test]
+#[ignore]
+fn issue_2430_sparsity() {
+    ensure_init();
+    println!("\n=== #2430: read cost vs storage format (1,000 two-edge pairs read throughout) ===",);
+    println!(
+        "{:>10}  {:>10}  {:>9}  {:>12}  {:>12}  {:>12}  {:>12}",
+        "pairs", "instr/pair", "ns/pair", "m", "dp", "dm", "me(base)"
+    );
+    for pairs in [1_000u64, 11_000, 41_000, 88_000, 121_000, 160_000] {
+        let t = built(pairs, PROBES.min(pairs));
+        let (instr, ns) = probe_cost(&t);
+        println!(
+            "{:>10}  {:>10.1}  {:>9.1}  {:>12}  {:>12}  {:>12}  {:>12}",
+            pairs,
+            instr,
+            ns,
+            t.fwd_m().sparsity_status(),
+            t.fwd_dp().sparsity_status(),
+            t.fwd_dm().sparsity_status(),
+            t.edge_versioned().m().sparsity_status(),
+        );
+    }
+}
+
+/// **Candidate 2**: the same read with no query pipeline around it, at the same
+/// sizes. The boundary says a sentinel read is flat; if it is flat here too
+/// while the engine-level number flips, the defect is outside edge storage.
+#[test]
+#[ignore]
+fn issue_2430_boundary() {
+    ensure_init();
+    println!("\n=== #2430: the same read at the data-structure boundary ===");
+    println!("{:>10}  {:>12}  {:>10}", "pairs", "instr/pair", "ns/pair");
+    for pairs in [1_000u64, 11_000, 41_000, 88_000, 121_000, 160_000] {
+        let t = built(pairs, PROBES.min(pairs));
+        let mut best = f64::MAX;
+        let mut bns = f64::MAX;
+        for _ in 0..3 {
+            let (i, n) = probe_cost(&t);
+            best = best.min(i);
+            bns = bns.min(n);
+        }
+        println!("{:>10}  {:>12.1}  {:>10.1}", pairs, best, bns);
+    }
+}

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -70,6 +70,8 @@
 
 #[cfg(test)]
 mod fold_cost_bench;
+#[cfg(test)]
+mod issue_2430_bench;
 pub mod lagraph_bindings;
 pub mod lagraphx_bindings;
 pub mod matrix;


### PR DESCRIPTION
Closes #2567. Follow-up to #2430.

**Stacked on #2566** (which is stacked on #2565) — this PR's own diff is `bench/studies/issue_2430/` plus `issue_2430_bench.rs`.

#2430 reports a bound multi-edge point read landing in one of two cost states, selected by graph size. The issue already refutes three hypotheses; this narrows what is left, with a measurement at each grain.

| grain | 1,000 pairs | 121k–160k pairs | shape |
| --- | --- | --- | --- |
| whole query (`engine_two_states.py`) | 8,725 | 9,943 | **step** of ~1,150 between 41k and 88k |
| the read alone (`issue_2430_bench.rs`) | 2,771 | 2,879 | **drift** of ~108, roughly logarithmic |

The two states still reproduce on `main`.

## Edge storage is not the cause

Two independent grounds:

1. **Magnitude** — the tensor contributes at most a tenth of the effect.
2. **Shape** — the tensor's cost drifts smoothly and roughly logarithmically, which is what a binary search inside a lengthening row should do. The engine-level cost *steps*. A drift cannot produce a step.

Storage format is constant throughout (`m` sparse, `dp`/`dm`/`me` hypersparse at every size), which refutes the leading remaining hypothesis — a GraphBLAS format switch.

## The fixture detail that makes this trustworthy, and that I got wrong first

Node count is held at 1,000 while pairs grow, so a bigger graph means *longer adjacency rows*, not more of them. An earlier version of this bench gave every pair its own row — pinning row length at 1 at every size — and so measured a perfectly flat 2,769 and cleared edge storage outright. **That was an artifact of the fixture, not a result.** Row length is exactly the variable a point read is sensitive to, since `GrB_Matrix_extractElement` searches within a row, and the corrected fixture does show the tensor responding to it — just far too little, and in the wrong shape, to be the effect under investigation.

The conclusion survived; the evidence for it did not. Both are recorded.

## Still open

Which pipeline stage steps, and why the selection is not monotonic in graph size — the issue reports low/high/low/high/high, while this fixture reproduces a single crossing, so the non-monotonicity is fixture-sensitive and worth pinning down. The tensor can be excluded from that search.

## Verification

160 passed, 0 failed; `cargo fmt --check` clean. Both benches are `#[ignore]`d / standalone, so nothing runs in CI.
