### PR TITLE
fix: nested index scans could freeze the whole server; track RediSearch as a deps/ submodule

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -16,7 +16,8 @@ Only needed once per machine/container (skip if `cargo build` already works).
 
 ```bash
 ./graphblas.sh    # clones, builds (static, PIC) and installs GraphBLAS v10.5.0 + LAGraph
-./redisearch.sh   # clones and builds RediSearch (static) into deps/RediSearch/bin
+git submodule update --init --recursive   # populates deps/RediSearch (git owns it)
+./redisearch.sh   # builds that checkout (static) into deps/RediSearch/bin
 ```
 
 If a script fails, read it before retrying by hand — `graphblas.sh` documents

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -16,7 +16,7 @@ Only needed once per machine/container (skip if `cargo build` already works).
 
 ```bash
 ./graphblas.sh    # clones, builds (static, PIC) and installs GraphBLAS v10.5.0 + LAGraph
-./redisearch.sh   # clones and builds RediSearch (static) into redisearch/RediSearch/bin
+./redisearch.sh   # clones and builds RediSearch (static) into deps/RediSearch/bin
 ```
 
 If a script fails, read it before retrying by hand — `graphblas.sh` documents

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -65,11 +65,10 @@ RUN chmod +x graphblas.sh && \
     CC=clang-22 CXX=clang++-22 ./graphblas.sh
 
 # Build and install RediSearch using project script
-# Build in /data so output lands at /data/redisearch/RediSearch/
-# Symlink bin/ so build.rs can find it at /data/redisearch/bin/
+# Build in /data so output lands at /data/deps/RediSearch/bin/, which is one of
+# graph/build.rs's absolute fallbacks -- no symlink needed.
 RUN chmod +x redisearch.sh && \
-    ./redisearch.sh && \
-    ln -sf /data/redisearch/RediSearch/bin /data/redisearch/bin
+    ./redisearch.sh
 
 WORKDIR /workspace
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,8 +57,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # Set working directory for build scripts
 WORKDIR /data
 
-# Copy build scripts
+# Copy build scripts, and the RediSearch submodule they build (git owns the pin;
+# redisearch.sh only builds what is checked out, so the source must be present)
 COPY graphblas.sh redisearch.sh /data/
+COPY deps/RediSearch /data/deps/RediSearch
 
 # Build and install GraphBLAS using project script
 RUN chmod +x graphblas.sh && \
@@ -67,7 +69,12 @@ RUN chmod +x graphblas.sh && \
 # Build and install RediSearch using project script
 # Build in /data so output lands at /data/deps/RediSearch/bin/, which is one of
 # graph/build.rs's absolute fallbacks -- no symlink needed.
-RUN chmod +x redisearch.sh && \
+# RediSearch's redisearch_rs build scripts find their source root by walking up
+# for a `.git` entry (build_utils::git_root; existence check only, never invokes
+# git). All git metadata is .dockerignore'd, so create an empty marker -- see
+# .dockerignore for why this is a marker rather than the real gitlink.
+RUN mkdir -p /data/deps/RediSearch/.git && \
+    chmod +x redisearch.sh && \
     ./redisearch.sh
 
 WORKDIR /workspace

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 target/
 # Host-built native dep outputs that would shadow the build image's prebuilt versions
-# (graph/build.rs's link-search adds ../lagraph_lib and redisearch/... before /data paths).
+# (graph/build.rs's link-search adds ../lagraph_lib and deps/RediSearch/... before /data paths).
 lagraph_lib/
+deps/RediSearch/
 redisearch/
 .git/
 .github/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,28 @@
 target/
 # Host-built native dep outputs that would shadow the build image's prebuilt versions
 # (graph/build.rs's link-search adds ../lagraph_lib and deps/RediSearch/... before /data paths).
+#
+# Only the OUTPUT is a hazard, not the source: deps/RediSearch/bin is ~2.2GB of
+# host-arch archives that a Linux image build must never link, while the source
+# it is built from is ~60MB and is exactly what the images now COPY in (git owns
+# the submodule; redisearch.sh no longer clones it).
 lagraph_lib/
-deps/RediSearch/
+deps/RediSearch/bin/
 redisearch/
+# All git metadata, at any depth. A submodule's `.git` is normally a small
+# `gitdir:` pointer file, but one bootstrapped by an older redisearch.sh is a
+# full repository (~62MB of objects) -- so leaving these in would make the build
+# context, and what lands in the image, depend on how the developer's checkout
+# happened to be created. Nothing in the image build runs git.
+#
+# RediSearch's redisearch_rs build scripts do need a `.git` ENTRY to exist:
+# build_utils::git_root walks up for one to locate the source root (an existence
+# check -- it never invokes git), and without it the ffi build script panics with
+# "Could not find git root". The Dockerfiles that build RediSearch create an
+# empty marker directory for that, which keeps it explicit and identical
+# everywhere instead of depending on what got copied in.
 .git/
+**/.git
 .github/
 .claude/
 .devcontainer/

--- a/.github/workflows/_build-artifacts-macos.yml
+++ b/.github/workflows/_build-artifacts-macos.yml
@@ -57,6 +57,9 @@ jobs:
       # that a later release build restores.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # redisearch.sh builds the deps/RediSearch submodule and no longer
+          # clones it, so it must be checked out here.
+          submodules: recursive
           ref: ${{ inputs.revision }}
           persist-credentials: false
 
@@ -86,6 +89,14 @@ jobs:
       # Hosted macOS has no Docker toolchain image, so rebuild GraphBLAS +
       # LAGraph + RediSearch from source and cache them (keyed on the build
       # scripts + vendored PreJIT + the exact Homebrew LLVM version).
+      # The RediSearch pin used to ride along in hashFiles('redisearch.sh')
+      # (REDISEARCH_REF lived there). It is now only the submodule gitlink, which
+      # hashFiles cannot see and which hashing the 60MB checkout would be a silly
+      # way to reach -- so read the SHA and put it in the key directly.
+      - name: Resolve the deps/RediSearch pin
+        id: rs-pin
+        run: echo "sha=$(git rev-parse HEAD:deps/RediSearch)" >> "$GITHUB_OUTPUT"
+
       - name: Restore GraphBLAS + RediSearch native builds
         id: native-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
@@ -94,7 +105,7 @@ jobs:
             .deps/graphblas
             lagraph_lib
             deps/RediSearch/bin
-          key: macos-native-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('graphblas.sh', 'redisearch.sh', 'build/graphblas/**') }}-llvm${{ env.BREW_LLVM_VERSION }}
+          key: macos-native-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('graphblas.sh', 'redisearch.sh', 'build/graphblas/**') }}-rs${{ steps.rs-pin.outputs.sha }}-llvm${{ env.BREW_LLVM_VERSION }}
 
       - name: Build GraphBLAS + LAGraph
         if: steps.native-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/_build-artifacts-macos.yml
+++ b/.github/workflows/_build-artifacts-macos.yml
@@ -93,7 +93,7 @@ jobs:
           path: |
             .deps/graphblas
             lagraph_lib
-            redisearch/RediSearch/bin
+            deps/RediSearch/bin
           key: macos-native-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('graphblas.sh', 'redisearch.sh', 'build/graphblas/**') }}-llvm${{ env.BREW_LLVM_VERSION }}
 
       - name: Build GraphBLAS + LAGraph
@@ -115,7 +115,7 @@ jobs:
           path: |
             .deps/graphblas
             lagraph_lib
