### PR TITLE
ci: validate regex full-match fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "phf",
  "rand",
  "regex",
+ "regex-automata",
  "roaring",
  "rquickjs",
  "rustc-hash",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -38,6 +38,7 @@ phf = { version = "0.14", features = ["macros"] }
 orx-tree = "2.2.0"
 rand = "0.10.2"
 regex = "1.13.0"
+regex-automata = { version = "0.4.16", default-features = false, features = ["meta", "std", "syntax", "unicode"] }
 rquickjs = { version = "0.12", features = ["bindgen", "classes", "parallel"] }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 roaring = "0.11.4"

--- a/graph/src/parser/ast.rs
+++ b/graph/src/parser/ast.rs
@@ -67,6 +67,7 @@ use std::{collections::HashSet, fmt::Display, hash::Hash, sync::Arc};
 
 use itertools::Itertools;
 use orx_tree::{Dfs, DynTree, NodeRef};
+use regex_automata::{Anchored, Input, MatchKind, meta, util::syntax};
 
 use crate::{
     entity_type::EntityType,
@@ -283,9 +284,10 @@ pub enum ExprIR<TVar> {
 
 /// Payload of [`ExprIR::CompiledRegex`].
 #[derive(Clone, Debug)]
-pub struct RegexFn {
-    pub kind: RegexFnKind,
-    pub regex: Arc<regex::Regex>,
+pub enum RegexFn {
+    Matches(Arc<meta::Regex>),
+    MatchList(Arc<regex::Regex>),
+    Replace(Arc<regex::Regex>),
 }
 
 /// Which regex function [`ExprIR::CompiledRegex`] replaces.
@@ -297,6 +299,128 @@ pub enum RegexFnKind {
     MatchList,
     /// `string.replaceRegEx(text, pattern[, replacement])`
     Replace,
+}
+
+impl RegexFn {
+    pub(crate) fn compile_matches(pattern: &str) -> Result<meta::Regex, regex::Error> {
+        meta::Regex::builder()
+            // Anchoring fixes the start offset; All keeps searching past a
+            // shorter alternative so a later branch can consume all input.
+            .configure(
+                meta::Regex::config()
+                    .match_kind(MatchKind::All)
+                    .utf8_empty(true),
+            )
+            .syntax(syntax::Config::new().utf8(true))
+            .build(pattern)
+            .map_err(|error| {
+                if let Some(limit) = error.size_limit() {
+                    regex::Error::CompiledTooBig(limit)
+                } else if let Some(error) = error.syntax_error() {
+                    regex::Error::Syntax(error.to_string())
+                } else {
+                    regex::Error::Syntax(error.to_string())
+                }
+            })
+    }
+
+    pub(crate) fn is_full_match(
+        regex: &meta::Regex,
+        text: &str,
+    ) -> bool {
+        regex
+            .find(Input::new(text).anchored(Anchored::Yes))
+            .is_some_and(|matched| matched.end() == text.len())
+    }
+
+    pub(crate) fn compile(
+        kind: RegexFnKind,
+        pattern: &str,
+    ) -> Result<Self, regex::Error> {
+        match kind {
+            RegexFnKind::Matches => {
+                Self::compile_matches(pattern).map(|regex| Self::Matches(Arc::new(regex)))
+            }
+            RegexFnKind::MatchList => {
+                regex::Regex::new(pattern).map(|regex| Self::MatchList(Arc::new(regex)))
+            }
+            RegexFnKind::Replace => {
+                regex::Regex::new(pattern).map(|regex| Self::Replace(Arc::new(regex)))
+            }
+        }
+    }
+
+    pub(crate) fn is_match(
+        &self,
+        text: &str,
+    ) -> bool {
+        match self {
+            Self::Matches(regex) => Self::is_full_match(regex, text),
+            Self::MatchList(regex) | Self::Replace(regex) => regex.is_match(text),
+        }
+    }
+}
+
+#[cfg(test)]
+mod regex_fn_tests {
+    use super::{RegexFn, RegexFnKind};
+
+    fn assert_matches(
+        pattern: &str,
+        text: &str,
+        expected: bool,
+    ) {
+        let regex = RegexFn::compile(RegexFnKind::Matches, pattern).unwrap();
+        assert_eq!(expected, regex.is_match(text), "{pattern:?} on {text:?}");
+    }
+
+    #[test]
+    fn matches_entire_string() {
+        assert_matches("Alpha", "Alpha", true);
+        assert_matches("Alph", "Alpha", false);
+        assert_matches("A.*", "Alpha", true);
+        assert_matches("A.*", "xAlpha", false);
+        assert_matches("a|ab", "ab", true);
+        assert_matches("|a", "a", true);
+        assert_matches("a+?", "aaa", true);
+        assert_matches("(?i)alpha", "Alpha", true);
+        assert_matches(r"\w+", "δ", true);
+        assert_matches("", "", true);
+        assert_matches("", "a", false);
+        assert_matches("a", "a\n", false);
+        assert_matches("a$", "a\n", false);
+    }
+
+    #[test]
+    fn matches_verbose_patterns_without_rewriting_them() {
+        assert_matches("(?x)a#comment", "a", true);
+        assert_matches("(?x)a # comment\n b", "ab", true);
+    }
+
+    #[test]
+    fn preserves_unanchored_search_functions() {
+        for kind in [RegexFnKind::MatchList, RegexFnKind::Replace] {
+            let regex = RegexFn::compile(kind, "Alpha").unwrap();
+            assert!(regex.is_match("xAlpha"));
+        }
+    }
+
+    #[test]
+    fn reports_errors_from_the_original_pattern() {
+        let error = RegexFn::compile(RegexFnKind::Matches, "[").unwrap_err();
+        assert!(error.to_string().contains("unclosed character class"));
+    }
+
+    #[test]
+    fn matches_large_inputs_across_threads() {
+        let regex = RegexFn::compile(RegexFnKind::Matches, "a+").unwrap();
+        let text = "a".repeat(100_000);
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| assert!(regex.is_match(&text)));
+            }
+        });
+    }
 }
 
 /// Payload of [`ExprIR::Reduce`].
