### PR TITLE
perf(tensor): answer degree without materialising edge ids

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1888,8 +1888,8 @@ impl Graph {
     ) -> usize {
         self.relationship_matrices
             .iter()
-            .flat_map(move |m| m.iter(id.0, id.0, true))
-            .count()
+            .map(|m| m.col_degree(id.0) as usize)
+            .sum()
     }
 
     /// Count the number of incoming edges to a node, filtered by relationship types.
@@ -1902,8 +1902,8 @@ impl Graph {
         types
             .iter()
             .filter_map(|t| self.get_relationship_matrix(t))
-            .flat_map(|m| m.iter(id.0, id.0, true))
-            .count()
+            .map(|m| m.col_degree(id.0) as usize)
+            .sum()
     }
 
     /// Count the number of outgoing edges from a node.
@@ -1914,8 +1914,8 @@ impl Graph {
     ) -> usize {
         self.relationship_matrices
             .iter()
-            .flat_map(move |m| m.iter(id.0, id.0, false))
-            .count()
+            .map(|m| m.row_degree(id.0) as usize)
+            .sum()
     }
 
     /// Count the number of outgoing edges from a node, filtered by relationship types.
@@ -1928,8 +1928,8 @@ impl Graph {
         types
             .iter()
             .filter_map(|t| self.get_relationship_matrix(t))
-            .flat_map(|m| m.iter(id.0, id.0, false))
-            .count()
+            .map(|m| m.row_degree(id.0) as usize)
+            .sum()
     }
 
     #[must_use]