-            redisearch/RediSearch/bin
+            deps/RediSearch/bin
           key: ${{ steps.native-cache.outputs.cache-primary-key }}
 
       - name: Build libfalkordb.dylib

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -63,6 +63,10 @@ jobs:
       # on `cache-to` below.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # redisearch.sh builds the deps/RediSearch submodule and no longer
+          # clones it, and the Dockerfile COPYs that source in, so the build
+          # context must carry it.
+          submodules: recursive
           ref: ${{ inputs.revision }}
           persist-credentials: false
 

--- a/.github/workflows/_build-flavour.yml
+++ b/.github/workflows/_build-flavour.yml
@@ -97,6 +97,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # redisearch.sh builds the deps/RediSearch submodule and no longer
+          # clones it, and the Dockerfile COPYs that source in, so the build
+          # context must carry it.
+          submodules: recursive
           ref: ${{ inputs.commit_sha }}
           persist-credentials: false
 

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -65,6 +65,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # redisearch.sh builds the deps/RediSearch submodule and no longer
+          # clones it, and the Dockerfile COPYs that source in, so the build
+          # context must carry it.
+          submodules: recursive
           persist-credentials: false
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -76,37 +76,13 @@ jobs:
           fi
           git fetch --no-tags origin "$DIFF_TARGET"
           MERGE_BASE=$(git merge-base "origin/$DIFF_TARGET" "$HEAD_SHA")
-          if git diff --name-only "$MERGE_BASE" "$HEAD_SHA" | grep -qE "^(build/Dockerfile|build/libomp\.sh|build/graphblas/.*|graphblas\.sh|redisearch\.sh|\.github/workflows/build-toolchain\.yml)$"; then
+          if git diff --name-only "$MERGE_BASE" "$HEAD_SHA" | grep -qE "^(build/Dockerfile|build/libomp\.sh|build/graphblas/.*|graphblas\.sh|redisearch\.sh|deps/RediSearch|\.gitmodules|\.github/workflows/build-toolchain\.yml)$"; then
             echo "changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-  # The deps/RediSearch pin lives in two places by necessity: the gitlink (what a
-  # submodule checkout builds) and REDISEARCH_REF in redisearch.sh (what the
-  # Docker toolchain images clone, since deps/RediSearch and .git are
-  # .dockerignore'd and the image only ever gets the script). redisearch.sh
-  # refuses to build when they disagree -- but every Linux job here runs inside
-  # the prebuilt toolchain container and never executes it, so nothing would
-  # catch a gitlink-only bump: it would go green while Docker quietly built the
-  # old ref. This job is where that check actually runs on a PR.
-  #
-  # It deliberately does not need the toolchain image, so it reports in seconds
-  # and independently of the docker job.
-  redisearch-pin:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # This job runs a script from the PR branch. The default
-          # persist-credentials writes GITHUB_TOKEN into .git/config, which that
-          # script could read; --check-pin only inspects the local index, so it
-          # needs no credentials at all.
-          persist-credentials: false
-      - name: deps/RediSearch gitlink matches REDISEARCH_REF
-        run: ./redisearch.sh --check-pin
-
   # When build/Dockerfile changes, rebuild the toolchain image at a PR-scoped
   # tag (ghcr.io/falkordb/falkordb-build:pr-<N>, multi-arch). Other jobs in
   # this workflow pick up the new toolchain via the `container:` references

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -98,6 +98,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs a script from the PR branch. The default
+          # persist-credentials writes GITHUB_TOKEN into .git/config, which that
+          # script could read; --check-pin only inspects the local index, so it
+          # needs no credentials at all.
+          persist-credentials: false
       - name: deps/RediSearch gitlink matches REDISEARCH_REF
         run: ./redisearch.sh --check-pin
 

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -83,6 +83,24 @@ jobs:
             echo "changed=false"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
+  # The deps/RediSearch pin lives in two places by necessity: the gitlink (what a
+  # submodule checkout builds) and REDISEARCH_REF in redisearch.sh (what the
+  # Docker toolchain images clone, since deps/RediSearch and .git are
+  # .dockerignore'd and the image only ever gets the script). redisearch.sh
+  # refuses to build when they disagree -- but every Linux job here runs inside
+  # the prebuilt toolchain container and never executes it, so nothing would
+  # catch a gitlink-only bump: it would go green while Docker quietly built the
+  # old ref. This job is where that check actually runs on a PR.
+  #
+  # It deliberately does not need the toolchain image, so it reports in seconds
+  # and independently of the docker job.
+  redisearch-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: deps/RediSearch gitlink matches REDISEARCH_REF
+        run: ./redisearch.sh --check-pin
+
   # When build/Dockerfile changes, rebuild the toolchain image at a PR-scoped
   # tag (ghcr.io/falkordb/falkordb-build:pr-<N>, multi-arch). Other jobs in
   # this workflow pick up the new toolchain via the `container:` references

--- a/.github/workflows/rust-push.yml
+++ b/.github/workflows/rust-push.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check if specific file changed
         id: check
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE "^(build/Dockerfile|build/libomp\.sh|build/graphblas/.*|graphblas\.sh|\.github/workflows/build-toolchain\.yml)$"; then
+          if git diff --name-only HEAD~1 HEAD | grep -qE "^(build/Dockerfile|build/libomp\.sh|build/graphblas/.*|graphblas\.sh|redisearch\.sh|deps/RediSearch|\.gitmodules|\.github/workflows/build-toolchain\.yml)$"; then
             echo "changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT
           else

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ outg
 data
 tests/flow/logs
 tests/flow/csvs
-redisearch
+# legacy pre-submodule RediSearch checkout (now deps/RediSearch)
+/redisearch/
 lagraph_lib
 /GraphBLAS/
 /LAGraph/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "deps/RediSearch"]
 	path = deps/RediSearch
 	url = https://github.com/FalkorDB/RediSearch.git
-	branch = falkordb/llapi-extensions-8.6

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "deps/RediSearch"]
+	path = deps/RediSearch
+	url = https://github.com/FalkorDB/RediSearch.git
+	branch = falkordb/llapi-extensions-8.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ RELEASE=1 VERBOSE=0 TEST=test_name ./flow.sh
 
 Before building, GraphBLAS and RediSearch must be compiled and installed:
 - GraphBLAS: `./graphblas.sh` or build manually with `make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on'`
-- RediSearch: `./redisearch.sh`
+- RediSearch: `./redisearch.sh` (builds the `deps/RediSearch` submodule; the pinned
+  commit is `REDISEARCH_REF` in that script and must match the committed gitlink)
 
 ### PreJIT kernels (`build/graphblas/PreJIT/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,10 @@ RELEASE=1 VERBOSE=0 TEST=test_name ./flow.sh
 
 Before building, GraphBLAS and RediSearch must be compiled and installed:
 - GraphBLAS: `./graphblas.sh` or build manually with `make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on'`
-- RediSearch: `./redisearch.sh` (builds the `deps/RediSearch` submodule; the pinned
-  commit is `REDISEARCH_REF` in that script and must match the committed gitlink)
+- RediSearch: `git submodule update --init --recursive` then `./redisearch.sh`.
+  git owns `deps/RediSearch`; the script only builds what is checked out, and the
+  gitlink is the only record of the pinned commit. The Docker images COPY that
+  submodule in, so any workflow feeding one needs `submodules: recursive`.
 
 ### PreJIT kernels (`build/graphblas/PreJIT/`)
 

