### PR TITLE
fix: element-wise Vectorf32 equality in compare_value

### DIFF
--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -1974,12 +1974,22 @@ mod vecf32_compare_tests {
         assert!(!disjoint(&a, &vecf32(&[1.0, 2.0])));
     }
 
+    fn ordering(
+        a: &Value,
+        b: &Value,
+    ) -> Ordering {
+        a.compare_value(b).0
+    }
+
     #[test]
     fn vecf32_unequals_different_vector() {
         let a = vecf32(&[0.1, 0.1, 0.1, 0.1, 0.1]);
         let b = vecf32(&[0.2, 0.2, 0.2, 0.2, 0.9]);
         assert!(!eq(&a, &b));
         assert!(!disjoint(&a, &b));
+        // Both directions: the smaller operand orders Less both ways round.
+        assert_eq!(ordering(&a, &b), Ordering::Less);
+        assert_eq!(ordering(&b, &a), Ordering::Greater);
     }
 
     #[test]
@@ -1988,11 +1998,17 @@ mod vecf32_compare_tests {
         let b = vecf32(&[1.0, 2.0]);
         assert!(!eq(&a, &b));
         assert!(!disjoint(&a, &b));
+        // Dimension decides first: the shorter vector is Less.
+        assert_eq!(ordering(&a, &b), Ordering::Less);
+        assert_eq!(ordering(&b, &a), Ordering::Greater);
     }
 
     #[test]
     fn vecf32_empty_vectors_equal() {
         assert!(eq(&vecf32(&[]), &vecf32(&[])));
+        // Empty is the shortest vector: Less than any non-empty one.
+        assert_eq!(ordering(&vecf32(&[]), &vecf32(&[1.0])), Ordering::Less);
+        assert_eq!(ordering(&vecf32(&[1.0]), &vecf32(&[])), Ordering::Greater);
     }
 
     #[test]
@@ -2000,5 +2016,14 @@ mod vecf32_compare_tests {
         // NaN orders below everything and compares equal only to NaN.
         assert!(eq(&vecf32(&[1.0, f32::NAN]), &vecf32(&[1.0, f32::NAN])));
         assert!(!eq(&vecf32(&[1.0, f32::NAN]), &vecf32(&[1.0, 2.0])));
+        // NaN orders below a number in both directions.
+        assert_eq!(
+            ordering(&vecf32(&[f32::NAN]), &vecf32(&[1.0])),
+            Ordering::Less
+        );
+        assert_eq!(
+            ordering(&vecf32(&[1.0]), &vecf32(&[f32::NAN])),
+            Ordering::Greater
+        );
     }
 }

--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -1234,6 +1234,33 @@ impl CompareValue for Value {
                 Self::compare_list(a, b)
             }
             (Self::Map(a), Self::Map(b)) => Self::compare_map(a, b),
