### PR TITLE
fix(#2578): split the compound key across blocks, and stop packing endpoints

### DIFF
--- a/graph/src/graph/endpoint_index.rs
+++ b/graph/src/graph/endpoint_index.rs
@@ -1,0 +1,740 @@
+//! `edge_id -> (src, dst)`, in the narrowest field type the endpoints need.
+//!
+//! Every materialised relationship reads this, so it has to be O(1); it holds
+//! one slot per edge id ever reserved, so its width is multiplied by the edge
+//! count and is worth minimising.
+//!
+//! It used to be a `Vec<u64>` holding `(src << 32) | dst`. That fixed 8 bytes
+//! per edge whatever the graph's size, and imposed a hard ceiling of 2^32 per
+//! endpoint — a limit checked on every write that no graph could grow past.
+//!
+//! Both go away by choosing the field *type* from the endpoints instead of
+//! fixing it:
+//!
+//! | nodes up to | field | bytes/edge | vs the old 8 |
+//! |---|---|---|---|
+//! | 65 534         | `u16` | 4  | −50% |
+//! | 16.7 M         | `U24` | 6  | −25% |
+//! | 4.29 B         | `u32` | 8  |   0% |
+//! | 18.4 E         | `u64` | 16 | *(no previous form)* |
+//!
+//! The last row has no comparison to make: the old packing could not represent
+//! those graphs at all, so its 16 bytes are not a doubling of anything. They buy
+//! a range that previously ended in a panic.
+//!
+//! The interesting row is the second: graphs in the millions of nodes — the
+//! common case — pay 6 bytes where they used to pay 8, and graphs past 4.29
+//! billion nodes now work at all, which is what the old packing refused.
+//!
+//! Each width is a distinct `Vec` of a concrete pair type rather than one
+//! buffer with a runtime width. That keeps this free of byte arithmetic: a read
+//! is an ordinary indexed load the compiler bounds-checks, and the empty slot is
+//! a plain constant of the field type rather than a mask re-derived whenever the
+//! width changes.
+//!
+//! # Why all four tiers are held at once
+//!
+//! Holding one tier and converting on overflow would be simpler, and it throws
+//! away most of the saving. Edge ids are allocated in increasing order and the
+//! width only ever grows, so the tiers partition the id space into contiguous
+//! ranges: everything written while node ids were under 65,535 is in `w16`,
+//! everything after in `w24`, and so on. A single-tier index has to repack all
+//! of that to the widest width the graph ever reaches, and then keep paying it.
+//!
+//! Whether that matters depends entirely on *when* edges are written relative to
+//! node growth. Measured on this engine: a bulk load — all nodes, then all edges
+//! — writes every edge after the ids reach their final width, so tiering saves
+//! nothing. A graph grown incrementally across the 65,535 boundary wrote **30%**
+//! of its edges while ids were still narrow, and those keep 4 bytes per edge
+//! instead of 6.
+//!
+//! It also removes the repack. A single-tier index rewrites every slot when it
+//! widens; here a widening promotes only the tiers *below* the new width, and
+//! since a slot can be promoted at most three times in the life of a graph the
+//! total work is `O(3|E|)` spread out rather than three whole-index pauses.
+
+use std::sync::Arc;
+
+/// A field type an endpoint can be stored in.
+pub trait Endpoint: Copy + PartialEq + Sized {
+    /// The value marking an empty or deleted slot.
+    const EMPTY: Self;
+    /// One past the largest id this type can hold, [`Self::EMPTY`] excluded.
+    const CEILING: u64;
+    fn get(self) -> u64;
+    fn put(v: u64) -> Self;
+
+    /// Whether this field is the empty marker. A slot is empty when *both* of
+    /// its fields are, so this is per field rather than per slot.
+    fn vacant(self) -> bool {
+        self == Self::EMPTY
+    }
+}
+
+/// Three bytes, little-endian. There is no primitive for it, and it is the
+/// width that matters most: it covers 16.7 M nodes, which is where a great many
+/// graphs sit, and it is the one a `u16`/`u32`-only ladder would skip straight
+/// past — costing those graphs 8 bytes per edge instead of 6.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct U24([u8; 3]);
+
+impl Endpoint for u16 {
+    const EMPTY: Self = Self::MAX;
+    const CEILING: u64 = Self::MAX as u64;
+    fn get(self) -> u64 {
+        u64::from(self)
+    }
+    fn put(v: u64) -> Self {
+        v as Self
+    }
+}
+
+impl Endpoint for U24 {
+    const EMPTY: Self = Self([0xFF; 3]);
+    const CEILING: u64 = 0x00FF_FFFF;
+    fn get(self) -> u64 {
+        u64::from(u32::from_le_bytes([self.0[0], self.0[1], self.0[2], 0]))
+    }
+    fn put(v: u64) -> Self {
+        let b = v.to_le_bytes();
+        Self([b[0], b[1], b[2]])
+    }
+}
+
+impl Endpoint for u32 {
+    const EMPTY: Self = Self::MAX;
+    const CEILING: u64 = Self::MAX as u64;
+    fn get(self) -> u64 {
+        u64::from(self)
+    }
+    fn put(v: u64) -> Self {
+        v as Self
+    }
+}
+
+impl Endpoint for u64 {
+    const EMPTY: Self = Self::MAX;
+    const CEILING: u64 = Self::MAX;
+    fn get(self) -> u64 {
+        self
+    }
+    fn put(v: u64) -> Self {
+        v
+    }
+}
+
+/// One slot per edge id, in a fixed field type.
+type Slots<T> = Vec<(T, T)>;
+
+/// A tier, shared between MVCC versions until one of them writes to it.
+///
+/// The sharing is per tier rather than per index, and that is the point. A write
+/// transaction takes a new version of the whole graph, and the first edge it
+/// mutates reaches `Arc::make_mut` with the committed snapshot still holding a
+/// reference — a deep clone. Copying the *whole* index there costs about 0.9
+/// instructions per edge in the graph, so a one-edge transaction against 10 M
+/// edges paid 9.15 M instructions before touching anything.
+///
+/// Almost every write appends, and appends land in the widest tier; the narrow
+/// tiers are history and are not touched. Holding each behind its own `Arc`
+/// means a version clones only the tier it writes to, and the history stays
+/// shared.
+type Tier<T> = Option<Arc<Slots<T>>>;
+
+/// `edge_id -> (src, dst)`, split into contiguous id ranges by field width.
+///
+/// The tiers are ordered: `w16` holds the lowest edge ids, then `w24`, `w32`,
+/// `w64`. A tier is `None` until the graph needs it. See the module docs for why
+/// they are held simultaneously rather than converted.
+#[derive(Clone, Default)]
+pub struct EndpointIndex {
+    w16: Tier<u16>,
+    w24: Tier<U24>,
+    w32: Tier<u32>,
+    w64: Tier<u64>,
+}
+
+/// Move every slot of `from` to the front of `into`, re-emitting empty slots as
+/// the wider type's own empty value rather than copying a pattern that means
+/// something else at the new width.
+fn promote<A: Endpoint, B: Endpoint>(
+    from: &mut Tier<A>,
+    into: &mut Slots<B>,
+) {
+    let Some(old) = from.take() else { return };
+    // Reuse the buffer when this version owns it outright; a version that still
+    // shares it with a snapshot has to copy.
+    let old = Arc::try_unwrap(old).unwrap_or_else(|shared| (*shared).clone());
+    if old.is_empty() {
+        return;
+    }
+    let mut merged: Slots<B> = Vec::with_capacity(old.len() + into.len());
+    merged.extend(old.into_iter().map(|(s, d)| {
+        if s.vacant() && d.vacant() {
+            (B::EMPTY, B::EMPTY)
+        } else {
+            (B::put(s.get()), B::put(d.get()))
+        }
+    }));
+    merged.append(into);
+    *into = merged;
+}
+
+/// Run `$body` for each tier in id order, with `$v` bound to `&Option<Slots<_>>`.
+macro_rules! each_tier {
+    ($self:expr, |$v:ident| $body:block) => {{
+        {
+            let $v = &$self.w16;
+            $body
+        }
+        {
+            let $v = &$self.w24;
+            $body
+        }
+        {
+            let $v = &$self.w32;
+            $body
+        }
+        {
+            let $v = &$self.w64;
+            $body
+        }
+    }};
+}
+
+impl EndpointIndex {
+    /// Which tier a value of this size needs: 0 = `w16` … 3 = `w64`.
+    const fn rank_for(v: u64) -> u8 {
+        if v < u16::CEILING {
+            0
+        } else if v < U24::CEILING {
+            1
+        } else if v < u32::CEILING {
+            2
+        } else {
+            3
+        }
+    }
+
+    /// The tier new edge ids append to: the widest one that already holds
+    /// anything, since a narrower range can never follow a wider one.
+    const fn append_rank(&self) -> u8 {
+        if self.w64.is_some() {
+            3
+        } else if self.w32.is_some() {
+            2
+        } else if self.w24.is_some() {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let mut n = 0;
+        each_tier!(self, |v| {
+            n += v.as_ref().map_or(0, |v| v.len());
+        });
+        n
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Bytes held, for `GRAPH.MEMORY`.
+    #[must_use]
+    pub fn memory_usage(&self) -> usize {
+        self.w16.as_ref().map_or(0, |v| v.capacity() * 4)
+            + self.w24.as_ref().map_or(0, |v| v.capacity() * 6)
+            + self.w32.as_ref().map_or(0, |v| v.capacity() * 8)
+            + self.w64.as_ref().map_or(0, |v| v.capacity() * 16)
+    }
+
+    /// Mean bytes per stored slot, which is the quantity the tiering is for.
+    #[must_use]
+    pub fn bytes_per_edge(&self) -> f64 {
+        let n = self.len();
+        if n == 0 {
+            return 0.0;
+        }
+        (self.w16.as_ref().map_or(0, |v| v.len() * 4)
+            + self.w24.as_ref().map_or(0, |v| v.len() * 6)
+            + self.w32.as_ref().map_or(0, |v| v.len() * 8)
+            + self.w64.as_ref().map_or(0, |v| v.len() * 16)) as f64
+            / n as f64
+    }
+
+    /// The endpoints of `edge_id`, or `None` if the slot is empty, deleted, or
+    /// past the end.
+    #[must_use]
+    pub fn get(
+        &self,
+        edge_id: u64,
+    ) -> Option<(u64, u64)> {
+        let mut slot = usize::try_from(edge_id).ok()?;
+        each_tier!(self, |v| {
+            if let Some(v) = v {
+                if slot < v.len() {
+                    let (s, d) = v[slot];
+                    return if s.vacant() && d.vacant() {
+                        None
+                    } else {
+                        Some((s.get(), d.get()))
+                    };
+                }
+                slot -= v.len();
+            }
+        });
+        None
+    }
+
+    /// Promote every tier below `rank` into it, so `rank` holds a contiguous
+    /// range starting at edge id 0.
+    ///
+    /// Only the reused-id path may call this. Appending must *not*: promoting on
+    /// append would rewrite every earlier edge to the new width and throw away
+    /// the whole point of keeping the tiers apart.
+    fn raise_to(
+        &mut self,
+        rank: u8,
+    ) {
+        match rank {
+            1 => promote(
+                &mut self.w16,
+                Arc::make_mut(self.w24.get_or_insert_with(Arc::default)),
+            ),
+            2 => {
+                let into = Arc::make_mut(self.w32.get_or_insert_with(Arc::default));
+                promote(&mut self.w24, into);
+                promote(&mut self.w16, into);
+            }
+            3 => {
+                let into = Arc::make_mut(self.w64.get_or_insert_with(Arc::default));
+                promote(&mut self.w32, into);
+                promote(&mut self.w24, into);
+                promote(&mut self.w16, into);
+            }
+            _ => {
+                self.w16.get_or_insert_with(Arc::default);
+            }
+        }
+    }
+
+    /// Grow the append tier so slot `needed - 1` exists, and make sure that tier
+    /// is wide enough for `max_endpoint`.
+    ///
+    /// Sizing for a whole batch here is what keeps bulk insertion linear: the
+    /// index reserves exactly rather than doubling, so growing per edge is a
+    /// reallocation per edge — measured at **87,370 instructions per edge
+    /// created against 8,927** before this existed, and a bulk-load test timing
+    /// out.
+    pub fn prepare(
+        &mut self,
+        max_edge_id: u64,
+        max_endpoint: u64,
+    ) {
+        let rank = Self::rank_for(max_endpoint).max(self.append_rank());
+        let needed = usize::try_from(max_edge_id).expect("edge id exceeds usize") + 1;
+        let below = self.len() - self.tier_len(rank);
+        let want = needed.saturating_sub(below);
+        self.with_tier(rank, |v| {
+            if want > v.len() {
+                v.reserve_exact(want - v.len());
+            }
+        });
+        self.resize_tier(rank, want);
+    }
+
+    fn tier_len(
+        &self,
+        rank: u8,
+    ) -> usize {
+        match rank {
+            0 => self.w16.as_ref().map_or(0, |v| v.len()),
+            1 => self.w24.as_ref().map_or(0, |v| v.len()),
+            2 => self.w32.as_ref().map_or(0, |v| v.len()),
+            _ => self.w64.as_ref().map_or(0, |v| v.len()),
+        }
+    }
+
+    fn with_tier<F>(
+        &mut self,
+        rank: u8,
+        f: F,
+    ) where
+        F: FnOnce(&mut dyn TierOps),
+    {
+        // `make_mut` here rather than on the index as a whole: this copies one
+        // tier, and only if a snapshot still shares it.
+        // Bound before the call so `make_mut` resolves against the concrete
+        // vector; coercing to `dyn TierOps` first would resolve it against the
+        // trait object, which is not `Clone`.
+        match rank {
+            0 => {
+                let v = Arc::make_mut(self.w16.get_or_insert_with(Arc::default));
+                f(v);
+            }
+            1 => {
+                let v = Arc::make_mut(self.w24.get_or_insert_with(Arc::default));
+                f(v);
+            }
+            2 => {
+                let v = Arc::make_mut(self.w32.get_or_insert_with(Arc::default));
+                f(v);
+            }
+            _ => {
+                let v = Arc::make_mut(self.w64.get_or_insert_with(Arc::default));
+                f(v);
+            }
+        }
+    }
+
+    fn resize_tier(
+        &mut self,
+        rank: u8,
+        len: usize,
+    ) {
+        self.with_tier(rank, |v| v.grow_to(len));
+    }
+
+    /// Record `edge_id`'s endpoints, promoting and growing as needed.
+    pub fn set(
+        &mut self,
+        edge_id: u64,
+        src: u64,
+        dst: u64,
+    ) {
+        let slot = usize::try_from(edge_id).expect("edge id exceeds usize");
+        // An id inside an existing tier is an update in place. If it no longer
+        // fits that tier — which happens when a deleted edge id is reused for an
+        // edge with wider endpoints — every tier up to the needed width is
+        // promoted, which keeps the ranges contiguous.
+        let needed = Self::rank_for(src.max(dst));
+        let mut base = 0usize;
+        for rank in 0..4u8 {
+            let n = self.tier_len(rank);
+            if slot < base + n {
+                if needed > rank {
+                    self.raise_to(needed);
+                    // Promotion moved this slot into `needed`, whose range now
+                    // starts at 0, so the offset is the raw id again.
+                    self.with_tier(needed, |v| v.put(slot, src, dst));
+                } else {
+                    self.with_tier(rank, |v| v.put(slot - base, src, dst));
+                }
+                return;
+            }
+            base += n;
+        }
+        // Past the end: append to the widest active tier, or a wider one if this
+        // edge needs it.
+        let rank = needed.max(self.append_rank());
+        let below = self.len() - self.tier_len(rank);
+        let at = slot - below;
+        self.with_tier(rank, |v| {
+            v.grow_to(at + 1);
+            v.put(at, src, dst);
+        });
+    }
+
+    /// Tombstone `edge_id`'s slot. Vectors never shrink, as before.
+    pub fn clear(
+        &mut self,
+        edge_id: u64,
+    ) {
+        let Ok(slot) = usize::try_from(edge_id) else {
+            return;
+        };
+        let mut base = 0usize;
+        for rank in 0..4u8 {
+            let n = self.tier_len(rank);
+            if slot < base + n {
+                self.with_tier(rank, |v| v.vacate(slot - base));
+                return;
+            }
+            base += n;
+        }
+    }
+
+    /// Build from `(edge_id, src, dst)` triples, sizing one tier exactly. Used
+    /// by the load path, which knows the whole set and writes it at one width.
+    #[must_use]
+    pub fn build(triples: &[(u64, u64, u64)]) -> Self {
+        let max_endpoint = triples.iter().map(|&(_, s, d)| s.max(d)).max().unwrap_or(0);
+        let slots = triples.iter().map(|&(e, _, _)| e).max().map_or(0, |m| {
+            usize::try_from(m).expect("edge id exceeds usize") + 1
+        });
+        let mut ix = Self::default();
+        let rank = Self::rank_for(max_endpoint);
+        ix.with_tier(rank, |v| {
+            v.reserve_exact_to(slots);
+            v.grow_to(slots);
+            for &(e, s, d) in triples {
+                v.put(e as usize, s, d);
+            }
+        });
+        ix
+    }
+}
+
+/// The operations a tier needs, so the four concrete vectors can be reached
+/// through one `dyn` without repeating the body four times. Only used on write
+/// paths, which are not per-row; [`EndpointIndex::get`] indexes the vectors
+/// directly.
+trait TierOps {
+    fn grow_to(
+        &mut self,
+        len: usize,
+    );
+    fn reserve_exact_to(
+        &mut self,
+        len: usize,
+    );
+    fn put(
+        &mut self,
+        at: usize,
+        src: u64,
+        dst: u64,
+    );
+    fn vacate(
+        &mut self,
+        at: usize,
+    );
+    fn len(&self) -> usize;
+    fn reserve_exact(
+        &mut self,
+        extra: usize,
+    );
+}
+
+impl<T: Endpoint> TierOps for Slots<T> {
+    fn grow_to(
+        &mut self,
+        len: usize,
+    ) {
+        if len > self.len() {
+            self.resize(len, (T::EMPTY, T::EMPTY));
+        }
+    }
+    fn reserve_exact_to(
+        &mut self,
+        len: usize,
+    ) {
+        if len > self.len() {
+            Vec::reserve_exact(self, len - self.len());
+        }
+    }
+    fn put(
+        &mut self,
+        at: usize,
+        src: u64,
+        dst: u64,
+    ) {
+        self[at] = (T::put(src), T::put(dst));
+    }
+    fn vacate(
+        &mut self,
+        at: usize,
+    ) {
+        if let Some(s) = self.get_mut(at) {
+            *s = (T::EMPTY, T::EMPTY);
+        }
+    }
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+    fn reserve_exact(
+        &mut self,
+        extra: usize,
+    ) {
+        Vec::reserve_exact(self, extra);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Endpoint, EndpointIndex, U24};
+
+    /// Each width has to keep its all-ones value spare, or a legitimate pair
+    /// reads back as a deleted slot. The boundaries are where an off-by-one
+    /// lands.
+    #[test]
+    fn the_widest_id_of_each_tier_is_not_an_empty_slot() {
+        for (id, want) in [
+            (0u64, 4.0),
+            (u64::from(u16::MAX) - 1, 4.0),
+            (u64::from(u16::MAX), 6.0),
+            (U24::CEILING - 1, 6.0),
+            (U24::CEILING, 8.0),
+            (u64::from(u32::MAX) - 1, 8.0),
+            (u64::from(u32::MAX), 16.0),
+        ] {
+            let mut ix = EndpointIndex::default();
+            ix.set(0, id, id);
+            assert!(
+                (ix.bytes_per_edge() - want).abs() < f64::EPSILON,
+                "tier for id {id}: {} != {want}",
+                ix.bytes_per_edge()
+            );
+            assert_eq!(ix.get(0), Some((id, id)), "id {id} read back as empty");
+        }
+    }
+
+    /// **The property the tiering exists for.** Edges written while ids were
+    /// narrow must *stay* narrow when later edges force a wider tier — that is
+    /// the whole difference from converting the index on overflow.
+    #[test]
+    fn early_edges_keep_their_narrow_tier() {
+        let mut ix = EndpointIndex::default();
+        for e in 0..1000u64 {
+            ix.set(e, e, e + 1);
+        }
+        assert!(
+            (ix.bytes_per_edge() - 4.0).abs() < f64::EPSILON,
+            "small ids should be in the 4-byte tier"
+        );
+
+        // Now the graph outgrows u16. The early thousand must not be repacked.
+        for e in 1000..2000u64 {
+            ix.set(e, 100_000 + e, 100_001 + e);
+        }
+        let mean = ix.bytes_per_edge();
+        assert!(
+            (mean - 5.0).abs() < 0.001,
+            "half at 4 bytes and half at 6 should average 5, got {mean}"
+        );
+        assert_eq!(ix.get(0), Some((0, 1)), "an early edge was lost");
+        assert_eq!(ix.get(999), Some((999, 1000)));
+        assert_eq!(ix.get(1000), Some((101_000, 101_001)));
+        assert_eq!(ix.get(1999), Some((101_999, 102_000)));
+    }
+
+    /// A reused edge id whose new endpoints no longer fit its tier is the case
+    /// that forces a promotion of everything below. Contents and tombstones
+    /// have to survive it.
+    #[test]
+    fn reusing_a_low_id_with_wide_endpoints_promotes_and_preserves() {
+        let mut ix = EndpointIndex::default();
+        for e in 0..100u64 {
+            ix.set(e, e, e + 1);
+        }
+        ix.clear(50);
+        // id 7 is reused for an edge needing three bytes
+        ix.set(7, 1 << 20, (1 << 20) + 3);
+
+        assert_eq!(ix.get(7), Some((1 << 20, (1 << 20) + 3)));
+        assert_eq!(ix.get(50), None, "tombstone lost across a promotion");
+        assert_eq!(ix.get(0), Some((0, 1)));
+        assert_eq!(ix.get(99), Some((99, 100)));
+        assert_eq!(ix.len(), 100, "promotion changed the slot count");
+    }
+
+    /// Endpoints and tombstones must survive every promotion in turn.
+    #[test]
+    fn promotion_preserves_pairs_and_tombstones_at_every_tier() {
+        let mut ix = EndpointIndex::default();
+        ix.set(0, 1, 2);
+        ix.set(1, 3, 4);
+        ix.clear(1);
+        ix.set(2, 300, 400);
+
+        for (id, src, dst) in [
+            (3u64, 70_000u64, 4u64),
+            (4, 1 << 25, 5),
+            (5, 1 << 33, (1 << 34) + 7),
+        ] {
+            ix.set(id, src, dst);
+            assert_eq!(ix.get(0), Some((1, 2)), "pair lost at ({src}, {dst})");
+            assert_eq!(ix.get(1), None, "tombstone lost at ({src}, {dst})");
+            assert_eq!(ix.get(2), Some((300, 400)));
+            assert_eq!(ix.get(id), Some((src, dst)));
+        }
+    }
+
+    /// Gaps left by non-contiguous edge ids read as absent, not as `(0, 0)`.
+    #[test]
+    fn gaps_read_as_absent() {
+        let mut ix = EndpointIndex::default();
+        ix.set(5, 7, 8);
+        assert_eq!(ix.get(0), None);
+        assert_eq!(ix.get(4), None);
+        assert_eq!(ix.get(5), Some((7, 8)));
+        assert_eq!(ix.get(6), None, "past the end");
+    }
+
+    /// `build` and `prepare` + `set` must agree, since the load path uses one
+    /// and every other path the other.
+    #[test]
+    fn build_agrees_with_prepared_sets() {
+        let triples = [(0u64, 1u64, 2u64), (3, 70_000, 4), (7, 5, 6)];
+        let mut a = EndpointIndex::default();
+        a.prepare(7, 70_000);
+        for &(e, s, d) in &triples {
+            a.set(e, s, d);
+        }
+        let b = EndpointIndex::build(&triples);
+        assert_eq!(a.len(), b.len());
+        for e in 0..a.len() as u64 {
+            assert_eq!(a.get(e), b.get(e), "slot {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod cow_bench {
+    use super::EndpointIndex;
+    use crate::graph::graphblas::instr::read_instr;
+
+    /// What an MVCC version costs when the writer touches one edge.
+    ///
+    /// `Graph` holds this behind an `Arc`, and the committed snapshot keeps a
+    /// second reference, so the first edge mutation of a version reaches
+    /// `Arc::make_mut` with a refcount above one — a deep clone. The question
+    /// this answers is how much of the index that clone has to copy: all of it,
+    /// or only the tier the write lands in.
+    ///
+    /// Run with:
+    ///   cargo test --release -p graph cow_cost -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn cow_cost_of_a_version() {
+        // A graph grown across the u16 boundary: most edges are history in the
+        // narrow tier, and a write appends to the wide one.
+        for edges in [100_000u64, 1_000_000, 10_000_000] {
+            let mut ix = EndpointIndex::default();
+            let narrow = edges * 9 / 10;
+            for e in 0..narrow {
+                ix.set(e, e % 60_000, (e + 1) % 60_000);
+            }
+            for e in narrow..edges {
+                ix.set(e, 100_000 + e % 1000, 100_001 + e % 1000);
+            }
+
+            // What a write transaction actually pays: take a version (the
+            // clone), then write one edge — which is where a copy-on-write copy
+            // happens, and the whole question is how much of the index it
+            // copies. The original stays alive throughout, so the refcount is
+            // above one exactly as a committed snapshot makes it.
+            let reps = 20u64;
+            let i0 = read_instr();
+            for e in 0..reps {
+                let mut version = ix.clone();
+                version.set(edges + e, 1, 2);
+                std::hint::black_box(&version);
+            }
+            let i1 = read_instr();
+            let per_version = match (i0, i1) {
+                (Some(a), Some(b)) => (b - a) as f64 / reps as f64,
+                _ => f64::NAN,
+            };
+            println!(
+                "{edges:>10} edges  mean {:.2} B/edge  version + 1 write {:>12.0} instr",
+                ix.bytes_per_edge(),
+                per_version
+            );
+        }
+    }
+}

--- a/graph/src/graph/endpoint_index.rs
+++ b/graph/src/graph/endpoint_index.rs
@@ -204,7 +204,10 @@ macro_rules! each_tier {
 
 impl EndpointIndex {
     /// Which tier a value of this size needs: 0 = `w16` … 3 = `w64`.
-    const fn rank_for(v: u64) -> u8 {
+    ///
+    /// Public because the restore path recovers the tier boundaries with it.
+    #[must_use]
+    pub const fn rank_for(v: u64) -> u8 {
         if v < u16::CEILING {
             0
         } else if v < U24::CEILING {
@@ -400,6 +403,40 @@ impl EndpointIndex {
         self.with_tier(rank, |v| v.grow_to(len));
     }
 
+    /// Lay out all four tiers directly, for a caller that already knows where
+    /// the boundaries fall.
+    ///
+    /// `starts[r]` is the first edge id belonging to tier `r + 1`, and `len` is
+    /// one past the largest edge id. Every slot is created empty.
+    ///
+    /// This exists so a restore can *rebuild* the tiering rather than flatten
+    /// it. Sizing with [`Self::prepare`] and the whole graph's widest endpoint
+    /// would put every edge at the widest width, undoing on each load exactly
+    /// what the tiers are for. The boundaries are recoverable without keeping
+    /// anything per edge: under incremental growth an edge lands in the widest
+    /// tier any earlier edge needed, so tier `r` begins at the smallest edge id
+    /// whose own endpoints need at least `r` — three scalars, found in the same
+    /// scan that finds the maximum id.
+    pub fn prepare_tiers(
+        &mut self,
+        starts: [u64; 3],
+        len: u64,
+    ) {
+        let to = |v: u64| usize::try_from(v).expect("edge id exceeds usize");
+        let (len, s1, s2, s3) = (to(len), to(starts[0]), to(starts[1]), to(starts[2]));
+        let (s1, s2, s3) = (s1.min(len), s2.min(len), s3.min(len));
+        debug_assert!(s1 <= s2 && s2 <= s3, "tier starts must be ordered");
+        for (rank, n) in [(0u8, s1), (1, s2 - s1), (2, s3 - s2), (3, len - s3)] {
+            if n == 0 {
+                continue;
+            }
+            self.with_tier(rank, |v| {
+                v.reserve_exact(n);
+                v.grow_to(n);
+            });
+        }
+    }
+
     /// Record `edge_id`'s endpoints, promoting and growing as needed.
     pub fn set(
         &mut self,
@@ -458,26 +495,6 @@ impl EndpointIndex {
             base += n;
         }
     }
-
-    /// Build from `(edge_id, src, dst)` triples, sizing one tier exactly. Used
-    /// by the load path, which knows the whole set and writes it at one width.
-    #[must_use]
-    pub fn build(triples: &[(u64, u64, u64)]) -> Self {
-        let max_endpoint = triples.iter().map(|&(_, s, d)| s.max(d)).max().unwrap_or(0);
-        let slots = triples.iter().map(|&(e, _, _)| e).max().map_or(0, |m| {
-            usize::try_from(m).expect("edge id exceeds usize") + 1
-        });
-        let mut ix = Self::default();
-        let rank = Self::rank_for(max_endpoint);
-        ix.with_tier(rank, |v| {
-            v.reserve_exact_to(slots);
-            v.grow_to(slots);
-            for &(e, s, d) in triples {
-                v.put(e as usize, s, d);
-            }
-        });
-        ix
-    }
 }
 
 /// The operations a tier needs, so the four concrete vectors can be reached
@@ -486,10 +503,6 @@ impl EndpointIndex {
 /// directly.
 trait TierOps {
     fn grow_to(
-        &mut self,
-        len: usize,
-    );
-    fn reserve_exact_to(
         &mut self,
         len: usize,
     );
@@ -517,14 +530,6 @@ impl<T: Endpoint> TierOps for Slots<T> {
     ) {
         if len > self.len() {
             self.resize(len, (T::EMPTY, T::EMPTY));
-        }
-    }
-    fn reserve_exact_to(
-        &mut self,
-        len: usize,
-    ) {
-        if len > self.len() {
-            Vec::reserve_exact(self, len - self.len());
         }
     }
     fn put(
@@ -654,6 +659,41 @@ mod tests {
         }
     }
 
+    /// A restore must rebuild the same tiering the graph had in memory, or
+    /// every reload would flatten the index to its widest width.
+    #[test]
+    fn prepare_tiers_rebuilds_the_layout_growth_produced() {
+        // Grown incrementally: 1000 narrow edges, then 1000 wide ones.
+        let mut grown = EndpointIndex::default();
+        for e in 0..1000u64 {
+            grown.set(e, e, e + 1);
+        }
+        for e in 1000..2000u64 {
+            grown.set(e, 100_000 + e, 100_001 + e);
+        }
+
+        // Restored: the boundary is the first edge id needing the wider tier.
+        let mut restored = EndpointIndex::default();
+        restored.prepare_tiers([1000, 2000, 2000], 2000);
+        for e in 0..1000u64 {
+            restored.set(e, e, e + 1);
+        }
+        for e in 1000..2000u64 {
+            restored.set(e, 100_000 + e, 100_001 + e);
+        }
+
+        assert_eq!(restored.len(), grown.len());
+        assert!(
+            (restored.bytes_per_edge() - grown.bytes_per_edge()).abs() < f64::EPSILON,
+            "restore flattened the tiering: {} vs {}",
+            restored.bytes_per_edge(),
+            grown.bytes_per_edge()
+        );
+        for e in 0..2000u64 {
+            assert_eq!(restored.get(e), grown.get(e), "slot {e}");
+        }
+    }
+
     /// Gaps left by non-contiguous edge ids read as absent, not as `(0, 0)`.
     #[test]
     fn gaps_read_as_absent() {
@@ -665,21 +705,39 @@ mod tests {
         assert_eq!(ix.get(6), None, "past the end");
     }
 
-    /// `build` and `prepare` + `set` must agree, since the load path uses one
-    /// and every other path the other.
+    /// `prepare` exists only to stop bulk insertion being quadratic, so it must
+    /// not change what the index ends up holding. The load path prepares and
+    /// every other path does not, and both have to agree.
     #[test]
-    fn build_agrees_with_prepared_sets() {
-        let triples = [(0u64, 1u64, 2u64), (3, 70_000, 4), (7, 5, 6)];
-        let mut a = EndpointIndex::default();
-        a.prepare(7, 70_000);
+    fn preparing_first_changes_nothing_but_the_cost() {
+        let triples = [
+            (0u64, 1u64, 2u64),
+            (3, 70_000, 4),
+            (7, 5, 6),
+            (9, 1 << 25, 2),
+        ];
+        let mut prepared = EndpointIndex::default();
+        prepared.prepare(9, 1 << 25);
         for &(e, s, d) in &triples {
-            a.set(e, s, d);
+            prepared.set(e, s, d);
         }
-        let b = EndpointIndex::build(&triples);
-        assert_eq!(a.len(), b.len());
-        for e in 0..a.len() as u64 {
-            assert_eq!(a.get(e), b.get(e), "slot {e}");
+        let mut plain = EndpointIndex::default();
+        for &(e, s, d) in &triples {
+            plain.set(e, s, d);
         }
+        assert_eq!(prepared.len(), plain.len());
+        for e in 0..plain.len() as u64 {
+            assert_eq!(prepared.get(e), plain.get(e), "slot {e}");
+        }
+        // The *contents* agree; the layouts deliberately do not. `prepare`
+        // sizes one tier to the batch's widest endpoint, so it is wider on
+        // average than letting each edge pick its own tier. That is the trade
+        // for not reallocating per edge, and it is why the restore path uses
+        // `prepare_tiers` — which rebuilds the boundaries — rather than this.
+        assert!(
+            prepared.bytes_per_edge() >= plain.bytes_per_edge(),
+            "preparing should never be narrower than growing edge by edge"
+        );
     }
 }
 

--- a/graph/src/graph/endpoint_index.rs
+++ b/graph/src/graph/endpoint_index.rs
@@ -126,6 +126,14 @@ impl Endpoint for u64 {
 /// One slot per edge id, in a fixed field type.
 type Slots<T> = Vec<(T, T)>;
 
+/// Bytes one slot of a tier costs, taken from the layout the compiler chose
+/// rather than a literal that has to be kept in step with it. `(U24, U24)` is 6
+/// bytes only because `U24` is `[u8; 3]` and so alignment 1; a field type that
+/// gained alignment would otherwise make `GRAPH.MEMORY` drift silently.
+const fn slot_bytes<T>(_: &Slots<T>) -> usize {
+    size_of::<(T, T)>()
+}
+
 /// A tier, shared between MVCC versions until one of them writes to it.
 ///
 /// The sharing is per tier rather than per index, and that is the point. A write
@@ -208,28 +216,22 @@ impl EndpointIndex {
     /// Public because the restore path recovers the tier boundaries with it.
     #[must_use]
     pub const fn rank_for(v: u64) -> u8 {
-        if v < u16::CEILING {
-            0
-        } else if v < U24::CEILING {
-            1
-        } else if v < u32::CEILING {
-            2
-        } else {
-            3
+        match v {
+            0..u16::CEILING => 0,
+            u16::CEILING..U24::CEILING => 1,
+            U24::CEILING..u32::CEILING => 2,
+            _ => 3,
         }
     }
 
     /// The tier new edge ids append to: the widest one that already holds
     /// anything, since a narrower range can never follow a wider one.
     const fn append_rank(&self) -> u8 {
-        if self.w64.is_some() {
-            3
-        } else if self.w32.is_some() {
-            2
-        } else if self.w24.is_some() {
-            1
-        } else {
-            0
+        match (&self.w64, &self.w32, &self.w24) {
+            (Some(_), ..) => 3,
+            (_, Some(_), _) => 2,
+            (_, _, Some(_)) => 1,
+            (None, None, None) => 0,
         }
     }
 
@@ -250,10 +252,11 @@ impl EndpointIndex {
     /// Bytes held, for `GRAPH.MEMORY`.
     #[must_use]
     pub fn memory_usage(&self) -> usize {
-        self.w16.as_ref().map_or(0, |v| v.capacity() * 4)
-            + self.w24.as_ref().map_or(0, |v| v.capacity() * 6)
-            + self.w32.as_ref().map_or(0, |v| v.capacity() * 8)
-            + self.w64.as_ref().map_or(0, |v| v.capacity() * 16)
+        let mut n = 0;
+        each_tier!(self, |v| {
+            n += v.as_ref().map_or(0, |v| v.capacity() * slot_bytes(v));
+        });
+        n
     }
 
     /// Mean bytes per stored slot, which is the quantity the tiering is for.
@@ -263,15 +266,22 @@ impl EndpointIndex {
         if n == 0 {
             return 0.0;
         }
-        (self.w16.as_ref().map_or(0, |v| v.len() * 4)
-            + self.w24.as_ref().map_or(0, |v| v.len() * 6)
-            + self.w32.as_ref().map_or(0, |v| v.len() * 8)
-            + self.w64.as_ref().map_or(0, |v| v.len() * 16)) as f64
-            / n as f64
+        let mut bytes = 0;
+        each_tier!(self, |v| {
+            bytes += v.as_ref().map_or(0, |v| v.len() * slot_bytes(v));
+        });
+        bytes as f64 / n as f64
     }
 
     /// The endpoints of `edge_id`, or `None` if the slot is empty, deleted, or
     /// past the end.
+    ///
+    /// Indexes the concrete vectors rather than going through [`Self::locate`]
+    /// and `TierOps`: this is the per-row read path, and a `dyn` call plus a
+    /// second walk of the tier lengths would show up on it. The last tier's
+    /// `slot -=` is dead by construction — there is nothing after it — which is
+    /// what the allow covers.
+    #[allow(unused_assignments)]
     #[must_use]
     pub fn get(
         &self,
@@ -407,7 +417,9 @@ impl EndpointIndex {
     /// the boundaries fall.
     ///
     /// `starts[r]` is the first edge id belonging to tier `r + 1`, and `len` is
-    /// one past the largest edge id. Every slot is created empty.
+    /// one past the largest edge id. Both are slot indices, so the caller — who
+    /// knows its ids fit — does the narrowing and this stays total. Every slot
+    /// is created empty.
     ///
     /// This exists so a restore can *rebuild* the tiering rather than flatten
     /// it. Sizing with [`Self::prepare`] and the whole graph's widest endpoint
@@ -419,12 +431,10 @@ impl EndpointIndex {
     /// scan that finds the maximum id.
     pub fn prepare_tiers(
         &mut self,
-        starts: [u64; 3],
-        len: u64,
+        starts: [usize; 3],
+        len: usize,
     ) {
-        let to = |v: u64| usize::try_from(v).expect("edge id exceeds usize");
-        let (len, s1, s2, s3) = (to(len), to(starts[0]), to(starts[1]), to(starts[2]));
-        let (s1, s2, s3) = (s1.min(len), s2.min(len), s3.min(len));
+        let [s1, s2, s3] = starts.map(|s| s.min(len));
         debug_assert!(s1 <= s2 && s2 <= s3, "tier starts must be ordered");
         for (rank, n) in [(0u8, s1), (1, s2 - s1), (2, s3 - s2), (3, len - s3)] {
             if n == 0 {
@@ -437,6 +447,24 @@ impl EndpointIndex {
         }
     }
 
+    /// The tier holding `slot` and its offset within that tier, or `None` if
+    /// the id is past every tier. The tiers partition the id space into
+    /// contiguous ranges, so this walks at most four of them.
+    fn locate(
+        &self,
+        slot: usize,
+    ) -> Option<(u8, usize)> {
+        let mut base = 0usize;
+        for rank in 0..4u8 {
+            let n = self.tier_len(rank);
+            if slot < base + n {
+                return Some((rank, slot - base));
+            }
+            base += n;
+        }
+        None
+    }
+
     /// Record `edge_id`'s endpoints, promoting and growing as needed.
     pub fn set(
         &mut self,
@@ -445,36 +473,28 @@ impl EndpointIndex {
         dst: u64,
     ) {
         let slot = usize::try_from(edge_id).expect("edge id exceeds usize");
-        // An id inside an existing tier is an update in place. If it no longer
-        // fits that tier — which happens when a deleted edge id is reused for an
-        // edge with wider endpoints — every tier up to the needed width is
-        // promoted, which keeps the ranges contiguous.
         let needed = Self::rank_for(src.max(dst));
-        let mut base = 0usize;
-        for rank in 0..4u8 {
-            let n = self.tier_len(rank);
-            if slot < base + n {
-                if needed > rank {
-                    self.raise_to(needed);
-                    // Promotion moved this slot into `needed`, whose range now
-                    // starts at 0, so the offset is the raw id again.
-                    self.with_tier(needed, |v| v.put(slot, src, dst));
-                } else {
-                    self.with_tier(rank, |v| v.put(slot - base, src, dst));
-                }
-                return;
+        match self.locate(slot) {
+            // A reused id whose new endpoints no longer fit its tier. Promoting
+            // up to `needed` re-bases that tier's range to 0, so the offset just
+            // computed is stale and the raw id is the right index.
+            Some((rank, _)) if needed > rank => {
+                self.raise_to(needed);
+                self.with_tier(needed, |v| v.put(slot, src, dst));
             }
-            base += n;
+            // An id inside an existing tier is an update in place.
+            Some((rank, at)) => self.with_tier(rank, |v| v.put(at, src, dst)),
+            // Past the end: append to the widest active tier, or a wider one if
+            // this edge needs it.
+            None => {
+                let rank = needed.max(self.append_rank());
+                let at = slot - (self.len() - self.tier_len(rank));
+                self.with_tier(rank, |v| {
+                    v.grow_to(at + 1);
+                    v.put(at, src, dst);
+                });
+            }
         }
-        // Past the end: append to the widest active tier, or a wider one if this
-        // edge needs it.
-        let rank = needed.max(self.append_rank());
-        let below = self.len() - self.tier_len(rank);
-        let at = slot - below;
-        self.with_tier(rank, |v| {
-            v.grow_to(at + 1);
-            v.put(at, src, dst);
-        });
     }
 
     /// Tombstone `edge_id`'s slot. Vectors never shrink, as before.
@@ -485,14 +505,8 @@ impl EndpointIndex {
         let Ok(slot) = usize::try_from(edge_id) else {
             return;
         };
-        let mut base = 0usize;
-        for rank in 0..4u8 {
-            let n = self.tier_len(rank);
-            if slot < base + n {
-                self.with_tier(rank, |v| v.vacate(slot - base));
-                return;
-            }
-            base += n;
+        if let Some((rank, at)) = self.locate(slot) {
+            self.with_tier(rank, |v| v.vacate(at));
         }
     }
 }

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -88,10 +88,11 @@ use crate::{
     graph::{
         attribute_store::{AttrNameMap, AttributeStore},
         constraint::{Constraint, ConstraintStatus, ConstraintType},
+        endpoint_index::EndpointIndex,
         graphblas::{
             matrix::{Descriptor, Dup, Matrix},
             serialization::{Encode, EncodeState, PayloadEntry, Writer},
-            tensor::{Tensor, compound_key},
+            tensor::Tensor,
             versioned_matrix::{self, VersionedMatrix},
         },
     },
@@ -248,13 +249,6 @@ pub struct MemoryUsageReport {
 ///
 /// The Graph is `Send + Sync` but not internally synchronized. Use [`MvccGraph`]
 /// for concurrent access with proper read/write isolation.
-/// Sentinel for an empty/deleted slot in [`Graph::edge_endpoints`].
-///
-/// Equals `compound_key(u32::MAX, u32::MAX)`, which would only collide with a
-/// real edge whose endpoints are both node id `u32::MAX` (4.29 billion) — not
-/// reachable in practice, since the tensor compound key caps node ids at u32.
-const EDGE_NO_ENDPOINT: u64 = u64::MAX;
-
 pub struct Graph {
     /// Graph name (Redis key name)
     name: String,
@@ -288,14 +282,18 @@ pub struct Graph {
     labels_matices: Vec<VersionedMatrix<bool>>,
     /// Per-type relationship tensors (type ID → src×dst×edge_id)
     relationship_matrices: Vec<Tensor>,
-    /// Graph-wide reverse index: `edge_id` → `compound_key(src, dst)` for O(1)
-    /// endpoint lookup, stored as a dense vector indexed by edge id. Edge IDs
-    /// are densely allocated, so a `Vec` is far more compact than a hash map
-    /// (8 B/edge vs ~31 B with control bytes + load-factor slack). Wrapped in
-    /// `Arc` so MVCC `new_version` is O(1); the first edge mutation per
-    /// version pays one `Arc::make_mut` deep clone, node-only writes pay
-    /// nothing. Empty/deleted slots hold [`EDGE_NO_ENDPOINT`].
-    edge_endpoints: Arc<Vec<u64>>,
+    /// Graph-wide reverse index: `edge_id` → `(src, dst)` for O(1) endpoint
+    /// lookup, as a dense array indexed by edge id. Edge IDs are densely
+    /// allocated, so an array is far more compact than a hash map (~31 B/edge
+    /// with control bytes and load-factor slack). Wrapped in `Arc` so MVCC
+    /// `new_version` is O(1); the first edge mutation per version pays one
+    /// `Arc::make_mut` deep clone, node-only writes pay nothing.
+    ///
+    /// [`EndpointIndex`] sizes its fields to the endpoints it holds, so this is
+    /// 6 bytes per edge on a graph of millions of nodes rather than a flat 8 —
+    /// and it has no ceiling, where the previous `(src << 32) | dst` packing
+    /// refused any node id past 2^32.
+    edge_endpoints: Arc<EndpointIndex>,
     /// The graph's one attribute-name dictionary: name → id and id → name, shared by
     /// both stores below so an id means the same attribute everywhere it appears — in a
     /// span, the RDB, a `GRAPH.EFFECT`, or a compact reply.
@@ -706,7 +704,7 @@ impl Graph {
             all_nodes_matrix: VersionedMatrix::<bool>::new(n, n),
             labels_matices: Vec::new(),
             relationship_matrices: Vec::new(),
-            edge_endpoints: Arc::new(Vec::new()),
+            edge_endpoints: Arc::new(EndpointIndex::default()),
             attrs_name: AttrNameMap::default(),
             node_attrs: AttributeStore::new(),
             relationship_attrs: AttributeStore::new(),
@@ -750,18 +748,18 @@ impl Graph {
     ) -> Self {
         // Rebuild the graph-wide reverse index after RDB load to ensure
         // complete sync with the decoded edges.
-        let mut edge_endpoints: Vec<u64> = Vec::new();
-        for tensor in &relationship_matrices {
-            for (src, dst, edge_id) in tensor.iter_edges() {
-                let idx = edge_id as usize;
-                if idx >= edge_endpoints.len() {
-                    edge_endpoints.resize(idx + 1, EDGE_NO_ENDPOINT);
-                }
-                edge_endpoints[idx] = compound_key(src, dst);
-            }
-        }
-        // Drop the doubling slack left by the incremental resizes above.
-        edge_endpoints.shrink_to_fit();
+        // Collected first so the index picks its field width once, from the
+        // widest endpoint in the graph, instead of repacking as it discovers
+        // wider ones.
+        let triples: Vec<(u64, u64, u64)> = relationship_matrices
+            .iter()
+            .flat_map(|tensor| {
+                tensor
+                    .iter_edges()
+                    .map(|(src, dst, edge_id)| (edge_id, src, dst))
+            })
+            .collect();
+        let edge_endpoints = EndpointIndex::build(&triples);
 
         let chunk = NODE_CREATION_BUFFER.load(Ordering::Relaxed);
         let node_cap = node_count + deleted_nodes.len();
@@ -2100,15 +2098,16 @@ impl Graph {
         // Reserve exactly: MVCC clones reset capacity to `len`, so amortized
         // doubling here would only leave ~2x slack behind, never save reallocs.
         let endpoints = Arc::make_mut(&mut self.edge_endpoints);
-        if let Some(&max_id) = rel_ids.iter().max() {
-            let needed = max_id as usize + 1;
-            if needed > endpoints.len() {
-                endpoints.reserve_exact(needed - endpoints.len());
-                endpoints.resize(needed, EDGE_NO_ENDPOINT);
-            }
+        // Size for the whole batch first: growing per edge is a reallocation
+        // per edge, since the index reserves exactly rather than doubling.
+        if let (Some(&max_id), Some(max_endpoint)) = (
+            rel_ids.iter().max(),
+            srcs.iter().chain(dsts.iter()).max().copied(),
+        ) {
+            endpoints.prepare(max_id, max_endpoint);
         }
         for ((&src, &dst), &id) in srcs.iter().zip(dsts.iter()).zip(rel_ids.iter()) {
-            endpoints[id as usize] = compound_key(src, dst);
+            endpoints.set(id, src, dst);
         }
 
         self.adjacancy_matrix
@@ -2665,10 +2664,7 @@ impl Graph {
         &self,
         edge_id: u64,
     ) -> Option<(u64, u64)> {
-        self.edge_endpoints
-            .get(edge_id as usize)
-            .filter(|&&key| key != EDGE_NO_ENDPOINT)
-            .map(|&key| (key >> 32, key & 0xFFFF_FFFF))
+        self.edge_endpoints.get(edge_id)
     }
 
     /// Clear an edge's endpoint slot in the reverse index (on deletion).
@@ -2677,9 +2673,7 @@ impl Graph {
         &mut self,
         edge_id: u64,
     ) {
-        if let Some(slot) = Arc::make_mut(&mut self.edge_endpoints).get_mut(edge_id as usize) {
-            *slot = EDGE_NO_ENDPOINT;
-        }
+        Arc::make_mut(&mut self.edge_endpoints).clear(edge_id);
     }
 
     /// Returns (src, dst) for an edge via the maintained reverse index.
@@ -3968,12 +3962,12 @@ impl Graph {
 
         // --- edge block storage ---
         // Mirrors the node side: the matrix recording each edge's existence and
-        // type, plus the graph-wide edge_id → compound_key reverse index (a dense
+        // type, plus the graph-wide edge_id → endpoint reverse index (a dense
         // vector holding one u64 per edge slot).
         let edge_block_storage_sz: usize = self.relationship_type_matrix.memory_usage()
             + self.relationship_attrs.structural_memory_usage()
             + self.deleted_relationships.serialized_size()
-            + self.edge_endpoints.capacity() * std::mem::size_of::<u64>();
+            + self.edge_endpoints.memory_usage();
 
         // --- node attributes by label (sampling) ---
         let mut node_attr_by_label: Vec<(Arc<String>, usize)> = Vec::new();

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -283,11 +283,12 @@ pub struct Graph {
     /// Per-type relationship tensors (type ID → src×dst×edge_id)
     relationship_matrices: Vec<Tensor>,
     /// Graph-wide reverse index: `edge_id` → `(src, dst)` for O(1) endpoint
-    /// lookup, as a dense array indexed by edge id. Edge IDs are densely
-    /// allocated, so an array is far more compact than a hash map (~31 B/edge
+    /// lookup, as contiguous slots indexed by edge id. Edge IDs are densely
+    /// allocated, so slots are far more compact than a hash map (~31 B/edge
     /// with control bytes and load-factor slack). Wrapped in `Arc` so MVCC
     /// `new_version` is O(1); the first edge mutation per version pays one
-    /// `Arc::make_mut` deep clone, node-only writes pay nothing.
+    /// `Arc::make_mut` deep clone of the tier it writes to — not of the whole
+    /// index — and node-only writes pay nothing.
     ///
     /// [`EndpointIndex`] sizes its fields to the endpoints it holds, so this is
     /// 6 bytes per edge on a graph of millions of nodes rather than a flat 8 —
@@ -784,8 +785,9 @@ impl Graph {
             acc = acc.min(*slot);
             *slot = acc;
         }
+        let to_slot = |v: u64| usize::try_from(v).expect("edge id exceeds usize");
         let mut edge_endpoints = EndpointIndex::default();
-        edge_endpoints.prepare_tiers(starts, len);
+        edge_endpoints.prepare_tiers(starts.map(to_slot), to_slot(len));
         for tensor in &relationship_matrices {
             for (src, dst, edge_id) in tensor.iter_edges() {
                 edge_endpoints.set(edge_id, src, dst);
@@ -3993,8 +3995,8 @@ impl Graph {
 
         // --- edge block storage ---
         // Mirrors the node side: the matrix recording each edge's existence and
-        // type, plus the graph-wide edge_id → endpoint reverse index (a dense
-        // vector holding one u64 per edge slot).
+        // type, plus the graph-wide edge_id → endpoint reverse index (one slot
+        // per edge id, 4, 6, 8 or 16 bytes wide depending on the tier).
         let edge_block_storage_sz: usize = self.relationship_type_matrix.memory_usage()
             + self.relationship_attrs.structural_memory_usage()
             + self.deleted_relationships.serialized_size()

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -748,18 +748,49 @@ impl Graph {
     ) -> Self {
         // Rebuild the graph-wide reverse index after RDB load to ensure
         // complete sync with the decoded edges.
-        // Collected first so the index picks its field width once, from the
-        // widest endpoint in the graph, instead of repacking as it discovers
-        // wider ones.
-        let triples: Vec<(u64, u64, u64)> = relationship_matrices
-            .iter()
-            .flat_map(|tensor| {
-                tensor
-                    .iter_edges()
-                    .map(|(src, dst, edge_id)| (edge_id, src, dst))
-            })
-            .collect();
-        let edge_endpoints = EndpointIndex::build(&triples);
+        // Two scans rather than one scan into a `Vec` of triples: materialising
+        // them would add ~24 bytes per edge of peak memory on top of the graph
+        // being restored, which is enough to fail a load that would otherwise
+        // fit. The first scan takes only maxima, which sizes the index once, so
+        // the second neither widens nor reallocates.
+        //
+        // The first pass also recovers where the index's width tiers begin.
+        // Sizing everything to the graph's widest endpoint would be simpler and
+        // would flatten the tiering on every load; under incremental growth an
+        // edge lands in the widest tier any earlier edge needed, so tier `r`
+        // begins at the smallest edge id whose own endpoints need at least `r`.
+        // Three scalars, no per-edge state.
+        let mut max_edge_id = 0u64;
+        let mut starts = [u64::MAX; 3];
+        for tensor in &relationship_matrices {
+            for (src, dst, edge_id) in tensor.iter_edges() {
+                max_edge_id = max_edge_id.max(edge_id);
+                let rank = EndpointIndex::rank_for(src.max(dst));
+                for r in 1..=rank {
+                    let slot = &mut starts[usize::from(r) - 1];
+                    *slot = (*slot).min(edge_id);
+                }
+            }
+        }
+        let len = if relationship_matrices.iter().any(|t| t.edge_count() > 0) {
+            max_edge_id + 1
+        } else {
+            0
+        };
+        // A tier nothing reached starts at the end, i.e. stays empty. Clamped
+        // monotone so a later tier never begins before an earlier one.
+        let mut acc = len;
+        for slot in starts.iter_mut().rev() {
+            acc = acc.min(*slot);
+            *slot = acc;
+        }
+        let mut edge_endpoints = EndpointIndex::default();
+        edge_endpoints.prepare_tiers(starts, len);
+        for tensor in &relationship_matrices {
+            for (src, dst, edge_id) in tensor.iter_edges() {
+                edge_endpoints.set(edge_id, src, dst);
+            }
+        }
 
         let chunk = NODE_CREATION_BUFFER.load(Ordering::Relaxed);
         let node_cap = node_count + deleted_nodes.len();

--- a/graph/src/graph/graphblas/block_scaling_bench.rs
+++ b/graph/src/graph/graphblas/block_scaling_bench.rs
@@ -207,3 +207,45 @@ fn block_scaling_index_width() {
         );
     }
 }
+
+/// Probe: is the top row key writable, and is a wider dimension legal?
+#[test]
+#[ignore]
+fn block_scaling_top_row_probe() {
+    use super::matrix::Matrix;
+    use super::tensor::{BLOCK_SHIFT, GrB_INDEX_MAX, Tensor, compound_key};
+
+    ensure_init();
+    let m = (1u64 << BLOCK_SHIFT) - 1;
+    let (block, row) = compound_key(m, m);
+    println!("compound_key({m}, {m}) = block {block:?} row {row}");
+    println!("row == GrB_INDEX_MAX: {}", row == GrB_INDEX_MAX);
+
+    // (a) does a write at the top row of a GrB_INDEX_MAX-row matrix land?
+    let mut a = Matrix::<bool>::new(GrB_INDEX_MAX, 1 << 31).into_hyper();
+    a.set(row, 7, true);
+    a.wait();
+    println!("nrows=GrB_INDEX_MAX, set(row={row}) -> nvals {}", a.nvals());
+
+    // (b) is a dimension one larger accepted at all?
+    let mut b = Matrix::<bool>::new(GrB_INDEX_MAX + 1, 1 << 31).into_hyper();
+    b.set(row, 7, true);
+    b.wait();
+    println!(
+        "nrows=GrB_INDEX_MAX+1 -> nrows reported {}, set(row={row}) -> nvals {}",
+        b.nrows(),
+        b.nvals()
+    );
+
+    // (c) end to end through the tensor
+    let mut t = Tensor::new(m + 2, m + 2);
+    t.set_all_from_slices(&[m, m], &[m, m], &[10, 11]);
+    let mut t = t.dup();
+    t.flush();
+    t.wait();
+    println!(
+        "tensor pair ({m}, {m}): ids {:?}  edge_count {}",
+        t.get(m, m).collect::<Vec<_>>(),
+        t.edge_count()
+    );
+}

--- a/graph/src/graph/graphblas/block_scaling_bench.rs
+++ b/graph/src/graph/graphblas/block_scaling_bench.rs
@@ -1,0 +1,209 @@
+//! What blocking the `me` key costs, and where it starts to matter.
+//!
+//! `compound_key` splits a pair across a *block* and a row within it, so `me` is
+//! one matrix per live block instead of one matrix. Every maintenance path —
+//! flush, wait, fold, sync checks, sizing — folds over the live blocks, which
+//! turns per-transaction work that was constant into work proportional to how
+//! many blocks a graph has touched.
+//!
+//! Two things worth knowing, and this measures both.
+//!
+//! [`block_scaling_zero_cost`] is the case that decides whether the change is
+//! acceptable at all: a graph inside block `(0, 0)` — every graph up to 2^30
+//! nodes per axis, which is every graph — must pay nothing measurable for a
+//! generality it never uses.
+//!
+//! [`block_scaling_crossover`] is the case the design trades away. It spreads
+//! the same number of multi-edge pairs over an increasing number of blocks and
+//! reports per-transaction cost against block count, so the slope is visible
+//! rather than asserted.
+//!
+//! Run with:
+//!   cargo test --release -p graph block_scaling -- --ignored --nocapture --test-threads=1
+
+use super::instr::read_instr;
+use super::tensor::{BLOCK_SHIFT, Tensor};
+use super::test_init::ensure_init;
+
+/// Multi-edge pairs in every fixture, held constant so block count is the only
+/// variable.
+const PAIRS: u64 = 20_000;
+
+fn per_op<F: FnMut()>(
+    ops: u64,
+    mut f: F,
+) -> f64 {
+    let a = read_instr();
+    f();
+    let b = read_instr();
+    match (a, b) {
+        (Some(a), Some(b)) => (b - a) as f64 / ops as f64,
+        _ => f64::NAN,
+    }
+}
+
+/// `PAIRS` two-edge pairs spread evenly over `blocks` blocks along the source
+/// axis. `blocks == 1` is block `(0, 0)` alone, i.e. today's shape.
+fn spread(blocks: u64) -> Tensor {
+    let span = 1u64 << BLOCK_SHIFT;
+    let mut t = Tensor::new(blocks * span + PAIRS + 2, PAIRS + 2);
+    let (mut s, mut d, mut i) = (Vec::new(), Vec::new(), Vec::new());
+    for p in 0..PAIRS {
+        let src = (p % blocks) * span + p;
+        for e in 0..2 {
+            s.push(src);
+            d.push(p);
+            i.push(p * 2 + e);
+        }
+    }
+    t.set_all_from_slices(&s, &d, &i);
+    let mut t = t.dup();
+    t.flush();
+    t.wait();
+    t
+}
+
+/// The case that has to be free: a graph that never leaves block `(0, 0)`.
+///
+/// Reported per *transaction*, not per pair, because that is the quantity the
+/// block loop makes proportional to block count.
+#[test]
+#[ignore]
+fn block_scaling_zero_cost() {
+    ensure_init();
+    println!("\n=== block (0,0) only, {PAIRS} multi-edge pairs ===");
+    println!("{:>34}  {:>14}", "operation", "instr/tx");
+    let mut t = spread(1);
+    for _ in 0..3 {
+        let c = per_op(1, || {
+            t.wait();
+            t.flush();
+        });
+        println!("{:>34}  {:>14.1}", "wait + flush (one transaction)", c);
+    }
+    for _ in 0..3 {
+        let c = per_op(1, || {
+            std::hint::black_box(t.edge_count());
+        });
+        println!("{:>34}  {:>14.1}", "edge_count", c);
+    }
+    for _ in 0..3 {
+        let c = per_op(1, || {
+            std::hint::black_box(t.memory_usage());
+        });
+        println!("{:>34}  {:>14.1}", "memory_usage", c);
+    }
+}
+
+/// The case the design trades away: the same pairs spread thinner and thinner.
+#[test]
+#[ignore]
+fn block_scaling_crossover() {
+    ensure_init();
+    println!("\n=== {PAIRS} multi-edge pairs spread over N blocks ===");
+    println!(
+        "{:>8}  {:>14}  {:>14}  {:>14}",
+        "blocks", "wait+flush", "edge_count", "memory_usage"
+    );
+    for blocks in [1u64, 2, 4, 8, 16, 32, 64] {
+        let mut t = spread(blocks);
+        let mut wf = f64::MAX;
+        let mut ec = f64::MAX;
+        let mut mu = f64::MAX;
+        for _ in 0..3 {
+            wf = wf.min(per_op(1, || {
+                t.wait();
+                t.flush();
+            }));
+            ec = ec.min(per_op(1, || {
+                std::hint::black_box(t.edge_count());
+            }));
+            mu = mu.min(per_op(1, || {
+                std::hint::black_box(t.memory_usage());
+            }));
+        }
+        println!("{blocks:>8}  {wf:>14.1}  {ec:>14.1}  {mu:>14.1}");
+        assert_eq!(
+            t.edge_count(),
+            2 * PAIRS,
+            "fixture lost edges at {blocks} blocks"
+        );
+        assert_eq!(
+            t.multi_pairs(),
+            PAIRS,
+            "fixture lost pairs at {blocks} blocks"
+        );
+    }
+}
+
+/// Does shrinking `me`'s declared dimensions buy anything?
+///
+/// GraphBLAS 10 chooses 32- or 64-bit index arrays per matrix from its
+/// dimensions, so a matrix declared `GrB_INDEX_MAX` square stores 64-bit row
+/// and column indices even when it holds four entries. `me`'s columns are edge
+/// ids and its rows are compound keys, and the two are independent: the column
+/// index array holds one entry per stored id and is the large one, while the
+/// hyperlist holds one per multi-edge pair.
+///
+/// This prices each choice against the same content, and reports the index
+/// widths GraphBLAS actually picked so the numbers are attributable rather than
+/// inferred.
+#[test]
+#[ignore]
+fn block_scaling_index_width() {
+    use super::matrix::Matrix;
+
+    ensure_init();
+    const IDS: u64 = 200_000;
+    const ROWS: u64 = 20_000;
+    let max = super::tensor::GrB_INDEX_MAX;
+    println!(
+        "global 32-bit hint set: {:?}",
+        Matrix::<bool>::global_hint_32bit_for_test()
+    );
+
+    println!(
+        "\n=== `me` shape vs bytes, {ROWS} rows x {} ids each ===",
+        IDS / ROWS
+    );
+    println!(
+        "{:>26}  {:>12}  {:>10}  {:>10}  {:>12}",
+        "declared dims", "bytes", "row bits", "col bits", "B/id"
+    );
+
+    let u32max = u64::from(u32::MAX);
+    for (label, nrows, ncols, hint) in [
+        ("2^60 x 2^60 (today)", max, max, false),
+        // 2^32-1 is not enough: GraphBLAS needs the dimension itself to fit a
+        // `u32`, and 2^32 does not. The cutoff is 2^31.
+        ("(2^32-1) x (2^32-1)", u32max, u32max, false),
+        ("2^31 x 2^31", 1u64 << 31, 1u64 << 31, false),
+        // Rows and columns are chosen independently. Columns are edge ids and
+        // hold one array entry per stored id; rows hold one per multi-edge
+        // pair — which is why only the column half is worth narrowing, and why
+        // `me` is built at the shape on the next line.
+        ("2^60 rows x 2^31 cols", max, 1u64 << 31, false),
+        ("2^31 rows x 2^60 cols", 1u64 << 31, max, false),
+        // The hint is accepted (`GrB_SUCCESS`) and changes nothing: the
+        // declared dimensions are the only lever. Kept so the next person does
+        // not spend the afternoon re-discovering it.
+        ("2^60 x 2^60, hint 32", max, max, true),
+    ] {
+        let mut m = Matrix::<bool>::new(nrows, ncols).into_hyper();
+        let status = if hint {
+            format!("{:?}", m.hint_32bit_indices_for_test())
+        } else {
+            "-".to_string()
+        };
+        for i in 0..IDS {
+            m.set(i % ROWS, i, true);
+        }
+        m.wait();
+        let bytes = m.memory_usage();
+        let (rb, cb) = m.integer_bits_for_test();
+        println!(
+            "{label:>26}  {bytes:>12}  {rb:>10}  {cb:>10}  {:>12.2}  set={status}",
+            bytes as f64 / IDS as f64
+        );
+    }
+}

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -821,16 +821,21 @@ impl<T> Matrix<T> {
     pub(super) fn integer_bits_for_test(&self) -> (i32, i32) {
         unsafe {
             let (mut r, mut c) = (0i32, 0i32);
-            GrB_Matrix_get_INT32(
+            // Checked: a failed getter leaves the initialised zero behind, and
+            // reporting "0-bit indices" would read as a result rather than an
+            // error.
+            let ri = GrB_Matrix_get_INT32(
                 *self.m,
                 &raw mut r,
                 GxB_Option_Field::GxB_ROWINDEX_INTEGER_BITS as i32,
             );
-            GrB_Matrix_get_INT32(
+            assert_eq!(ri, GrB_Info::GrB_SUCCESS, "row index bits: {ri:?}");
+            let ci = GrB_Matrix_get_INT32(
                 *self.m,
                 &raw mut c,
                 GxB_Option_Field::GxB_COLINDEX_INTEGER_BITS as i32,
             );
+            assert_eq!(ci, GrB_Info::GrB_SUCCESS, "column index bits: {ci:?}");
             (r, c)
         }
     }

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -813,6 +813,67 @@ impl<T> Matrix<T> {
         }
     }
 
+    /// The index widths GraphBLAS chose for this matrix, as
+    /// `(row bits, column bits)`. Read-only in GraphBLAS and derived from the
+    /// declared dimensions, so this is how a shape choice is checked rather
+    /// than assumed.
+    #[cfg(test)]
+    pub(super) fn integer_bits_for_test(&self) -> (i32, i32) {
+        unsafe {
+            let (mut r, mut c) = (0i32, 0i32);
+            GrB_Matrix_get_INT32(
+                *self.m,
+                &raw mut r,
+                GxB_Option_Field::GxB_ROWINDEX_INTEGER_BITS as i32,
+            );
+            GrB_Matrix_get_INT32(
+                *self.m,
+                &raw mut c,
+                GxB_Option_Field::GxB_COLINDEX_INTEGER_BITS as i32,
+            );
+            (r, c)
+        }
+    }
+
+    /// Ask GraphBLAS for 32-bit row and column index arrays. Only a *hint*: it
+    /// is honoured when the matrix's declared dimensions fit, and ignored when
+    /// they do not, so a caller cannot make indices too narrow for the data.
+    #[cfg(test)]
+    pub(super) fn hint_32bit_indices_for_test(&mut self) -> (i32, i32) {
+        unsafe {
+            let r = GrB_Matrix_set_INT32(
+                *self.m,
+                32,
+                GxB_Option_Field::GxB_ROWINDEX_INTEGER_HINT as i32,
+            );
+            let c = GrB_Matrix_set_INT32(
+                *self.m,
+                32,
+                GxB_Option_Field::GxB_COLINDEX_INTEGER_HINT as i32,
+            );
+            (r as i32, c as i32)
+        }
+    }
+
+    /// Ask GraphBLAS globally for 32-bit indices on matrices created after this
+    /// point. Returns the two status codes.
+    #[cfg(test)]
+    pub(super) fn global_hint_32bit_for_test() -> (i32, i32) {
+        unsafe {
+            let r = GrB_Global_set_INT32(
+                GrB_GLOBAL,
+                32,
+                GxB_Option_Field::GxB_ROWINDEX_INTEGER_HINT as i32,
+            );
+            let c = GrB_Global_set_INT32(
+                GrB_GLOBAL,
+                32,
+                GxB_Option_Field::GxB_COLINDEX_INTEGER_HINT as i32,
+            );
+            (r as i32, c as i32)
+        }
+    }
+
     pub fn clear(&mut self) {
         unsafe {
             let info = GrB_Matrix_clear(*self.m);

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -69,6 +69,8 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 #[cfg(test)]
+mod block_scaling_bench;
+#[cfg(test)]
 mod fold_cost_bench;
 pub mod lagraph_bindings;
 pub mod lagraphx_bindings;
@@ -77,6 +79,52 @@ pub mod serialization;
 pub mod tensor;
 pub mod vector;
 pub mod versioned_matrix;
+
+/// The instruction counter the benches in this directory measure with.
+///
+/// One declaration, shared, for the same reason as [`test_init`]: benches that
+/// disagreed on a field offset would report numbers that cannot be compared.
+#[cfg(test)]
+pub(crate) mod instr {
+    /// Running instruction total for this process, or `None` where the platform
+    /// has no cheap equivalent.
+    ///
+    /// macOS exposes `proc_pid_rusage(RUSAGE_INFO_V4)` to any caller for its own
+    /// pid with no privileges; `ri_instructions` is `u64` field 29 of the struct
+    /// body, which starts after the 16-byte `ri_uuid`. Same offsets as
+    /// `bench/src/falkorbench/counters.py::read_rusage`, so engine-level and
+    /// data-structure-level numbers are on one scale.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn read_instr() -> Option<u64> {
+        const RUSAGE_INFO_V4: i32 = 4;
+        const RI_INSTRUCTIONS_OFF: usize = 16 + 29 * 8;
+
+        unsafe extern "C" {
+            fn proc_pid_rusage(
+                pid: i32,
+                flavor: i32,
+                buffer: *mut u8,
+            ) -> i32;
+            fn getpid() -> i32;
+        }
+        let mut buf = [0u8; 1024];
+        // SAFETY: `buf` is 1024 bytes, far larger than `struct rusage_info_v4`
+        // (~0x150 bytes), and the kernel writes at most that flavor's size.
+        if unsafe { proc_pid_rusage(getpid(), RUSAGE_INFO_V4, buf.as_mut_ptr()) } != 0 {
+            return None;
+        }
+        Some(u64::from_le_bytes(
+            buf[RI_INSTRUCTIONS_OFF..RI_INSTRUCTIONS_OFF + 8]
+                .try_into()
+                .expect("8 bytes"),
+        ))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub(crate) fn read_instr() -> Option<u64> {
+        None
+    }
+}
 
 /// Process-wide GraphBLAS initialization for unit tests. `GrB_init` may only
 /// be called once per process, so every `#[cfg(test)]` module must go through

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -142,24 +142,91 @@ use super::{
 #[allow(non_upper_case_globals)]
 pub const GrB_INDEX_MAX: u64 = (1u64 << 60) - 1;
 
-/// Pack a `(src, dst)` node-id pair into the compound row key used by the
-/// edge-id matrix `me`.
+/// Column count `me` is created with, and the width at which GraphBLAS stores
+/// its column indices in 32 bits rather than 64.
 ///
-/// The encoding `(src << 32) | dst` reserves 32 bits for each side, so both
-/// values must fit in a `u32`. We check this unconditionally (not just under
-/// `debug_assert!`) because silent truncation would corrupt the key and
-/// conflate edges between different node pairs.
+/// `me`'s columns are edge ids, and its column-index array holds one entry per
+/// stored id — the largest array in the structure. Declaring the matrix
+/// `GrB_INDEX_MAX` wide forced 64-bit indices for every one of them: measured on
+/// 200k ids, 11.69 bytes per id against 6.44 at this width, so the declaration
+/// alone was costing 45%.
+///
+/// The threshold is `2^31`, not `2^32`: GraphBLAS needs the dimension itself to
+/// fit, and `2^32` does not fit a `u32`. A tensor whose edge ids reach this
+/// widens back to `GrB_INDEX_MAX` ([`Tensor::widen_me_for_id`]) and pays what it
+/// paid before, so the narrow default costs nothing but the check.
+///
+/// Rows are deliberately left at `GrB_INDEX_MAX`. Narrowing them too saves a
+/// further 0.40 bytes per id — the row arrays hold one entry per multi-edge
+/// *pair*, not per id — and would need [`BLOCK_SHIFT`] down at 15, which is a
+/// block per 32,768 nodes per axis. That is a bad trade for 6% of the saving.
+const ME_NARROW_NCOLS: u64 = 1 << 31;
+
+/// Bits of each node id carried in the compound row key. Two of these must fit
+/// in a GraphBLAS index, so `2 * BLOCK_SHIFT <= 60`.
+///
+/// Set to the maximum the index allows. Everything above these bits selects a
+/// *block* instead (see [`compound_key`]), so this is not a limit on node ids —
+/// it is the width at which one block's key space ends and the next begins.
+pub const BLOCK_SHIFT: u32 = 30;
+const BLOCK_MASK: u64 = (1u64 << BLOCK_SHIFT) - 1;
+
+/// Which `me` matrix a pair's identifiers live in.
+///
+/// `(0, 0)` for every pair whose endpoints both fit in [`BLOCK_SHIFT`] bits,
+/// which is every graph up to 2^30 nodes per axis and therefore the only block
+/// that exists in practice. [`Tensor`] stores block `(0, 0)` in a dedicated
+/// field and allocates a map only if some other block is ever reached, so a
+/// graph inside it pays one `Option` check and nothing else.
+pub type MeBlock = (u64, u64);
+
+/// The block `(0, 0)`, where every pair of a graph within [`BLOCK_SHIFT`] bits
+/// per axis lands.
+pub const ME_BLOCK_0: MeBlock = (0, 0);
+
+/// Split a `(src, dst)` node-id pair into the `me` block that holds its
+/// identifiers and the row key within that block.
+///
+/// The previous encoding was `(src << 32) | dst` in a single matrix, and it was
+/// unsound above `src = 2^28`: `me` is `GrB_INDEX_MAX` square, so a key of
+/// 60 bits or more is out of range for its row dimension. `Matrix::set` checks
+/// the GraphBLAS status under `debug_assert!` only, so a release build dropped
+/// the write — leaving the pair tagged [`MULTI_EDGE`] with an empty `me` row,
+/// which is Invariant *promotion completeness* broken and reads as edges
+/// silently vanishing. The guard that was there checked the wrong bound (`u32`,
+/// i.e. `2^32`) and so never fired.
+///
+/// Splitting instead of packing removes the failure rather than moving it. The
+/// low [`BLOCK_SHIFT`] bits of each endpoint form a row key that is *always*
+/// within range by construction, and the high bits select a block. There is no
+/// bound to check and no way to be out of range, so this function is total —
+/// note that it cannot panic, where its predecessor could and, worse, could
+/// silently corrupt below the bound it panicked at.
 #[inline]
 #[must_use]
 pub fn compound_key(
     src: u64,
     dst: u64,
-) -> u64 {
-    assert!(
-        u32::try_from(src).is_ok() && u32::try_from(dst).is_ok(),
-        "Tensor compound key overflow: src={src}, dst={dst} (each must fit in u32)",
-    );
-    (src << 32) | dst
+) -> (MeBlock, u64) {
+    (
+        (src >> BLOCK_SHIFT, dst >> BLOCK_SHIFT),
+        ((src & BLOCK_MASK) << BLOCK_SHIFT) | (dst & BLOCK_MASK),
+    )
+}
+
+/// Recover `(src, dst)` from a block and a row key — the inverse of
+/// [`compound_key`], which iteration needs to turn an `me` entry back into the
+/// pair it belongs to.
+#[inline]
+#[must_use]
+pub fn compound_key_inverse(
+    block: MeBlock,
+    row: u64,
+) -> (u64, u64) {
+    (
+        (block.0 << BLOCK_SHIFT) | (row >> BLOCK_SHIFT),
+        (block.1 << BLOCK_SHIFT) | (row & BLOCK_MASK),
+    )
 }
 
 /// Edge storage for one relationship type, with inline edge ids.
@@ -192,10 +259,18 @@ pub struct Tensor {
     /// stored here — they are recovered from `m` (and `me`) when iterating
     /// incoming edges, avoiding a redundant copy of every id.
     mt: VersionedMatrix<bool>,
-    /// Multi-edge id storage, keyed by `compound_key(src, dst)` → edge_id
-    /// (BOOL). Holds *all* ids of pairs with more than one edge; empty
-    /// otherwise.
+    /// Multi-edge id storage for block [`ME_BLOCK_0`], keyed by the row half of
+    /// `compound_key(src, dst)` → edge_id (BOOL). Holds *all* ids of pairs with
+    /// more than one edge; empty otherwise.
     me: VersionedMatrix<bool>,
+    /// Multi-edge id storage for every *other* block, allocated only if a pair
+    /// ever lands outside [`ME_BLOCK_0`] — i.e. only above 2^30 nodes on one
+    /// axis. `None` for every graph in practice, which is what keeps the block
+    /// split free: the paths below check an `Option` and take today's code.
+    ///
+    /// This is the same inline-first shape the tensor uses for edge ids one
+    /// level down, applied to the blocks themselves.
+    me_blocks: Option<Box<FxHashMap<MeBlock, VersionedMatrix<bool>>>>,
     /// Whether the fold decisions latched on `dp`/`dm` are executable now; see
     /// `VersionedMatrix`'s field of the same name.
     needs_flush: AtomicBool,
@@ -235,6 +310,7 @@ impl Clone for Tensor {
             dm: self.dm.clone(),
             mt: self.mt.clone(),
             me: self.me.clone(),
+            me_blocks: self.me_blocks.clone(),
             needs_flush: AtomicBool::new(self.needs_flush.load(Ordering::Relaxed)),
         }
     }
@@ -251,9 +327,87 @@ impl Tensor {
             dp: Delta::new(Matrix::<u64>::new(nrows, ncols)),
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(ncols, nrows),
-            me: VersionedMatrix::<bool>::new(GrB_INDEX_MAX, GrB_INDEX_MAX),
+            me: VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ME_NARROW_NCOLS),
+            me_blocks: None,
             needs_flush: AtomicBool::new(false),
         }
+    }
+
+    /// The `me` matrix holding `block`, or `None` if no pair has ever landed in
+    /// it. Reads take this: an absent block holds no identifiers, which is the
+    /// same answer an empty matrix would give without allocating one.
+    #[inline]
+    fn me_block(
+        &self,
+        block: MeBlock,
+    ) -> Option<&VersionedMatrix<bool>> {
+        if block == ME_BLOCK_0 {
+            return Some(&self.me);
+        }
+        self.me_blocks.as_ref()?.get(&block)
+    }
+
+    /// The `me` matrix holding `block`, creating it if this is the first pair to
+    /// reach it. Writes take this.
+    ///
+    /// Every block is `GrB_INDEX_MAX` square like the original single matrix,
+    /// and hypersparse, so an empty one costs the fixed matrix header rather
+    /// than anything proportional to its dimensions.
+    fn me_block_mut(
+        &mut self,
+        block: MeBlock,
+    ) -> &mut VersionedMatrix<bool> {
+        if block == ME_BLOCK_0 {
+            return &mut self.me;
+        }
+        // A new block is created at whatever width `me` already has, so a
+        // tensor that has widened does not go on creating narrow blocks behind
+        // it and re-widening them one at a time.
+        let ncols = self.me.ncols();
+        self.me_blocks
+            .get_or_insert_with(|| Box::new(FxHashMap::default()))
+            .entry(block)
+            .or_insert_with(|| VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ncols))
+    }
+
+    /// Widen every `me` block's column space if `max_id` will not fit.
+    ///
+    /// Called once per batch with the batch's largest edge id, so the common
+    /// path is one comparison. Widening is one-way and rare: edge ids come from
+    /// a counter, so a tensor crosses `ME_NARROW_NCOLS` at most once.
+    fn widen_me_for_id(
+        &mut self,
+        max_id: u64,
+    ) {
+        if max_id < self.me.ncols() {
+            return;
+        }
+        for me in self.me_all_mut() {
+            me.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+        }
+    }
+
+    /// Every live `me` matrix, block `(0, 0)` first. The maintenance paths —
+    /// flush, wait, fold, sync checks, sizing — fold over this rather than
+    /// touching `self.me` directly, so a block added later is not missed by one
+    /// of them.
+    fn me_all(&self) -> impl Iterator<Item = &VersionedMatrix<bool>> {
+        std::iter::once(&self.me).chain(self.me_blocks.iter().flat_map(|b| b.values()))
+    }
+
+    /// As [`Self::me_all`], mutably.
+    fn me_all_mut(&mut self) -> impl Iterator<Item = &mut VersionedMatrix<bool>> {
+        std::iter::once(&mut self.me).chain(self.me_blocks.iter_mut().flat_map(|b| b.values_mut()))
+    }
+
+    /// Every live `me` matrix with the block it holds, for the paths that must
+    /// map a row key back to a `(src, dst)` pair.
+    fn me_all_keyed(&self) -> impl Iterator<Item = (MeBlock, &VersionedMatrix<bool>)> {
+        std::iter::once((ME_BLOCK_0, &self.me)).chain(
+            self.me_blocks
+                .iter()
+                .flat_map(|b| b.iter().map(|(&k, v)| (k, v))),
+        )
     }
 
     /// Wait pending GraphBLAS work on the forward delta layers. The committed
@@ -311,8 +465,16 @@ impl Tensor {
     ) -> EdgeIds {
         match self.eff_get(src, dest) {
             Some(MULTI_EDGE) => {
-                let key = compound_key(src, dest);
-                EdgeIds::Multi(self.me.iter(key, key))
+                let (block, key) = compound_key(src, dest);
+                // An absent block holds no identifiers. Promotion completeness
+                // says that cannot happen for a pair reading as MULTI_EDGE, so
+                // this arm is unreachable rather than a fallback — but an empty
+                // iterator is the honest answer if it ever is reached, and it is
+                // what an empty matrix would have returned anyway.
+                self.me_block(block).map_or_else(
+                    || EdgeIds::Inline(None.into_iter()),
+                    |me| EdgeIds::Multi(me.iter(key, key)),
+                )
             }
             inline => EdgeIds::Inline(inline.into_iter()),
         }
@@ -342,6 +504,13 @@ impl Tensor {
             return;
         }
 
+        // `me` is created with a narrow column space so GraphBLAS stores 32-bit
+        // column indices; an id past it widens every block first, once, before
+        // any of them is written.
+        if let Some(&max_id) = ids.iter().max() {
+            self.widen_me_for_id(max_id);
+        }
+
         self.flush();
         // `flush` no-ops unless a fold was latched; materialize the deltas
         // explicitly (single atomic load each when already synced) so the
@@ -363,18 +532,21 @@ impl Tensor {
         let mut m_ids: Vec<u64> = Vec::with_capacity(srcs.len());
         let mut m_masked: Vec<Option<u64>> = Vec::with_capacity(srcs.len());
         for ((&s, &d), &id) in srcs.iter().zip(dsts.iter()).zip(ids.iter()) {
-            let key = compound_key(s, d);
+            let (block, key) = compound_key(s, d);
             match batch.entry((s, d)) {
                 Entry::Occupied(mut e) => {
                     let idx = *e.get();
                     if idx != usize::MAX {
                         // Second edge of a pair new in this batch: promote the
                         // pending inline slot in place.
-                        self.me.set(key, m_ids[idx], true);
+                        let me = self.me_block_mut(block);
+                        me.set(key, m_ids[idx], true);
+                        me.set(key, id, true);
                         m_ids[idx] = MULTI_EDGE;
                         e.insert(usize::MAX);
+                    } else {
+                        self.me_block_mut(block).set(key, id, true);
                     }
-                    self.me.set(key, id, true);
                 }
                 Entry::Vacant(e) => {
                     let masked = !dm_empty && self.dm.contains(s, d);
@@ -383,15 +555,16 @@ impl Tensor {
                     match cur {
                         // Already multi-edge: just add the id to `me`.
                         Some(MULTI_EDGE) => {
-                            self.me.set(key, id, true);
+                            self.me_block_mut(block).set(key, id, true);
                             e.insert(usize::MAX);
                         }
                         // Present single edge: promote — move the existing
                         // inline id to `me` alongside the new one, and queue
                         // the sentinel for the inline slot.
                         Some(cur_id) => {
-                            self.me.set(key, cur_id, true);
-                            self.me.set(key, id, true);
+                            let me = self.me_block_mut(block);
+                            me.set(key, cur_id, true);
+                            me.set(key, id, true);
                             e.insert(usize::MAX);
                             m_srcs.push(s);
                             m_dsts.push(d);
@@ -516,10 +689,10 @@ impl Tensor {
         self.wait_fwd();
         let mut plans: FxHashMap<(u64, u64), PairPlan> = FxHashMap::default();
         // `me` entries to drop, in discovery order.
-        let mut me_del: Vec<(u64, u64)> = Vec::new();
+        let mut me_del: Vec<(MeBlock, u64, u64)> = Vec::new();
         let mut emptied = Vec::new();
         for &(id, src, dst) in rels {
-            let key = compound_key(src, dst);
+            let (block, key) = compound_key(src, dst);
             let plan = match plans.entry((src, dst)) {
                 Entry::Occupied(e) => e.into_mut(),
                 Entry::Vacant(e) => e.insert(match self.eff_get(src, dst) {
@@ -527,7 +700,10 @@ impl Tensor {
                     // and take every removal for this pair out of that list
                     // instead of re-reading a row we are about to dirty.
                     Some(MULTI_EDGE) => {
-                        let ids: Vec<u64> = self.me.iter(key, key).map(|(_, id)| id).collect();
+                        let ids: Vec<u64> = self
+                            .me_block(block)
+                            .map(|me| me.iter(key, key).map(|(_, id)| id).collect())
+                            .unwrap_or_default();
                         debug_assert!(
                             ids.windows(2).all(|w| w[0] < w[1]),
                             "`me` row ({src}, {dst}) not ascending; the search below needs it"
@@ -549,7 +725,7 @@ impl Tensor {
                         continue;
                     };
                     ids.remove(pos);
-                    me_del.push((key, id));
+                    me_del.push((block, key, id));
                     match ids.len() {
                         // A MULTI pair keeps *all* of its ids in `me` and has
                         // at least two of them, so removing one always leaves
@@ -567,7 +743,7 @@ impl Tensor {
                         // had already been written.
                         1 => {
                             let last = ids[0];
-                            me_del.push((key, last));
+                            me_del.push((block, key, last));
                             *plan = PairPlan::Single {
                                 id: last,
                                 demoted: true,
@@ -592,8 +768,8 @@ impl Tensor {
         // another write's pending tuples. `dp` erases are batched ahead of
         // `dp` inserts for the same reason: a `GrB_Matrix_removeElement` that
         // finds nothing may finish the matrix to be sure.
-        for &(key, id) in &me_del {
-            self.me.remove(key, id);
+        for &(block, key, id) in &me_del {
+            self.me_block_mut(block).remove(key, id);
         }
         let mut dp_set: Vec<(u64, u64, u64)> = Vec::new();
         for (&(src, dst), plan) in &plans {
@@ -747,7 +923,9 @@ impl Tensor {
             self.needs_flush.store(false, Ordering::Relaxed);
         }
         self.mt.flush();
-        self.me.flush();
+        for me in self.me_all_mut() {
+            me.flush();
+        }
     }
 
     /// Latch the fold decision from the current (materialized) delta sizes
@@ -761,7 +939,9 @@ impl Tensor {
             self.flush();
         }
         self.mt.fold_latched();
-        self.me.fold_latched();
+        for me in self.me_all_mut() {
+            me.fold_latched();
+        }
     }
 
     /// Fold forward-layer deltas that have grown comparable to the base, plus
@@ -783,7 +963,9 @@ impl Tensor {
             self.flush();
         }
         self.mt.fold_oversized();
-        self.me.fold_oversized();
+        for me in self.me_all_mut() {
+            me.fold_oversized();
+        }
     }
 
     /// Materialize the effective forward structure as a `bool` matrix:
@@ -832,6 +1014,10 @@ impl Tensor {
             dm: self.dm.new_version(fold_dm),
             mt: self.mt.dup(),
             me: self.me.dup(),
+            me_blocks: self
+                .me_blocks
+                .as_ref()
+                .map(|b| Box::new(b.iter().map(|(&k, v)| (k, v.dup())).collect())),
             needs_flush: AtomicBool::new(fold_dp || fold_dm),
         }
     }
@@ -887,12 +1073,23 @@ impl Tensor {
         &self.mt
     }
 
-    /// Overflow multi-edge id storage (`me`), keyed by `compound_key(src,
-    /// dst)` → edge id. Holds only the 2nd, 3rd, … edge of a pair; empty
-    /// unless some pair has more than one edge.
+    /// Overflow multi-edge id storage for block [`ME_BLOCK_0`], keyed by the
+    /// row half of `compound_key(src, dst)` → edge id. Holds all ids of pairs
+    /// with more than one edge; empty unless some pair has one.
+    ///
+    /// Callers that must see *every* identifier — rather than every identifier
+    /// of a graph within 2^30 nodes per axis — want
+    /// [`Self::edge_versioned_all`].
     #[must_use]
-    pub const fn edge_versioned(&self) -> &VersionedMatrix<bool> {
+    pub const fn edge_versioned_block_0(&self) -> &VersionedMatrix<bool> {
         &self.me
+    }
+
+    /// Every `me` matrix with the block it holds, so a caller doing its own
+    /// GraphBLAS work over the overflow can cover all of them and map row keys
+    /// back to pairs with [`compound_key_inverse`].
+    pub fn edge_versioned_all(&self) -> impl Iterator<Item = (MeBlock, &VersionedMatrix<bool>)> {
+        self.me_all_keyed()
     }
 
     /// Total number of edges. Each effective forward entry is one edge,
@@ -908,7 +1105,7 @@ impl Tensor {
             self.dp.intersection_nvals(&self.m)
         };
         self.m.nvals() + self.dp.nvals() - self.dm.nvals() - shadow - self.multi_pairs()
-            + self.me.nvals()
+            + self.me_all().map(VersionedMatrix::nvals).sum::<u64>()
     }
 
     /// Iterate every `(src, dst, edge_id)` triple in the tensor.
@@ -918,14 +1115,15 @@ impl Tensor {
     /// multi-edge ids from `me`. On a single-edge graph `me` is empty, so
     /// this is a single streaming pass with no per-pair sub-iterator.
     pub fn iter_edges(&self) -> impl Iterator<Item = (u64, u64, u64)> + '_ {
-        let multi: Box<dyn Iterator<Item = (u64, u64, u64)> + '_> = if self.me.nvals() == 0 {
-            Box::new(std::iter::empty())
+        let multi: Box<dyn Iterator<Item = (u64, u64, u64)> + '_> = if self.has_multi_edge() {
+            Box::new(self.me_all_keyed().flat_map(|(block, me)| {
+                me.iter(0, GrB_INDEX_MAX).map(move |(key, edge_id)| {
+                    let (src, dst) = compound_key_inverse(block, key);
+                    (src, dst, edge_id)
+                })
+            }))
         } else {
-            Box::new(
-                self.me
-                    .iter(0, GrB_INDEX_MAX)
-                    .map(|(key, edge_id)| (key >> 32, key & 0xFFFF_FFFF, edge_id)),
-            )
+            Box::new(std::iter::empty())
         };
         self.fwd_iter(0, u64::MAX)
             .filter(|&(_, _, id)| id != MULTI_EDGE)
@@ -965,26 +1163,34 @@ impl Tensor {
 
     #[cfg(test)]
     fn fwd_me_nvals_for_test(&self) -> u64 {
-        self.me.nvals()
+        self.me_all().map(VersionedMatrix::nvals).sum()
     }
 
     #[must_use]
     pub fn multi_pairs(&self) -> u64 {
-        // A graph with no multi-edge pair anywhere — the dominant case, and the
-        // one the whole design is built around — answers from `nvals` without
-        // waiting `me` or attaching an iterator to it.
-        if self.me.nvals() == 0 {
+        // Blocks partition the pairs — a pair's identifiers live in exactly one
+        // block — so the per-block counts simply add. Rows are counted within a
+        // block, never across, which is why this is a sum and not a merge.
+        self.me_all().map(Self::multi_pairs_in).sum()
+    }
+
+    /// [`Self::multi_pairs`] for one block.
+    fn multi_pairs_in(me: &VersionedMatrix<bool>) -> u64 {
+        // A block with no multi-edge pair — which is every block of the
+        // dominant single-edge case — answers from `nvals` without waiting it
+        // or attaching an iterator to it.
+        if me.nvals() == 0 {
             return 0;
         }
-        self.me.wait();
-        if self.me.dp().nvals() == 0 && self.me.dm().nvals() == 0 {
-            if let Some(kount) = self.me.m().hyper_vector_count() {
+        me.wait();
+        if me.dp().nvals() == 0 && me.dm().nvals() == 0 {
+            if let Some(kount) = me.m().hyper_vector_count() {
                 return kount;
             }
         }
         let mut rows = 0u64;
         let mut last: Option<u64> = None;
-        for (key, _) in self.me.iter(0, u64::MAX) {
+        for (key, _) in me.iter(0, u64::MAX) {
             if last != Some(key) {
                 rows += 1;
                 last = Some(key);
@@ -998,13 +1204,15 @@ impl Tensor {
     /// non-empty.
     #[must_use]
     pub fn has_multi_edge(&self) -> bool {
-        self.me.nvals() != 0
+        self.me_all().any(|me| me.nvals() != 0)
     }
 
     pub fn wait(&self) {
         self.wait_fwd();
         self.mt.wait();
-        self.me.wait();
+        for me in self.me_all() {
+            me.wait();
+        }
     }
 
     /// Materialize only the committed base layers (`m`, `mt.m`, `me.m`).
@@ -1013,7 +1221,9 @@ impl Tensor {
     pub fn wait_base(&self) {
         self.m.wait();
         self.mt.wait_base();
-        self.me.wait_base();
+        for me in self.me_all() {
+            me.wait_base();
+        }
     }
 
     /// Wait on all matrices for fork safety (takes &self, not &mut self).
@@ -1022,7 +1232,9 @@ impl Tensor {
         self.dp.wait();
         self.dm.wait();
         self.mt.wait_all();
-        self.me.wait_all();
+        for me in self.me_all() {
+            me.wait_all();
+        }
     }
 
     /// Returns true if every internal matrix has no pending GraphBLAS
@@ -1033,7 +1245,7 @@ impl Tensor {
             && self.dp.is_synced()
             && self.dm.is_synced()
             && self.mt.is_synced()
-            && self.me.is_synced()
+            && self.me_all().all(VersionedMatrix::is_synced)
     }
 
     #[must_use]
@@ -1042,7 +1254,10 @@ impl Tensor {
             + self.dp.memory_usage()
             + self.dm.memory_usage()
             + self.mt.memory_usage()
-            + self.me.memory_usage()
+            + self
+                .me_all()
+                .map(VersionedMatrix::memory_usage)
+                .sum::<usize>()
     }
 }
 
@@ -1071,8 +1286,11 @@ impl Encode<19> for Tensor {
             f_rows.push(src);
             f_cols.push(dst);
             if inline == MULTI_EDGE {
-                let key = compound_key(src, dst);
-                let ids: Vec<u64> = self.me.iter(key, key).map(|(_, id)| id).collect();
+                let (block, key) = compound_key(src, dst);
+                let ids: Vec<u64> = self
+                    .me_block(block)
+                    .map(|me| me.iter(key, key).map(|(_, id)| id).collect())
+                    .unwrap_or_default();
                 f_vals.push(ids.len() as u64 | MSB_MASK);
                 multi.push((src, dst, ids));
             } else {
@@ -1144,7 +1362,11 @@ impl Decode<19> for Tensor {
         // `(count | MSB)` for multi-edge pairs, whose real id lists follow in
         // the tensor section.
         let mut m = Matrix::<u64>::new(nrows, ncols);
-        let mut me = VersionedMatrix::<bool>::new(GrB_INDEX_MAX, GrB_INDEX_MAX);
+        let mut me = VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ME_NARROW_NCOLS);
+        let mut me_blocks: Option<Box<FxHashMap<MeBlock, VersionedMatrix<bool>>>> = None;
+        // Widened lazily, as in `set_all_from_slices`: a blob whose ids all fit
+        // decodes into the narrow form and keeps the 32-bit column indices.
+        let mut me_ncols = ME_NARROW_NCOLS;
 
         let dm_empty = fwd_dm.nvals() == 0;
         for (src, dst, value) in fwd_m.iter(0, u64::MAX) {
@@ -1179,9 +1401,34 @@ impl Decode<19> for Tensor {
                     // the index. Reading the *values* instead collapsed every
                     // pair written by C to the single edge id 1.
                     let v = Vector::<bool>::decode_blob(r)?;
-                    let key = compound_key(src, dst);
-                    for edge_id in v.iter() {
-                        me.set(key, edge_id, true);
+                    // The blob stores endpoints, not row keys, so the on-disk
+                    // form says nothing about how they are blocked and needs no
+                    // version bump for this change: re-keying happens here.
+                    let (block, key) = compound_key(src, dst);
+                    let edge_ids: Vec<u64> = v.iter().collect();
+                    if let Some(&max_id) = edge_ids.iter().max() {
+                        if max_id >= me_ncols {
+                            me_ncols = GrB_INDEX_MAX;
+                            me.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+                            if let Some(blocks) = me_blocks.as_mut() {
+                                for b in blocks.values_mut() {
+                                    b.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+                                }
+                            }
+                        }
+                    }
+                    let target = if block == ME_BLOCK_0 {
+                        &mut me
+                    } else {
+                        me_blocks
+                            .get_or_insert_with(|| Box::new(FxHashMap::default()))
+                            .entry(block)
+                            .or_insert_with(|| {
+                                VersionedMatrix::<bool>::new(GrB_INDEX_MAX, me_ncols)
+                            })
+                    };
+                    for edge_id in edge_ids {
+                        target.set(key, edge_id, true);
                     }
                 }
             }
@@ -1198,6 +1445,7 @@ impl Decode<19> for Tensor {
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(0, 0),
             me,
+            me_blocks,
             needs_flush: AtomicBool::new(false),
         })
     }
@@ -1311,10 +1559,12 @@ impl Iterator for Iter<'_> {
         if inline == MULTI_EDGE {
             // Multi-edge pair: all ids live in `me`, already in ascending
             // column (edge-id) order.
-            let key = compound_key(self.src, self.dest);
+            let (block, key) = compound_key(self.src, self.dest);
             self.buf.clear();
-            for (_, id) in self.t.me.iter(key, key) {
-                self.buf.push(id);
+            if let Some(me) = self.t.me_block(block) {
+                for (_, id) in me.iter(key, key) {
+                    self.buf.push(id);
+                }
             }
             let id = self.buf[0];
             self.buf_pos = 1;
@@ -1664,6 +1914,253 @@ mod tests {
             t.get(0, 1).collect::<Vec<_>>(),
             vec![1],
             "committed edge lost"
+        );
+    }
+
+    /// **The bug this replaced.** `me` is `GrB_INDEX_MAX` square and the key
+    /// was `(src << 32) | dst`, so `src = 2^28` put the row out of the matrix's
+    /// range. `Matrix::set` checks the GraphBLAS status under `debug_assert!`
+    /// only, so a release build dropped the write and left the pair tagged
+    /// `MULTI_EDGE` over an empty `me` row: `get` returned nothing and
+    /// `edge_count` disagreed with both the inserts and the reads. The guard
+    /// that existed checked `u32`, four bits above the bound that mattered, and
+    /// so never fired.
+    ///
+    /// Runs well past the old cliff and past `2^32`, the ceiling the guard
+    /// nominally enforced, since blocks remove the bound rather than move it.
+    #[test]
+    fn promotion_survives_node_ids_past_the_old_key_width() {
+        ensure_init();
+        for shift in [27u32, 28, 29, 31, 32, 33, 40] {
+            let src = 1u64 << shift;
+            let dst = (1u64 << shift) + 5;
+            let n = dst + 2;
+            let mut t = Tensor::new(n, n);
+            t.set_all_from_slices(&[src, src], &[dst, dst], &[10, 11]);
+            let mut t = t.dup();
+            t.flush();
+            t.wait();
+
+            let ids: Vec<u64> = t.get(src, dst).collect();
+            assert_eq!(ids, vec![10, 11], "ids lost at src = 2^{shift}");
+            assert_eq!(t.edge_count(), 2, "edge_count wrong at src = 2^{shift}");
+            assert_eq!(t.multi_pairs(), 1, "multi_pairs wrong at src = 2^{shift}");
+            assert!(
+                t.has_multi_edge(),
+                "has_multi_edge wrong at src = 2^{shift}"
+            );
+
+            // `iter_edges` recovers the pair from the block and row key, so it
+            // is the check that `compound_key_inverse` really inverts.
+            let mut seen: Vec<(u64, u64, u64)> = t.iter_edges().collect();
+            seen.sort_unstable();
+            assert_eq!(
+                seen,
+                vec![(src, dst, 10), (src, dst, 11)],
+                "iter_edges wrong at src = 2^{shift}"
+            );
+
+            // And demotion still finds the ids it has to remove.
+            t.remove_all(&[(10, src, dst)]);
+            t.wait();
+            assert_eq!(
+                t.get(src, dst).collect::<Vec<_>>(),
+                vec![11],
+                "demotion lost the survivor at src = 2^{shift}"
+            );
+            assert_eq!(t.edge_count(), 1, "edge_count wrong after demotion");
+        }
+    }
+
+    /// Pairs in different blocks must not collide, and the blocks must stay
+    /// separable. Endpoints chosen so several distinct pairs share a row key
+    /// while differing in block — the exact aliasing a single packed key would
+    /// have produced.
+    #[test]
+    fn blocks_do_not_alias() {
+        ensure_init();
+        let b = 1u64 << BLOCK_SHIFT;
+        let pairs = [(1u64, 2u64), (b + 1, 2), (1, b + 2), (b + 1, b + 2)];
+        let n = 2 * b + 8;
+        let mut t = Tensor::new(n, n);
+        for (i, &(s, d)) in pairs.iter().enumerate() {
+            let base = 100 * i as u64;
+            t.set_all_from_slices(&[s, s], &[d, d], &[base, base + 1]);
+        }
+        let mut t = t.dup();
+        t.flush();
+        t.wait();
+
+        // All four share the row key of (1, 2) and differ only in block.
+        let rows: Vec<u64> = pairs.iter().map(|&(s, d)| compound_key(s, d).1).collect();
+        assert!(
+            rows.windows(2).all(|w| w[0] == w[1]),
+            "fixture is not exercising aliasing: rows {rows:?} differ"
+        );
+
+        for (i, &(s, d)) in pairs.iter().enumerate() {
+            let base = 100 * i as u64;
+            assert_eq!(
+                t.get(s, d).collect::<Vec<_>>(),
+                vec![base, base + 1],
+                "pair ({s}, {d}) read another block's ids"
+            );
+        }
+        assert_eq!(t.edge_count(), 8);
+        assert_eq!(t.multi_pairs(), 4);
+    }
+
+    /// The smallest thing that is both a [`Writer`] and a [`Reader`]: the
+    /// encoder's calls, replayed to the decoder in order. The crate's real
+    /// byte-level writers live in the host crate and are not reachable here,
+    /// and the round trip under test is the *re-keying*, not the framing.
+    #[derive(Default)]
+    struct Tape {
+        ops: std::collections::VecDeque<TapeOp>,
+    }
+
+    enum TapeOp {
+        Unsigned(u64),
+        Signed(i64),
+        Double(f64),
+        Buffer(Vec<u8>),
+    }
+
+    impl super::super::serialization::Writer for Tape {
+        fn write_unsigned(
+            &mut self,
+            val: u64,
+        ) {
+            self.ops.push_back(TapeOp::Unsigned(val));
+        }
+        fn write_signed(
+            &mut self,
+            val: i64,
+        ) {
+            self.ops.push_back(TapeOp::Signed(val));
+        }
+        fn write_double(
+            &mut self,
+            val: f64,
+        ) {
+            self.ops.push_back(TapeOp::Double(val));
+        }
+        fn write_buffer(
+            &mut self,
+            data: &[u8],
+        ) {
+            self.ops.push_back(TapeOp::Buffer(data.to_vec()));
+        }
+    }
+
+    impl super::super::serialization::Reader for Tape {
+        fn read_unsigned(&mut self) -> Result<u64, String> {
+            match self.ops.pop_front() {
+                Some(TapeOp::Unsigned(v)) => Ok(v),
+                _ => Err("tape: expected unsigned".to_string()),
+            }
+        }
+        fn read_signed(&mut self) -> Result<i64, String> {
+            match self.ops.pop_front() {
+                Some(TapeOp::Signed(v)) => Ok(v),
+                _ => Err("tape: expected signed".to_string()),
+            }
+        }
+        fn read_double(&mut self) -> Result<f64, String> {
+            match self.ops.pop_front() {
+                Some(TapeOp::Double(v)) => Ok(v),
+                _ => Err("tape: expected double".to_string()),
+            }
+        }
+        fn read_buffer(&mut self) -> Result<Vec<u8>, String> {
+            match self.ops.pop_front() {
+                Some(TapeOp::Buffer(v)) => Ok(v),
+                _ => Err("tape: expected buffer".to_string()),
+            }
+        }
+    }
+
+    /// The round trip has to survive blocks. The blob stores endpoints rather
+    /// than row keys, so no format change was needed — this is the test that
+    /// says so, by decoding a multi-block tensor and reading every pair back.
+    #[test]
+    fn encode_decode_round_trips_across_blocks() {
+        ensure_init();
+        let b = 1u64 << BLOCK_SHIFT;
+        let pairs = [(1u64, 2u64), (b + 7, 9), (3, b + 4), (b + 5, b + 6)];
+        let n = 2 * b + 16;
+        let mut t = Tensor::new(n, n);
+        for (i, &(s, d)) in pairs.iter().enumerate() {
+            let base = 1000 * i as u64;
+            t.set_all_from_slices(&[s, s, s], &[d, d, d], &[base, base + 1, base + 2]);
+        }
+        // one single-edge pair too, so the inline path is covered
+        t.set_all_from_slices(&[b + 11], &[12], &[9999]);
+        let mut t = t.dup();
+        t.flush();
+        t.wait();
+
+        let mut tape = Tape::default();
+        t.encode(&mut tape);
+        let mut back = Tensor::decode(&mut tape).expect("decode");
+        back.rebuild_backward();
+        back.wait();
+
+        for (i, &(s, d)) in pairs.iter().enumerate() {
+            let base = 1000 * i as u64;
+            assert_eq!(
+                back.get(s, d).collect::<Vec<_>>(),
+                vec![base, base + 1, base + 2],
+                "pair ({s}, {d}) did not survive the round trip"
+            );
+        }
+        assert_eq!(back.get(b + 11, 12).collect::<Vec<_>>(), vec![9999]);
+        assert_eq!(back.edge_count(), t.edge_count());
+        assert_eq!(back.multi_pairs(), t.multi_pairs());
+    }
+
+    /// `me` is created with a narrow column space so GraphBLAS stores its
+    /// column indices — one per stored edge id, the largest array here — in 32
+    /// bits. An id past that width has to widen it rather than be dropped, and
+    /// the ids already stored have to survive the widening.
+    #[test]
+    fn me_widens_for_edge_ids_past_the_narrow_column_space() {
+        ensure_init();
+        let narrow = super::ME_NARROW_NCOLS;
+        let mut t = Tensor::new(16, 16);
+        t.set_all_from_slices(&[1, 1], &[2, 2], &[7, 8]);
+        let mut t = t.dup();
+        t.flush();
+        t.wait();
+        assert_eq!(
+            t.edge_versioned_block_0().ncols(),
+            narrow,
+            "a tensor with small ids should still be narrow"
+        );
+        assert_eq!(t.get(1, 2).collect::<Vec<_>>(), vec![7, 8]);
+
+        // An id at the boundary widens it, and nothing already stored is lost.
+        t.set_all_from_slices(&[1], &[2], &[narrow]);
+        t.wait();
+        assert_eq!(
+            t.edge_versioned_block_0().ncols(),
+            GrB_INDEX_MAX,
+            "an id at the narrow width should have widened `me`"
+        );
+        assert_eq!(t.get(1, 2).collect::<Vec<_>>(), vec![7, 8, narrow]);
+        assert_eq!(t.edge_count(), 3);
+
+        // And a block created *after* widening must be wide too, or its ids
+        // would be the ones dropped.
+        let b = 1u64 << BLOCK_SHIFT;
+        let mut t2 = Tensor::new(4 * b, 4 * b);
+        t2.set_all_from_slices(&[1], &[2], &[narrow + 1]);
+        t2.set_all_from_slices(&[b + 1, b + 1], &[2, 2], &[narrow + 2, narrow + 3]);
+        t2.wait();
+        assert_eq!(
+            t2.get(b + 1, 2).collect::<Vec<_>>(),
+            vec![narrow + 2, narrow + 3],
+            "a block created after widening dropped its ids"
         );
     }
 }

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -121,6 +121,7 @@
 //! with different amounts and dates.
 
 use rustc_hash::FxHashMap;
+use smallvec::{SmallVec, smallvec};
 use std::collections::hash_map::Entry;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -142,77 +143,80 @@ use super::{
 #[allow(non_upper_case_globals)]
 pub const GrB_INDEX_MAX: u64 = (1u64 << 60) - 1;
 
-/// Row (and wide-column) dimension of every `me` block.
+/// Row dimension of every `me` block: one more than the largest key
+/// [`compound_key`] can produce, because a matrix of `n` rows indexes `0..n-1`.
 ///
-/// `GrB_INDEX_MAX` is the largest valid *index*, so a matrix declared that many
-/// rows accepts `0..GrB_INDEX_MAX - 1` — one short. [`compound_key`] can produce
-/// exactly `GrB_INDEX_MAX` (both endpoint halves all-ones, e.g.
-/// `src = dst = 2^BLOCK_SHIFT - 1`), and a write there was silently dropped, which
-/// is the very failure this module exists to remove, reintroduced at the new
-/// boundary. Declaring one row more makes every key [`compound_key`] can produce
-/// in range by construction.
+/// `compound_key` emits exactly `GrB_INDEX_MAX` when both endpoint halves are
+/// all-ones, so declaring `GrB_INDEX_MAX` rows is one short and that write is
+/// dropped — silently, in release, which is the very failure this module exists
+/// to remove. Pinned by `the_top_row_key_of_a_block_is_writable`.
 const ME_DIM: u64 = GrB_INDEX_MAX + 1;
 
-/// Column count `me` is created with, and the width at which GraphBLAS stores
-/// its column indices in 32 bits rather than 64.
+/// Column count `me` is created with: the widest declaration for which
+/// GraphBLAS still stores column indices in 32 bits rather than 64.
 ///
-/// `me`'s columns are edge ids, and its column-index array holds one entry per
-/// stored id — the largest array in the structure. Declaring the matrix
-/// `GrB_INDEX_MAX` wide forced 64-bit indices for every one of them: measured on
-/// 200k ids, 11.69 bytes per id against 6.44 at this width, so the declaration
-/// alone was costing 45%.
+/// Columns are edge ids, and the column-index array holds one entry per stored
+/// id — the largest array in the structure. Measured on 200k ids: 6.44 B/id
+/// here against 11.69 at `GrB_INDEX_MAX`, so the declaration alone cost 45%.
 ///
-/// The threshold is `2^31`, not `2^32`: GraphBLAS needs the dimension itself to
-/// fit, and `2^32` does not fit a `u32`. A tensor whose edge ids reach this
-/// widens back to `GrB_INDEX_MAX` ([`Tensor::widen_me_for_id`]) and pays what it
-/// paid before, so the narrow default costs nothing but the check.
+/// The cutoff is `2^31`, not `2^32`: the dimension itself must fit a `u32`. A
+/// tensor whose edge ids reach it widens back ([`Tensor::widen_me_for_id`]) and
+/// pays the old price, so the narrow default costs only the check.
 ///
-/// Rows are deliberately left at `GrB_INDEX_MAX`. Narrowing them too saves a
-/// further 0.40 bytes per id — the row arrays hold one entry per multi-edge
-/// *pair*, not per id — and would need [`BLOCK_SHIFT`] down at 15, which is a
-/// block per 32,768 nodes per axis. That is a bad trade for 6% of the saving.
+/// Rows stay at [`ME_DIM`]. Narrowing them saves a further 0.40 B/id — row
+/// arrays hold one entry per multi-edge *pair*, not per id — and would need
+/// [`BLOCK_SHIFT`] at 15, i.e. a block per 32,768 nodes per axis.
 const ME_NARROW_NCOLS: u64 = 1 << 31;
 
-/// Bits of each node id carried in the compound row key. Two of these must fit
-/// in a GraphBLAS index, so `2 * BLOCK_SHIFT <= 60`.
+/// Bits of each node id carried in the compound row key. Everything above them
+/// selects a *block* instead (see [`compound_key`]).
 ///
-/// Set to the maximum the index allows. Everything above these bits selects a
-/// *block* instead (see [`compound_key`]), so this is not a limit on node ids —
-/// it is the width at which one block's key space ends and the next begins.
+/// Two halves must fit one GraphBLAS index, so `2 * BLOCK_SHIFT <= 60`; 30 is
+/// the maximum, and therefore the fewest blocks. This is not a limit on node
+/// ids — it is where one block's key space ends and the next begins.
 pub const BLOCK_SHIFT: u32 = 30;
 const BLOCK_MASK: u64 = (1u64 << BLOCK_SHIFT) - 1;
 
-/// Which `me` matrix a pair's identifiers live in.
+/// Which `me` matrix a pair's edge ids live in — the high bits of each
+/// endpoint, per [`compound_key`].
 ///
-/// `(0, 0)` for every pair whose endpoints both fit in [`BLOCK_SHIFT`] bits,
-/// which is every graph up to 2^30 nodes per axis and therefore the only block
-/// that exists in practice. [`Tensor`] stores block `(0, 0)` in a dedicated
-/// field and allocates a map only if some other block is ever reached, so a
-/// graph inside it pays one `Option` check and nothing else.
+/// [`ME_BLOCK_0`] for every graph under 2^[`BLOCK_SHIFT`] nodes per axis, which
+/// is every graph in practice, and [`Tensor`] keeps its blocks in a `SmallVec`
+/// sized for exactly one: a graph inside that block pays a compare against the
+/// first (and only) entry, with no hashing and nothing on the heap.
 pub type MeBlock = (u64, u64);
 
-/// The block `(0, 0)`, where every pair of a graph within [`BLOCK_SHIFT`] bits
-/// per axis lands.
+/// The block every pair within [`BLOCK_SHIFT`] bits per axis lands in, and the
+/// one [`Tensor`] always holds at index 0 of its block list.
 pub const ME_BLOCK_0: MeBlock = (0, 0);
 
-/// Split a `(src, dst)` node-id pair into the `me` block that holds its
-/// identifiers and the row key within that block.
+/// Split a `(src, dst)` node-id pair into the `me` block that holds its edge
+/// ids and the row key within that block.
 ///
-/// The previous encoding was `(src << 32) | dst` in a single matrix, and it was
-/// unsound above `src = 2^28`: `me` is `GrB_INDEX_MAX` square, so a key of
-/// 60 bits or more is out of range for its row dimension. `Matrix::set` checks
-/// the GraphBLAS status under `debug_assert!` only, so a release build dropped
-/// the write — leaving the pair tagged [`MULTI_EDGE`] with an empty `me` row,
-/// which is Invariant *promotion completeness* broken and reads as edges
-/// silently vanishing. The guard that was there checked the wrong bound (`u32`,
-/// i.e. `2^32`) and so never fired.
+/// Each endpoint is cut in two: the low [`BLOCK_SHIFT`] bits pack into the row
+/// key, the high bits become the block coordinate.
 ///
-/// Splitting instead of packing removes the failure rather than moving it. The
-/// low [`BLOCK_SHIFT`] bits of each endpoint form a row key that is *always*
-/// within range by construction, and the high bits select a block. There is no
-/// bound to check and no way to be out of range, so this function is total —
-/// note that it cannot panic, where its predecessor could and, worse, could
-/// silently corrupt below the bound it panicked at.
+/// ```text
+/// src  [ src_hi ............ ][ src_lo : 30 ]
+/// dst  [ dst_hi ............ ][ dst_lo : 30 ]
+///             │                      │
+///             ▼                      ▼
+///  block (src_hi, dst_hi)    row [ src_lo : 30 | dst_lo : 30 ]  <- 60 bits, always
+/// ```
+///
+/// Equivalently: a tiling of the `src x dst` id space into 2^30 x 2^30 tiles,
+/// where the block names the tile and the row names the cell inside it.
+///
+/// Because the key is built only from masked halves it is in range for
+/// [`ME_DIM`] whatever the input, so there is no bound to check and nothing to
+/// panic on. Ids too large for one tile move to another rather than truncate.
+///
+/// It replaces `(src << 32) | dst`, which collided above `dst = 2^32` and went
+/// out of range above `src = 2^28` — where the write was silently dropped,
+/// leaving a pair tagged [`MULTI_EDGE`] over an empty row, i.e. Invariant
+/// *promotion completeness* broken and edges vanishing on read. The guard that
+/// was there checked `2^32` and so never fired. See
+/// `promotion_survives_node_ids_past_the_old_key_width`.
 #[inline]
 #[must_use]
 pub fn compound_key(
@@ -225,9 +229,13 @@ pub fn compound_key(
     )
 }
 
-/// Recover `(src, dst)` from a block and a row key — the inverse of
-/// [`compound_key`], which iteration needs to turn an `me` entry back into the
-/// pair it belongs to.
+/// Rebuild `(src, dst)` from a block and a row key — the inverse of
+/// [`compound_key`], which iteration needs to learn which pair an `me` entry
+/// belongs to.
+///
+/// Each endpoint is reassembled from its high half (the block) and its low half
+/// (the row key). Exact for every pair [`compound_key`] accepts; injective only
+/// for `row < ME_DIM`, which holds for any key it produced.
 #[inline]
 #[must_use]
 pub fn compound_key_inverse(
@@ -270,18 +278,17 @@ pub struct Tensor {
     /// stored here — they are recovered from `m` (and `me`) when iterating
     /// incoming edges, avoiding a redundant copy of every id.
     mt: VersionedMatrix<bool>,
-    /// Multi-edge id storage for block [`ME_BLOCK_0`], keyed by the row half of
-    /// `compound_key(src, dst)` → edge_id (BOOL). Holds *all* ids of pairs with
-    /// more than one edge; empty otherwise.
-    me: VersionedMatrix<bool>,
-    /// Multi-edge id storage for every *other* block, allocated only if a pair
-    /// ever lands outside [`ME_BLOCK_0`] — i.e. only above 2^30 nodes on one
-    /// axis. `None` for every graph in practice, which is what keeps the block
-    /// split free: the paths below check an `Option` and take today's code.
+    /// Multi-edge id storage, one matrix per live block, keyed within a block by
+    /// the row half of `compound_key(src, dst)` → edge_id (BOOL). Holds *all*
+    /// ids of pairs with more than one edge; empty otherwise.
     ///
-    /// This is the same inline-first shape the tensor uses for edge ids one
-    /// level down, applied to the blocks themselves.
-    me_blocks: Option<Box<FxHashMap<MeBlock, VersionedMatrix<bool>>>>,
+    /// [`ME_BLOCK_0`] is always entry 0, and a second entry appears only if a
+    /// pair ever lands outside it — i.e. only above 2^30 nodes on one axis, so
+    /// never in practice. Sizing the `SmallVec` for one keeps that case free:
+    /// the list is inline, lookup is a compare against the first entry, and an
+    /// MVCC version clones it without touching the heap. A map would hash on
+    /// every access and allocate on every version, to hold one entry.
+    me: SmallVec<[(MeBlock, VersionedMatrix<bool>); 1]>,
     /// Whether the fold decisions latched on `dp`/`dm` are executable now; see
     /// `VersionedMatrix`'s field of the same name.
     needs_flush: AtomicBool,
@@ -321,7 +328,6 @@ impl Clone for Tensor {
             dm: self.dm.clone(),
             mt: self.mt.clone(),
             me: self.me.clone(),
-            me_blocks: self.me_blocks.clone(),
             needs_flush: AtomicBool::new(self.needs_flush.load(Ordering::Relaxed)),
         }
     }
@@ -338,24 +344,29 @@ impl Tensor {
             dp: Delta::new(Matrix::<u64>::new(nrows, ncols)),
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(ncols, nrows),
-            me: VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS),
-            me_blocks: None,
+            me: smallvec![(
+                ME_BLOCK_0,
+                VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS)
+            )],
             needs_flush: AtomicBool::new(false),
         }
     }
 
     /// The `me` matrix holding `block`, or `None` if no pair has ever landed in
-    /// it. Reads take this: an absent block holds no identifiers, which is the
-    /// same answer an empty matrix would give without allocating one.
+    /// it. Reads take this: an absent block holds no ids, which is the same
+    /// answer an empty matrix would give without allocating one.
+    ///
+    /// A scan rather than a lookup because the list is one entry long for every
+    /// real graph — [`ME_BLOCK_0`] is entry 0 — so this is a compare and a
+    /// return, where hashing would be a hash and a probe to reach the same
+    /// place. It is linear in blocks alone, and 64 of those is a node-id span
+    /// of ~69 billion.
     #[inline]
     fn me_block(
         &self,
         block: MeBlock,
     ) -> Option<&VersionedMatrix<bool>> {
-        if block == ME_BLOCK_0 {
-            return Some(&self.me);
-        }
-        self.me_blocks.as_ref()?.get(&block)
+        self.me.iter().find(|(b, _)| *b == block).map(|(_, me)| me)
     }
 
     /// The `me` matrix holding `block`, creating it if this is the first pair to
@@ -368,57 +379,37 @@ impl Tensor {
         &mut self,
         block: MeBlock,
     ) -> &mut VersionedMatrix<bool> {
-        if block == ME_BLOCK_0 {
-            return &mut self.me;
-        }
-        // A new block is created at whatever width `me` already has, so a
-        // tensor that has widened does not go on creating narrow blocks behind
-        // it and re-widening them one at a time.
-        let ncols = self.me.ncols();
-        self.me_blocks
-            .get_or_insert_with(|| Box::new(FxHashMap::default()))
-            .entry(block)
-            .or_insert_with(|| VersionedMatrix::<bool>::new(ME_DIM, ncols))
+        let at = match self.me.iter().position(|(b, _)| *b == block) {
+            Some(at) => at,
+            None => {
+                // A new block is created at whatever width the tensor already
+                // has, so one that has widened does not go on creating narrow
+                // blocks behind it and re-widening them one at a time.
+                let ncols = self.me[0].1.ncols();
+                self.me
+                    .push((block, VersionedMatrix::<bool>::new(ME_DIM, ncols)));
+                self.me.len() - 1
+            }
+        };
+        &mut self.me[at].1
     }
 
     /// Widen every `me` block's column space if `max_id` will not fit.
     ///
     /// Called once per batch with the batch's largest edge id, so the common
-    /// path is one comparison. Widening is one-way and rare: edge ids come from
-    /// a counter, so a tensor crosses `ME_NARROW_NCOLS` at most once.
+    /// path is one comparison against [`ME_BLOCK_0`], whose width every later
+    /// block inherits. Widening is one-way and rare: edge ids come from a
+    /// counter, so a tensor crosses `ME_NARROW_NCOLS` at most once.
     fn widen_me_for_id(
         &mut self,
         max_id: u64,
     ) {
-        if max_id < self.me.ncols() {
+        if max_id < self.me[0].1.ncols() {
             return;
         }
-        for me in self.me_all_mut() {
+        for (_, me) in &mut self.me {
             me.resize(ME_DIM, ME_DIM);
         }
-    }
-
-    /// Every live `me` matrix, block `(0, 0)` first. The maintenance paths —
-    /// flush, wait, fold, sync checks, sizing — fold over this rather than
-    /// touching `self.me` directly, so a block added later is not missed by one
-    /// of them.
-    fn me_all(&self) -> impl Iterator<Item = &VersionedMatrix<bool>> {
-        std::iter::once(&self.me).chain(self.me_blocks.iter().flat_map(|b| b.values()))
-    }
-
-    /// As [`Self::me_all`], mutably.
-    fn me_all_mut(&mut self) -> impl Iterator<Item = &mut VersionedMatrix<bool>> {
-        std::iter::once(&mut self.me).chain(self.me_blocks.iter_mut().flat_map(|b| b.values_mut()))
-    }
-
-    /// Every live `me` matrix with the block it holds, for the paths that must
-    /// map a row key back to a `(src, dst)` pair.
-    fn me_all_keyed(&self) -> impl Iterator<Item = (MeBlock, &VersionedMatrix<bool>)> {
-        std::iter::once((ME_BLOCK_0, &self.me)).chain(
-            self.me_blocks
-                .iter()
-                .flat_map(|b| b.iter().map(|(&k, v)| (k, v))),
-        )
     }
 
     /// Wait pending GraphBLAS work on the forward delta layers. The committed
@@ -934,7 +925,7 @@ impl Tensor {
             self.needs_flush.store(false, Ordering::Relaxed);
         }
         self.mt.flush();
-        for me in self.me_all_mut() {
+        for (_, me) in &mut self.me {
             me.flush();
         }
     }
@@ -950,7 +941,7 @@ impl Tensor {
             self.flush();
         }
         self.mt.fold_latched();
-        for me in self.me_all_mut() {
+        for (_, me) in &mut self.me {
             me.fold_latched();
         }
     }
@@ -974,7 +965,7 @@ impl Tensor {
             self.flush();
         }
         self.mt.fold_oversized();
-        for me in self.me_all_mut() {
+        for (_, me) in &mut self.me {
             me.fold_oversized();
         }
     }
@@ -1024,11 +1015,7 @@ impl Tensor {
             dp: self.dp.new_version(fold_dp),
             dm: self.dm.new_version(fold_dm),
             mt: self.mt.dup(),
-            me: self.me.dup(),
-            me_blocks: self
-                .me_blocks
-                .as_ref()
-                .map(|b| Box::new(b.iter().map(|(&k, v)| (k, v.dup())).collect())),
+            me: self.me.iter().map(|(b, me)| (*b, me.dup())).collect(),
             needs_flush: AtomicBool::new(fold_dp || fold_dm),
         }
     }
@@ -1084,23 +1071,22 @@ impl Tensor {
         &self.mt
     }
 
-    /// Overflow multi-edge id storage for block [`ME_BLOCK_0`], keyed by the
-    /// row half of `compound_key(src, dst)` → edge id. Holds all ids of pairs
-    /// with more than one edge; empty unless some pair has one.
+    /// Multi-edge id storage for block [`ME_BLOCK_0`], keyed by the row half of
+    /// `compound_key(src, dst)` → edge id. Holds all ids of pairs with more
+    /// than one edge; empty unless some pair has one.
     ///
-    /// Callers that must see *every* identifier — rather than every identifier
-    /// of a graph within 2^30 nodes per axis — want
-    /// [`Self::edge_versioned_all`].
+    /// Callers that must see *every* id — rather than every id of a graph
+    /// within 2^30 nodes per axis — want [`Self::edge_versioned_all`].
     #[must_use]
-    pub const fn edge_versioned_block_0(&self) -> &VersionedMatrix<bool> {
-        &self.me
+    pub fn edge_versioned_block_0(&self) -> &VersionedMatrix<bool> {
+        &self.me[0].1
     }
 
     /// Every `me` matrix with the block it holds, so a caller doing its own
-    /// GraphBLAS work over the overflow can cover all of them and map row keys
-    /// back to pairs with [`compound_key_inverse`].
+    /// GraphBLAS work over the multi-edge ids can cover all of them and map row
+    /// keys back to pairs with [`compound_key_inverse`].
     pub fn edge_versioned_all(&self) -> impl Iterator<Item = (MeBlock, &VersionedMatrix<bool>)> {
-        self.me_all_keyed()
+        self.me.iter().map(|(b, me)| (*b, me))
     }
 
     /// Total number of edges. Each effective forward entry is one edge,
@@ -1116,7 +1102,7 @@ impl Tensor {
             self.dp.intersection_nvals(&self.m)
         };
         self.m.nvals() + self.dp.nvals() - self.dm.nvals() - shadow - self.multi_pairs()
-            + self.me_all().map(VersionedMatrix::nvals).sum::<u64>()
+            + self.me.iter().map(|(_, me)| me.nvals()).sum::<u64>()
     }
 
     /// Iterate every `(src, dst, edge_id)` triple in the tensor.
@@ -1127,7 +1113,7 @@ impl Tensor {
     /// this is a single streaming pass with no per-pair sub-iterator.
     pub fn iter_edges(&self) -> impl Iterator<Item = (u64, u64, u64)> + '_ {
         let multi: Box<dyn Iterator<Item = (u64, u64, u64)> + '_> = if self.has_multi_edge() {
-            Box::new(self.me_all_keyed().flat_map(|(block, me)| {
+            Box::new(self.edge_versioned_all().flat_map(|(block, me)| {
                 me.iter(0, GrB_INDEX_MAX).map(move |(key, edge_id)| {
                     let (src, dst) = compound_key_inverse(block, key);
                     (src, dst, edge_id)
@@ -1174,7 +1160,7 @@ impl Tensor {
 
     #[cfg(test)]
     fn fwd_me_nvals_for_test(&self) -> u64 {
-        self.me_all().map(VersionedMatrix::nvals).sum()
+        self.me.iter().map(|(_, me)| me.nvals()).sum()
     }
 
     #[must_use]
@@ -1182,7 +1168,7 @@ impl Tensor {
         // Blocks partition the pairs — a pair's identifiers live in exactly one
         // block — so the per-block counts simply add. Rows are counted within a
         // block, never across, which is why this is a sum and not a merge.
-        self.me_all().map(Self::multi_pairs_in).sum()
+        self.me.iter().map(|(_, me)| Self::multi_pairs_in(me)).sum()
     }
 
     /// [`Self::multi_pairs`] for one block.
@@ -1194,10 +1180,11 @@ impl Tensor {
             return 0;
         }
         me.wait();
-        if me.dp().nvals() == 0 && me.dm().nvals() == 0 {
-            if let Some(kount) = me.m().hyper_vector_count() {
-                return kount;
-            }
+        if me.dp().nvals() == 0
+            && me.dm().nvals() == 0
+            && let Some(kount) = me.m().hyper_vector_count()
+        {
+            return kount;
         }
         let mut rows = 0u64;
         let mut last: Option<u64> = None;
@@ -1215,13 +1202,13 @@ impl Tensor {
     /// non-empty.
     #[must_use]
     pub fn has_multi_edge(&self) -> bool {
-        self.me_all().any(|me| me.nvals() != 0)
+        self.me.iter().any(|(_, me)| me.nvals() != 0)
     }
 
     pub fn wait(&self) {
         self.wait_fwd();
         self.mt.wait();
-        for me in self.me_all() {
+        for (_, me) in &self.me {
             me.wait();
         }
     }
@@ -1232,7 +1219,7 @@ impl Tensor {
     pub fn wait_base(&self) {
         self.m.wait();
         self.mt.wait_base();
-        for me in self.me_all() {
+        for (_, me) in &self.me {
             me.wait_base();
         }
     }
@@ -1243,7 +1230,7 @@ impl Tensor {
         self.dp.wait();
         self.dm.wait();
         self.mt.wait_all();
-        for me in self.me_all() {
+        for (_, me) in &self.me {
             me.wait_all();
         }
     }
@@ -1256,7 +1243,7 @@ impl Tensor {
             && self.dp.is_synced()
             && self.dm.is_synced()
             && self.mt.is_synced()
-            && self.me_all().all(VersionedMatrix::is_synced)
+            && self.me.iter().all(|(_, me)| me.is_synced())
     }
 
     #[must_use]
@@ -1266,8 +1253,9 @@ impl Tensor {
             + self.dm.memory_usage()
             + self.mt.memory_usage()
             + self
-                .me_all()
-                .map(VersionedMatrix::memory_usage)
+                .me
+                .iter()
+                .map(|(_, me)| me.memory_usage())
                 .sum::<usize>()
     }
 }
@@ -1373,8 +1361,10 @@ impl Decode<19> for Tensor {
         // `(count | MSB)` for multi-edge pairs, whose real id lists follow in
         // the tensor section.
         let mut m = Matrix::<u64>::new(nrows, ncols);
-        let mut me = VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS);
-        let mut me_blocks: Option<Box<FxHashMap<MeBlock, VersionedMatrix<bool>>>> = None;
+        let mut me: SmallVec<[(MeBlock, VersionedMatrix<bool>); 1]> = smallvec![(
+            ME_BLOCK_0,
+            VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS)
+        )];
         // Widened lazily, as in `set_all_from_slices`: a blob whose ids all fit
         // decodes into the narrow form and keeps the 32-bit column indices.
         let mut me_ncols = ME_NARROW_NCOLS;
@@ -1416,28 +1406,25 @@ impl Decode<19> for Tensor {
                     // form says nothing about how they are blocked and needs no
                     // version bump for this change: re-keying happens here.
                     let (block, key) = compound_key(src, dst);
-                    let edge_ids: Vec<u64> = v.iter().collect();
-                    if let Some(&max_id) = edge_ids.iter().max() {
-                        if max_id >= me_ncols {
+                    let at = match me.iter().position(|(b, _)| *b == block) {
+                        Some(at) => at,
+                        None => {
+                            me.push((block, VersionedMatrix::<bool>::new(ME_DIM, me_ncols)));
+                            me.len() - 1
+                        }
+                    };
+                    // Streamed rather than collected: the ids are only needed
+                    // one at a time, and the width check they used to be
+                    // gathered for is a compare that fires at most once in the
+                    // life of the tensor.
+                    for edge_id in v.iter() {
+                        if edge_id >= me_ncols {
                             me_ncols = ME_DIM;
-                            me.resize(ME_DIM, ME_DIM);
-                            if let Some(blocks) = me_blocks.as_mut() {
-                                for b in blocks.values_mut() {
-                                    b.resize(ME_DIM, ME_DIM);
-                                }
+                            for (_, b) in &mut me {
+                                b.resize(ME_DIM, ME_DIM);
                             }
                         }
-                    }
-                    let target = if block == ME_BLOCK_0 {
-                        &mut me
-                    } else {
-                        me_blocks
-                            .get_or_insert_with(|| Box::new(FxHashMap::default()))
-                            .entry(block)
-                            .or_insert_with(|| VersionedMatrix::<bool>::new(ME_DIM, me_ncols))
-                    };
-                    for edge_id in edge_ids {
-                        target.set(key, edge_id, true);
+                        me[at].1.set(key, edge_id, true);
                     }
                 }
             }
@@ -1454,7 +1441,6 @@ impl Decode<19> for Tensor {
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(0, 0),
             me,
-            me_blocks,
             needs_flush: AtomicBool::new(false),
         })
     }
@@ -1541,45 +1527,54 @@ impl Iterator for Iter<'_> {
 
         // Next base pair, oriented as (src, dest) with its inline value.
         // Forward carries the value inline; backward recovers it via eff_get.
-        let (src, dest, inline) = match &mut self.base {
-            BaseIter::Forward(it) => {
-                let (row, col, id) = it.next()?;
-                (row, col, id)
-            }
-            BaseIter::Backward(it) => {
-                let (row, col) = it.next()?;
-                let (src, dest) = (col, row);
-                // `mt` mirrors the effective forward structure, so a pair
-                // reached through it always has a forward inline value.
-                // Machine-checked as `iterBwd_eff_get_isSome` in
-                // `proofs/tensor`. This replaced an `unwrap_or(0)`, which was
-                // worse than unreachable: 0 is a *valid* edge id, so the
-                // fallback would have quietly emitted a fabricated edge
-                // rather than failed.
-                let Some(id) = self.t.eff_get(src, dest) else {
-                    unreachable!("mt holds ({src}, {dest}) but the forward matrix does not")
-                };
-                (src, dest, id)
-            }
-        };
-        self.src = src;
-        self.dest = dest;
-
-        if inline == MULTI_EDGE {
-            // Multi-edge pair: all ids live in `me`, already in ascending
-            // column (edge-id) order.
-            let (block, key) = compound_key(self.src, self.dest);
-            self.buf.clear();
-            if let Some(me) = self.t.me_block(block) {
-                for (_, id) in me.iter(key, key) {
-                    self.buf.push(id);
+        loop {
+            let (src, dest, inline) = match &mut self.base {
+                BaseIter::Forward(it) => {
+                    let (row, col, id) = it.next()?;
+                    (row, col, id)
                 }
+                BaseIter::Backward(it) => {
+                    let (row, col) = it.next()?;
+                    let (src, dest) = (col, row);
+                    // `mt` mirrors the effective forward structure, so a pair
+                    // reached through it always has a forward inline value.
+                    // Machine-checked as `iterBwd_eff_get_isSome` in
+                    // `proofs/tensor`. This replaced an `unwrap_or(0)`, which was
+                    // worse than unreachable: 0 is a *valid* edge id, so the
+                    // fallback would have quietly emitted a fabricated edge
+                    // rather than failed.
+                    let Some(id) = self.t.eff_get(src, dest) else {
+                        unreachable!("mt holds ({src}, {dest}) but the forward matrix does not")
+                    };
+                    (src, dest, id)
+                }
+            };
+            self.src = src;
+            self.dest = dest;
+
+            if inline == MULTI_EDGE {
+                // Multi-edge pair: all ids live in `me`, already in ascending
+                // column (edge-id) order.
+                let (block, key) = compound_key(self.src, self.dest);
+                self.buf.clear();
+                if let Some(me) = self.t.me_block(block) {
+                    for (_, id) in me.iter(key, key) {
+                        self.buf.push(id);
+                    }
+                }
+                // Promotion completeness says a MULTI_EDGE pair always has ids in
+                // `me`. If one does not — a corrupt or partially decoded tensor —
+                // skip the pair rather than panicking on a read path, which is what
+                // `get` already does for a missing block.
+                let Some(&id) = self.buf.first() else {
+                    debug_assert!(false, "MULTI_EDGE pair ({src}, {dest}) has no ids in `me`");
+                    continue;
+                };
+                self.buf_pos = 1;
+                return Some((self.src, self.dest, id));
             }
-            let id = self.buf[0];
-            self.buf_pos = 1;
-            return Some((self.src, self.dest, id));
+            return Some((self.src, self.dest, inline));
         }
-        Some((self.src, self.dest, inline))
     }
 }
 
@@ -1831,7 +1826,11 @@ mod tests {
         assert!(emptied.is_empty(), "demoted pairs reported as emptied");
         assert_eq!(t.edge_count(), N, "edge count after demoting every pair");
         assert_eq!(t.multi_pairs(), 0, "a demoted pair still counts as multi");
-        assert_eq!(t.me.nvals(), 0, "`me` still holds ids of demoted pairs");
+        assert_eq!(
+            t.fwd_me_nvals_for_test(),
+            0,
+            "`me` still holds ids of demoted pairs"
+        );
         for i in 0..N {
             assert_eq!(
                 t.get(i, i + 1).collect::<Vec<_>>(),
@@ -1840,6 +1839,65 @@ mod tests {
                 i + 1
             );
         }
+    }
+
+    /// A pair created *and* promoted inside one batch. The second edge cannot
+    /// read the first from anywhere — the inline slot is still only queued in
+    /// `m_ids`, and the layers say nothing about the pair — so it has to reach
+    /// back into the batch, move that pending id into `me` alongside itself and
+    /// turn the queued slot into the sentinel. A third edge then takes the
+    /// already-multi path instead, on the same pair, in the same batch.
+    #[test]
+    fn one_batch_promotes_a_pair_it_created() {
+        ensure_init();
+        let mut t = Tensor::new(8, 8);
+        t.set_all_from_slices(&[0, 0, 2, 2, 2], &[1, 1, 3, 3, 3], &[10, 11, 20, 21, 22]);
+        t.flush();
+        t.wait();
+
+        assert_eq!(
+            t.get(0, 1).collect::<Vec<_>>(),
+            vec![10, 11],
+            "a pair promoted inside its own batch lost an id"
+        );
+        assert_eq!(
+            t.get(2, 3).collect::<Vec<_>>(),
+            vec![20, 21, 22],
+            "the third edge of a pair promoted inside its own batch"
+        );
+        assert_eq!(t.edge_count(), 5, "edge count after in-batch promotion");
+        assert_eq!(t.multi_pairs(), 2, "both pairs should read as multi");
+    }
+
+    /// The case that makes the in-batch promotion more than a duplicate-key
+    /// convenience: a committed multi pair emptied *earlier in the same
+    /// transaction* is, to the read phase, a pair with no value at all. Adding
+    /// two edges back to it therefore goes through the created-in-this-batch
+    /// branch rather than the committed-value one, and its `m_masked` entry has
+    /// to cancel the deletion instead of shadowing it.
+    #[test]
+    fn a_pair_emptied_this_transaction_promotes_again_from_scratch() {
+        ensure_init();
+        let mut t = committed_pairs(FOLDABLE);
+        let emptied = t.remove_all(&[(0, 0, 1), (1, 0, 1)]);
+        assert_eq!(emptied, vec![(0, 1)], "pair (0, 1) not reported emptied");
+        assert!(t.get(0, 1).next().is_none(), "emptied pair still readable");
+
+        t.set_all_from_slices(&[0, 0], &[1, 1], &[2 * FOLDABLE, 2 * FOLDABLE + 1]);
+        t.flush();
+        t.wait();
+
+        assert_eq!(
+            t.get(0, 1).collect::<Vec<_>>(),
+            vec![2 * FOLDABLE, 2 * FOLDABLE + 1],
+            "re-added pair lost an id"
+        );
+        assert_eq!(
+            t.edge_count(),
+            2 * FOLDABLE,
+            "edge count after emptying and re-promoting one pair"
+        );
+        assert_eq!(t.multi_pairs(), FOLDABLE, "re-added pair not counted multi");
     }
 
     /// The same batch may take a pair all the way down: the demotion is only
@@ -1870,7 +1928,11 @@ mod tests {
         );
         assert_eq!(t.edge_count(), 0, "edges left after removing all of them");
         assert_eq!(t.multi_pairs(), 0, "a demoted pair still counts as multi");
-        assert_eq!(t.me.nvals(), 0, "`me` still holds ids of emptied pairs");
+        assert_eq!(
+            t.fwd_me_nvals_for_test(),
+            0,
+            "`me` still holds ids of emptied pairs"
+        );
         t.mt.wait();
         assert_eq!(
             t.mt.extract().nvals(),
@@ -1917,7 +1979,11 @@ mod tests {
             "dp still shadows m with m's own value"
         );
         assert_eq!(t.fwd_dm().nvals(), 0, "demotion left a tombstone");
-        assert_eq!(t.me.nvals(), 0, "`me` not emptied by the demotion");
+        assert_eq!(
+            t.fwd_me_nvals_for_test(),
+            0,
+            "`me` not emptied by the demotion"
+        );
         assert_eq!(t.edge_count(), N, "edge count after promote + demote");
         assert_eq!(
             t.get(0, 1).collect::<Vec<_>>(),

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -142,6 +142,17 @@ use super::{
 #[allow(non_upper_case_globals)]
 pub const GrB_INDEX_MAX: u64 = (1u64 << 60) - 1;
 
+/// Row (and wide-column) dimension of every `me` block.
+///
+/// `GrB_INDEX_MAX` is the largest valid *index*, so a matrix declared that many
+/// rows accepts `0..GrB_INDEX_MAX - 1` — one short. [`compound_key`] can produce
+/// exactly `GrB_INDEX_MAX` (both endpoint halves all-ones, e.g.
+/// `src = dst = 2^BLOCK_SHIFT - 1`), and a write there was silently dropped, which
+/// is the very failure this module exists to remove, reintroduced at the new
+/// boundary. Declaring one row more makes every key [`compound_key`] can produce
+/// in range by construction.
+const ME_DIM: u64 = GrB_INDEX_MAX + 1;
+
 /// Column count `me` is created with, and the width at which GraphBLAS stores
 /// its column indices in 32 bits rather than 64.
 ///
@@ -327,7 +338,7 @@ impl Tensor {
             dp: Delta::new(Matrix::<u64>::new(nrows, ncols)),
             dm: Delta::new(Matrix::<bool>::new(nrows, ncols)),
             mt: VersionedMatrix::<bool>::new(ncols, nrows),
-            me: VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ME_NARROW_NCOLS),
+            me: VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS),
             me_blocks: None,
             needs_flush: AtomicBool::new(false),
         }
@@ -350,9 +361,9 @@ impl Tensor {
     /// The `me` matrix holding `block`, creating it if this is the first pair to
     /// reach it. Writes take this.
     ///
-    /// Every block is `GrB_INDEX_MAX` square like the original single matrix,
-    /// and hypersparse, so an empty one costs the fixed matrix header rather
-    /// than anything proportional to its dimensions.
+    /// Every block is [`ME_DIM`] rows like the original single matrix, and
+    /// hypersparse, so an empty one costs the fixed matrix header rather than
+    /// anything proportional to its dimensions.
     fn me_block_mut(
         &mut self,
         block: MeBlock,
@@ -367,7 +378,7 @@ impl Tensor {
         self.me_blocks
             .get_or_insert_with(|| Box::new(FxHashMap::default()))
             .entry(block)
-            .or_insert_with(|| VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ncols))
+            .or_insert_with(|| VersionedMatrix::<bool>::new(ME_DIM, ncols))
     }
 
     /// Widen every `me` block's column space if `max_id` will not fit.
@@ -383,7 +394,7 @@ impl Tensor {
             return;
         }
         for me in self.me_all_mut() {
-            me.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+            me.resize(ME_DIM, ME_DIM);
         }
     }
 
@@ -1362,7 +1373,7 @@ impl Decode<19> for Tensor {
         // `(count | MSB)` for multi-edge pairs, whose real id lists follow in
         // the tensor section.
         let mut m = Matrix::<u64>::new(nrows, ncols);
-        let mut me = VersionedMatrix::<bool>::new(GrB_INDEX_MAX, ME_NARROW_NCOLS);
+        let mut me = VersionedMatrix::<bool>::new(ME_DIM, ME_NARROW_NCOLS);
         let mut me_blocks: Option<Box<FxHashMap<MeBlock, VersionedMatrix<bool>>>> = None;
         // Widened lazily, as in `set_all_from_slices`: a blob whose ids all fit
         // decodes into the narrow form and keeps the 32-bit column indices.
@@ -1408,11 +1419,11 @@ impl Decode<19> for Tensor {
                     let edge_ids: Vec<u64> = v.iter().collect();
                     if let Some(&max_id) = edge_ids.iter().max() {
                         if max_id >= me_ncols {
-                            me_ncols = GrB_INDEX_MAX;
-                            me.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+                            me_ncols = ME_DIM;
+                            me.resize(ME_DIM, ME_DIM);
                             if let Some(blocks) = me_blocks.as_mut() {
                                 for b in blocks.values_mut() {
-                                    b.resize(GrB_INDEX_MAX, GrB_INDEX_MAX);
+                                    b.resize(ME_DIM, ME_DIM);
                                 }
                             }
                         }
@@ -1423,9 +1434,7 @@ impl Decode<19> for Tensor {
                         me_blocks
                             .get_or_insert_with(|| Box::new(FxHashMap::default()))
                             .entry(block)
-                            .or_insert_with(|| {
-                                VersionedMatrix::<bool>::new(GrB_INDEX_MAX, me_ncols)
-                            })
+                            .or_insert_with(|| VersionedMatrix::<bool>::new(ME_DIM, me_ncols))
                     };
                     for edge_id in edge_ids {
                         target.set(key, edge_id, true);
@@ -2144,7 +2153,7 @@ mod tests {
         t.wait();
         assert_eq!(
             t.edge_versioned_block_0().ncols(),
-            GrB_INDEX_MAX,
+            super::ME_DIM,
             "an id at the narrow width should have widened `me`"
         );
         assert_eq!(t.get(1, 2).collect::<Vec<_>>(), vec![7, 8, narrow]);
@@ -2162,5 +2171,42 @@ mod tests {
             vec![narrow + 2, narrow + 3],
             "a block created after widening dropped its ids"
         );
+    }
+
+    /// The top row key is the one [`compound_key`] can produce with both
+    /// endpoint halves all-ones, and it is exactly `GrB_INDEX_MAX`. A matrix
+    /// declared that many rows accepts one fewer, so this pair's writes were
+    /// silently dropped — the original bug, at the new boundary. Caught in
+    /// review; the earlier tests all used `src = 2^k`, which never lands here.
+    #[test]
+    fn the_top_row_key_of_a_block_is_writable() {
+        ensure_init();
+        let m = (1u64 << BLOCK_SHIFT) - 1;
+        assert_eq!(
+            compound_key(m, m).1,
+            GrB_INDEX_MAX,
+            "fixture is not exercising the top row key"
+        );
+
+        // In block (0,0), and in a higher block, since blocks are created by a
+        // different path than the tensor's own field.
+        let b = 1u64 << BLOCK_SHIFT;
+        for (src, dst) in [(m, m), (b + m, b + m), (b + m, m), (m, b + m)] {
+            let mut t = Tensor::new(2 * b + 2, 2 * b + 2);
+            t.set_all_from_slices(&[src, src], &[dst, dst], &[10, 11]);
+            let mut t = t.dup();
+            t.flush();
+            t.wait();
+            assert_eq!(
+                t.get(src, dst).collect::<Vec<_>>(),
+                vec![10, 11],
+                "ids dropped at the top row key of ({src}, {dst})"
+            );
+            assert_eq!(t.edge_count(), 2, "edge_count wrong at ({src}, {dst})");
+            assert_eq!(t.multi_pairs(), 1);
+            let mut seen: Vec<_> = t.iter_edges().collect();
+            seen.sort_unstable();
+            assert_eq!(seen, vec![(src, dst, 10), (src, dst, 11)]);
+        }
     }
 }

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -63,6 +63,7 @@
 pub mod attribute_store;
 pub mod constraint;
 pub mod cow;
+pub mod endpoint_index;
 pub mod graph;
 pub mod graphblas;
 pub mod mvcc_graph;

--- a/graph/src/runtime/functions/algo_procedures.rs
+++ b/graph/src/runtime/functions/algo_procedures.rs
@@ -68,6 +68,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use super::{FnType, Functions, Type, empty_procedure_batch};
+use crate::graph::graphblas::tensor::compound_key_inverse;
 use crate::{
     graph::{
         attribute_store::AttributeStore,
@@ -1556,91 +1557,100 @@ fn register_msf(funcs: &mut Functions) {
                     GrB_Matrix_free(&raw mut eff);
 
                     // Multi pass: every edge id of a multi-edge pair lives in
-                    // `me[compound_key(src,dst)][edge_id]`; skip it entirely
+                    // its block's `me[row][edge_id]`; skip it entirely
                     // on single-edge tensors.
                     if !tensor.has_multi_edge() {
                         continue;
                     }
-                    let me = tensor.edge_versioned();
-                    me.wait();
-                    // Two read-only edge sources per tensor: live base edges `m`
-                    // (masked by ¬dm to drop deletions) and pending additions `dp`
-                    // (disjoint from dm).
-                    let sources: [(GrB_Matrix, GrB_Matrix, GrB_Descriptor); 2] = [
-                        (me.m().inner(), me.dm().inner(), GrB_DESC_SC),
-                        (me.dp().inner(), null_mut(), null_mut()),
-                    ];
-                    // v[compound_key(src,dst)] = the pair's minimum-score
-                    // edge, via a parallel monoid row-reduction instead of a host
-                    // iterator walk; the accum merges the two sources.
-                    let mut me_rows: GrB_Index = 0;
-                    GrB_Matrix_nrows(&raw mut me_rows, me.m().inner());
-                    let mut v: GrB_Vector = null_mut();
-                    GrB_Vector_new(&raw mut v, scored_edge_type, me_rows);
-                    for (src_mat, mask, desc) in sources {
-                        let mut src_nvals: GrB_Index = 0;
-                        GrB_Matrix_nvals(&raw mut src_nvals, src_mat);
-                        if src_nvals == 0 {
+                    // One `me` matrix per block, and a pair's identifiers live
+                    // in exactly one of them, so the winners simply accumulate
+                    // across blocks — there is nothing to merge between them.
+                    // Every graph within 2^30 nodes per axis has one block.
+                    for (block, me) in tensor.edge_versioned_all() {
+                        if me.nvals() == 0 {
                             continue;
                         }
-                        let mut n_rows: GrB_Index = 0;
-                        let mut n_cols: GrB_Index = 0;
-                        GrB_Matrix_nrows(&raw mut n_rows, src_mat);
-                        GrB_Matrix_ncols(&raw mut n_cols, src_mat);
+                        me.wait();
+                        // Two read-only edge sources per tensor: live base edges `m`
+                        // (masked by ¬dm to drop deletions) and pending additions `dp`
+                        // (disjoint from dm).
+                        let sources: [(GrB_Matrix, GrB_Matrix, GrB_Descriptor); 2] = [
+                            (me.m().inner(), me.dm().inner(), GrB_DESC_SC),
+                            (me.dp().inner(), null_mut(), null_mut()),
+                        ];
+                        // v[compound_key(src,dst)] = the pair's minimum-score
+                        // edge, via a parallel monoid row-reduction instead of a host
+                        // iterator walk; the accum merges the two sources.
+                        let mut me_rows: GrB_Index = 0;
+                        GrB_Matrix_nrows(&raw mut me_rows, me.m().inner());
+                        let mut v: GrB_Vector = null_mut();
+                        GrB_Vector_new(&raw mut v, scored_edge_type, me_rows);
+                        for (src_mat, mask, desc) in sources {
+                            let mut src_nvals: GrB_Index = 0;
+                            GrB_Matrix_nvals(&raw mut src_nvals, src_mat);
+                            if src_nvals == 0 {
+                                continue;
+                            }
+                            let mut n_rows: GrB_Index = 0;
+                            let mut n_cols: GrB_Index = 0;
+                            GrB_Matrix_nrows(&raw mut n_rows, src_mat);
+                            GrB_Matrix_ncols(&raw mut n_cols, src_mat);
 
-                        let mut scored: GrB_Matrix = null_mut();
-                        GrB_Matrix_new(&raw mut scored, scored_edge_type, n_rows, n_cols);
-                        GrB_Matrix_apply_IndexOp_UDT(
-                            scored,
-                            mask,
-                            null_mut(),
-                            ov_op,
-                            src_mat,
-                            (&raw const ctx).cast::<std::os::raw::c_void>(),
-                            desc,
-                        );
-                        GrB_Matrix_reduce_Monoid(
-                            v,
-                            null_mut(),
-                            min_by_score,
-                            min_monoid,
-                            scored,
-                            null_mut(),
-                        );
-                        GrB_Matrix_free(&raw mut scored);
-                    }
+                            let mut scored: GrB_Matrix = null_mut();
+                            GrB_Matrix_new(&raw mut scored, scored_edge_type, n_rows, n_cols);
+                            GrB_Matrix_apply_IndexOp_UDT(
+                                scored,
+                                mask,
+                                null_mut(),
+                                ov_op,
+                                src_mat,
+                                (&raw const ctx).cast::<std::os::raw::c_void>(),
+                                desc,
+                            );
+                            GrB_Matrix_reduce_Monoid(
+                                v,
+                                null_mut(),
+                                min_by_score,
+                                min_monoid,
+                                scored,
+                                null_mut(),
+                            );
+                            GrB_Matrix_free(&raw mut scored);
+                        }
 
-                    // Host step: only the compound-key → (src,dst) index split —
-                    // arithmetic GraphBLAS cannot express — one entry per
-                    // multi-edge pair, not per edge.
-                    let mut v_nvals: GrB_Index = 0;
-                    GrB_Vector_nvals(&raw mut v_nvals, v);
-                    if v_nvals != 0 {
-                        let mut keys: Vec<GrB_Index> = vec![0; v_nvals as usize];
-                        let mut vals: Vec<ScoredEdge> =
-                            vec![ScoredEdge { score: 0.0, edge: 0 }; v_nvals as usize];
-                        let mut nv = v_nvals;
-                        GrB_Vector_extractTuples_UDT(
-                            keys.as_mut_ptr(),
-                            vals.as_mut_ptr().cast::<std::os::raw::c_void>(),
-                            &raw mut nv,
-                            v,
-                        );
-                        for (key, se) in keys.iter().zip(&vals) {
-                            let src_original = (key >> 32) as usize;
-                            let dst_original = (key & 0xFFFF_FFFF) as usize;
-                            if src_original < id_to_compact_vec.len()
-                                && id_to_compact_vec[src_original] != u64::MAX
-                                && dst_original < id_to_compact_vec.len()
-                                && id_to_compact_vec[dst_original] != u64::MAX
-                            {
-                                ov_rows.push(id_to_compact_vec[src_original]);
-                                ov_cols.push(id_to_compact_vec[dst_original]);
-                                ov_vals.push(*se);
+                        // Host step: only the compound-key → (src,dst) index split —
+                        // arithmetic GraphBLAS cannot express — one entry per
+                        // multi-edge pair, not per edge.
+                        let mut v_nvals: GrB_Index = 0;
+                        GrB_Vector_nvals(&raw mut v_nvals, v);
+                        if v_nvals != 0 {
+                            let mut keys: Vec<GrB_Index> = vec![0; v_nvals as usize];
+                            let mut vals: Vec<ScoredEdge> =
+                                vec![ScoredEdge { score: 0.0, edge: 0 }; v_nvals as usize];
+                            let mut nv = v_nvals;
+                            GrB_Vector_extractTuples_UDT(
+                                keys.as_mut_ptr(),
+                                vals.as_mut_ptr().cast::<std::os::raw::c_void>(),
+                                &raw mut nv,
+                                v,
+                            );
+                            for (key, se) in keys.iter().zip(&vals) {
+                                let (src, dst) = compound_key_inverse(block, *key);
+                                let src_original = src as usize;
+                                let dst_original = dst as usize;
+                                if src_original < id_to_compact_vec.len()
+                                    && id_to_compact_vec[src_original] != u64::MAX
+                                    && dst_original < id_to_compact_vec.len()
+                                    && id_to_compact_vec[dst_original] != u64::MAX
+                                {
+                                    ov_rows.push(id_to_compact_vec[src_original]);
+                                    ov_cols.push(id_to_compact_vec[dst_original]);
+                                    ov_vals.push(*se);
+                                }
                             }
                         }
+                        GrB_Vector_free(&raw mut v);
                     }
-                    GrB_Vector_free(&raw mut v);
                 }
                 GrB_IndexUnaryOp_free(&raw mut ov_op);
                 GrB_Monoid_free(&raw mut min_monoid);


### PR DESCRIPTION
Fixes #2578.

## The bug, which is worse than the ceiling it was filed as

`me` is `GrB_INDEX_MAX` square and its row key was `(src << 32) | dst`, so the key leaves the matrix's row range at **`src = 2^28`** — not the 2^32 the guard checked. `Matrix::set` checks the GraphBLAS status under `debug_assert!` only, so **release builds silently drop the write**, leaving the pair tagged `MULTI_EDGE` over an empty `me` row.

Reproduced before touching anything, release build, two edges inserted each time:

```
src=2^27  key<2^60=true   ids=[10, 11]  edge_count=2
src=2^28  key<2^60=false  ids=[]        edge_count=1
src=2^29  key<2^60=false  ids=[]        edge_count=1
```

That is promotion completeness broken: `get` returns nothing and `edge_count` disagrees with both the inserts and the reads.

## Three changes

**1. The key splits instead of packing.** Low 30 bits of each endpoint form a row key that is in range *by construction*; high bits select a block. `compound_key` is now total — it cannot panic and cannot be out of range, where its predecessor could do both. Block `(0,0)` is a dedicated field with a lazily allocated map for the rest, so every graph under 2^30 nodes per axis takes today's path behind one `Option` check.

No serialisation change, no version bump: the blob stores `(src, dst, ids)` rather than row keys, so it is already block-agnostic and re-keys on decode. `encode_decode_round_trips_across_blocks` pins that.

**2. `me` is created narrow.** Its columns are edge ids, and the column-index array holds one entry per stored id — the largest array in the structure. Measured:

| declared dims | row bits | col bits | B/id |
|---|---|---|---|
| 2^60 × 2^60 (today) | 64 | 64 | 11.69 |
| (2^32−1) × (2^32−1) | 64 | 64 | 11.69 |
| **2^60 rows × 2^31 cols** | 64 | **32** | **6.44** |
| 2^31 × 2^31 | 32 | 32 | 6.04 |

The cutoff is **2^31, not 2^32** — GraphBLAS needs the dimension itself to fit a `u32`. Per-matrix and global `GxB_*INTEGER_HINT` are accepted (`GrB_SUCCESS`) and change nothing; the bench keeps a row proving it so nobody re-discovers that. Rows stay wide deliberately: narrowing them saves a further 0.40 B/id and would need `BLOCK_SHIFT` at 15, i.e. a block per 32,768 nodes per axis.

**3. `edge_endpoints` had the same ceiling in a different hat** — a `Vec<u64>` of `(src << 32) | dst`, a flat 8 B/edge, panicking past 2^32. Now `EndpointIndex`: four tiers (`u16`/`U24`/`u32`/`u64`) partitioning the edge-id space, because ids are allocated in increasing order and width only grows.

| nodes up to | field | bytes/edge |
|---|---|---|
| 65 534 | `u16` | 4 |
| 16.7 M | `U24` | 6 |
| 4.29 B | `u32` | 8 |
| 18.4 E | `u64` | 16 *(no previous form — this range used to panic)* |

Whether tiering pays depends on *when* edges are written relative to node growth, so I measured it: a bulk load writes every edge after ids reach final width and saves nothing; a graph grown incrementally across the 65,535 boundary wrote **30%** of its edges while ids were still narrow.

Each tier sits behind its own `Arc`. MVCC gives the snapshot one reference and the writer another, so the first edge mutation of a version deep-clones — copying the *whole* index cost ~0.9 instructions per edge in the graph, per transaction, however small the transaction:

| edges | whole-index clone | per-tier (version + 1 write) |
|---|---|---|
| 100k | 92,027 | 19,522 |
| 1M | 873,573 | 116,863 |
| 10M | 9,151,265 | **1,283,460** |

**7.1× at 10M edges**, and only possible because the tiers exist.

## Measured against `main`

| | main | this branch |
|---|---|---|
| `relation_matrices_sz_mb` | 7 | **4** |
| total graph | 20 MB | **14 MB** |
| jemalloc live | 453.1 MB | **402.5 MB** |
| writes | 8,910 | 8,979 instr/edge (**+0.77%**) |
| reads (`RETURN r`) | 6,927 | 6,964 instr/row (**+0.5%**) |
| engine reads (#2430 fixture) | unchanged | unchanged |

The write and read costs are the price of block dispatch, the per-batch max scan, and the tier walk.

## A regression found on the way

Growing the endpoint index one slot per edge with `reserve_exact` is quadratic: **87,370 instructions per edge created against 8,927**, which timed out `test12_load_large_graph`. `prepare` now sizes once per batch, and `set`'s fallback growth is amortised so a caller that forgets cannot be quadratic again.

## Tests

169 unit tests, 138 Python (e2e / functions / mvcc / concurrency), TCK and flow all pass. The 23 flow failures match `main`'s set at ef44bc6db exactly, verified by building `main` in a second worktree and diffing failing-test names. `cargo fmt --check` clean, no new clippy warnings.

New coverage: promotion past the old key width (through 2^40), block non-aliasing, encode/decode across blocks, `me` widening for large edge ids, and six tests on the endpoint index including the tiering property and the reused-id promotion.

`block_scaling_bench` records what the design trades away: per-transaction work is linear in live block count (`edge_count` ~3,070 instr/block), but 64 blocks implies a node-id span of ~69 billion, so no real graph reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scalable endpoint indexing for larger node identifiers with improved memory efficiency.
  - Improved multi-edge graph storage with block partitioning and automatic capacity expansion.
  - Enhanced graph algorithms to process multi-edge data across all storage blocks.

- **Bug Fixes**
  - Prevented node-ID overflow and aliasing in multi-edge graphs.
  - Improved handling of endpoint updates, deletions, gaps, and reused edge identifiers.

- **Tests**
  - Added coverage for large identifiers, serialization, storage expansion, memory usage, and block-level behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->