--- a/README.md
+++ b/README.md
@@ -372,18 +372,28 @@ CC=clang-22 CXX=clang++-22 ./graphblas.sh
 ##### Building RediSearch
 
 RediSearch lives at `deps/RediSearch` as a git submodule (same layout as the C
-engine on `master`), pinned to the commit in `redisearch.sh`. The script
-populates it if needed, so a plain clone works:
+engine on `master`). **git owns that checkout** — `redisearch.sh` only builds
+what is there, so populate it first:
 
 ```bash
+git submodule update --init --recursive
 ./redisearch.sh
 ```
 
+(`git clone --recurse-submodules` does the first step for you. The script exits
+with instructions if the submodule is empty.)
+
 To work on RediSearch itself, edit `deps/RediSearch` in place and re-run
-`./redisearch.sh`; it warns but never resets a checkout that has moved off the
-pinned commit. When you land a RediSearch change, bump **both** the submodule
-gitlink (`git add deps/RediSearch`) and `REDISEARCH_REF` in `redisearch.sh` —
-the script fails the build if they disagree.
+`./redisearch.sh` — it never fetches or resets, so local work is never
+clobbered. To land a RediSearch change, move the pin the ordinary way:
+
+```bash
+git -C deps/RediSearch checkout <sha>
+git add deps/RediSearch
+```
+
+The gitlink is the only place the commit is recorded, so there is nothing else
+to keep in step.
 
 - pytest - create virtualenv and install tests/requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -371,9 +371,19 @@ CC=clang-22 CXX=clang++-22 ./graphblas.sh
 
 ##### Building RediSearch
 
+RediSearch lives at `deps/RediSearch` as a git submodule (same layout as the C
+engine on `master`), pinned to the commit in `redisearch.sh`. The script
+populates it if needed, so a plain clone works:
+
 ```bash
 ./redisearch.sh
 ```
+
+To work on RediSearch itself, edit `deps/RediSearch` in place and re-run
+`./redisearch.sh`; it warns but never resets a checkout that has moved off the
+pinned commit. When you land a RediSearch change, bump **both** the submodule
+gitlink (`git add deps/RediSearch`) and `REDISEARCH_REF` in `redisearch.sh` —
+the script fails the build if they disagree.
 
 - pytest - create virtualenv and install tests/requirements.txt
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -156,13 +156,27 @@ RUN cd /data && \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-# Build the RediSearch 8.6 fork (falkordb/llapi-extensions-8.6) as an embeddable
-# static library. redisearch.sh is the single source of truth (also used for
-# local dev); output lands at /data/deps/RediSearch/bin/<variant>/, which
-# graph/build.rs discovers. Prune the source tree afterwards (keep only bin/) to
-# keep the toolchain image lean.
+# Build the RediSearch 8.6 fork as an embeddable static library. redisearch.sh
+# is the single source of truth for HOW (also used for local dev); the
+# deps/RediSearch submodule is the single source of truth for WHICH commit, so
+# the source is COPY'd in rather than cloned by the script. That makes this
+# layer's cache key the submodule's content: it turns over exactly when the pin
+# moves, with no SHA duplicated into a script to keep in step.
+#
+# Requires the build context to carry a populated submodule --
+# `submodules: recursive` on actions/checkout. deps/RediSearch/bin is
+# .dockerignore'd so a host-built (wrong-arch) output can never come along.
+#
+# Output lands at /data/deps/RediSearch/bin/<variant>/, which graph/build.rs
+# discovers. Prune the source afterwards (keep only bin/) to keep the image lean.
 COPY redisearch.sh /data/redisearch.sh
-RUN . /data/venv/bin/activate && \
+COPY deps/RediSearch /data/deps/RediSearch
+# RediSearch's redisearch_rs build scripts find their source root by walking up
+# for a `.git` entry (build_utils::git_root; existence check only, never invokes
+# git). All git metadata is .dockerignore'd, so create an empty marker -- see
+# .dockerignore for why this is a marker rather than the real gitlink.
+RUN mkdir -p /data/deps/RediSearch/.git && \
+    . /data/venv/bin/activate && \
     cd /data && \
     CC=clang-${CLANG_MAJOR} CXX=clang++-${CLANG_MAJOR} bash redisearch.sh && \
     find /data/deps/RediSearch -mindepth 1 -maxdepth 1 ! -name bin -exec rm -rf {} + && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -158,14 +158,14 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Build the RediSearch 8.6 fork (falkordb/llapi-extensions-8.6) as an embeddable
 # static library. redisearch.sh is the single source of truth (also used for
-# local dev); output lands at /data/redisearch/RediSearch/bin/<variant>/, which
+# local dev); output lands at /data/deps/RediSearch/bin/<variant>/, which
 # graph/build.rs discovers. Prune the source tree afterwards (keep only bin/) to
 # keep the toolchain image lean.
 COPY redisearch.sh /data/redisearch.sh
 RUN . /data/venv/bin/activate && \
     cd /data && \
     CC=clang-${CLANG_MAJOR} CXX=clang++-${CLANG_MAJOR} bash redisearch.sh && \
-    find /data/redisearch/RediSearch -mindepth 1 -maxdepth 1 ! -name bin -exec rm -rf {} + && \
+    find /data/deps/RediSearch -mindepth 1 -maxdepth 1 ! -name bin -exec rm -rf {} + && \
     rm -f /data/redisearch.sh
 
 CMD "/bin/bash"

--- a/build/runtime/Dockerfile.amazonlinux2023
+++ b/build/runtime/Dockerfile.amazonlinux2023
@@ -67,13 +67,13 @@ COPY build/graphblas /data/build/graphblas
 RUN LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
     rm -rf /data/graphblas.sh /data/build
 
-# RediSearch (static) → /data/redisearch/RediSearch/bin
+# RediSearch (static) → /data/deps/RediSearch/bin
 COPY redisearch.sh /data/redisearch.sh
 RUN bash /data/redisearch.sh && \
     rm -f /data/redisearch.sh
 
 # Build the cdylib from the repo source. Deps resolve via graph/build.rs's
-# absolute fallbacks (/data/lagraph_lib, /data/redisearch/RediSearch/bin),
+# absolute fallbacks (/data/lagraph_lib, /data/deps/RediSearch/bin),
 # GRAPHBLAS_LIB_DIR (/usr/local/lib default) and LIBOMP_PREFIX (/opt/libomp).
 ARG CXX
 WORKDIR /src

--- a/build/runtime/Dockerfile.amazonlinux2023
+++ b/build/runtime/Dockerfile.amazonlinux2023
@@ -68,8 +68,16 @@ RUN LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
     rm -rf /data/graphblas.sh /data/build
 
 # RediSearch (static) → /data/deps/RediSearch/bin
+# Source comes from the deps/RediSearch submodule in the build context (git owns
+# the pin; redisearch.sh only builds). Needs `submodules: recursive` on checkout.
 COPY redisearch.sh /data/redisearch.sh
-RUN bash /data/redisearch.sh && \
+COPY deps/RediSearch /data/deps/RediSearch
+# RediSearch's redisearch_rs build scripts find their source root by walking up
+# for a `.git` entry (build_utils::git_root; existence check only, never invokes
+# git). All git metadata is .dockerignore'd, so create an empty marker -- see
+# .dockerignore for why this is a marker rather than the real gitlink.
+RUN mkdir -p /data/deps/RediSearch/.git && \
+    bash /data/redisearch.sh && \
     rm -f /data/redisearch.sh
 
 # Build the cdylib from the repo source. Deps resolve via graph/build.rs's

--- a/build/runtime/Dockerfile.asan
+++ b/build/runtime/Dockerfile.asan
@@ -44,7 +44,7 @@ WORKDIR /src
 # Rebuild the RediSearch 8.6 fork WITH AddressSanitizer so the embedded
 # VectorSimilarity is instrumented. The toolchain image ships a
 # non-instrumented RediSearch; redisearch.sh with REDISEARCH_SAN=address
