### PR TITLE
fix(#2582): make the filter comparison kernels answer what the evaluator answers

### DIFF
--- a/graph/src/runtime/batch.rs
+++ b/graph/src/runtime/batch.rs
@@ -251,6 +251,22 @@ pub fn classify_column(values: Vec<Value>) -> (Column, NullBitmap) {
     (column, nulls)
 }
 
+/// Classifies a `Vec<Value>` for the comparison kernels, keeping every lane
+/// exact: an all-`Int` (or null) column becomes [`Column::Ints`], an all-`Float`
+/// one becomes [`Column::Floats`], and anything else — including a *mixed*
+/// int/float column — stays [`Column::Values`].
+///
+/// The difference from [`classify_column`] is [`FloatLane::Pure`]: promoting a
+/// mixed column to `f64` would round integers past 2^53, so `p.v = 9007199254740993`
+/// would match a stored `9007199254740992` in a filter while the scalar
+/// evaluator (which compares `Int` to `Int` exactly) says it does not.
+#[must_use]
+pub fn classify_exact_column(values: Vec<Value>) -> (Column, NullBitmap) {
+    let nulls = NullBitmap::from_values(&values);
+    let column = classify_numeric(values, true, FloatLane::Pure);
+    (column, nulls)
+}
+
 /// Appends the active rows of one batch's typed column slice `src` onto `out`.
 ///
 /// `selection` is the owning batch's active-row mask: `None` means the batch is

--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -32,7 +32,7 @@ use crate::parser::ast::{ExprIR, QueryExpr, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
 use crate::runtime::{
-    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp, BatchRow, Column, NullBitmap},
+    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp, BatchRow},
     functions::{FnType, GraphFn},
     row::{Row, RowView},
     runtime::Runtime,
@@ -629,8 +629,11 @@ impl<'a> AggregateOp<'a> {
                 KeyExprKind::Property { var, attr } => {
                     let node_ids = batch.extract_node_ids(var.id).ok_or(())?;
                     let active_ids: Vec<_> = active.iter().map(|&i| node_ids[i]).collect();
-                    let (col, nulls) = runtime.materialize_node_property(&active_ids, attr);
-                    key_columns.push(column_to_values(&col, &nulls, active.len()));
+                    // Unclassified: a grouping key must be the stored value, and
+                    // the classifier's float lane would promote a mixed
+                    // int/float column, merging 9007199254740993 and
+                    // 9007199254740992 into one group.
+                    key_columns.push(runtime.materialize_node_property_values(&active_ids, attr));
                 }
             }
         }