@@ -379,10 +503,10 @@ impl<TVar: Display + std::fmt::Debug> Display for ExprIR<TVar> {
             Self::Pattern(_) => write!(f, "<pattern>"),
             Self::ShortestPath(_) => write!(f, "shortestPath()"),
             Self::MapProjection => write!(f, "map_projection"),
-            Self::CompiledRegex(rf) => match rf.kind {
-                RegexFnKind::Matches => write!(f, "regex_matches()"),
-                RegexFnKind::MatchList => write!(f, "string.matchRegEx()"),
-                RegexFnKind::Replace => write!(f, "string.replaceRegEx()"),
+            Self::CompiledRegex(rf) => match rf {
+                RegexFn::Matches(_) => write!(f, "regex_matches()"),
+                RegexFn::MatchList(_) => write!(f, "string.matchRegEx()"),
+                RegexFn::Replace(_) => write!(f, "string.replaceRegEx()"),
             },
             Self::Case { .. } => write!(f, "CASE"),
         }

--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -2506,7 +2506,16 @@ fn rewrite_compiled_regex(
     else {
         return (new_data, children);
     };
-    let Ok(regex) = regex::Regex::new(pattern.as_str()) else {
+    // openCypher `=~` is a whole-string match (Neo4j/Memgraph semantics):
+    // anchor the pattern at compile time. The non-capturing group keeps a
+    // top-level alternation (`a|b`) from binding to only one side, and \A/\z
+    // avoid `$`'s before-trailing-newline match in the Rust regex crate
+    // (#2603). matchRegEx/replaceRegEx keep unanchored search semantics.
+    let compiled_pattern = match kind {
+        RegexFnKind::Matches => format!(r"\A(?:{pattern})\z"),
+        _ => pattern.clone(),
+    };
+    let Ok(regex) = regex::Regex::new(compiled_pattern.as_str()) else {
         return (new_data, children);
     };
     let mut children = children;

--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -2506,27 +2506,12 @@ fn rewrite_compiled_regex(
     else {
         return (new_data, children);
     };
-    // openCypher `=~` is a whole-string match (Neo4j/Memgraph semantics):
-    // anchor the pattern at compile time. The non-capturing group keeps a
-    // top-level alternation (`a|b`) from binding to only one side, and \A/\z
-    // avoid `$`'s before-trailing-newline match in the Rust regex crate
-    // (#2603). matchRegEx/replaceRegEx keep unanchored search semantics.
-    let compiled_pattern = match kind {
-        RegexFnKind::Matches => format!(r"\A(?:{pattern})\z"),
-        _ => pattern.clone(),
-    };
-    let Ok(regex) = regex::Regex::new(compiled_pattern.as_str()) else {
+    let Ok(regex) = RegexFn::compile(kind, pattern) else {
         return (new_data, children);
     };
     let mut children = children;
     children.remove(1);
-    (
-        ExprIR::CompiledRegex(RegexFn {
-            kind,
-            regex: Arc::new(regex),
-        }),
-        children,
-    )
+    (ExprIR::CompiledRegex(regex), children)
 }
 
 /// Recursively walk an ORDER BY expression tree and replace any aggregation

--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -53,7 +53,7 @@ use thin_vec::{ThinVec, thin_vec};
 
 use crate::{
     graph::graph::NodeId,
-    parser::ast::{ExprIR, QuantifierType, RegexFn, RegexFnKind, Variable},
+    parser::ast::{ExprIR, QuantifierType, RegexFn, Variable},
     runtime::{
         batch::{Batch, BatchRow, Column, FloatLane, NullBitmap, classify_numeric},
         functions::{FnType, Type, apply_pow, regex_captures_list},
@@ -1257,16 +1257,16 @@ impl<'a> ExprEval<'a> {
 
         let text = self.eval_node(&node.child(0), env, agg_group_key)?;
         check_string_or_null(&text)?;
-        match rf.kind {
-            RegexFnKind::Matches => match text {
-                Value::String(s) => Ok(Value::Bool(rf.regex.is_match(s.as_str()))),
+        match rf {
+            RegexFn::Matches(_) => match text {
+                Value::String(s) => Ok(Value::Bool(rf.is_match(s.as_str()))),
                 _ => Ok(Value::Null),
             },
-            RegexFnKind::MatchList => match text {
-                Value::String(s) => Ok(regex_captures_list(&rf.regex, s.as_str())),
+            RegexFn::MatchList(regex) => match text {
+                Value::String(s) => Ok(regex_captures_list(regex, s.as_str())),
                 _ => Ok(Value::List(Arc::new(thin_vec![]))),
             },
-            RegexFnKind::Replace => {
+            RegexFn::Replace(regex) => {
                 let replacement = if node.num_children() > 1 {
                     let r = self.eval_node(&node.child(1), env, agg_group_key)?;
                     check_string_or_null(&r)?;
@@ -1279,13 +1279,11 @@ impl<'a> ExprEval<'a> {
                 };
                 match replacement {
                     None => Ok(Value::String(Arc::new(
-                        rf.regex.replace_all(text.as_str(), "").into_owned(),
+                        regex.replace_all(text.as_str(), "").into_owned(),
                     ))),
                     Some(Value::Null) => Ok(Value::Null),
                     Some(Value::String(repl)) => Ok(Value::String(Arc::new(
-                        rf.regex
-                            .replace_all(text.as_str(), repl.as_str())
-                            .into_owned(),
+                        regex.replace_all(text.as_str(), repl.as_str()).into_owned(),
                     ))),
                     Some(_) => unreachable!(),
                 }

--- a/graph/src/runtime/functions/internal.rs
+++ b/graph/src/runtime/functions/internal.rs
@@ -26,7 +26,10 @@
 #![allow(clippy::unnecessary_wraps)]
 
 use super::{FnType, Functions, Type};
-use crate::runtime::{runtime::Runtime, value::Value};
+use crate::{
+    parser::ast::RegexFn,
+    runtime::{runtime::Runtime, value::Value},
+};
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "starts_with",
@@ -108,17 +111,11 @@ pub fn register(funcs: &mut Functions) {
             let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(pattern))) => {
-                    // openCypher `=~` is a whole-string match; \A/\z anchor
-                    // without matching before a trailing newline (#2603).
-                    let anchored = format!(r"\A(?:{pattern})\z");
-                    match regex::Regex::new(anchored.as_str()) {
-                        Ok(re) => Ok(Value::Bool(re.is_match(s.as_str()))),
-                        Err(_) => match regex::Regex::new(pattern.as_str()) {
-                            // Report the original pattern's error, not the
-                            // wrapped form's.
-                            Ok(_) => unreachable!("anchored compile failed but raw compiled"),
-                            Err(e) => Err(format!("Invalid regex pattern: {e}")),
-                        },
+                    match RegexFn::compile_matches(pattern.as_str()) {
+                        Ok(regex) => {
+                            Ok(Value::Bool(RegexFn::is_full_match(&regex, s.as_str())))
+                        }
+                        Err(error) => Err(format!("Invalid regex pattern: {error}")),
                     }
                 }
                 (Some(Value::Null), _) | (_, Some(Value::Null)) => Ok(Value::Null),

--- a/graph/src/runtime/functions/internal.rs
+++ b/graph/src/runtime/functions/internal.rs
@@ -108,9 +108,17 @@ pub fn register(funcs: &mut Functions) {
             let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(pattern))) => {
-                    match regex::Regex::new(pattern.as_str()) {
+                    // openCypher `=~` is a whole-string match; \A/\z anchor
+                    // without matching before a trailing newline (#2603).
+                    let anchored = format!(r"\A(?:{pattern})\z");
+                    match regex::Regex::new(anchored.as_str()) {
                         Ok(re) => Ok(Value::Bool(re.is_match(s.as_str()))),
-                        Err(e) => Err(format!("Invalid regex pattern: {e}")),
+                        Err(_) => match regex::Regex::new(pattern.as_str()) {
+                            // Report the original pattern's error, not the
+                            // wrapped form's.
+                            Ok(_) => unreachable!("anchored compile failed but raw compiled"),
+                            Err(e) => Err(format!("Invalid regex pattern: {e}")),
+                        },
                     }
                 }
                 (Some(Value::Null), _) | (_, Some(Value::Null)) => Ok(Value::Null),


### PR DESCRIPTION
## Summary

Temporary organization-owned CI mirror of #2608. It points to the exact same commit so package-writing image, sanitizer, and flow jobs can run with a trusted repository token.

## Changes

- No additional code changes beyond #2608.
- This PR exists only to validate commit `3f19e25f8`.

## Testing

- Safe cross-platform artifact verification passed on #2608.
- This PR runs the full Rust PR image, ASAN, coverage, and flow matrix.

## Memory / Performance Impact

Same as #2608: no per-entity overhead; constant regex patterns remain plan-cached.

## Related Issues

Closes #2603
References #2608