-# produces the `debug-asan` flavor in-tree (./redisearch/RediSearch/bin),
+# produces the `debug-asan` flavor in-tree (./deps/RediSearch/bin),
 # which graph/build.rs discovers ahead of the toolchain's /data copy.
 # Copied on its own first so editing module source doesn't bust this
 # expensive layer (redisearch/ is .dockerignore'd, so the later COPY won't
@@ -66,7 +66,7 @@ RUN set -eux; \
     # archives. The pin lives in the in-image RediSearch checkout (redisearch/ is
     # .dockerignore'd, so `COPY . .` didn't clobber it). redisearch.sh already
     # installed this toolchain (with rust-src) during the SAN build.
-    rustup default "$(cat redisearch/RediSearch/.rust-nightly)"; \
+    rustup default "$(cat deps/RediSearch/.rust-nightly)"; \
     case "$TARGETARCH" in \
       amd64) RT=x86_64-unknown-linux-gnu ;; \
       arm64) RT=aarch64-unknown-linux-gnu ;; \

--- a/build/runtime/Dockerfile.asan
+++ b/build/runtime/Dockerfile.asan
@@ -46,11 +46,18 @@ WORKDIR /src
 # non-instrumented RediSearch; redisearch.sh with REDISEARCH_SAN=address
 # produces the `debug-asan` flavor in-tree (./deps/RediSearch/bin),
 # which graph/build.rs discovers ahead of the toolchain's /data copy.
-# Copied on its own first so editing module source doesn't bust this
-# expensive layer (redisearch/ is .dockerignore'd, so the later COPY won't
-# clobber the build output).
+# Copied on their own first so editing module source doesn't bust this expensive
+# layer: both inputs change only when the RediSearch pin or build recipe does.
+# deps/RediSearch/bin is .dockerignore'd, so the later `COPY . .` re-copies the
+# (identical) source but cannot clobber the debug-asan output built here.
 COPY redisearch.sh redisearch.sh
-RUN CC=clang-22 CXX=clang++-22 REDISEARCH_SAN=address bash redisearch.sh
+COPY deps/RediSearch deps/RediSearch
+# RediSearch's redisearch_rs build scripts find their source root by walking up
+# for a `.git` entry (build_utils::git_root; existence check only, never invokes
+# git). All git metadata is .dockerignore'd, so create an empty marker -- see
+# .dockerignore for why this is a marker rather than the real gitlink.
+RUN mkdir -p deps/RediSearch/.git && \
+    CC=clang-22 CXX=clang++-22 REDISEARCH_SAN=address bash redisearch.sh
 
 COPY . .
 
@@ -63,8 +70,8 @@ RUN set -eux; \
     # Build the module with the SAME pinned nightly that redisearch.sh used for
     # redisearch_rs (RediSearch's .rust-nightly), not the floating `nightly`
     # alias defaulted above — so the -Zsanitizer toolchain matches across both
-    # archives. The pin lives in the in-image RediSearch checkout (redisearch/ is
-    # .dockerignore'd, so `COPY . .` didn't clobber it). redisearch.sh already
+    # archives. The pin is read from the RediSearch checkout, which `COPY . .`
+    # re-copies identically from the submodule. redisearch.sh already
     # installed this toolchain (with rust-src) during the SAN build.
     rustup default "$(cat deps/RediSearch/.rust-nightly)"; \
     case "$TARGETARCH" in \

--- a/build/runtime/Dockerfile.rhel9
+++ b/build/runtime/Dockerfile.rhel9
@@ -60,8 +60,16 @@ RUN CC=clang CXX=clang++ LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.s
     rm -rf /data/graphblas.sh /data/build
 
 # RediSearch (static) → /data/deps/RediSearch/bin
+# Source comes from the deps/RediSearch submodule in the build context (git owns
+# the pin; redisearch.sh only builds). Needs `submodules: recursive` on checkout.
 COPY redisearch.sh /data/redisearch.sh
-RUN CC=clang CXX=clang++ bash /data/redisearch.sh && \
+COPY deps/RediSearch /data/deps/RediSearch
+# RediSearch's redisearch_rs build scripts find their source root by walking up
+# for a `.git` entry (build_utils::git_root; existence check only, never invokes
+# git). All git metadata is .dockerignore'd, so create an empty marker -- see
+# .dockerignore for why this is a marker rather than the real gitlink.
+RUN mkdir -p /data/deps/RediSearch/.git && \
+    CC=clang CXX=clang++ bash /data/redisearch.sh && \
     rm -f /data/redisearch.sh
 
 # Build the cdylib from the repo source. Deps resolve via graph/build.rs's

--- a/build/runtime/Dockerfile.rhel9
+++ b/build/runtime/Dockerfile.rhel9
@@ -59,13 +59,13 @@ COPY build/graphblas /data/build/graphblas
 RUN CC=clang CXX=clang++ LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
     rm -rf /data/graphblas.sh /data/build
 
-# RediSearch (static) → /data/redisearch/RediSearch/bin
+# RediSearch (static) → /data/deps/RediSearch/bin
 COPY redisearch.sh /data/redisearch.sh
 RUN CC=clang CXX=clang++ bash /data/redisearch.sh && \
     rm -f /data/redisearch.sh
 
 # Build the cdylib from the repo source. Deps resolve via graph/build.rs's
-# absolute fallbacks (/data/lagraph_lib, /data/redisearch/RediSearch/bin),
+# absolute fallbacks (/data/lagraph_lib, /data/deps/RediSearch/bin),
 # GRAPHBLAS_LIB_DIR (/usr/local/lib default) and LIBOMP_PREFIX (/opt/libomp).
 ARG CXX
 WORKDIR /src

--- a/graph/build.rs
+++ b/graph/build.rs
@@ -93,21 +93,25 @@ fn main() {
     }
 
     // ---- RediSearch 8.6, embedded as a static library ----
-    // `redisearch.sh` builds the fork into
-    // redisearch/RediSearch/bin/<variant>/search-community. The main archive is
+    // `redisearch.sh` builds the fork (the deps/RediSearch submodule) into
+    // deps/RediSearch/bin/<variant>/search-community. The main archive is
     // `redisearch.so` (an ar archive despite the suffix); its C/C++ dependencies are
     // sibling .a files; the Rust crate is a separate libredisearch_rs.a one level up.
     // Local dev (and the asan Dockerfile, which runs redisearch.sh in-tree)
-    // build into `<repo>/redisearch/RediSearch/bin`; the Docker toolchain image
-    // (build/Dockerfile) builds into `/data/redisearch/RediSearch/bin`. Take the
+    // build into `<repo>/deps/RediSearch/bin`; the Docker toolchain image
+    // (build/Dockerfile) builds into `/data/deps/RediSearch/bin`. Take the
     // first that exists so the same build.rs works in every environment.
+    // `redisearch/RediSearch` is the pre-submodule layout, kept last so an
+    // existing local checkout still links until it is removed.
     let rs_bin = [
+        std::path::Path::new(&manifest_dir).join("../deps/RediSearch/bin"),
+        std::path::PathBuf::from("/data/deps/RediSearch/bin"),
         std::path::Path::new(&manifest_dir).join("../redisearch/RediSearch/bin"),
         std::path::PathBuf::from("/data/redisearch/RediSearch/bin"),
     ]
     .into_iter()
     .find_map(|p| p.canonicalize().ok().filter(|p| p.is_dir()))