@@ -671,13 +674,13 @@ impl<'a> AggregateOp<'a> {
                     // this path.
                     if let Some(node_ids) = batch.extract_node_ids(var.id) {
                         let active_ids: Vec<_> = active.iter().map(|&i| node_ids[i]).collect();
-                        let (col, nulls) = runtime.materialize_node_property(&active_ids, attr);
-                        agg_columns.push(column_to_values(&col, &nulls, active.len()));
+                        agg_columns
+                            .push(runtime.materialize_node_property_values(&active_ids, attr));
                     } else if let Some(rel_ids) = batch.extract_rel_ids(var.id) {
                         let active_ids: Vec<_> = active.iter().map(|&i| rel_ids[i]).collect();
-                        let (col, nulls) =
-                            runtime.materialize_relationship_property(&active_ids, attr);
-                        agg_columns.push(column_to_values(&col, &nulls, active.len()));
+                        agg_columns.push(
+                            runtime.materialize_relationship_property_values(&active_ids, attr),
+                        );
                     } else {
                         // Neither a node nor a relationship id column — e.g. a
                         // `Values` column carrying entities past a `WITH`. Read
@@ -1074,37 +1077,6 @@ impl<'a> Iterator for AggregateOp<'a> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Converts a `Column` + `NullBitmap` from `materialize_node_property` into
-/// a `Vec<Value>` for use in grouping and accumulation.
-fn column_to_values(
-    col: &Column,
-    nulls: &NullBitmap,
-    len: usize,
-) -> Vec<Value> {
-    match col {
-        Column::Ints(data) => (0..len)
-            .map(|i| {
-                if nulls.is_null(i) {
-                    Value::Null
-                } else {
-                    Value::Int(data[i])
-                }
-            })
-            .collect(),
-        Column::Floats(data) => (0..len)
-            .map(|i| {
-                if nulls.is_null(i) {
-                    Value::Null
-                } else {
-                    Value::Float(data[i])
-                }
-            })
-            .collect(),
-        Column::Values(data) => data.clone(),
-        _ => vec![Value::Null; len],
-    }
-}
 
 /// Recursively walks an expression tree and unbinds each aggregate function's
 /// accumulator variable from the environment. This mirrors the recursion in

--- a/graph/src/runtime/ops/filter.rs
+++ b/graph/src/runtime/ops/filter.rs
@@ -8,32 +8,39 @@
 //!  Single columnar evaluation entry point (`eval`):
 //!
 //!  1. Vectorized kernel (simple predicates like `n.age > 30`):
-//!     node_ids ──► materialize_node_property ──► compare_i64_column ──► selection
+//!     node_ids ──► property column ──► compare_*_column ──► surviving rows
 //!
 //!  2. Columnar per-row fallback (complex expressions):
 //!     for each active row: run_expr(predicate, BatchRow) ──► collect passing
 //! ```
 //!
 //! When the filter expression matches a vectorizable pattern (e.g.,
-//! `n.age > 30`), `eval` uses the fast columnar kernel path:
-//! extract node IDs → materialize property column → run comparison kernel.
-//! For unrecognized patterns it reads each row through a [`BatchRow`] view
-//! (no `Env` materialization) and emits the survivors as a selection vector.
+//! `n.age > 30`), `eval` uses the fast columnar kernel path: extract node IDs
+//! for the rows still active → materialize the property column in one bulk
+//! fetch → run the comparison kernel, each conjunct narrowing the rows the next
+//! one has to read. For unrecognized patterns it reads each row through a
+//! [`BatchRow`] view (no `Env` materialization) and emits the survivors as a
+//! selection vector.
+//!
+//! Both paths answer identically by construction: the kernels in
+//! [`vectorized`](crate::runtime::vectorized) compare with the same `Value`
+//! semantics the per-row evaluator applies, so which path a predicate takes is
+//! a performance decision and never a semantic one.
 
 use crate::parser::ast::{QueryExpr, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
 use crate::runtime::{
-    batch::{Batch, BatchOp, BatchRow, Column},
+    batch::{Batch, BatchOp, BatchRow, Column, classify_exact_column},
     runtime::Runtime,
     value::Value,
     vectorized::{
         SimplePredicate, VectorizablePredicate, compare_f64_column, compare_i64_column,
-        compare_string_column, mask_intersect_selection, mask_to_selection,
-        try_extract_vectorizable_predicate,
+        compare_value_column, try_extract_vectorizable_predicate,
     },
 };
 use orx_tree::{Dyn, NodeIdx, NodeRef};
+use std::slice;
 
 /// Cached predicate analysis result.
 /// `None` means the expression has not been analyzed yet.
@@ -88,7 +95,7 @@ impl<'a> FilterOp<'a> {
                 let Some(Some(pred)) = &self.vectorized else {
                     unreachable!("guarded by matches! above")
                 };
-                self.eval_vectorized(&batch, pred)
+                self.eval_vectorized(&batch, pred, batch.active_indices().collect())
             };
             match result {
                 Ok(Some(sel)) => {
@@ -139,6 +146,9 @@ impl<'a> FilterOp<'a> {
     /// Evaluates a vectorizable predicate with comparison kernels, returning a
     /// selection vector of passing rows.
     ///
+    /// `rows` are the batch's active rows; each conjunct narrows them, so a
+    /// second predicate only fetches properties for the rows the first one kept.
+    ///
     /// Returns `Ok(Some(sel))` with the passing indices, `Ok(None)` when no row
     /// passes, or `Err(())` when the kernel can't apply (caller falls back to
     /// per-row evaluation).
@@ -146,61 +156,60 @@ impl<'a> FilterOp<'a> {
         &self,
         batch: &Batch<'a>,
         pred: &VectorizablePredicate,
+        mut rows: Vec<usize>,
     ) -> Result<Option<Vec<u16>>, ()> {
-        match pred {
-            VectorizablePredicate::Single(p) => {
-                let sel = self.eval_single_predicate(batch, p)?;
-                Ok((!sel.is_empty()).then_some(sel))
+        let preds = match pred {
+            VectorizablePredicate::Single(p) => slice::from_ref(p),
+            VectorizablePredicate::Conjunction(preds) => preds.as_slice(),
+        };
+
+        for p in preds {
+            if rows.is_empty() {
+                return Ok(None);
             }
-            VectorizablePredicate::Conjunction(preds) => {
-                let mut sel: Option<Vec<u16>> = None;
-                for p in preds {
-                    let mask = self.eval_single_mask(batch, p)?;
-                    sel = Some(sel.map_or_else(
-                        || mask_to_selection(&mask),
-                        |existing| mask_intersect_selection(&mask, &existing),
-                    ));
-                    // Early exit if nothing passes.
-                    if sel.as_ref().is_some_and(Vec::is_empty) {
-                        return Ok(None);
-                    }
-                }
-                match sel {
-                    Some(s) if s.is_empty() => Ok(None),
-                    Some(s) => Ok(Some(s)),
-                    None => Ok(None), // empty conjunction
-                }
-            }
+            let mask = self.eval_single_mask(batch, p, &rows)?;
+            let mut i = 0;
+            rows.retain(|_| {
+                let keep = mask[i];
+                i += 1;
+                keep
+            });
+        }
+
+        if rows.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(rows.into_iter().map(|r| r as u16).collect()))
         }
     }
 
-    /// Evaluates a single predicate and returns a selection vector of passing row indices.
-    fn eval_single_predicate(
-        &self,
-        batch: &Batch<'a>,
-        pred: &SimplePredicate,
-    ) -> Result<Vec<u16>, ()> {
-        let mask = self.eval_single_mask(batch, pred)?;
-        Ok(mask_to_selection(&mask))
-    }
-
-    /// Evaluates a single predicate and returns a boolean mask.
+    /// Evaluates a single predicate over `rows`, returning one boolean per row
+    /// (entry `i` answers row `rows[i]`).
     fn eval_single_mask(
         &self,
         batch: &Batch<'a>,
         pred: &SimplePredicate,
+        rows: &[usize],
     ) -> Result<Vec<bool>, ()> {
-        let node_ids = batch.extract_node_ids(pred.var.id).ok_or(())?;
-        let (col, nulls) = self
-            .runtime
-            .materialize_node_property(&node_ids, &pred.attr);
+        let Column::NodeIds(ids) = batch.column(pred.var.id) else {
+            return Err(()); // not a node column, fall back to per-row
+        };
+        let node_ids: Vec<_> = rows.iter().map(|&r| ids[r]).collect();
+        let (col, nulls) = classify_exact_column(
+            self.runtime
+                .materialize_node_property_values(&node_ids, &pred.attr),
+        );
 
+        // Only column/constant pairs whose primitive comparison is exactly the
+        // `Value` comparison take a typed lane; `compare_value_column` handles
+        // the rest by calling the scalar comparator itself.
         let mask = match (&col, &pred.constant) {
             (Column::Ints(data), Value::Int(threshold)) => {
                 compare_i64_column(data, pred.op, *threshold, &nulls)
             }
             (Column::Ints(data), Value::Float(threshold)) => {
-                // Promote int column to float for comparison.
+                // `Value::compare_value` compares `Int` against `Float` as
+                // `i as f64`, so promoting the whole column matches it.
                 let floats: Vec<f64> = data.iter().map(|&i| i as f64).collect();
                 compare_f64_column(&floats, pred.op, *threshold, &nulls)
             }
@@ -210,10 +219,10 @@ impl<'a> FilterOp<'a> {
             (Column::Floats(data), Value::Int(threshold)) => {
                 compare_f64_column(data, pred.op, *threshold as f64, &nulls)
             }
-            (Column::Values(data), Value::String(threshold)) => {
-                compare_string_column(data, pred.op, threshold)
-            }
-            _ => return Err(()), // type mismatch, fall back to per-row
+            (Column::Values(data), _) => compare_value_column(data, pred.op, &pred.constant),
+            // A numeric column against a non-numeric constant: rare enough to
+            // leave to the per-row path rather than widen the kernel.
+            _ => return Err(()),
         };
 
         Ok(mask)

--- a/graph/src/runtime/ops/project.rs
+++ b/graph/src/runtime/ops/project.rs
@@ -106,38 +106,15 @@ impl<'a> ProjectOp<'a> {
         for kind in plan {
             let col = match kind {
                 ProjectionKind::Property { var, attr } => {
-                    batch.extract_node_ids(var.id).and_then(|node_ids| {
+                    // The stored values are what the projection emits, so take
+                    // them unclassified: classifying and rebuilding `Value`s
+                    // costs two extra passes, and its float lane would promote
+                    // a mixed int/float column, printing a stored
+                    // 9007199254740993 as 9.00719925474099e+15.
+                    batch.extract_node_ids(var.id).map(|node_ids| {
                         let active_ids: Vec<_> = active.iter().map(|&i| node_ids[i]).collect();
-                        let (col, nulls) =
-                            self.runtime.materialize_node_property(&active_ids, attr);
-                        match col {
-                            Column::Ints(data) => Some(
-                                data.iter()
-                                    .enumerate()
-                                    .map(|(i, &v)| {
-                                        if nulls.is_null(i) {
-                                            Value::Null
-                                        } else {
-                                            Value::Int(v)
-                                        }
-                                    })
-                                    .collect(),
-                            ),
-                            Column::Floats(data) => Some(
-                                data.iter()
-                                    .enumerate()
-                                    .map(|(i, &v)| {
-                                        if nulls.is_null(i) {
-                                            Value::Null
-                                        } else {
-                                            Value::Float(v)
-                                        }
-                                    })
-                                    .collect(),
-                            ),
-                            Column::Values(data) => Some(data),
-                            _ => None,
-                        }
+                        self.runtime
+                            .materialize_node_property_values(&active_ids, attr)
                     })
                 }
                 ProjectionKind::Variable(var) => Some(

--- a/graph/src/runtime/vectorized.rs
+++ b/graph/src/runtime/vectorized.rs
@@ -12,7 +12,7 @@
 //!    eval(n.age > 30)                  ages = [25, 42, 18, 55, ...]
 //!    if true -> keep row            2. compare_i64_column(ages, Gt, 30)
 //!                                      mask = [F, T, F, T, ...]
-//!  O(rows * expr_depth)            3. mask_to_selection(mask)
+//!  O(rows * expr_depth)            3. keep the rows the mask kept
 //!                                      sel  = [1, 3, ...]
 //!                                   O(rows) with SIMD lanes
 //! ```
@@ -20,24 +20,36 @@
 //! ## Components
 //!
 //! - [`CmpOp`] -- comparison operator enum (Eq, Neq, Lt, Le, Gt, Ge)
-//! - Comparison kernels: [`compare_i64_column`], [`compare_f64_column`],
-//!   [`compare_string_column`] -- tight indexed loops for auto-vectorization
+//! - Comparison kernels: [`compare_i64_column`] and [`compare_f64_column`] --
+//!   tight indexed loops for auto-vectorization over primitive columns, plus
+//!   [`compare_value_column`] -- the general lane for every other column shape
 //! - [`SimplePredicate`] / [`VectorizablePredicate`] -- detected filter patterns
 //!   that can use the bulk path instead of per-row expression evaluation
 //! - [`try_extract_vectorizable_predicate`] -- analyzes a filter expression tree
 //!   to detect `entity.property <cmp> constant` patterns
-//! - [`mask_to_selection`] / [`mask_intersect_selection`] -- convert boolean
-//!   masks to/from the selection vector used by [`Batch`](super::batch::Batch)
 //!
-//! The comparison kernels are written as tight indexed loops to enable
+//! ## Agreement with the scalar evaluator
+//!
+//! Every kernel answers exactly what the scalar evaluator would answer for the
+//! same row. The primitive lanes are entered only for column/constant pairs
+//! whose primitive comparison *is* the `Value` comparison (`Int` against `Int`,
+//! and the `f64` promotion `Value::compare_value` itself performs for mixed
+//! numerics); every other shape goes through [`compare_value_column`], which
+//! calls the same `compare_value` / `partial_cmp` the per-row path uses. A
+//! filter and a projection of the same predicate therefore cannot disagree —
+//! the divergence issue #2582 reported, where `WHERE p <> 'x'` dropped rows
+//! that `RETURN p <> 'x'` called `true`.
+//!
+//! The primitive kernels are written as tight indexed loops to enable
 //! LLVM auto-vectorization on all target platforms (x86_64 SSE/AVX, ARM NEON).
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::parser::ast::{ExprIR, Variable};
 use crate::runtime::batch::NullBitmap;
-use crate::runtime::value::Value;
+use crate::runtime::value::{CompareValue, DisjointOrNull, Value};
 
 use orx_tree::{Dyn, DynTree, NodeIdx, NodeRef};
 
@@ -200,51 +212,51 @@ pub fn compare_f64_column(
     result
 }
 
-/// Compares string values in a `Value` slice against `threshold`.
-/// Non-string and Null values produce `false`.
+/// Compares a heterogeneous `Value` column against `constant`, row by row, with
+/// exactly the semantics the scalar evaluator applies to the same comparison.
+///
+/// This is the general lane: it backs every column the typed kernels above do
+/// not cover (strings, points, lists, maps, booleans, mixed int/float). A row
+/// passes only when the comparison yields `true` — a `null` result drops the
+/// row, matching how [`FilterOp`](crate::runtime::ops::filter::FilterOp) treats
+/// `Value::Null` on the per-row path.
+///
+/// Mirrors `eval.rs`:
+/// - `=` is `all_equals`: disjoint types, `NaN` and `null` are all *not* equal.
+/// - `<>` is `all_not_equals`, i.e. `Value::partial_cmp`, which is `None` only
+///   when a `null` is involved. Two values of disjoint types are therefore
+///   **unequal**, not `false` — `point(...) <> 'Dhaka'` is `true`.
+/// - `<`, `<=`, `>`, `>=` are `null` (so: drop) for disjoint types and `null`,
+///   and `false` for `NaN`.
 #[must_use]
-pub fn compare_string_column(
+pub fn compare_value_column(
     data: &[Value],
     op: CmpOp,
-    threshold: &str,
+    constant: &Value,
 ) -> Vec<bool> {
-    let len = data.len();
-    let mut result = vec![false; len];
-    for i in 0..len {
-        if let Value::String(s) = &data[i] {
-            result[i] = match op {
-                CmpOp::Eq => s.as_str() == threshold,
-                CmpOp::Neq => s.as_str() != threshold,
-                CmpOp::Lt => s.as_str() < threshold,
-                CmpOp::Le => s.as_str() <= threshold,
-                CmpOp::Gt => s.as_str() > threshold,
-                CmpOp::Ge => s.as_str() >= threshold,
-            };
-        }
-    }
-    result
-}
-
-/// Converts a boolean mask to a selection vector of passing row indices.
-#[must_use]
-pub fn mask_to_selection(mask: &[bool]) -> Vec<u16> {
-    mask.iter()
-        .enumerate()
-        .filter_map(|(i, &pass)| if pass { Some(i as u16) } else { None })
-        .collect()
-}
-
-/// Intersects a boolean mask with an existing selection vector.
-/// Only rows present in both the mask AND the existing selection pass.
-#[must_use]
-pub fn mask_intersect_selection(
-    mask: &[bool],
-    existing: &[u16],
-) -> Vec<u16> {
-    existing
-        .iter()
-        .copied()
-        .filter(|&i| mask[i as usize])
+    data.iter()
+        .map(|v| {
+            let (ord, flag) = v.compare_value(constant);
+            match op {
+                // Equality is total across types: only an exact match passes,
+                // and a null operand makes the whole comparison null.
+                CmpOp::Eq => flag == DisjointOrNull::None && ord == Ordering::Equal,
+                // `partial_cmp` is `None` only for a null operand; every other
+                // pair — including disjoint types — is ordered, hence unequal.
+                CmpOp::Neq => flag != DisjointOrNull::ComparedNull && ord != Ordering::Equal,
+                // Ordering across disjoint types (or with a null, or a NaN) is
+                // not a truth value, so the row drops.
+                _ => {
+                    flag == DisjointOrNull::None
+                        && match op {
+                            CmpOp::Lt => ord == Ordering::Less,
+                            CmpOp::Le => ord != Ordering::Greater,
+                            CmpOp::Gt => ord == Ordering::Greater,
+                            _ => ord != Ordering::Less,
+                        }
+                }
+            }
+        })
         .collect()
 }
 
@@ -373,6 +385,10 @@ fn try_property_vs_constant(
 mod tests {
     use super::*;
 
+    use crate::runtime::eval::{ExprEval, NO_ROW};
+    use crate::runtime::value::Point;
+    use orx_tree::NodeMut;
+
     #[test]
     fn test_cmp_op_flip() {
         assert_eq!(CmpOp::Eq.flip(), CmpOp::Eq);
@@ -435,37 +451,104 @@ mod tests {
     }
 
     #[test]
-    fn test_mask_to_selection() {
-        let mask = vec![true, false, true, false, true];
-        assert_eq!(mask_to_selection(&mask), vec![0, 2, 4]);
-    }
-
-    #[test]
-    fn test_mask_intersect_selection() {
-        let mask = vec![true, false, true, true, false];
-        let existing = vec![0, 2, 3, 4];
-        assert_eq!(mask_intersect_selection(&mask, &existing), vec![0, 2, 3]);
-    }
-
-    #[test]
-    fn test_compare_string_column() {
-        let data = vec![
-            Value::String(Arc::new("Alice".to_string())),
-            Value::String(Arc::new("Bob".to_string())),
-            Value::Null,
-            Value::String(Arc::new("Alice".to_string())),
-        ];
-        let result = compare_string_column(&data, CmpOp::Eq, "Alice");
-        assert_eq!(result, vec![true, false, false, true]);
-    }
-
-    #[test]
     fn test_compare_empty() {
         let data: Vec<i64> = vec![];
         let nulls = NullBitmap::none(0);
         assert_eq!(
             compare_i64_column(&data, CmpOp::Eq, 0, &nulls),
             Vec::<bool>::new()
+        );
+    }
+
+    /// Every kernel answer must equal what the scalar evaluator produces for
+    /// the same pair, so a filter and a projection can never disagree. `null`
+    /// is the one asymmetry: the evaluator yields `Value::Null`, which the
+    /// filter drops — i.e. `false` in the mask.
+    fn scalar_says(
+        value: &Value,
+        op: CmpOp,
+        constant: &Value,
+    ) -> bool {
+        let tree: DynTree<ExprIR<Variable>> = DynTree::new(match op {
+            CmpOp::Eq => ExprIR::Eq,
+            CmpOp::Neq => ExprIR::Neq,
+            CmpOp::Lt => ExprIR::Lt,
+            CmpOp::Le => ExprIR::Le,
+            CmpOp::Gt => ExprIR::Gt,
+            CmpOp::Ge => ExprIR::Ge,
+        });
+        let mut tree = tree;
+        let mut root = tree.root_mut();
+        root.push_child(ExprIR::Constant(value.clone()));
+        root.push_child(ExprIR::Constant(constant.clone()));
+        let root = tree.root();
+        matches!(
+            ExprEval::constant().eval(&tree, root.idx(), NO_ROW, None),
+            Ok(Value::Bool(true))
+        )
+    }
+
+    fn sample_values() -> Vec<Value> {
+        vec![
+            Value::Null,
+            Value::Bool(true),
+            Value::Int(7),
+            Value::Float(7.0),
+            Value::Float(f64::NAN),
+            Value::String(Arc::new("Dhaka".to_string())),
+            Value::String(Arc::new("Alice".to_string())),
+            Value::List(Arc::new(vec![Value::Int(1), Value::Int(2)].into())),
+            Value::Point(Point {
+                latitude: 31.18,
+                longitude: 34.22,
+            }),
+        ]
+    }
+
+    #[test]
+    fn test_compare_value_column_matches_scalar_eval() {
+        let ops = [
+            CmpOp::Eq,
+            CmpOp::Neq,
+            CmpOp::Lt,
+            CmpOp::Le,
+            CmpOp::Gt,
+            CmpOp::Ge,
+        ];
+        let data = sample_values();
+        for constant in sample_values() {
+            for op in ops {
+                let kernel = compare_value_column(&data, op, &constant);
+                let scalar: Vec<bool> =
+                    data.iter().map(|v| scalar_says(v, op, &constant)).collect();
+                assert_eq!(
+                    kernel, scalar,
+                    "kernel and scalar disagree for {op:?} against {constant:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_compare_value_column_neq_keeps_disjoint_types() {
+        // Issue #2582: every non-string is `<> 'Dhaka'`, not `false`.
+        let data = sample_values();
+        let dhaka = Value::String(Arc::new("Dhaka".to_string()));
+        assert_eq!(
+            compare_value_column(&data, CmpOp::Neq, &dhaka),
+            vec![false, true, true, true, true, false, true, true, true]
+        );
+        // `=` is unaffected: only the matching string passes.
+        assert_eq!(
+            compare_value_column(&data, CmpOp::Eq, &dhaka),
+            vec![false, false, false, false, false, true, false, false, false]
+        );
+        // Ordering against a disjoint type stays `null`, so no row survives.
+        assert!(
+            compare_value_column(&data, CmpOp::Lt, &dhaka)
+                .iter()
+                .zip(&data)
+                .all(|(&pass, v)| pass == matches!(v, Value::String(s) if s.as_str() < "Dhaka"))
         );
     }
 }

--- a/tests/flow/test_filters.py
+++ b/tests/flow/test_filters.py
@@ -101,3 +101,58 @@ class testFilters():
         plan = self.g.explain(q)
         self.env.assertFalse('Filter' in plan)
 
+
+    def test05_bulk_filter_matches_scalar_eval(self):
+        # A filter on `var.prop <op> constant` runs through the columnar
+        # comparison kernels, while the same expression in a RETURN is
+        # evaluated per row. The two must agree for every property type.
+        #
+        # Issue #2582: the kernel answered `false` for every non-string cell of
+        # `prop <> 'string'`, so `WHERE n.v <> 'abc'` dropped rows that
+        # `RETURN n.v <> 'abc'` called true, and `WHERE a AND b` disagreed with
+        # `WHERE a WITH n WHERE b`.
+        g = self.db.select_graph("bulk_filter_parity")
+        g.query("""CREATE (:V {k:'int', v:1}), (:V {k:'float', v:1.5}),
+                          (:V {k:'bool', v:true}), (:V {k:'str', v:'abc'}),
+                          (:V {k:'other', v:'Dhaka'}), (:V {k:'list', v:[1,2]}),
+                          (:V {k:'missing'})""")
+        g.query("MATCH (n:V {k:'point'}) DELETE n")
+        g.query("CREATE (:V {k:'point'})")
+        g.query("MATCH (n:V {k:'point'}) SET n.v = point({latitude:31.18, longitude:34.22})")
+
+        for op in ['=', '<>', '<', '<=', '>', '>=']:
+            for const in ["'abc'", '1', '1.5', 'true']:
+                # what the per-row evaluator says, keyed by node
+                scalar = g.query(f"MATCH (n:V) RETURN n.k, n.v {op} {const} ORDER BY n.k")
+                expected = sorted([[k] for k, r in scalar.result_set if r is True])
+                # what the columnar kernel says for the same predicate
+                bulk = g.query(f"MATCH (n:V) WHERE n.v {op} {const} RETURN n.k ORDER BY n.k")
+                self.env.assertEqual(sorted(bulk.result_set), expected)
+
+        # `WHERE a AND b` must equal `WHERE a WITH n WHERE b`: the first is one
+        # conjunction kernel, the second two separate filters.
+        conj = g.query("MATCH (n:V) WHERE n.k <> 'zz' AND n.v <> 'abc' RETURN n.k ORDER BY n.k")
+        split = g.query("MATCH (n:V) WHERE n.k <> 'zz' WITH n WHERE n.v <> 'abc' RETURN n.k ORDER BY n.k")
+        self.env.assertEqual(conj.result_set, split.result_set)
+        # and parentheses, which keep the predicate off the kernel, must not
+        # change the answer either
+        paren = g.query("MATCH (n:V) WHERE (n.v <> 'abc') RETURN n.k ORDER BY n.k")
+        plain = g.query("MATCH (n:V) WHERE n.v <> 'abc' RETURN n.k ORDER BY n.k")
+        self.env.assertEqual(paren.result_set, plain.result_set)
+
+    def test06_bulk_paths_keep_integer_precision(self):
+        # A mixed int/float property column must not be promoted to f64 by the
+        # bulk paths: 9007199254740993 and 9007199254740992 are the same double,
+        # so promotion would make the filter match the wrong row, print the
+        # wrong number, and merge two grouping keys into one.
+        g = self.db.select_graph("bulk_precision")
+        g.query("CREATE (:P {v: 9007199254740993}), (:P {v: 1.5})")
+
+        res = g.query("MATCH (n:P) WHERE n.v = 9007199254740992 RETURN count(n)")
+        self.env.assertEqual(res.result_set, [[0]])
+
+        res = g.query("MATCH (n:P) WHERE n.v = 9007199254740993 RETURN n.v")
+        self.env.assertEqual(res.result_set, [[9007199254740993]])
+
+        res = g.query("MATCH (n:P) WITH n.v AS k, count(*) AS c RETURN k ORDER BY k")
+        self.env.assertEqual(res.result_set, [[1.5], [9007199254740993]])


### PR DESCRIPTION
Fixes #2582.

## The bug

`WHERE n.location <> 'Dhaka'` returned no rows while `RETURN n.location <> 'Dhaka'` returned `true` for the same node. The columnar comparison kernel behind `entity.property <op> constant` only understood `Value::String` cells and defaulted every other variant to `false`, so `<>` dropped rows for all of Int / Float / Bool / List / Map / Point. `=` was unaffected (a non-string really is not equal), which is why only `<>` diverged — and parenthesising the predicate, which keeps it off the kernel, silently "fixed" it.

## Should the kernels just be deleted?

That was the first thing checked: if the runtime already evaluated filters columnarly, the special-cased kernels could go and the divergence with them. Measured both ways with `bench/` on `filter scan` (`MATCH (p:Person) WHERE p.age > 45 AND p.score < 2000.0 RETURN count(p)`, 10k nodes):

| build | instructions |
|---|---|
| `main` | 4,999,178 |
| `vectorized.rs` deleted, filter always per-row | **13,570,816 (2.71x)** |
| this PR | 4,466,334 (0.89x) |

The fallback is columnar only in that it reads a `BatchRow` without materialising an `Env`; it still walks the expression tree and does one property lookup per row. The kernel path's prize is the single bulk attribute fetch, and nothing else in the runtime provides one for a comparison tree. So the kernels stay — they just must not be able to disagree with the evaluator.

## The fix

- `compare_string_column` becomes **`compare_value_column`**, comparing through the same `compare_value` / `partial_cmp` that `eval.rs` uses for `=`, `<>` and the ordering operators. The primitive `i64`/`f64` lanes are now entered *only* for column/constant pairs whose primitive comparison **is** the `Value` comparison, so which path a predicate takes is a performance decision and never a semantic one.
- Conjuncts narrow progressively: the second predicate only fetches properties for the rows the first one kept.
- `compare_string_column`, `mask_to_selection` and `mask_intersect_selection` are now genuinely dead and are deleted.

Two further divergences of the same shape turned up while verifying, both from classifying a property column with the promoting float lane, both fixed by reading the stored values directly:

- `ProjectOp` printed a stored `9007199254740993` as `9.00719925474099e+15` when the column also held a float.
- `AggregateOp` merged `9007199254740993` and `9007199254740992` into one grouping key in `WITH n.v AS k`.

## Performance

`bench/` (317 queries, macOS rusage instruction counts), this PR vs its base:

| query | base | PR | ratio |
|---|---|---|---|
| filter scan | 4,999,178 | 4,466,334 | **0.89x** |
| aggregates | 16,655,429 | 14,637,389 | **0.88x** |
| agg count | 4,996,849 | 4,505,200 | **0.90x** |
| agg min | 5,523,368 | 5,004,334 | 0.91x |
| agg sum | 6,585,985 | 6,067,665 | 0.92x |

Median across 322 rows: **1.001x**. The aggregate wins come from dropping the classify-and-rebuild round trip (two passes and a `Vec` per column) rather than from the parity work itself.

## Tests

- `tests/flow/test_filters.py::test05_bulk_filter_matches_scalar_eval` cross-checks `WHERE` against `RETURN` for 6 operators x 4 constants x 8 property types, and asserts `WHERE a AND b` ≡ `WHERE a WITH n WHERE b` ≡ the parenthesised form.
- `test06_bulk_paths_keep_integer_precision` covers the filter, projection and grouping-key precision cases.
- Both fail on the base commit and pass here.
- A Rust unit test asserts kernel ≡ scalar evaluator across all 9x9x6 value/constant/operator combinations.
- Green locally: 179 Rust unit tests, 124 e2e/function, 1440 flow, TCK (173 features / 2456 scenarios), 14 MVCC + concurrency, `cargo fmt --check`, clippy.

## Not covered

Relationship properties, and a numeric column compared against a non-numeric constant, still fall to the per-row path — correct, but bulk-fetch performance left on the table. Follow-up work extends the columnar path to computed expression trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved exact integer values in filters, returned properties, and grouping results, including very large integers.
  * Improved consistency between bulk and row-by-row filtering across strings, numbers, booleans, points, lists, missing values, and mixed types.
  * Corrected comparisons involving nulls, NaN values, and incompatible data types.
* **Tests**
  * Added coverage for heterogeneous comparisons, compound predicates, parenthesized filters, and integer precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->