--- a/graph/src/graph/graphblas/degree_bench.rs
+++ b/graph/src/graph/graphblas/degree_bench.rs
@@ -1,0 +1,179 @@
+//! Where node degree spends its instructions.
+//!
+//! The C engine answers degree in time proportional to the number of *pairs* in
+//! the row: `Tensor_RowDegree` scans the row's cells and adds
+//! `GrB_Vector_nvals` of any container it finds, which is a stored length. This
+//! engine has no degree entry point at all — `Graph::get_node_outdegree` counts
+//! `Tensor::iter(id, id, false)`, which materialises every identifier into a
+//! `Vec` and throws them away.
+//!
+//! Measured at the data-structure boundary the gap was about 2x at `k = 1` and
+//! 4x at `k = 2`. This decomposes it, because the two obvious explanations imply
+//! different fixes: if the cost is *materialising identifiers* then not
+//! materialising them is the fix, and if it is *attaching a `GxB_Iterator` per
+//! call* then no amount of counting-instead-of-collecting will move it.
+//!
+//! **It is mostly the second, and that was not the expectation.** At `k = 1`
+//! counting the identifiers costs 113 instructions of the 2,065; the row scan
+//! underneath costs 1,952, of which 1,654 is getting an iterator — the same scan
+//! through one that is re-seeked costs 298. So the dominant term is per-call
+//! iterator setup, and a degree that merely stops collecting identifiers cannot
+//! move much of it.
+//!
+//! `row_degree` / `col_degree` take what that leaves reachable, and no more:
+//! they drop the per-pair `Vec`, and share one `me` cursor across a row instead
+//! of attaching per multi-edge pair. That is worth 4% at `k = 1` and 12% at
+//! `k = 2`, and rows (3) and (4) below show what it does not reach — the
+//! per-call attach, which a cursor shared within one call cannot amortise across
+//! calls. Removing that means not attaching, i.e. a reusable cursor threaded
+//! through the callers, which is a larger API change than this one.
+//!
+//! Run with:
+//!   cargo test --release -p graph degree_ -- --ignored --nocapture --test-threads=1
+
+use super::instr::read_instr;
+use super::tensor::Tensor;
+use super::test_init::ensure_init;
+
+const PAIRS: u64 = 100_000;
+const OPS: u64 = 200_000;
+
+fn per_op<F: FnMut()>(
+    ops: u64,
+    mut f: F,
+) -> f64 {
+    let a = read_instr();
+    f();
+    let b = read_instr();
+    match (a, b) {
+        (Some(a), Some(b)) => (b - a) as f64 / ops as f64,
+        _ => f64::NAN,
+    }
+}
+
+/// `PAIRS` pairs on the diagonal, `k` edges each, committed.
+fn built(k: u64) -> Tensor {
+    let mut t = Tensor::new(PAIRS + 1, PAIRS + 1);
+    let (mut s, mut d, mut i) = (Vec::new(), Vec::new(), Vec::new());
+    for p in 0..PAIRS {
+        for e in 0..k {
+            s.push(p);
+            d.push(p);
+            i.push(p * k + e);
+        }
+    }
+    t.set_all_from_slices(&s, &d, &i);
+    let mut t = t.dup();
+    t.flush();
+    t.wait();
+    t
+}
+
+#[test]
+#[ignore]
+fn degree_decomposition() {
+    ensure_init();
+    for k in [1u64, 2] {
+        let t = built(k);
+        println!("\n=== degree, {PAIRS} pairs x {k} edge(s) ===");
+        println!("{:>44}  {:>12}", "operation", "instr/op");
+
+        // (0) the dedicated entry points
+        for _ in 0..3 {
+            let c = per_op(OPS, || {
+                let mut n = 0u64;
+                for r in 0..OPS {
+                    n += t.row_degree(r % PAIRS);
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "row_degree", c);
+        }
+        for _ in 0..3 {
+            let c = per_op(OPS, || {
+                let mut n = 0u64;
+                for r in 0..OPS {
+                    n += t.col_degree(r % PAIRS);
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "col_degree", c);
+        }
+
+        // (1) what the engine did before
+        for _ in 0..3 {
+            let c = per_op(OPS, || {
+                let mut n = 0usize;
+                for r in 0..OPS {
+                    n += t.iter(r % PAIRS, r % PAIRS, false).count();
+                }
+                std::hint::black_box(n);
+            });
+            println!(
+                "{:>44}  {:>12.1}",
+                "was: Tensor::iter(r,r,false).count()", c
+            );
+        }
+
+        // (2) the same, transposed — the in-degree path
+        for _ in 0..3 {
+            let c = per_op(OPS, || {
+                let mut n = 0usize;
+                for r in 0..OPS {
+                    n += t.iter(r % PAIRS, r % PAIRS, true).count();
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "was: transposed", c);
+        }
+
+        // (3) the forward row scan alone, counting cells rather than edges.
+        // This is the floor any degree implementation pays: it must learn which
+        // pairs the row holds. The difference from (1) is everything spent on
+        // turning cells into identifiers.
+        for _ in 0..3 {
+            let c = per_op(OPS, || {
+                let mut n = 0usize;
+                for r in 0..OPS {
+                    n += t.fwd_iter_for_test(r % PAIRS, r % PAIRS).count();
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "floor: forward row scan, cells only", c);
+        }
+
+        // (4) the same forward row scan through *one* iterator, re-seeked. The
+        // difference from (3) is the per-call `GxB_Iterator` attach and free,
+        // which no amount of counting-instead-of-collecting can remove.
+        for _ in 0..3 {
+            let mut it = t.fwd_iter_for_test(0, 0);
+            let c = per_op(OPS, || {
+                let mut n = 0usize;
+                for r in 0..OPS {
+                    it.seek(r % PAIRS, r % PAIRS);
+                    n += it.by_ref().count();
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "forward row scan, one iterator", c);
+        }
+
+        // (5) and the `me` side, likewise: one iterator re-seeked per row. At
+        // `k = 1` this reads nothing and prices the wasted attach alone. The
+        // fixture is on the diagonal below 2^30, so every pair is in block 0.
+        for _ in 0..3 {
+            let me = t.edge_versioned_block_0();
+            let mut it = me.iter(0, 0);
+            let c = per_op(OPS, || {
+                let mut n = 0usize;
+                for r in 0..OPS {
+                    let (_, key) = super::tensor::compound_key(r % PAIRS, r % PAIRS);
+                    it.seek(key, key);
+                    n += it.by_ref().count();
+                }
+                std::hint::black_box(n);
+            });
+            println!("{:>44}  {:>12.1}", "me row scan, one iterator", c);
+        }
+    }
+}

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -71,6 +71,8 @@
 #[cfg(test)]
 mod block_scaling_bench;
 #[cfg(test)]
+mod degree_bench;
+#[cfg(test)]
 mod fold_cost_bench;
 pub mod lagraph_bindings;
 pub mod lagraphx_bindings;

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -1065,6 +1065,104 @@ impl Tensor {
         )
     }
 
+    /// How many edges leave `row`, without materialising any of them.
+    ///
+    /// [`Self::iter`] answers this today by counting the triples it yields,
+    /// which buffers every identifier of every multi-edge pair into a `Vec`
+    /// only to drop it. Degree does not need the identifiers, only how many
+    /// there are, and the C engine's `Tensor_RowDegree` is built on exactly
+    /// that observation.
+    ///
+    /// The row's `me` lookups share one cursor. A row with several multi-edge
+    /// pairs would otherwise attach a `GxB_Iterator` per pair, and attaching is
+    /// most of what a short scan costs. The cursor is tied to the block it was
+    /// attached to, so it is rebuilt when a pair lands in another one — which
+    /// takes more than 2^30 nodes on an axis, and so never happens in practice.
+    #[must_use]
+    pub fn row_degree(
+        &self,
+        row: u64,
+    ) -> u64 {
+        let mut degree = 0;
+        let mut ids: Option<(MeBlock, versioned_matrix::Iter)> = None;
+        for (_, dst, inline) in self.fwd_iter(row, row) {
+            if inline != MULTI_EDGE {
+                degree += 1;
+                continue;
+            }
+            degree += self.me_degree(&mut ids, row, dst);
+        }
+        degree
+    }
+
+    /// Identifiers held in `me` for one promoted pair, counted through `ids` —
+    /// a cursor kept across the pairs of a single row and re-seeked, rather than
+    /// a fresh iterator per pair.
+    ///
+    /// An absent block holds no identifiers. Promotion completeness says that
+    /// cannot happen for a pair reading as [`MULTI_EDGE`], so zero here is
+    /// unreachable rather than a fallback — and it is what an empty matrix would
+    /// have counted anyway. See [`Self::get`].
+    fn me_degree(
+        &self,
+        ids: &mut Option<(MeBlock, versioned_matrix::Iter)>,
+        src: u64,
+        dst: u64,
+    ) -> u64 {
+        let (block, key) = compound_key(src, dst);
+        let Some(me) = self.me_block(block) else {
+            return 0;
+        };
+        let it = match ids {
+            Some((b, it)) if *b == block => {
+                it.seek(key, key);
+                it
+            }
+            slot => &mut slot.insert((block, me.iter(key, key))).1,
+        };
+        it.count() as u64
+    }
+
+    /// How many edges enter `col`, without materialising any of them.
+    ///
+    /// The mirror of [`Self::row_degree`], and dearer for the reason
+    /// transposed iteration is: `mt` carries structure only, so each
+    /// incoming pair costs one forward point lookup to learn whether it is
+    /// inline or promoted. That is the trade the transpose makes by not storing
+    /// every identifier twice.
+    #[must_use]
+    pub fn col_degree(
+        &self,
+        col: u64,
+    ) -> u64 {
+        let mut degree = 0;
+        let mut ids: Option<(MeBlock, versioned_matrix::Iter)> = None;
+        for (_, src) in self.mt.iter(col, col) {
+            // `mt` mirrors the effective forward structure, so a pair reached
+            // through it always has a forward inline value — the same fact
+            // `Iter::next` relies on, machine-checked as
+            // `iterBwd_eff_get_isSome` in `proofs/tensor`.
+            let Some(inline) = self.eff_get(src, col) else {
+                unreachable!("mt holds ({src}, {col}) but the forward matrix does not")
+            };
+            if inline != MULTI_EDGE {
+                degree += 1;
+                continue;
+            }
+            degree += self.me_degree(&mut ids, src, col);
+        }
+        degree
+    }
+
+    #[cfg(test)]
+    pub(super) fn fwd_iter_for_test(
+        &self,
+        min_row: u64,
+        max_row: u64,
+    ) -> versioned_matrix::Iter<Uint64Extract> {
+        self.fwd_iter(min_row, max_row)
+    }
+
     /// Transposed/backward pair-level adjacency (dst → src), structure only.
     #[must_use]
     pub const fn matrix_t(&self) -> &VersionedMatrix<bool> {
@@ -2386,5 +2484,80 @@ mod tests {
             seen.sort_unstable();
             assert_eq!(seen, vec![(src, dst, 10), (src, dst, 11)]);
         }
+    }
+
+    /// `row_degree`/`col_degree` exist to be cheaper than counting what
+    /// `iter` yields, so the property that matters is that they agree with it —
+    /// on every row, under every mix of inline and promoted pairs, and with
+    /// live deltas rather than a freshly committed tensor.
+    ///
+    /// Deltas matter here because the two paths reach `me` differently: `iter`
+    /// buffers a row's identifiers, these count them through a shared cursor
+    /// that is re-seeked, and a re-seek is exactly where a skipped delta layer
+    /// would show up as a lost edge.
+    #[test]
+    fn degree_agrees_with_counting_the_iterator() {
+        ensure_init();
+        const N: u64 = 64;
+        let mut t = Tensor::new(N, N);
+        // A deliberately uneven shape: row `r` holds `r % 5` pairs, and every
+        // third pair is multi-edge with a different fan-out.
+        let (mut srcs, mut dsts, mut ids) = (Vec::new(), Vec::new(), Vec::new());
+        let mut next_id = 0u64;
+        for r in 0..N {
+            for c in 0..(r % 5) {
+                let dst = (r * 7 + c * 11) % N;
+                let k = if c % 3 == 0 { 1 + (c % 4) } else { 1 };
+                for _ in 0..k {
+                    srcs.push(r);
+                    dsts.push(dst);
+                    ids.push(next_id);
+                    next_id += 1;
+                }
+            }
+        }
+        t.set_all_from_slices(&srcs, &dsts, &ids);
+        let mut t = t.dup();
+        t.flush();
+        t.wait();
+
+        let check = |t: &Tensor, what: &str| {
+            for r in 0..N {
+                assert_eq!(
+                    t.row_degree(r),
+                    t.iter(r, r, false).count() as u64,
+                    "row {r} out-degree disagrees ({what})"
+                );
+                assert_eq!(
+                    t.col_degree(r),
+                    t.iter(r, r, true).count() as u64,
+                    "col {r} in-degree disagrees ({what})"
+                );
+            }
+        };
+        check(&t, "committed");
+
+        // Now with live deltas: a promotion, a fresh pair, and a deletion, none
+        // of them folded.
+        t.set_all_from_slices(
+            &[3, 3, 40],
+            &[21, 21, 41],
+            &[next_id, next_id + 1, next_id + 2],
+        );
+        t.wait();
+        check(&t, "pending adds");
+
+        // Edge 0 is the first pair the fixture wrote: row 1, column
+        // `(1 * 7 + 0 * 11) % N` = 7. Assert it goes, or the delete leg would
+        // pass by removing nothing.
+        let before = t.row_degree(1);
+        t.remove_all(&[(0, 1, 7)]);
+        t.wait();
+        assert_eq!(
+            t.row_degree(1),
+            before - 1,
+            "fixture is not exercising deletion: no edge was removed"
+        );
+        check(&t, "pending add and delete");
     }
 }


### PR DESCRIPTION
Partially addresses #2621. Rebased onto `main` now that #2571 has merged; the iterator-pool half is gone, so this is the degree change alone.

## What the decomposition found

`Graph::get_node_{in,out}degree{,_by_type}` counted what `Tensor::iter` yields, which buffers every identifier of every multi-edge pair into a `Vec` only to drop it. The tensor paper attributed the gap against C to exactly that: C's `Tensor_RowDegree` adds `GrB_Vector_nvals` of a container — a stored length — where this engine materialises.

`degree_bench.rs` decomposes it, and that explanation is **mostly wrong**:

| | instr/op |
|---|---|
| degree today, k=1 | 2,065 |
| the forward row scan alone, cells only | 1,952 |
| the same row scan through **one** re-seeked iterator | **298** |

Collecting the identifiers accounts for 113 of the 2,065. **1,654 is per-call `GxB_Iterator` setup.** So this change is bounded from the start: it takes what is reachable without a new cursor API, and the bench keeps the rest of the gap visible.

## The change

`Tensor::row_degree` / `col_degree` count rather than collect: an inline pair is one edge, a promoted pair is the length of its `me` row, and a row's `me` lookups share one cursor instead of attaching a `GxB_Iterator` per pair. The cursor is keyed by `me` block and rebuilt if a pair lands outside the block it is attached to — which takes more than 2^30 nodes on an axis, so never in practice.

Measured by `degree_bench` in one binary, 100k pairs:

| | was | now | delta |
|---|---|---|---|
| row degree, k=1 | 2,065 | **1,980** | −4.1% |
| row degree, k=2 | 4,926 | **4,338** | −11.9% |
| col degree, k=1 | 2,665 | **2,575** | −3.4% |
| col degree, k=2 | 5,524 | **4,934** | −10.7% |

## Correctness

`degree_agrees_with_counting_the_iterator` pins the new entry points to the iterator they replace, on an uneven fixture — rows of differing length, mixed inline and promoted pairs — and **with live deltas**, since the shared cursor is re-seeked and a re-seek is exactly where a skipped delta layer would show up as a lost edge. Its deletion leg now asserts the edge it removes was really there; as written before the rebase it deleted a pair the fixture never created, so that leg tested nothing.

178 Rust unit tests, 124 Python e2e/functions, 14 MVCC/concurrency, and the degree-touching flow files (`test_function_calls` 93, `test_results` 18, `test_social` 31) all pass. `cargo fmt --check` and `clippy --all-targets` are clean.

## Follow-up this does not take

The remaining gap is `GxB_rowIterator_attach` per call, which only *not attaching* can remove — a cursor reused across calls, threaded through the hot traversal callers (`ExpandInto`, `CondTraverse`, and these degree entry points). That is a larger API change, and it subsumes the thread-local handle pool this PR previously carried.

**#2621 stays open after this merges** — it holds the decomposition, and 1,654 of the 2,065 instructions it identifies are still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