-    .expect("redisearch/RediSearch/bin missing - run ./redisearch.sh first");
+    .expect("deps/RediSearch/bin missing - run ./redisearch.sh first");
 
     // The main archive is `redisearch.so` (macOS release) or `redisearch.a`
     // (Linux / sanitizer `debug-asan`), an ar archive in both cases. The

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -4,18 +4,26 @@ set -e
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 # RediSearch lives at deps/RediSearch as a git submodule, the same layout the C
-# engine uses on `master`. The committed gitlink is the source of truth for a
-# git checkout; REDISEARCH_REF below is the same commit spelled out for builds
-# that only have this script and no repository (the Docker toolchain images COPY
-# redisearch.sh alone, so bumping REDISEARCH_REF busts their cached
-# `RUN redisearch.sh` layer and keeps those builds reproducible).
+# engine uses on `master`. Like every submodule it is pinned to a COMMIT (the
+# gitlink, `160000 <sha>` in the tree) -- never to a branch. REDISEARCH_REF below
+# is that same commit spelled out for builds that have this script and no
+# repository: the Docker toolchain images COPY redisearch.sh alone, so this
+# file's content is also what busts their cached `RUN redisearch.sh` layer and
+# what `.github/workflows/rust-pr.yml`'s check-files matches to rebuild the
+# toolchain image.
+#
+# REDISEARCH_BRANCH is documentation only -- where new RediSearch work lands, so
+# you know what to fetch. Nothing resolves it at build time, and .gitmodules
+# deliberately carries no `branch` key: it would only be read by
+# `git submodule update --remote`, which moves the pin to a branch tip, i.e. the
+# one operation this pin exists to prevent.
 #
 # To move to a new RediSearch commit, do BOTH:
 #   git -C deps/RediSearch fetch origin && git -C deps/RediSearch checkout <sha>
 #   git add deps/RediSearch          # bump the gitlink
 #   ...and set REDISEARCH_REF=<sha> here
-# The two are checked against each other below, so a half-done bump fails loudly
-# instead of building a different RediSearch locally than in Docker.
+# `--check-pin` (below, and run in CI) fails when they disagree, so a half-done
+# bump cannot quietly build a different RediSearch in Docker than locally.
 REDISEARCH_BRANCH="falkordb/llapi-extensions-8.6"
 REDISEARCH_REF="ea1a6f40cbc959d13c63617b3a2e0ed6b8616037"
 REDISEARCH_DIR="$ROOT/deps/RediSearch"
@@ -29,9 +37,24 @@ fi
 
 if [ -n "$gitlink_ref" ] && [ "$gitlink_ref" != "$REDISEARCH_REF" ]; then
   echo "ERROR: deps/RediSearch gitlink ($gitlink_ref) != REDISEARCH_REF ($REDISEARCH_REF)." >&2
-  echo "       These must agree: the gitlink drives submodule builds, REDISEARCH_REF" >&2
-  echo "       drives the Docker toolchain images. Update REDISEARCH_REF in $0." >&2
+  echo "       These must agree: the gitlink is what a submodule checkout builds," >&2
+  echo "       REDISEARCH_REF is what the Docker toolchain images clone." >&2
+  echo "       Update REDISEARCH_REF in $0 (or re-point the gitlink)." >&2
   exit 1
+fi
+
+# `--check-pin` stops here: assert the two agree and exit, building nothing.
+# Linux CI builds run inside the prebuilt toolchain container and never execute
+# this script, so without a job that calls this the check would only ever fire
+# on a developer machine -- and a gitlink-only bump would go green while Docker
+# silently built the old REDISEARCH_REF.
+if [ "${1:-}" = "--check-pin" ]; then
+  if [ -z "$gitlink_ref" ]; then
+    echo "ERROR: --check-pin needs a git checkout with deps/RediSearch in the index." >&2
+    exit 1
+  fi
+  echo "deps/RediSearch pin OK: gitlink and REDISEARCH_REF both $REDISEARCH_REF"
+  exit 0
 fi
 
 if [ ! -d "$REDISEARCH_DIR/.git" ]; then
@@ -50,8 +73,8 @@ if [ ! -d "$REDISEARCH_DIR/.git" ]; then
   mkdir -p "$REDISEARCH_DIR"
   git init -q "$REDISEARCH_DIR"
   git -C "$REDISEARCH_DIR" remote add origin https://github.com/FalkorDB/RediSearch.git
-  # GitHub allows fetching a reachable SHA, so no branch fetch is needed. The
-  # branch name is recorded in .gitmodules (and REDISEARCH_BRANCH) for humans.
+  # GitHub allows fetching a reachable SHA, so no branch fetch is needed --
+  # which is also why .gitmodules needs no `branch` key (see the header).
   git -C "$REDISEARCH_DIR" fetch -q --depth 1 origin "$REDISEARCH_REF"
   git -C "$REDISEARCH_DIR" checkout -q FETCH_HEAD
   git -C "$REDISEARCH_DIR" submodule update --init --recursive --depth 1

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -2,45 +2,89 @@
 set -e
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-# Pin RediSearch to a specific commit on falkordb/llapi-extensions-8.6 rather
-# than tracking the branch tip. The commit lives in this file, which is COPY'd
-# into build/Dockerfile, so bumping REDISEARCH_REF busts the toolchain image's
-# cached `RUN redisearch.sh` layer and keeps the build reproducible. To pick up
-# new RediSearch work, update REDISEARCH_REF to the new commit (check-files in
-# .github/workflows/rust-pr.yml rebuilds the toolchain when this file changes).
+
+# RediSearch lives at deps/RediSearch as a git submodule, the same layout the C
+# engine uses on `master`. The committed gitlink is the source of truth for a
+# git checkout; REDISEARCH_REF below is the same commit spelled out for builds
+# that only have this script and no repository (the Docker toolchain images COPY
+# redisearch.sh alone, so bumping REDISEARCH_REF busts their cached
+# `RUN redisearch.sh` layer and keeps those builds reproducible).
+#
+# To move to a new RediSearch commit, do BOTH:
+#   git -C deps/RediSearch fetch origin && git -C deps/RediSearch checkout <sha>
+#   git add deps/RediSearch          # bump the gitlink
+#   ...and set REDISEARCH_REF=<sha> here
+# The two are checked against each other below, so a half-done bump fails loudly
+# instead of building a different RediSearch locally than in Docker.
 REDISEARCH_BRANCH="falkordb/llapi-extensions-8.6"
 REDISEARCH_REF="ac45247834fec495f4d3ec76f337e3709260fdd5"
-REDISEARCH_DIR="$ROOT/redisearch/RediSearch"
+REDISEARCH_DIR="$ROOT/deps/RediSearch"
 
-mkdir -p "$ROOT/redisearch"
+# The committed gitlink, when we are in a repository at all (empty otherwise).
+gitlink_ref=""
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  # From the index, not HEAD, so a staged submodule bump is what gets checked.
+  gitlink_ref="$(git -C "$ROOT" ls-files -s -- deps/RediSearch 2>/dev/null | awk '{print $2}')"
+fi
+
+if [ -n "$gitlink_ref" ] && [ "$gitlink_ref" != "$REDISEARCH_REF" ]; then
+  echo "ERROR: deps/RediSearch gitlink ($gitlink_ref) != REDISEARCH_REF ($REDISEARCH_REF)." >&2
+  echo "       These must agree: the gitlink drives submodule builds, REDISEARCH_REF" >&2
+  echo "       drives the Docker toolchain images. Update REDISEARCH_REF in $0." >&2
+  exit 1
+fi
+
 if [ ! -d "$REDISEARCH_DIR/.git" ]; then
