### PR TITLE
fix(ci): drop Actions cache from untrusted macOS artifact build

### DIFF
--- a/.github/workflows/_build-artifacts-macos.yml
+++ b/.github/workflows/_build-artifacts-macos.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   build:
     runs-on: macos-14
-    timeout-minutes: 90
+    timeout-minutes: 120
     permissions:
       contents: read
     env:
@@ -34,7 +34,7 @@ jobs:
       # matching the Linux single-.so contract). graph/build.rs links static
       # when ${LIBOMP_PREFIX}/lib/libomp.a exists.
       LIBOMP_PREFIX: /opt/homebrew/opt/libomp
-      # Workspace-local GraphBLAS install (no sudo; cacheable). graphblas.sh
+      # Workspace-local GraphBLAS install (no sudo). graphblas.sh
       # reads GRAPHBLAS_INSTALL_PREFIX; build.rs reads GRAPHBLAS_LIB_DIR.
       GRAPHBLAS_INSTALL_PREFIX: ${{ github.workspace }}/.deps/graphblas
       GRAPHBLAS_LIB_DIR: ${{ github.workspace }}/.deps/graphblas/lib
@@ -54,47 +54,28 @@ jobs:
           echo "${LLVM_PREFIX}/bin"             >> "$GITHUB_PATH"
           echo "CC=${LLVM_PREFIX}/bin/clang"    >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
-          # Bust the native-deps cache when Homebrew LLVM moves (the C artefacts
-          # are ABI-tied to it).
-          echo "BREW_LLVM_VERSION=$(brew list --versions llvm | awk '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Install Rust stable
         run: rustup default stable
 
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          shared-key: "macos-artifact-release"
+      # NOTE: no Actions cache (neither rust-cache nor actions/cache) in this
+      # job, deliberately. The job checks out and compiles arbitrary code
+      # (`inputs.commit_sha`, e.g. a PR head), so anything it wrote to the
+      # cache would be attacker-controlled content living in a cache scope that
+      # privileged, default-branch runs can restore from — the cache-poisoning
+      # class of supply-chain attack (CodeQL `actions/cache-poisoning/*`).
+      # Cache scope is decided by GitHub, not by the key, so a custom key
+      # cannot isolate it; the only safe option for an untrusted-code build is
+      # not to write the cache at all. This is a rarely-run, manually triggered
+      # verification build, so a cold rebuild of the native deps is acceptable.
 
-      # Hosted macOS has no Docker toolchain image, so rebuild GraphBLAS +
-      # LAGraph + RediSearch from source and cache them (keyed on the build
-      # scripts + vendored PreJIT + the exact Homebrew LLVM version).
-      - name: Restore GraphBLAS + RediSearch native builds
-        id: native-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: |
-            .deps/graphblas
-            lagraph_lib
-            redisearch/RediSearch/bin
-          key: macos-native-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('graphblas.sh', 'redisearch.sh', 'build/graphblas/**') }}-llvm${{ env.BREW_LLVM_VERSION }}
-
+      # Hosted macOS has no Docker toolchain image, so GraphBLAS + LAGraph +
+      # RediSearch are rebuilt from source on every run.
       - name: Build GraphBLAS + LAGraph
-        if: steps.native-cache.outputs.cache-hit != 'true'
         run: ./graphblas.sh
 
       - name: Build RediSearch
-        if: steps.native-cache.outputs.cache-hit != 'true'
         run: ./redisearch.sh
-
-      - name: Save GraphBLAS + RediSearch native builds
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: |
-            .deps/graphblas
-            lagraph_lib
-            redisearch/RediSearch/bin
-          key: ${{ steps.native-cache.outputs.cache-primary-key }}
 
       - name: Build libfalkordb.dylib
         run: cargo build --release


### PR DESCRIPTION
## Summary
Fixes the four open high-severity code scanning alerts on `.github/workflows/_build-artifacts-macos.yml` (285, 286, 287, 288) — `actions/cache-poisoning/direct-cache` and `actions/cache-poisoning/poisonable-step`.

The job checks out and compiles arbitrary code (`inputs.commit_sha`, e.g. a PR head via the `verify-artifacts` label path) and then wrote to the GitHub Actions cache. Cache scope is assigned by GitHub, not by the cache key, so entries written from an untrusted build are restorable by privileged default-branch runs — the cache-poisoning supply-chain vector. A custom key cannot isolate this; the only safe option for a job that builds untrusted code is to not write the cache at all.

## Changes
- Removed `Swatinem/rust-cache` (wrote the `target/` dir produced from untrusted code).
- Removed the `actions/cache/restore` + `actions/cache/save` pair for the GraphBLAS / LAGraph / RediSearch native builds; those are now rebuilt on every run.
- Dropped the now-unused `BREW_LLVM_VERSION` export (it only existed to bust the native-deps cache key).
- Bumped `timeout-minutes` 90 to 120 to cover the always-cold build.
- Added a comment explaining why this job deliberately has no cache, so it isn't re-added.

## Testing
- YAML parse check on the workflow.
- Ran the CodeQL Actions pack locally (bundle v2.24.1, `codeql/actions-queries`, default + `actions-security-extended` suites) against the branch: 0 cache-poisoning results. Both `CWE-349` queries require a `CacheWritingStep` (`actions/cache`, `actions/cache/save`, `setup-ruby` with `bundler-cache`) in the job that runs the untrusted checkout — no such step remains.
- No behavioural change to the produced artifact: the same `graphblas.sh` / `redisearch.sh` / `cargo build --release` steps run, only unconditionally now.

## Memory / Performance Impact
N/A to the engine. CI only: macOS verify builds now always rebuild GraphBLAS + RediSearch + the Rust release build from scratch. This is a manually triggered / label-gated verification workflow, not a per-push job, so the trade is acceptable.

## Related Issues
Closes #2600

Fixes code scanning alerts 285, 286, 287, 288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum build time for macOS artifacts.
  * Updated the build process to compile native components from scratch on each run.
  * Added documentation explaining the build and cache-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