+            // Vector equality is element-wise: vecf32([1.0,2.0]) equals
+            // vecf32([1.0,2.0]). Without this arm the fallthrough compared
+            // only the type order, so `=` and `<>` were both always false
+            // for vectors and MERGE on a vector property duplicated on
+            // every execution (#2604).
+            (Self::VecF32(a), Self::VecF32(b)) => {
+                let len_a = a.len();
+                let len_b = b.len();
+                let ord = len_a.cmp(&len_b).then_with(|| {
+                    a.iter()
+                        .zip(b.iter())
+                        .map(|(x, y)| {
+                            // NaN components order less than everything; a
+                            // NaN compares equal only to another NaN.
+                            x.partial_cmp(y).unwrap_or(if x.is_nan() && y.is_nan() {
+                                Ordering::Equal
+                            } else if x.is_nan() {
+                                Ordering::Less
+                            } else {
+                                Ordering::Greater
+                            })
+                        })
+                        .find(|ord| *ord != Ordering::Equal)
+                        .unwrap_or(Ordering::Equal)
+                });
+                (ord, DisjointOrNull::None)
+            }
             (Self::Node(a), Self::Node(b)) => (a.cmp(b), DisjointOrNull::None),
             (Self::Relationship(rel_a), Self::Relationship(rel_b)) => {
                 (rel_a.cmp(rel_b), DisjointOrNull::None)
@@ -1907,5 +1934,71 @@ impl Decode<19> for Value {
             si_type::T_DURATION => Ok(Self::Duration(r.read_signed()?)),
             _ => Err(format!("unknown SIType tag: {tag}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod vecf32_compare_tests {
+    use super::CompareValue;
+    use super::DisjointOrNull;
+    use super::Ordering;
+    use super::Value;
+    use std::sync::Arc;
+    use thin_vec::{ThinVec, thin_vec as thin_vec_from_slice};
+
+    fn vecf32(values: &[f32]) -> Value {
+        Value::VecF32(Arc::new(ThinVec::from_slice(values)))
+    }
+
+    fn eq(
+        a: &Value,
+        b: &Value,
+    ) -> bool {
+        a.compare_value(b).0 == Ordering::Equal
+    }
+
+    fn disjoint(
+        a: &Value,
+        b: &Value,
+    ) -> bool {
+        a.compare_value(b).1 == DisjointOrNull::Disjoint
+    }
+
+    // Regression (#2604): vector equality was always false (and `<>` also
+    // always false), because compare_value had no VecF32 arm and the
+    // fallthrough compared only the type order.
+    #[test]
+    fn vecf32_equals_identical_vector() {
+        let a = vecf32(&[1.0, 2.0]);
+        assert!(eq(&a, &vecf32(&[1.0, 2.0])));
+        assert!(!disjoint(&a, &vecf32(&[1.0, 2.0])));
+    }
+
+    #[test]
+    fn vecf32_unequals_different_vector() {
+        let a = vecf32(&[0.1, 0.1, 0.1, 0.1, 0.1]);
+        let b = vecf32(&[0.2, 0.2, 0.2, 0.2, 0.9]);
+        assert!(!eq(&a, &b));
+        assert!(!disjoint(&a, &b));
+    }
+
+    #[test]
+    fn vecf32_unequals_different_dimension() {
+        let a = vecf32(&[1.0]);
+        let b = vecf32(&[1.0, 2.0]);
+        assert!(!eq(&a, &b));
+        assert!(!disjoint(&a, &b));
+    }
+
+    #[test]
+    fn vecf32_empty_vectors_equal() {
+        assert!(eq(&vecf32(&[]), &vecf32(&[])));
+    }
+
+    #[test]
+    fn vecf32_with_nan_components() {
+        // NaN orders below everything and compares equal only to NaN.
+        assert!(eq(&vecf32(&[1.0, f32::NAN]), &vecf32(&[1.0, f32::NAN])));
+        assert!(!eq(&vecf32(&[1.0, f32::NAN]), &vecf32(&[1.0, 2.0])));
     }
 }


### PR DESCRIPTION
Fixes #2604.

## Root cause

`compare_value` in `graph/src/runtime/value.rs` had **no `(VecF32, VecF32)` arm**, so two vectors fell through to the final disjoint-type branch, which compares only the **type order** — never `Ordering::Equal`. Result: `=` and `<>` both evaluated to `false` for any vector pair (violating reflexivity), property filters on vectors returned nothing, and `MERGE` on a vector property created a duplicate node on every execution. `IN` worked because list containment uses `compare_list`, which is why the issue localized the defect to the scalar comparison operator.

## Fix

Add the missing arm: dimension first (`len_a.cmp(&len_b)`), then element-wise comparison — `partial_cmp` per component with NaN equal only to NaN and ordered below everything — and report `DisjointOrNull::None` so the pair is treated as a comparable combination (the disjoint branch was what made `<>` also false).

## Tests

Added `#[cfg(test)] mod vecf32_compare_tests` to `value.rs`:

- identical vectors compare equal (the reported reflexivity violation);
- different values and different dimensions compare unequal — and **not disjoint**, so `<>` is true;
- empty vectors equal;
- NaN components: equal to NaN, unequal to a number.

**Verification note:** the `graph` crate's `build.rs` requires Unix (`std::os::unix::fs::symlink`) and prebuilt RediSearch archives, so the crate cannot build on this Windows machine — the patch was verified with `rustfmt --edition 2024 --check` (clean parse) and the tests run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison of vector values by applying consistent element-by-element ordering.
  * Added deterministic handling for vectors containing NaN values.
  * Ensured vectors of different lengths and empty vectors compare correctly.
  * Comparisons now produce predictable results across equal, unequal, and differently sized vectors.

* **Tests**
  * Added regression coverage for identical, differing, empty, differently sized, and NaN-containing vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->