-  # Shallow-fetch just the pinned commit (GitHub allows fetching a reachable SHA).
+  # Bootstrap the submodule path ourselves rather than via `git submodule
+  # update`, and identically whether or not there is a repository here (the
+  # Docker toolchain images COPY only this script). Two reasons:
+  #   * `git submodule update --depth 1` shallow-clones the *default branch* and
+  #     then cannot check out the pinned commit, which is usually not its tip;
+  #     without --depth it clones RediSearch's full history, which is large and
+  #     needless in CI.
+  #   * a shallow fetch of the exact SHA lands the tree at the gitlink, so
+  #     `git submodule status` is clean afterwards.
+  # A developer who wants full RediSearch history can instead run
+  # `git submodule update --init --recursive -- deps/RediSearch` before this
+  # script; it sees the populated checkout below and leaves it alone.
+  mkdir -p "$REDISEARCH_DIR"
   git init -q "$REDISEARCH_DIR"
   git -C "$REDISEARCH_DIR" remote add origin https://github.com/FalkorDB/RediSearch.git
+  # GitHub allows fetching a reachable SHA, so no branch fetch is needed. The
+  # branch name is recorded in .gitmodules (and REDISEARCH_BRANCH) for humans.
   git -C "$REDISEARCH_DIR" fetch -q --depth 1 origin "$REDISEARCH_REF"
   git -C "$REDISEARCH_DIR" checkout -q FETCH_HEAD
   git -C "$REDISEARCH_DIR" submodule update --init --recursive --depth 1
 else
-  # Reusing an existing checkout (fast local iteration; CI always clones fresh
-  # because redisearch/ is .dockerignore'd). Warn loudly if it isn't on the
-  # pinned ref so a stale or branch-switched clone doesn't silently build
-  # against the wrong RediSearch ABI. We deliberately do NOT auto-reset — that
-  # would clobber local RediSearch work; remove the directory to force a clean
-  # re-fetch.
+  # Reusing an existing checkout (fast local iteration, and the case that makes
+  # a submodule worth having: edit deps/RediSearch in place, build, test, then
+  # commit the gitlink bump). Warn rather than reset if it isn't on the pinned
+  # ref -- a reset would clobber local RediSearch work -- so a stale or
+  # branch-switched clone doesn't silently build against the wrong ABI.
   current_ref="$(git -C "$REDISEARCH_DIR" rev-parse HEAD 2>/dev/null || echo '?')"
   if [ "$current_ref" != "$REDISEARCH_REF" ]; then
     echo "WARNING: $REDISEARCH_DIR is at '$current_ref', expected '$REDISEARCH_REF'." >&2
-    echo "         Remove that directory to re-fetch, or check out the expected ref." >&2
+    echo "         Building it anyway. To return to the pinned ref:" >&2
+    echo "         git -C $ROOT submodule update --init --recursive -- deps/RediSearch" >&2
   fi
+  # A checkout that predates a nested-submodule addition (or a `git submodule
+  # update` without --recursive) leaves VectorSimilarity et al. empty.
+  git -C "$REDISEARCH_DIR" submodule update --init --recursive --depth 1
 fi
 
 cd "$REDISEARCH_DIR"
 
-# VecSim promotes some warnings to errors; relax for our toolchain.
+# VecSim promotes some warnings to errors; relax for our toolchain. Restore the
+# file afterwards so the submodule does not show up as dirty in the parent repo.
+VECSIM_CMAKE="deps/VectorSimilarity/src/VecSim/CMakeLists.txt"
+restore_vecsim() {
+  git -C deps/VectorSimilarity checkout -- src/VecSim/CMakeLists.txt 2>/dev/null || true
+}
+trap restore_vecsim EXIT
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  sed -i '' 's/-Werror//g' deps/VectorSimilarity/src/VecSim/CMakeLists.txt
+  sed -i '' 's/-Werror//g' "$VECSIM_CMAKE"
 else
-  sed -i 's/-Werror//g' deps/VectorSimilarity/src/VecSim/CMakeLists.txt
+  sed -i 's/-Werror//g' "$VECSIM_CMAKE"
 fi
 
 # Build RediSearch 8.6 as an embeddable STATIC library:

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -4,100 +4,43 @@ set -e
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 # RediSearch lives at deps/RediSearch as a git submodule, the same layout the C
-# engine uses on `master`. Like every submodule it is pinned to a COMMIT (the
-# gitlink, `160000 <sha>` in the tree) -- never to a branch. REDISEARCH_REF below
-# is that same commit spelled out for builds that have this script and no
-# repository: the Docker toolchain images COPY redisearch.sh alone, so this
-# file's content is also what busts their cached `RUN redisearch.sh` layer and
-# what `.github/workflows/rust-pr.yml`'s check-files matches to rebuild the
-# toolchain image.
+# engine uses on `master`. GIT owns that checkout: this script only BUILDS what
+# is there, and never fetches, clones, resets or otherwise moves the pin. That
+# is what keeps the pinned commit single-sourced in the gitlink
+# (`160000 <sha>` in the tree) instead of also being spelled out here.
 #
-# REDISEARCH_BRANCH is documentation only -- where new RediSearch work lands, so
-# you know what to fetch. Nothing resolves it at build time, and .gitmodules
-# deliberately carries no `branch` key: it would only be read by
-# `git submodule update --remote`, which moves the pin to a branch tip, i.e. the
-# one operation this pin exists to prevent.
+# So every consumer must populate the submodule before calling this:
+#   locally   git submodule update --init --recursive
+#   CI        actions/checkout with `submodules: recursive`
+#   Docker    the image COPYs deps/RediSearch in (see build/Dockerfile); the
+#             build context carries the checked-out submodule, which is also
+#             what makes the COPY layer's cache key the submodule CONTENT --
+#             it turns over exactly when the pin moves.
 #
-# To move to a new RediSearch commit, do BOTH:
+# New RediSearch work lands on falkordb/llapi-extensions-8.6. To move the pin:
 #   git -C deps/RediSearch fetch origin && git -C deps/RediSearch checkout <sha>
-#   git add deps/RediSearch          # bump the gitlink
-#   ...and set REDISEARCH_REF=<sha> here
-# `--check-pin` (below, and run in CI) fails when they disagree, so a half-done
-# bump cannot quietly build a different RediSearch in Docker than locally.
-REDISEARCH_BRANCH="falkordb/llapi-extensions-8.6"
-REDISEARCH_REF="ea1a6f40cbc959d13c63617b3a2e0ed6b8616037"
+#   git add deps/RediSearch
+# and nothing else -- there is no second copy of the SHA to keep in step.
 REDISEARCH_DIR="$ROOT/deps/RediSearch"
 
-# The committed gitlink, when we are in a repository at all (empty otherwise).
-gitlink_ref=""
-if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
-  # From the index, not HEAD, so a staged submodule bump is what gets checked.
-  gitlink_ref="$(git -C "$ROOT" ls-files -s -- deps/RediSearch 2>/dev/null | awk '{print $2}')"
-fi
-
-if [ -n "$gitlink_ref" ] && [ "$gitlink_ref" != "$REDISEARCH_REF" ]; then
-  echo "ERROR: deps/RediSearch gitlink ($gitlink_ref) != REDISEARCH_REF ($REDISEARCH_REF)." >&2
-  echo "       These must agree: the gitlink is what a submodule checkout builds," >&2
-  echo "       REDISEARCH_REF is what the Docker toolchain images clone." >&2
-  echo "       Update REDISEARCH_REF in $0 (or re-point the gitlink)." >&2
+# Populated means "has files". An uninitialized submodule is an empty directory,
+# which would otherwise fail much later inside RediSearch's own build with
+# something unhelpful.
+if [ -z "$(ls -A "$REDISEARCH_DIR" 2>/dev/null || true)" ]; then
+  echo "ERROR: $REDISEARCH_DIR is empty -- the RediSearch submodule is not checked out." >&2
+  echo "       Run:  git submodule update --init --recursive" >&2
+  echo "       (in CI, set \`submodules: recursive\` on actions/checkout)" >&2
   exit 1
 fi
 
