### PR TITLE
fix(#2430): skip a delta layer a single-row read cannot touch

### DIFF
--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -1491,7 +1491,9 @@ impl<E: IterExtract> Drop for Iter<E> {
                 // debug_assert: don't panic in Drop (see Matrix::drop above).
                 debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
             }
-            GxB_Iterator_free(&raw mut self.inner);
+            if !self.inner.is_null() {
+                GxB_Iterator_free(&raw mut self.inner);
+            }
         }
     }
 }
@@ -1509,6 +1511,37 @@ impl<E: IterExtract> Iter<E> {
         min_row: u64,
         max_row: u64,
     ) -> Self {
+        let mut it = Self::detached(m);
+        it.seek(min_row, max_row);
+        it
+    }
+
+    /// An iterator over `m` with no `GxB_Iterator` behind it yet: it yields
+    /// nothing until [`Self::seek`] attaches one.
+    ///
+    /// `GxB_Iterator_new` + `GxB_rowIterator_attach` + the matching free cost
+    /// about 1,700 instructions, which is most of what a single-row scan of a
+    /// small matrix pays. A caller that has established the range holds no
+    /// entry can skip all of it and still hand back a real iterator — one that
+    /// attaches if it is ever re-seeked somewhere the answer differs, so
+    /// skipping stays an optimisation rather than a promise the caller has to
+    /// keep.
+    #[must_use]
+    pub fn detached<T>(m: &Matrix<T>) -> Self {
+        Self {
+            m: m.m.clone(),
+            inner: null_mut(),
+            depleted: true,
+            max_row: 0,
+            _extract: PhantomData,
+        }
+    }
+
+    /// Attach the GraphBLAS iterator if this is still detached.
+    fn attach(&mut self) {
+        if !self.inner.is_null() {
+            return;
+        }
         unsafe {
             let mut iter = MaybeUninit::uninit();
             let info = GxB_Iterator_new(iter.as_mut_ptr());
@@ -1518,25 +1551,9 @@ impl<E: IterExtract> Iter<E> {
                 "GxB_Iterator_new failed: {info:?}"
             );
             let iter = iter.assume_init();
-            let info = GxB_rowIterator_attach(iter, *m.m, null_mut());
+            let info = GxB_rowIterator_attach(iter, *self.m, null_mut());
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
-            let mut info = GxB_rowIterator_seekRow(iter, min_row);
-            debug_assert!(
-                info == GrB_Info::GrB_SUCCESS
-                    || info == GrB_Info::GrB_NO_VALUE
-                    || info == GrB_Info::GxB_EXHAUSTED
-            );
-            while info == GrB_Info::GrB_NO_VALUE && GxB_rowIterator_getRowIndex(iter) < max_row {
-                info = GxB_rowIterator_nextRow(iter);
-            }
-            Self {
-                m: m.m.clone(),
-                inner: iter,
-                depleted: info != GrB_Info::GrB_SUCCESS
-                    || GxB_rowIterator_getRowIndex(iter) > max_row,
-                max_row,
-                _extract: PhantomData,
-            }
+            self.inner = iter;
         }
     }
 }
