### PR TITLE
ci(security): gate artifact-build caches on a trusted revision

### DIFF
--- a/.github/workflows/_build-artifacts-macos.yml
+++ b/.github/workflows/_build-artifacts-macos.yml
@@ -13,10 +13,21 @@ name: Build artifacts macOS (reusable)
 on:
   workflow_call:
     inputs:
-      commit_sha:
-        description: "Commit SHA to check out and build"
+      revision:
+        description: "Git revision (commit SHA) to check out and build"
         required: true
         type: string
+      trusted_revision:
+        description: >-
+          Whether `revision` is already-reviewed code (release tags, the default
+          branch, a maintainer dispatch). Defaults to FALSE — a caller must opt
+          in — so a caller that forwards a pull-request head is untrusted by
+          construction. Untrusted builds never WRITE a cache, which is what keeps
+          a PR build from poisoning the native deps / Rust artefacts a later
+          release build restores.
+        required: false
+        type: boolean
+        default: false
       suffix:
         description: "Asset suffix → falkordb-<suffix>.so"
         required: false
@@ -39,9 +50,14 @@ jobs:
       GRAPHBLAS_INSTALL_PREFIX: ${{ github.workspace }}/.deps/graphblas
       GRAPHBLAS_LIB_DIR: ${{ github.workspace }}/.deps/graphblas/lib
     steps:
+      # This job compiles caller-supplied code that may come from a pull request.
+      # `persist-credentials: false` keeps no GITHUB_TOKEN on disk, `permissions`
+      # is read-only, callers pass no secrets, and every cache WRITE below is
+      # gated on `trusted_revision` so an untrusted build cannot seed artefacts
+      # that a later release build restores.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.commit_sha }}
+          ref: ${{ inputs.revision }}
           persist-credentials: false
 
       - name: Install Homebrew build deps
@@ -64,6 +80,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: "macos-artifact-release"
+          # Untrusted revisions restore the cache but never save it.
+          save-if: ${{ inputs.trusted_revision }}
 
       # Hosted macOS has no Docker toolchain image, so rebuild GraphBLAS +
       # LAGraph + RediSearch from source and cache them (keyed on the build
@@ -87,7 +105,11 @@ jobs:
         run: ./redisearch.sh
 
       - name: Save GraphBLAS + RediSearch native builds