-# `--check-pin` stops here: assert the two agree and exit, building nothing.
-# Linux CI builds run inside the prebuilt toolchain container and never execute
-# this script, so without a job that calls this the check would only ever fire
-# on a developer machine -- and a gitlink-only bump would go green while Docker
-# silently built the old REDISEARCH_REF.
-if [ "${1:-}" = "--check-pin" ]; then
-  if [ -z "$gitlink_ref" ]; then
-    echo "ERROR: --check-pin needs a git checkout with deps/RediSearch in the index." >&2
-    exit 1
-  fi
-  echo "deps/RediSearch pin OK: gitlink and REDISEARCH_REF both $REDISEARCH_REF"
-  exit 0
-fi
-
-# `-e`, not `-d`: `git submodule update --init` leaves `.git` as a FILE holding
-# `gitdir: ../../.git/modules/deps/RediSearch`, and only the bootstrap below
-# creates it as a directory. Testing for a directory sent every properly cloned
-# checkout down the bootstrap path, where `git remote add origin` fails with
-# "remote origin already exists" and set -e kills the build.
-if [ ! -e "$REDISEARCH_DIR/.git" ]; then
-  # Bootstrap the submodule path ourselves rather than via `git submodule
-  # update`, and identically whether or not there is a repository here (the
-  # Docker toolchain images COPY only this script). Two reasons:
-  #   * `git submodule update --depth 1` shallow-clones the *default branch* and
-  #     then cannot check out the pinned commit, which is usually not its tip;
-  #     without --depth it clones RediSearch's full history, which is large and
-  #     needless in CI.
-  #   * a shallow fetch of the exact SHA lands the tree at the gitlink, so
-  #     `git submodule status` is clean afterwards.
-  # A developer who wants full RediSearch history can instead run
-  # `git submodule update --init --recursive -- deps/RediSearch` before this
-  # script; it sees the populated checkout below and leaves it alone.
-  mkdir -p "$REDISEARCH_DIR"
-  git init -q "$REDISEARCH_DIR"
-  git -C "$REDISEARCH_DIR" remote add origin https://github.com/FalkorDB/RediSearch.git
-  # GitHub allows fetching a reachable SHA, so no branch fetch is needed --
-  # which is also why .gitmodules needs no `branch` key (see the header).
-  git -C "$REDISEARCH_DIR" fetch -q --depth 1 origin "$REDISEARCH_REF"
-  git -C "$REDISEARCH_DIR" checkout -q FETCH_HEAD
-  git -C "$REDISEARCH_DIR" submodule update --init --recursive --depth 1
-else
-  # Reusing an existing checkout (fast local iteration, and the case that makes
-  # a submodule worth having: edit deps/RediSearch in place, build, test, then
-  # commit the gitlink bump). Warn rather than reset if it isn't on the pinned
-  # ref -- a reset would clobber local RediSearch work -- so a stale or
-  # branch-switched clone doesn't silently build against the wrong ABI.
-  current_ref="$(git -C "$REDISEARCH_DIR" rev-parse HEAD 2>/dev/null || echo '?')"
-  if [ "$current_ref" != "$REDISEARCH_REF" ]; then
-    echo "WARNING: $REDISEARCH_DIR is at '$current_ref', expected '$REDISEARCH_REF'." >&2
-    echo "         Building it anyway. To return to the pinned ref:" >&2
-    echo "         git -C $ROOT submodule update --init --recursive -- deps/RediSearch" >&2
-  fi
-  # A checkout that predates a nested-submodule addition (or a `git submodule
-  # update` without --recursive) leaves VectorSimilarity et al. empty.
-  git -C "$REDISEARCH_DIR" submodule update --init --recursive --depth 1
+# RediSearch's own nested submodules are build inputs, not optional extras --
+# VectorSimilarity is the one that fails loudest, so name it. A non-recursive
+# `git submodule update` leaves these empty.
+if [ -z "$(ls -A "$REDISEARCH_DIR/deps/VectorSimilarity" 2>/dev/null || true)" ]; then
+  echo "ERROR: $REDISEARCH_DIR/deps/VectorSimilarity is empty -- RediSearch's own" >&2
+  echo "       submodules are not checked out. Run:" >&2
+  echo "       git submodule update --init --recursive" >&2
+  exit 1
 fi
 
 cd "$REDISEARCH_DIR"

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -17,7 +17,7 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 # The two are checked against each other below, so a half-done bump fails loudly
 # instead of building a different RediSearch locally than in Docker.
 REDISEARCH_BRANCH="falkordb/llapi-extensions-8.6"
-REDISEARCH_REF="ac45247834fec495f4d3ec76f337e3709260fdd5"
+REDISEARCH_REF="f44243456192c8f39be59756fb777dc829a98d00"
 REDISEARCH_DIR="$ROOT/deps/RediSearch"
 
 # The committed gitlink, when we are in a repository at all (empty otherwise).

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -57,7 +57,12 @@ if [ "${1:-}" = "--check-pin" ]; then
   exit 0
 fi
 
-if [ ! -d "$REDISEARCH_DIR/.git" ]; then
+# `-e`, not `-d`: `git submodule update --init` leaves `.git` as a FILE holding
+# `gitdir: ../../.git/modules/deps/RediSearch`, and only the bootstrap below
+# creates it as a directory. Testing for a directory sent every properly cloned
+# checkout down the bootstrap path, where `git remote add origin` fails with
+# "remote origin already exists" and set -e kills the build.
+if [ ! -e "$REDISEARCH_DIR/.git" ]; then
   # Bootstrap the submodule path ourselves rather than via `git submodule
   # update`, and identically whether or not there is a repository here (the
   # Docker toolchain images COPY only this script). Two reasons:
@@ -99,9 +104,16 @@ cd "$REDISEARCH_DIR"
 
 # VecSim promotes some warnings to errors; relax for our toolchain. Restore the
 # file afterwards so the submodule does not show up as dirty in the parent repo.
+#
+# Restore the BYTES we saw, not `git checkout --` of the tracked version: this
+# script deliberately supports editing deps/RediSearch in place, and checking
+# out would silently throw away uncommitted VecSim work.
 VECSIM_CMAKE="deps/VectorSimilarity/src/VecSim/CMakeLists.txt"
+VECSIM_BACKUP="$(mktemp)"
+cp "$VECSIM_CMAKE" "$VECSIM_BACKUP"
 restore_vecsim() {
-  git -C deps/VectorSimilarity checkout -- src/VecSim/CMakeLists.txt 2>/dev/null || true
+  cp "$VECSIM_BACKUP" "$VECSIM_CMAKE" 2>/dev/null || true
+  rm -f "$VECSIM_BACKUP"
 }
 trap restore_vecsim EXIT
 if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/redisearch.sh
+++ b/redisearch.sh
@@ -17,7 +17,7 @@ ROOT="$(cd "$(dirname "$0")" && pwd)"
 # The two are checked against each other below, so a half-done bump fails loudly
 # instead of building a different RediSearch locally than in Docker.
 REDISEARCH_BRANCH="falkordb/llapi-extensions-8.6"