@@ -1551,6 +1568,7 @@ impl<E: IterExtract> Iter<E> {
         min_row: u64,
         max_row: u64,
     ) {
+        self.attach();
         unsafe {
             let mut info = GxB_rowIterator_seekRow(self.inner, min_row);
             debug_assert!(

--- a/graph/src/graph/graphblas/me_delta_bench.rs
+++ b/graph/src/graph/graphblas/me_delta_bench.rs
@@ -1,0 +1,173 @@
+//! #2430: a multi-edge point read costs ~1,200 extra instructions whenever
+//! `me`'s delta-plus is non-empty, however little it holds.
+//!
+//! The issue reports point-read cost occupying two discrete states, selected by
+//! graph size in a way that is not monotonic in size. The cause is that `me` is
+//! a three-layer [`VersionedMatrix`] and reading a row builds a merge over all
+//! three; the layer-empty short-circuit in `Iter::from_layers` is *global* — it
+//! asks whether the delta holds anything at all, not whether it holds anything
+//! in the row being read. So one pending identifier anywhere in `me` puts every
+//! multi-edge read in the high state, and which state a graph is in is decided
+//! by where the fold policy last fired relative to the final write, which is not
+//! a function of size.
+//!
+//! [`me_delta_step`] is the repro: the same tensor, the same rows, read with
+//! `me.dp` empty and then with a single pending identifier on a pair the probes
+//! never touch. Before the row filter that step was **+1,275 instructions per
+//! read**; with it, +102.
+//!
+//! [`me_delta_attach_vs_seek`] decomposes the step, and is why the fix skips the
+//! `GxB_Iterator` rather than skipping the merge: on this fixture a fresh
+//! iterator per read costs 2,310 where one re-seeked costs 638, so attaching is
+//! most of what a narrow scan pays, and a delta that adds a second attach is
+//! most of what #2430 reports. **That decomposition also names a larger cost
+//! this fix does not address**: `Tensor::get` builds a fresh merge per call, so
+//! every multi-edge point read pays ~1,670 instructions of attach whether or not
+//! a delta exists. Removing that means giving the hot callers a reusable cursor,
+//! which is an API change and a separate piece of work.
+//!
+//! Run with:
+//!   cargo test --release -p graph me_delta -- --ignored --nocapture --test-threads=1
+
+use super::instr::read_instr;
+use super::tensor::Tensor;
+use super::test_init::ensure_init;
+
+/// Pairs in the fixture. Large enough that the per-read cost dominates the loop
+/// and small enough to stay in cache, so the step is not confounded by misses.
+const PAIRS: u64 = 100_000;
+
+/// Reads per measured block.
+const READS: u64 = 200_000;
+
+fn per_op<F: FnMut()>(
+    ops: u64,
+    mut f: F,
+) -> f64 {
+    let a = read_instr();
+    f();
+    let b = read_instr();
+    match (a, b) {
+        (Some(a), Some(b)) => (b - a) as f64 / ops as f64,
+        _ => f64::NAN,
+    }
+}
+
+/// `PAIRS` two-edge pairs on the diagonal, committed: `me` holds `2 * PAIRS`
+/// identifiers in its base and nothing in either delta.
+fn committed_multi() -> Tensor {
+    let mut t = Tensor::new(PAIRS + 1, PAIRS + 1);
+    let (mut s, mut d, mut i) = (Vec::new(), Vec::new(), Vec::new());
+    for p in 0..PAIRS {
+        for e in 0..2 {
+            s.push(p);
+            d.push(p);
+            i.push(p * 2 + e);
+        }
+    }
+    t.set_all_from_slices(&s, &d, &i);
+    let mut t = t.dup();
+    t.flush();
+    t.wait();
+    assert_eq!(t.edge_versioned().dp().nvals(), 0, "fixture starts clean");
+    t
+}
+
+/// **The repro.** One pending identifier in `me.dp`, on a pair no probe reads,
+/// and every multi-edge read gets dearer.
+#[test]
+#[ignore]
+fn me_delta_step() {
+    ensure_init();
+    let mut t = committed_multi();
+    println!("\n=== multi-edge point read, {PAIRS} pairs x 2 edges ===");
+    println!("{:>34}  {:>10}  {:>12}", "state", "|me.dp|", "instr/read");
+
+    let probe = |t: &Tensor| {
+        per_op(READS, || {
+            let mut acc = 0u64;
+            for r in 0..READS {
+                let p = r % PAIRS;
+                for id in t.get(p, p) {
+                    acc = acc.wrapping_add(id);
+                }
+            }
+            std::hint::black_box(acc);
+        })
+    };
+
+    for _ in 0..3 {
+        println!(
+            "{:>34}  {:>10}  {:>12.1}",
+            "committed, delta empty",
+            t.edge_versioned().dp().nvals(),
+            probe(&t)
+        );
+    }
+
+    // One extra identifier on the *last* pair. The probes above read pairs
+    // `0..PAIRS` in order and every one of them is already multi-edge, so this
+    // changes what any of them holds by nothing — only whether `me.dp` is empty.
+    t.set_all_from_slices(&[PAIRS - 1], &[PAIRS - 1], &[u64::from(u32::MAX)]);
+    t.wait();
+    assert_eq!(
+        t.edge_versioned().dp().nvals(),
+        1,
+        "expected exactly one pending id"
+    );
+
+    for _ in 0..3 {
+        println!(
+            "{:>34}  {:>10}  {:>12.1}",
+            "one pending id in me.dp",
+            t.edge_versioned().dp().nvals(),
+            probe(&t)
+        );
+    }
+}
+
+/// Where the step goes. `Tensor::get` builds a fresh three-layer merge per call,
+/// so a non-empty delta adds one `GxB_Iterator` attach *and* one seek per read.
+/// The fix is different depending on which dominates: a cheap "is this row in
+/// the delta at all" test removes both, but reusing an attached iterator removes
+/// only the attach.
+#[test]
+#[ignore]
+fn me_delta_attach_vs_seek() {
+    ensure_init();
+    println!("\n=== where a non-empty me.dp spends its instructions ===");
+    println!("{:>34}  {:>10}  {:>12}", "operation", "|me.dp|", "instr/op");
+
+    let mut t = committed_multi();
+    for round in 0..2 {
+        let me = t.edge_versioned();
+        let n = me.dp().nvals();
+
+        for _ in 0..3 {
+            let c = per_op(READS, || {
+                for r in 0..READS {
+                    let k = super::tensor::compound_key(r % PAIRS, r % PAIRS);
+                    std::hint::black_box(me.iter(k, k).count());
+                }
+            });
+            println!("{:>34}  {:>10}  {:>12.1}", "fresh me.iter per read", n, c);
+        }
+
+        for _ in 0..3 {
+            let mut it = me.iter(0, 0);
+            let c = per_op(READS, || {
+                for r in 0..READS {
+                    let k = super::tensor::compound_key(r % PAIRS, r % PAIRS);
+                    it.seek(k, k);
+                    std::hint::black_box(it.by_ref().count());
+                }
+            });
+            println!("{:>34}  {:>10}  {:>12.1}", "one iterator, re-seeked", n, c);
+        }
+
+        if round == 0 {
+            t.set_all_from_slices(&[PAIRS - 1], &[PAIRS - 1], &[u64::from(u32::MAX)]);
+            t.wait();
+        }
+    }
+}

--- a/graph/src/graph/graphblas/me_delta_bench.rs
+++ b/graph/src/graph/graphblas/me_delta_bench.rs
@@ -69,7 +69,11 @@ fn committed_multi() -> Tensor {
     let mut t = t.dup();
     t.flush();
     t.wait();
-    assert_eq!(t.edge_versioned().dp().nvals(), 0, "fixture starts clean");
+    assert_eq!(
+        t.edge_versioned_block_0().dp().nvals(),
+        0,
+        "fixture starts clean"
+    );
     t
 }
 
@@ -100,7 +104,7 @@ fn me_delta_step() {
         println!(
             "{:>34}  {:>10}  {:>12.1}",
             "committed, delta empty",
-            t.edge_versioned().dp().nvals(),
+            t.edge_versioned_block_0().dp().nvals(),
             probe(&t)
         );
     }
@@ -111,7 +115,7 @@ fn me_delta_step() {
     t.set_all_from_slices(&[PAIRS - 1], &[PAIRS - 1], &[u64::from(u32::MAX)]);
     t.wait();
     assert_eq!(
-        t.edge_versioned().dp().nvals(),
+        t.edge_versioned_block_0().dp().nvals(),
         1,
         "expected exactly one pending id"
     );
@@ -120,7 +124,7 @@ fn me_delta_step() {
         println!(
             "{:>34}  {:>10}  {:>12.1}",
             "one pending id in me.dp",
-            t.edge_versioned().dp().nvals(),
+            t.edge_versioned_block_0().dp().nvals(),
             probe(&t)
         );
     }
@@ -140,13 +144,13 @@ fn me_delta_attach_vs_seek() {
 
     let mut t = committed_multi();
     for round in 0..2 {
-        let me = t.edge_versioned();
+        let me = t.edge_versioned_block_0();
         let n = me.dp().nvals();
 
         for _ in 0..3 {
             let c = per_op(READS, || {
                 for r in 0..READS {
-                    let k = super::tensor::compound_key(r % PAIRS, r % PAIRS);
+                    let (_, k) = super::tensor::compound_key(r % PAIRS, r % PAIRS);
                     std::hint::black_box(me.iter(k, k).count());
                 }
             });
@@ -157,7 +161,7 @@ fn me_delta_attach_vs_seek() {
             let mut it = me.iter(0, 0);
             let c = per_op(READS, || {
                 for r in 0..READS {
-                    let k = super::tensor::compound_key(r % PAIRS, r % PAIRS);
+                    let (_, k) = super::tensor::compound_key(r % PAIRS, r % PAIRS);
                     it.seek(k, k);
                     std::hint::black_box(it.by_ref().count());
                 }

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -73,10 +73,58 @@ mod fold_cost_bench;
 pub mod lagraph_bindings;
 pub mod lagraphx_bindings;
 pub mod matrix;
+#[cfg(test)]
+mod me_delta_bench;
 pub mod serialization;
 pub mod tensor;
 pub mod vector;
 pub mod versioned_matrix;
+
+/// The instruction counter the benches in this directory measure with.
+///
+/// One declaration, shared, for the same reason as [`test_init`]: benches that
+/// disagreed on a field offset would report numbers that cannot be compared.
+#[cfg(test)]
+pub(crate) mod instr {
+    /// Running instruction total for this process, or `None` where the platform
+    /// has no cheap equivalent.
+    ///
+    /// macOS exposes `proc_pid_rusage(RUSAGE_INFO_V4)` to any caller for its own
+    /// pid with no privileges; `ri_instructions` is `u64` field 29 of the struct
+    /// body, which starts after the 16-byte `ri_uuid`. Same offsets as
+    /// `bench/src/falkorbench/counters.py::read_rusage`, so engine-level and
+    /// data-structure-level numbers are on one scale.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn read_instr() -> Option<u64> {
+        const RUSAGE_INFO_V4: i32 = 4;
+        const RI_INSTRUCTIONS_OFF: usize = 16 + 29 * 8;
+
+        unsafe extern "C" {
+            fn proc_pid_rusage(
+                pid: i32,
+                flavor: i32,
+                buffer: *mut u8,
+            ) -> i32;
+            fn getpid() -> i32;
+        }
+        let mut buf = [0u8; 1024];
+        // SAFETY: `buf` is 1024 bytes, far larger than `struct rusage_info_v4`
+        // (~0x150 bytes), and the kernel writes at most that flavor's size.
+        if unsafe { proc_pid_rusage(getpid(), RUSAGE_INFO_V4, buf.as_mut_ptr()) } != 0 {
+            return None;
+        }
+        Some(u64::from_le_bytes(
+            buf[RI_INSTRUCTIONS_OFF..RI_INSTRUCTIONS_OFF + 8]
+                .try_into()
+                .expect("8 bytes"),
+        ))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub(crate) fn read_instr() -> Option<u64> {
+        None
+    }
+}
 
 /// Process-wide GraphBLAS initialization for unit tests. `GrB_init` may only
 /// be called once per process, so every `#[cfg(test)]` module must go through

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -211,6 +211,92 @@ pub(super) fn delta_dominates_base(
 /// `count` leaves the fold policy reading a delta size that never happened, so
 /// writes go through the counted [`Self::insert`] / [`Self::erase`], or through
 /// [`Self::layer_mut`] for callers that resync the count themselves.
+/// Bits in [`RowFilter`]'s bitmap. 4096 bits is 512 bytes, allocated only once
+/// a delta actually holds something, and enough that the deltas the fold policy
+/// permits stay well below saturation.
+const ROW_FILTER_BITS: usize = 32768;
+const ROW_FILTER_WORDS: usize = ROW_FILTER_BITS / 64;
+
+/// Which rows a delta layer may hold entries in.
+///
+/// Readers merge three layers per scan, and the existing short-circuit asks
+/// whether a layer is empty *in total*. That is the wrong question for a narrow
+/// scan: one pending entry anywhere makes every single-row read attach and seek
+/// a GraphBLAS iterator that yields nothing (#2430). This answers the narrower
+/// question — may this layer hold row `r`? — without touching GraphBLAS.
+///
+/// **The only safety property that matters is that it never says "no" when the
+/// answer is yes.** [`Self::Unknown`] is therefore the default for anything not
+/// explicitly tracked: a bulk write, a transpose, any future path that reaches
+/// [`Delta::layer_mut`]. Being wrong in the conservative direction costs the
+/// scan it would have done anyway.
+#[derive(Clone)]
+enum RowFilter {
+    /// Nothing has been added since the last clear, so no row is present. The
+    /// state a fresh or just-folded delta is in, and the one that costs nothing.
+    Empty,
+    /// A row is present only if its hash bit is set. False positives are
+    /// expected (hash collisions, and entries erased since); false negatives
+    /// are not possible.
+    Bits(Box<[u64; ROW_FILTER_WORDS]>),
+    /// A bulk write moved entries this cannot track. Every row may be present.
+    Unknown,
+}
+
+impl RowFilter {
+    /// Fibonacci hashing: rows here are `compound_key(src, dst)` values whose
+    /// low bits are a raw destination id, so the multiply is what spreads them.
+    const fn slot(row: u64) -> (usize, u64) {
+        let h = (row.wrapping_mul(0x9E37_79B9_7F4A_7C15) >> (64 - 15)) as usize;
+        (h / 64, 1u64 << (h % 64))
+    }
+
+    fn add(
+        &mut self,
+        row: u64,
+    ) {
+        match self {
+            Self::Unknown => {}
+            Self::Empty => {
+                let mut bits = Box::new([0u64; ROW_FILTER_WORDS]);
+                let (w, b) = Self::slot(row);
+                bits[w] |= b;
+                *self = Self::Bits(bits);
+            }
+            Self::Bits(bits) => {
+                let (w, b) = Self::slot(row);
+                bits[w] |= b;
+            }
+        }
+    }
+
+    /// Whether any row in `min..=max` may be present. Wide ranges answer `true`
+    /// without testing: a scan that broad wants the delta anyway, and the point
+    /// of this is the single-row case.
+    fn may_hold(
+        &self,
+        min_row: u64,
+        max_row: u64,
+    ) -> bool {
+        match self {
+            Self::Unknown => true,
+            Self::Empty => false,
+            Self::Bits(bits) => {
+                let Some(span) = max_row.checked_sub(min_row) else {
+                    return false;
+                };
+                if span >= 64 {
+                    return true;
+                }
+                (min_row..=max_row).any(|r| {
+                    let (w, b) = Self::slot(r);
+                    bits[w] & b != 0
+                })
+            }
+        }
+    }
+}
+
 pub(super) struct Delta<T> {
     layer: Cow<Matrix<T>>,
     /// Approximate `layer.nvals()`, maintained by the mutation methods without
@@ -232,6 +318,9 @@ pub(super) struct Delta<T> {
     /// the base. The flag carries the decision across that gap (and across
     /// versions, via `new_version`).
     fold: AtomicBool,
+    /// Which rows this layer may hold, so a single-row scan can skip it
+    /// entirely. Conservative by construction; see [`RowFilter`].
+    rows: RowFilter,
 }
 
 // Manual `Clone` so it holds for every `T` without a `T: Clone` bound (see the
@@ -255,18 +344,29 @@ impl<T> Delta<T> {
     /// Wrap a layer whose size is exactly known — a fresh empty matrix, or one
     /// just decoded. Pins it hypersparse, as every delta is.
     pub(super) fn new(layer: Matrix<T>) -> Self {
+        let rows = if layer.nvals() == 0 {
+            RowFilter::Empty
+        } else {
+            // A decoded layer arrives with entries this never saw inserted.
+            RowFilter::Unknown
+        };
         Self {
             count: AtomicU64::new(layer.nvals()),
             layer: Cow::new(layer.into_hyper()),
             tx_nvals: 0,
             fold: AtomicBool::new(false),
+            rows,
         }
     }
 
     /// This delta, transposed: same bookkeeping over the transposed layer, since
     /// a transpose moves no entries.
     pub(super) fn transposed(&self) -> Self {
-        self.relayer(Cow::new(self.transpose().into_hyper()))
+        let mut t = self.relayer(Cow::new(self.transpose().into_hyper()));
+        // A transpose turns rows into columns, so the filter describes the
+        // wrong axis and no cheap correction exists.
+        t.rows = RowFilter::Unknown;
+        t
     }
 
     /// This delta's bookkeeping over a different layer of the same size (a
@@ -280,6 +380,8 @@ impl<T> Delta<T> {
             count: AtomicU64::new(self.count()),
             tx_nvals: self.tx_nvals,
             fold: AtomicBool::new(self.fold.load(Ordering::Relaxed)),
+            // Same entries at the same coordinates; `transposed` overrides.
+            rows: self.rows.clone(),
         }
     }
 
@@ -296,6 +398,7 @@ impl<T> Delta<T> {
             count: AtomicU64::new(count),
             tx_nvals: count,
             fold: AtomicBool::new(fold),
+            rows: self.rows.clone(),
         }
     }
 
@@ -363,6 +466,9 @@ impl<T> Delta<T> {
         *self.count.get_mut() = 0;
         self.tx_nvals = 0;
         *self.fold.get_mut() = false;
+        // The layer is empty again, which is the one state that can be asserted
+        // rather than approximated.
+        self.rows = RowFilter::Empty;
     }
 
     /// Swap in a layer holding the same entries at different dimensions (a
@@ -383,14 +489,43 @@ impl<T> Delta<T> {
         nrows: u64,
         ncols: u64,
     ) {
+        // A resize moves no entry to a different row, so the filter stands —
+        // and it must be restored explicitly, since `layer_mut` invalidates.
+        let rows = std::mem::replace(&mut self.rows, RowFilter::Unknown);
         self.layer_mut().resize(nrows, ncols);
+        self.rows = rows;
     }
 
     /// The layer, mutably, *without* counting the mutation. For bulk callers
     /// that resync `count` themselves (`remove_mask`) or that cannot change the
     /// entry count at all (`resize`).
     pub(super) fn layer_mut(&mut self) -> &mut Matrix<T> {
+        // Every path that adds entries reaches the layer through here, so
+        // invalidating by default is what makes the filter safe: a caller that
+        // knows better says so (`insert`, `resize`), and one that says nothing
+        // costs a scan rather than a wrong answer.
+        self.rows = RowFilter::Unknown;
         &mut self.layer
+    }
+
+    /// The layer, mutably, recording that row `i` now holds an entry. For the
+    /// counted single-entry inserts, which are the paths worth tracking.
+    fn layer_mut_row(
+        &mut self,
+        i: u64,
+    ) -> &mut Matrix<T> {
+        self.rows.add(i);
+        &mut self.layer
+    }
+
+    /// Whether this layer may hold an entry in rows `min_row..=max_row`. Only
+    /// ever over-reports; see [`RowFilter`].
+    pub(super) fn may_hold_rows(
+        &self,
+        min_row: u64,
+        max_row: u64,
+    ) -> bool {
+        self.rows.may_hold(min_row, max_row)
     }
 
     /// Drop `(i, j)` and un-count it. Saturates: the caller may not know
@@ -401,7 +536,9 @@ impl<T> Delta<T> {
         i: u64,
         j: u64,
     ) {
-        self.layer_mut().remove(i, j);
+        // A removal only shrinks the true row set, so the filter is still a
+        // superset — `layer_mut_row` keeps it that way without invalidating.
+        self.layer_mut_row(i).remove(i, j);
         let count = self.count.get_mut();
         *count = count.saturating_sub(1);
     }
@@ -418,7 +555,7 @@ impl Delta<bool> {
         i: u64,
         j: u64,
     ) {
-        self.layer_mut().set(i, j, true);
+        self.layer_mut_row(i).set(i, j, true);
         *self.count.get_mut() += 1;
     }
 
@@ -463,6 +600,10 @@ impl Delta<u64> {
         j: u64,
         value: u64,
     ) {
+        // No row filter here: `VersionedMatrix::iter` — the only thing that
+        // reads one — exists for `bool` matrices alone, so tracking rows on a
+        // valued delta would be a per-insert cost nothing can spend. `layer_mut`
+        // pins the filter at `Unknown`, which is the answer that is always safe.
         self.layer_mut().set(i, j, value);
         *self.count.get_mut() += 1;
     }
@@ -1144,7 +1285,20 @@ impl<E: IterExtract> Iter<E> {
         min_row: u64,
         max_row: u64,
     ) -> Self {
-        Self::from_layers(&vm.m, &vm.dp, &vm.dm, min_row, max_row)
+        // A layer whose row filter rules this range out is left *detached*: no
+        // `GxB_Iterator` is allocated, attached or seeked for it, and it yields
+        // nothing. It is still carried, so a later `seek` to a range the filter
+        // does not rule out attaches it and reads normally — the skip is an
+        // optimisation, not a promise the caller has to keep.
+        Self::from_layers_detaching(
+            &vm.m,
+            &vm.dp,
+            !vm.dp.may_hold_rows(min_row, max_row),
+            &vm.dm,
+            !vm.dm.may_hold_rows(min_row, max_row),
+            min_row,
+            max_row,
+        )
     }
 
     /// Build the effective-content iterator directly from the three delta
@@ -1160,8 +1314,26 @@ impl<E: IterExtract> Iter<E> {
         min_row: u64,
         max_row: u64,
     ) -> Self {
+        Self::from_layers_detaching(m, dp, false, dm, false, min_row, max_row)
+    }
+
+    /// As [`Self::from_layers`], but a layer flagged `detach` is one the caller
+    /// has established holds nothing in `min_row..=max_row`. It yields nothing
+    /// now and attaches on the first [`Self::seek`], so the stream is identical
+    /// either way and only the cost differs.
+    fn from_layers_detaching<V>(
+        m: &Matrix<V>,
+        dp: &Matrix<V>,
+        detach_dp: bool,
+        dm: &Matrix<bool>,
+        detach_dm: bool,
+        min_row: u64,
+        max_row: u64,
+    ) -> Self {
         let mut dmit = if dm.nvals() == 0 {
             None
+        } else if detach_dm {
+            Some(matrix::Iter::<BoolExtract>::detached(dm))
         } else {
             Some(matrix::Iter::<BoolExtract>::new(dm, min_row, max_row))
         };
@@ -1171,6 +1343,8 @@ impl<E: IterExtract> Iter<E> {
             m_next: None,
             dpit: if dp.nvals() == 0 {
                 None
+            } else if detach_dp {
+                Some(matrix::Iter::detached(dp))
             } else {
                 Some(matrix::Iter::new(dp, min_row, max_row))
             },
@@ -1520,5 +1694,115 @@ mod tests {
         );
         assert_eq!(v.get(probe.0, probe.1), Some(true));
         assert_eq!(v.nvals(), filler + 2, "nvals double-counted the re-add");
+    }
+
+    /// The row filter lets a single-row scan skip a delta layer entirely, which
+    /// is only sound if it never rules out a row the layer holds. These pin the
+    /// two halves of that: the skip happens, and it is never wrong.
+    ///
+    /// This one is the wrong half — a scan of a row the delta *does* hold must
+    /// still see it, whether the entry is the only one in the delta or one of
+    /// many.
+    #[test]
+    fn row_filter_never_hides_a_pending_entry() {
+        ensure_init();
+        let mut v = VersionedMatrix::<bool>::new(1 << 12, 1 << 12);
+        for r in (0..2048).step_by(2) {
+            v.set(r, r + 1, true);
+        }
+        let mut v = v.dup();
+        v.flush();
+        v.wait_all();
+        // Pending entries on rows that are *not* in the committed base, so the
+        // only way to read them is through `dp`.
+        let pending: Vec<u64> = vec![1, 3, 777, 2047];
+        for &r in &pending {
+            v.set(r, r, true);
+        }
+        v.wait_all();
+        for &r in &pending {
+            let got: Vec<_> = v.iter(r, r).collect();
+            assert_eq!(got, vec![(r, r)], "row {r}'s pending entry was skipped");
+        }
+        // And every committed row still reads, with the delta non-empty.
+        for r in (0..2048).step_by(2) {
+            let got: Vec<_> = v.iter(r, r).collect();
+            let want = if pending.contains(&r) {
+                vec![(r, r), (r, r + 1)]
+            } else {
+                vec![(r, r + 1)]
+            };
+            assert_eq!(got, want, "row {r} misread with a non-empty delta");
+        }
+    }
+
+    /// **The hazard the design has to answer.** A skipped layer is skipped for
+    /// *a range*, but `Iter::seek` re-points an existing iterator at a different
+    /// range — so a layer dropped because the first range missed it would
+    /// silently swallow entries in every later one. Detaching rather than
+    /// dropping is what makes that safe, and this is the test that says so:
+    /// build the iterator on a row the delta does not hold, then seek to one it
+    /// does.
+    #[test]
+    fn seek_after_a_skipped_layer_still_reads_the_delta() {
+        ensure_init();
+        let mut v = VersionedMatrix::<bool>::new(1 << 12, 1 << 12);
+        v.set(10, 10, true);
+        let mut v = v.dup();
+        v.flush();
+        v.wait_all();
+        v.set(900, 901, true);
+        v.wait_all();
+
+        // Row 10 is committed and holds no delta entry, so this iterator is
+        // built with `dp` detached.
+        let mut it = v.iter(10, 10);
+        assert_eq!(it.by_ref().collect::<Vec<_>>(), vec![(10, 10)]);
+
+        // Re-seeking must attach it rather than keep answering "empty".
+        it.seek(900, 900);
+        assert_eq!(
+            it.collect::<Vec<_>>(),
+            vec![(900, 901)],
+            "a re-seeked iterator lost the pending entry"
+        );
+    }
+
+    /// The filter is only worth having if the resizes a bulk create performs
+    /// constantly leave it usable — degrading to `Unknown` would be safe and
+    /// would silently switch the optimisation off. Both directions are checked,
+    /// because they take different paths and end in different states.
+    #[test]
+    fn row_filter_stays_exact_across_both_resize_paths() {
+        ensure_init();
+        let mut v = VersionedMatrix::<bool>::new(4096, 4096);
+        v.set(5, 6, true);
+        v.wait_all();
+        assert!(v.dp.may_hold_rows(5, 5), "the row it just took");
+        assert!(!v.dp.may_hold_rows(7, 7), "a row it never took");
+
+        // Shrink keeps the delta and resizes it in place, so the filter has to
+        // survive `Delta::resize` — which reaches the layer through the same
+        // `layer_mut` that invalidates by default.
+        v.resize(2048, 2048);
+        v.wait_all();
+        assert!(v.dp.may_hold_rows(5, 5), "shrink lost the entry's row");
+        assert!(
+            !v.dp.may_hold_rows(7, 7),
+            "shrink degraded the filter to Unknown"
+        );
+        assert_eq!(v.iter(5, 5).collect::<Vec<_>>(), vec![(5, 6)]);
+
+        // Growing with a non-empty delta rebuilds the base with the delta
+        // folded in, so afterwards nothing is pending and no row is claimed —
+        // and the entry must still read, now out of the base.
+        v.resize(8192, 8192);
+        v.wait_all();
+        assert_eq!(v.dp().nvals(), 0, "grow did not fold the delta");
+        assert!(
+            !v.dp.may_hold_rows(5, 5),
+            "a folded delta still claims a row"
+        );
+        assert_eq!(v.iter(5, 5).collect::<Vec<_>>(), vec![(5, 6)]);
     }
 }


### PR DESCRIPTION
Closes #2430.

A bound multi-edge point read costs ~1,150 extra instructions whenever `me`'s delta-plus holds anything, however little. The issue reports this as two discrete cost states selected by graph size, non-monotonically — which is what it looks like from outside, because which state a graph is in depends on where the fold policy last fired relative to the final write, and that is not a function of size. The issue's own third hypothesis ("a lingering delta") was right; its refutation test could not see it, because the fold policy is size-based and a delta of one entry never meets the threshold, so the unrelated write it tried was never obliged to fold `me`.

## Cause

The layer-empty short-circuit in `Iter::from_layers` asks whether a delta is empty *in total*, not whether it holds anything in the row being read. One pending identifier anywhere therefore makes every single-row scan allocate, attach and seek a `GxB_Iterator` that yields nothing.

## Fix

`RowFilter` answers the narrower question without touching GraphBLAS: a 4 KB bitmap of which rows a delta may hold, allocated only once the delta holds something and dropped when it folds.

The only property that matters is that it never says "no" when the answer is yes. `Delta::layer_mut` — the single choke point every entry-adding path goes through — therefore **invalidates it by default**. A caller that knows better says so (`insert`, `resize`); a caller that says nothing costs a scan rather than a wrong answer, so a bulk path added later without touching this stays correct.

A skipped layer is **detached, not dropped**. `Iter::seek` re-points an existing iterator at a different range, so a layer dropped because the first range missed it would silently swallow entries in every later one. `matrix::Iter::detached` keeps the matrix handle and attaches on the first seek, which makes the skip an optimisation rather than a promise the caller has to keep. `seek_after_a_skipped_layer_still_reads_the_delta` is the test for exactly that hazard.

## Measured, same repro before and after

Engine level (`bench/studies/issue_2430/engine_two_states.py`), instructions per probed pair:

| pairs | 1k | 11k | 41k | 88k | 121k | step |
|---|---|---|---|---|---|---|
| before | 8,723 | 8,787 | 8,786 | 9,929 | 9,963 | **+1,143** |
| after | 8,738 | 8,774 | 8,796 | 8,912 | 8,915 | **+116** |

Structure level (`me_delta_bench.rs`), instructions per multi-edge read: delta empty 2,995 → one pending id 3,097 (was 3,022 → 4,297).

**90% of the step is gone and the two states are one.**

## Costs

- **Writes: +0.64%** — 8,882 → 8,939 instructions per edge created, three runs each (`main` reproduces to within 1). That is the hash and bit-set on every `bool` delta insert. Valued deltas skip the filter entirely, since `VersionedMatrix::iter` — the only thing that reads a filter — exists for `bool` matrices alone; that alone took the write cost from +1.05% to +0.64%.
- **Memory: unchanged.** `GRAPH.MEMORY` byte-for-byte identical, jemalloc live bytes within noise (240.30 MB vs 240.20 MB).

## Tests

162 unit tests, 138 Python (e2e / functions / mvcc / concurrency), TCK, and flow all pass. The 23 flow failures are identical to the set `main` fails at ef44bc6db — verified by building `main` in a second worktree and diffing the failing-test names.

Three new correctness tests cover the filter's contract: it never hides a pending entry, it survives both resize paths without degrading to `Unknown`, and the re-seek hazard above.

## What this does *not* fix

`me_delta_attach_vs_seek` decomposes the step and, in doing so, names a larger cost left standing: `Tensor::get` builds a fresh three-layer merge per call, so every multi-edge point read pays **~1,670 instructions of `GxB_Iterator` attach** whether or not a delta exists (2,310 fresh against 638 re-seeked, on the same fixture). That is bigger than the bug fixed here. Removing it means giving the hot callers — `ExpandInto` reads through `Tensor::get` per row — a reusable cursor, which is an API change and a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sparse matrix iteration by skipping unnecessary work when requested ranges are known to be empty.
  * Iterators now attach only when needed and can be reused efficiently for later searches.
* **Bug Fixes**
  * Improved iterator cleanup and re-seeking behavior as matrix data changes.
  * Preserved accurate results after updates, resizing, and other data-layer changes.
* **Testing**
  * Added benchmarks and coverage for filtered scans, iterator reuse, and multi-edge point reads.
  * Added validation for index-width configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->