-        if: steps.native-cache.outputs.cache-hit != 'true'
+        # Only a trusted revision may WRITE this cache. `graphblas.sh` /
+        # `redisearch.sh` come from the checked-out tree, so on a PR build their
+        # output is attacker-controlled and must never be published for a later
+        # release build to restore.
+        if: ${{ inputs.trusted_revision && steps.native-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -28,10 +28,20 @@ on:
           per-OS Dockerfiles; `cxx` is the C++ compiler passed to the builder.
         required: true
         type: string
-      commit_sha:
-        description: "Commit SHA to check out and build"
+      revision:
+        description: "Git revision (commit SHA) to check out and build"
         required: true
         type: string
+      trusted_revision:
+        description: >-
+          Whether `revision` is already-reviewed code (release tags, the default
+          branch, a maintainer dispatch). Defaults to FALSE — a caller must opt
+          in — so a caller that forwards a pull-request head is untrusted by
+          construction. Untrusted builds never WRITE a build cache, which is what
+          keeps a PR build from poisoning the layers a later release build reuses.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -48,9 +58,12 @@ jobs:
       # safe even though it builds caller-supplied (potentially PR) code: no
       # GITHUB_TOKEN is left on disk and the job cannot write anything. Callers
       # do not pass `secrets: inherit`, so no custom secrets reach the build.
+      # The remaining cross-run risk — an untrusted build writing a cache that a
+      # later trusted build consumes — is closed by the `trusted_revision` gate
+      # on `cache-to` below.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.commit_sha }}
+          ref: ${{ inputs.revision }}
           persist-credentials: false
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -85,8 +98,11 @@ jobs:
             CXX=${{ matrix.cxx }}
           # Per-suffix GitHub Actions cache so each platform's build layers are
           # independent and sticky across runs (no packages:write needed).
+          # Untrusted revisions READ the cache but never write it: a PR build
+          # compiles attacker-controlled sources, so letting it publish layers
+          # would let it seed the cache a later release build restores.
           cache-from: type=gha,scope=artifact-${{ matrix.suffix }}
-          cache-to: type=gha,mode=max,scope=artifact-${{ matrix.suffix }}
+          cache-to: ${{ inputs.trusted_revision && format('type=gha,mode=max,scope=artifact-{0}', matrix.suffix) || '' }}
 
       - name: Stage + checksum
         env:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -97,7 +97,11 @@ jobs:
       packages: read
     with:
       cells: ${{ needs.prepare.outputs.cells }}
-      commit_sha: ${{ needs.prepare.outputs.commit_sha }}
+      revision: ${{ needs.prepare.outputs.commit_sha }}
+      # On a `pull_request` run the revision is the PR head — untrusted code, so
+      # the build may not write any cache. Only a maintainer dispatch (which can
+      # only target a ref already in this repo) is treated as trusted.
+      trusted_revision: ${{ github.event_name == 'workflow_dispatch' }}
     # No `secrets: inherit` — the reusable workflow only needs the auto-provided
     # GITHUB_TOKEN (GHCR read). Keeping custom secrets out of a PR-triggered
     # build that compiles untrusted code is deliberate.
@@ -109,4 +113,5 @@ jobs:
     permissions:
       contents: read
     with:
-      commit_sha: ${{ needs.prepare.outputs.commit_sha }}
+      revision: ${{ needs.prepare.outputs.commit_sha }}
+      trusted_revision: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -121,7 +121,10 @@ jobs:
       packages: read
     with:
       cells: ${{ needs.prepare.outputs.cells }}
-      commit_sha: ${{ needs.prepare.outputs.commit_sha }}
+      revision: ${{ needs.prepare.outputs.commit_sha }}
+      # Release builds run on a tag / maintainer-supplied commit that is already
+      # in this repository — reviewed code, so this build may write the cache.
+      trusted_revision: true
     # No `secrets: inherit` — the reusable build only needs the auto GITHUB_TOKEN.
 
   publish:


### PR DESCRIPTION
## Summary

Fixes code scanning alerts [#250](https://github.com/FalkorDB/FalkorDB/security/code-scanning/250) and [#251](https://github.com/FalkorDB/FalkorDB/security/code-scanning/251) (`actions/untrusted-checkout/medium`), and as a side effect the four `actions/cache-poisoning` alerts (285–288) on the same workflows.

`_build-artifacts.yml` and `_build-artifacts-macos.yml` compile whatever revision the caller hands them — including a pull-request head via the `verify-artifacts` label path — and then wrote the shared build caches unconditionally. That is the concrete risk the CodeQL query describes: an untrusted build seeding the buildx layer cache / GraphBLAS+RediSearch native cache / Rust cache that a later trusted (release) build restores.

Both reusable workflows now take an explicit `trusted_revision` input that **defaults to false** (callers must opt in), and every cache *write* is gated on it. Untrusted builds still *restore* caches, so PR verification stays fast, but they can never publish artefacts another run consumes.

## Changes

- `_build-artifacts.yml`
  - new `trusted_revision` boolean input (default `false`); `commit_sha` renamed to `revision`
  - `cache-to` is emitted only for a trusted revision; `cache-from` unchanged
- `_build-artifacts-macos.yml`
  - same two input changes
  - `Swatinem/rust-cache` gets `save-if: ${{ inputs.trusted_revision }}`
  - the GraphBLAS + RediSearch cache-save step is additionally gated on `trusted_revision`
- `build-artifacts.yml` (PR verification) passes `trusted_revision: ${{ github.event_name == 'workflow_dispatch' }}` — a labeled PR run is untrusted, a maintainer dispatch (which can only target a ref already in this repo) is trusted
- `release-artifacts.yml` passes `trusted_revision: true` — release builds run on a tag / maintainer-supplied commit

## Testing

Ran the CodeQL `actions-security-extended` suite (CodeQL CLI 2.26.3) against the workspace before and after:

| | before | after |
|---|---|---|
| `actions/untrusted-checkout/medium` (`_build-artifacts*.yml`) | 2 | **0** |
| `actions/cache-poisoning/*` (`_build-artifacts-macos.yml`) | 4 | **0** |
| `actions/code-injection/medium` (`cleanup-runner`, pre-existing, out of scope) | 4 | 4 |

All four touched workflow files also re-validated as well-formed YAML. No engine/runtime code is touched.

## Memory / Performance Impact

N/A — CI configuration only. PR-triggered artifact verification builds no longer *write* caches, so a run whose base cache is cold pays a full build; those runs are opt-in via the `verify-artifacts` label and are rare.

## Related Issues

Closes #2599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved artifact builds by distinguishing trusted and untrusted revisions.
  * Untrusted builds can restore existing caches but cannot write new dependency or build caches.
  * Updated release and build workflows to use the selected revision consistently.
  * Manual and release builds retain cache-writing access, while pull-request builds remain restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->