-REDISEARCH_REF="f44243456192c8f39be59756fb777dc829a98d00"
+REDISEARCH_REF="ea1a6f40cbc959d13c63617b3a2e0ed6b8616037"
 REDISEARCH_DIR="$ROOT/deps/RediSearch"
 
 # The committed gitlink, when we are in a repository at all (empty otherwise).


### PR DESCRIPTION
Fixes #2623.

Four commits, reviewable separately:

1. `build:` the submodule migration (pin unchanged)
2. `fix:` pin the RediSearch spec-lock fix
3. `fix:` move the pin to the merged tip
4. `ci:` @DvirDukhan's review points — pin check on every PR, drop the `.gitmodules` `branch` key

FalkorDB/RediSearch#27 is **merged**; the pin is at the branch tip `ea1a6f4`, which also picks up RediSearch#26 (`ALIGNED` macro guard). Rebuilt from scratch and re-verified there — see Test results below.

---

## 1. The deadlock

A plan with one index scan nested under another **on the same index** could freeze the entire server — PING included, not just the query.

`NodeByIndexScanOp` parks a partially-drained RediSearch iterator in [`BatchedResultEmitter::pending`](graph/src/runtime/ops/batched_result_emitter.rs#L503) across `next()` calls, and RediSearch's `handleIterCommon` holds the per-spec **read** lock for that iterator's whole lifetime. So the child scan's read lock is still held while the parent opens one iterator per row on the same spec, from the same thread. `IndexSpec.rwlock` is writer-preferring, so once the fork GC queues as a writer, the next of those recursive read acquires blocks forever — and the GC waits forever for the read lock that same thread holds.

That alone hangs the reader threads. What takes the *whole server* down is [`QuerySession::escalate`](src/query_session.rs#L230): it holds the module GIL while waiting for the per-graph write lock. Captured with `sample(1)` on a frozen server:

| thread | stack | state |
|---|---|---|
| 8 × worker | `NodeByIndexScanOp::next` → `Index::query` → `handleIterCommon` → `__psynch_rw_rdlock` | wants a spec read lock it already holds |
| `gc-*` | `FGC_parentHandleFromChild` → `RedisSearchCtx_LockSpecWrite` → `__psynch_rw_wrlock` | wants the spec write lock |
| write-queue | `CommitOp::next` → `upgrade_to_write` → `wait_for_readers` | **holds the module GIL** |
| main | `aeProcessEvents` → `afterSleep` → GIL mutex | PING dead |

### Reproduction and control

| run | result |
|---|---|
| before | froze after **~50 s** (declared at 127 s / 130 s after 3 dead PINGs), reproduced on two builds |
| after | **420 s**, 3080 reads, 250 write rounds, ~14 fork-GC cycles, **131/131 pings OK**, 0 errors |
| control | child scan narrowed below `BATCH_SIZE` so no iterator is parked — same plan shape, same GC pressure — **13,171 reads / 180 s / clean**, *before* the fix too |

The control is the part that matters for the diagnosis: it rules out "index scans" and "fork GC pressure" as the cause and pins it on the parked iterator specifically.

### The fix itself

In RediSearch (FalkorDB/RediSearch#27): count per-spec lock depth per thread, exactly as the **global** `RWLock` already does in `rwlock.c`, so a nested read on a spec this thread already holds never goes back to pthread. This is the general fix — it covers all six FalkorDB ops that can hold a RediSearch iterator across `next()`, any nesting depth, and the C engine too, since it shares this RediSearch.

Rejected alternatives:

- **Materialize each row's matches** (FalkorDB-only, no submodule bump) — breaks the C-parity memory bar. `MATCH (n:L) WHERE n.v > 0 RETURN n LIMIT 1` would materialize the whole index and lose early exit; the LLAPI has no resume cursor, so chunking degenerates to re-scanning.
- **Optimizer refuses same-spec nesting** — cheapest, but makes a liveness guarantee rest on an optimizer rule, misses other routes to the same spec (constraint checks, node+edge index on one label), and costs real performance on a legitimate plan.

### Known follow-up, deliberately not in this PR

The GIL amplifier in `escalate` is why a hung reader takes the server down rather than just itself. C has the same structure and an explicit TODO for it — `QueryCtx_AcquireWriteLock`: *"TODO: change to TryAcquireWriteLock with the appropriate timeout"* — so we are at parity, not worse. Worth its own change: a bounded `try_write_arc_for` retry loop that releases the GIL between attempts, preserving the GIL→write-lock order that #726 requires.

---

## 2. RediSearch as a `deps/` submodule

RediSearch was fetched into a **gitignored** `redisearch/RediSearch`, so the checkout was invisible to git — no way to see what you had, diff it, or record what you built against beyond a SHA in a shell variable. This PR needed exactly that workflow, which is why the migration is here.

Now `deps/RediSearch`, matching the C engine's layout on `master`.

- `redisearch.sh` still bootstraps the path itself, identically with or without a repository present (the Docker toolchain images COPY only the script). It deliberately avoids `git submodule update --depth 1`: that shallow-clones the *default branch* and then cannot check out the pinned commit, which is usually not its tip, while a non-shallow update clones RediSearch's full history for no CI benefit. A shallow fetch of the exact SHA lands the tree on the gitlink, so `git submodule status` is clean afterwards.
- The pin lives in two places — the gitlink (submodule builds) and `REDISEARCH_REF` (Docker images, where its value in the COPY'd script is what busts the cached `RUN redisearch.sh` layer). The script **hard-errors** when they disagree, so a half-done bump can't quietly build a different RediSearch locally than in Docker. A checkout moved off the pin only warns and is never reset, so in-place RediSearch work isn't clobbered.

Two subtleties worth a look during review:

- `.gitignore`'s bare `redisearch` entry had to become `/redisearch/`. With `core.ignorecase=true` (macOS default) it was also matching `deps/RediSearch` — silently ignoring the new submodule.
- The VecSim `-Werror` sed now restores the file on exit. Previously invisible because the whole tree was gitignored; as a submodule it would show the parent repo dirty after every build.

`graph/build.rs` prefers the new paths and keeps the old ones as a fallback, so an existing local checkout still links until removed. `.dockerignore` shadow-proofs the new path as it did the old. The devcontainer loses a `ln -sf` that only existed to fake up a path `build.rs` now finds directly. **No CI change needed** — the script populates the submodule, so no workflow needs `submodules: true`.

---

## Test results

| suite | result |
|---|---|
| `cargo test -p graph` | 178 passed, 0 failed |
| `tests/test_e2e.py` + `tests/test_functions.py` | 124 passed |
| index / edge-index / fulltext / constraint flow tests | **134 passed, 0 failed** |
| `tests/test_mvcc.py` + `tests/test_concurrency.py` | 14 passed |
| `cargo fmt --all -- --check` | clean |

Read throughput was 13–27 per 2 s with the fix vs 17–28 before the freeze — same range; not enough samples to call any difference real. The fix removes a lock/unlock pair on the nested path, so it should be neutral-to-faster.

Platform note: verified on macOS/arm64. The bug is not platform-specific — `PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP` is only set on glibc, but Darwin's rwlock blocks new readers behind a queued writer too, which is why it reproduces here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release**
  * RediSearch is now provided through a pinned source dependency for more consistent builds.
  * Updated container, macOS, ASAN, and RHEL build configurations to use a standardized artifact location.
  * Legacy artifact paths remain supported as fallbacks where applicable.
  * Changes to RediSearch sources now trigger relevant toolchain and build workflows.

* **Documentation**
  * Clarified dependency initialization and build guidance for development and container environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

