### PR TITLE
ci: run the RC-image pipeline for fork PRs behind an ok-to-test label

### DIFF
--- a/.github/workflows/_flow-flavour.yml
+++ b/.github/workflows/_flow-flavour.yml
@@ -47,6 +47,15 @@ on:
         description: "PR number — used for log-artifact naming + coverage image lookup"
         required: true
         type: string
+      ref:
+        description: >-
+          Commit SHA to check out for the test sources. Must be set explicitly
+          by callers reached from a `pull_request_target` run, where a bare
+          checkout resolves to the base branch and would silently run the base's
+          tests against the PR's image. Empty keeps checkout's default.
+        required: false
+        type: string
+        default: ""
       sanitizer_env:
         description: "Value for the SANITIZER env var (set to 'address' for a-sanitizer; empty otherwise)"
         required: false
@@ -116,6 +125,8 @@ jobs:
         arch: ${{ fromJson(inputs.archs) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
       - name: Run Flow test - ${{ matrix.test_file }} (${{ inputs.flavour }}, ${{ matrix.arch }})
         env:
           TEST_FILE: ${{ matrix.test_file }}
@@ -207,6 +218,8 @@ jobs:
         arch: ${{ fromJson(inputs.archs) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
       - name: Pre-create cov dir (coverage flavour only)
         if: inputs.collect_coverage
         run: mkdir -p "${GITHUB_WORKSPACE}/cov" && chmod 0777 "${GITHUB_WORKSPACE}/cov"

--- a/.github/workflows/_rc-pipeline.yml
+++ b/.github/workflows/_rc-pipeline.yml
@@ -1,0 +1,263 @@
+# Reusable workflow: the RC-image half of PR CI.
+#
+# Everything in here needs a *published* runtime image: the flavour builds push
+# `rc-pr-<N>` tags to GHCR, and `test` / `flow-*` then pull those tags as service
+# containers. That push is the whole reason this half is factored out.
+#
+# A `pull_request` run triggered from a fork gets a read-only GITHUB_TOKEN — the
+# `permissions:` block cannot grant what the event withholds — so the push fails
+# with "denied: installation not allowed to Write organization package" and every
+# consumer below is skipped. That is a permissions fact, not a bug in the PR, and
+# no amount of retrying fixes it.
+#
+# So the same pipeline is called from two places:
+#
+#   rust-pr.yml        `pull_request`, same-repo branches only — the common case.
+#   rust-pr-fork.yml   `pull_request_target`, fork PRs, gated behind a maintainer
+#                      applying the `action:ok-to-test` label to a reviewed head.
+#
+# Because the second caller runs in the base repo's context, NOTHING here may
+# rely on the event payload to decide what to check out: under
+# `pull_request_target` a bare `actions/checkout` resolves to the base branch,
+# which would run the base's tests against the PR's image and report a
+# meaningless pass. Every checkout below — and `_flow-flavour.yml`'s, via its
+# `ref:` input — is pinned to `inputs.commit_sha` for that reason.
+
+name: RC image pipeline (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "PR number — drives the rc-pr-<N> tag and log-artifact names"
+        required: true
+        type: string
+      commit_sha:
+        description: "PR head SHA to build and to check out for tests"
+        required: true
+        type: string
+      build_image:
+        description: "Toolchain image (ghcr.io/falkordb/falkordb-build:<tag>) used as job container and chef base"
+        required: true
+        type: string
+
+jobs:
+  # Build the runtime image (rc-pr-<N>) once, push to GHCR. All flow / e2e test
+  # jobs below pull this image as a services container instead of dynamically
+  # loading a locally-built .so. When the toolchain was rebuilt this PR
+  # (build/Dockerfile changed), the runtime build uses the PR's toolchain too —
+  # so test feedback reflects the same image bytes main will publish on merge.
+  build-rc-image:
+    uses: ./.github/workflows/_build-flavour.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      flavour: release
+      tag: rc-pr-${{ inputs.pr_number }}
+      commit_sha: ${{ inputs.commit_sha }}
+      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"full","repo":"falkordb"},{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb-server"},{"arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","target":"full","repo":"falkordb"},{"arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","target":"server","repo":"falkordb-server"}]'
+      browser_tag: edge
+      build_image: ${{ inputs.build_image }}
+      # push_to_dockerhub left at default false — PR RC builds stay on GHCR.
+      # create_manifest defaults true (release is multi-arch).
+
+  # Build the asan instrumented runtime image (amd64-only). Single cell,
+  # no manifest needed (push directly to the bare tag).
+  build-rc-asan-image:
+    uses: ./.github/workflows/_build-flavour.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      flavour: a-sanitizer
+      # Note: asan image lives under the `falkordb` repo (not `falkordb-server`)
+      # — historical from when the asan image bundled the browser stage.
+      tag: rc-pr-${{ inputs.pr_number }}-asan
+      commit_sha: ${{ inputs.commit_sha }}
+      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb"}]'
+      dockerfile: build/runtime/Dockerfile.asan
+      build_image: ${{ inputs.build_image }}
+      create_manifest: false
+
+  # Build the coverage-instrumented runtime image (amd64-only).
+  build-rc-coverage-image:
+    uses: ./.github/workflows/_build-flavour.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      flavour: coverage
+      tag: rc-pr-${{ inputs.pr_number }}-coverage
+      commit_sha: ${{ inputs.commit_sha }}
+      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb-server"}]'
+      dockerfile: build/runtime/Dockerfile.coverage
+      build_image: ${{ inputs.build_image }}
+      create_manifest: false
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.build_image }}
+      # Mount the runner's docker socket so the "Capture service container
+      # logs on failure" step below can run `docker ps`/`docker logs` against
+      # the GHA service container. Without this the log-capture step is a
+      # silent no-op (and could mask the upload-artifact step).
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
+    needs: build-rc-image
+    permissions:
+      contents: read
+      packages: read
+    services:
+      falkordb:
+        image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ inputs.pr_number }}
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        ports: ["6379:6379"]
+        env:
+          # Empty FALKORDB_ARGS overrides the image's compiled-in default
+          # (MAX_QUEUED_QUERIES 25 ...) so the service starts with the
+          # module's true zero-config defaults; tests that need specific
+          # config bring it via GRAPH.CONFIG SET.
+          FALKORDB_ARGS: ""
+    env:
+      EXISTING_ENV: "1"
+      FALKORDB_HOST: falkordb
+      FALKORDB_PORT: "6379"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          persist-credentials: false
+      - run: rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "release"
+      # Cargo unit tests run against in-process code and don't touch redis.
+      - name: Run cargo unit tests
+        run: |
+          # Doctests are linked separately by rustdoc (which ignores RUSTFLAGS /
+          # .cargo rustflags), so they need the duplicate-symbol allowance for
+          # libredisearch_rs.a's bundled std via RUSTDOCFLAGS. Also disable release
+          # LTO for the test build: the embedded C/Rust archives carry no LLVM
+          # bitcode, so a release-LTO doctest fails with "Can't find section .llvmbc"
+          # (same reason the fuzz job sets CARGO_PROFILE_RELEASE_LTO=false).
+          CARGO_PROFILE_RELEASE_LTO=false RUSTDOCFLAGS="-C link-arg=-Wl,--allow-multiple-definition" cargo test --release -p graph
+      - name: Run pytest tests against the RC image
+        run: |
+          . /data/venv/bin/activate
+          pytest tests/test_e2e.py tests/test_functions.py tests/test_mvcc.py tests/test_concurrency.py -vv
+      - name: Run TCK tests against the RC image
+        run: |
+          . /data/venv/bin/activate
+          TCK_DONE=tck_done.txt pytest tests/tck/test_tck.py -s
+      # Capture the GHA service container's stdout/stderr so a failing run
+      # carries the redis lifecycle, module RedisModule_Log output, and any
+      # ASAN/LSan reports off the runner. The service container is named
+      # after its YAML key ("falkordb"); `docker logs` is run via the
+      # /var/run/docker.sock the runner shares with the job container.
+      - name: Capture service container logs on failure
+        if: failure()
+        run: |
+          mkdir -p tests/flow/logs
+          # Dump every container the runner can see — GHA service containers
+          # are named after their YAML key but a workflow-run prefix can show
+          # up too; iterating all containers is safer than matching by name.
+          for cid in $(docker ps -aq); do
+            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
+          done
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-service-logs
+          path: tests/flow/logs/
+          if-no-files-found: ignore
+
+  flow-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      services_files: ${{ steps.set-matrix.outputs.services_files }}
+      spawn_files: ${{ steps.set-matrix.outputs.spawn_files }}
+      # Union of services_files + spawn_files for callers like coverage-flow
+      # that don't go through docker and just need every test file.
+      test_files: ${{ steps.set-matrix.outputs.test_files }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.commit_sha }}
+          persist-credentials: false
+      - name: Generate test matrix
+        id: set-matrix
+        # tests/flow/test_matrix_split.py classifies each entry in
+        # flow_tests_done.txt: files whose Env() invocations never pass
+        # special flags (moduleArgs / useSlaves / enableDebugCommand /
+        # oss-cluster / shardsCount) go to services_files (cheap shared
+        # service); the rest go to spawn_files (private docker run per class).
+        run: |
+          python3 tests/flow/test_matrix_split.py >> $GITHUB_OUTPUT
+
+  # Per-flavour flow-test cells. Each `flow-<flavour>` block calls
+  # _flow-flavour.yml, which runs the services + spawn matrices for that
+  # one flavour. Calling the reusable workflow once per flavour gives each
+  # call its own 256-cell GHA matrix budget — splitting the otherwise
+  # over-the-limit (97 × multi-flavour × multi-arch) matrix into chunks.
+  # Adding a new flavour later = one more block here + one Dockerfile.<f> +
+  # one build-rc-<f>-image job.
+
+  flow-release:
+    needs: [flow-test-matrix, build-rc-image]
+    uses: ./.github/workflows/_flow-flavour.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      flavour: release
+      image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ inputs.pr_number }}
+      archs: '["amd64", "arm64"]'
+      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
+      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
+      build_image: ${{ inputs.build_image }}
+      pr_number: ${{ inputs.pr_number }}
+      ref: ${{ inputs.commit_sha }}
+    secrets: inherit
+
+  flow-asan:
+    needs: [flow-test-matrix, build-rc-asan-image]
+    uses: ./.github/workflows/_flow-flavour.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      flavour: a-sanitizer
+      # Note: asan image lives under the `falkordb` repo (not `falkordb-server`)
+      # — historical from when the asan image bundled the browser stage.
+      image: ghcr.io/falkordb/falkordb:rc-pr-${{ inputs.pr_number }}-asan
+      archs: '["amd64"]'
+      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
+      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
+      build_image: ${{ inputs.build_image }}
+      pr_number: ${{ inputs.pr_number }}
+      ref: ${{ inputs.commit_sha }}
+      sanitizer_env: address
+    secrets: inherit
+
+  flow-coverage:
+    needs: [flow-test-matrix, build-rc-coverage-image]
+    uses: ./.github/workflows/_flow-flavour.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      flavour: coverage
+      image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ inputs.pr_number }}-coverage
+      archs: '["amd64"]'
+      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
+      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
+      build_image: ${{ inputs.build_image }}
+      pr_number: ${{ inputs.pr_number }}
+      ref: ${{ inputs.commit_sha }}
+      collect_coverage: true
+    secrets: inherit

--- a/.github/workflows/rust-pr-fork.yml
+++ b/.github/workflows/rust-pr-fork.yml
@@ -1,0 +1,146 @@
+# Fork PRs: run the RC-image half of CI under the base repo's credentials.
+#
+# ## Why this file exists
+#
+# rust-pr.yml runs on `pull_request`. For a PR raised from a fork GitHub hands
+# that run a read-only GITHUB_TOKEN — `permissions: packages: write` cannot grant
+# what the event withholds — so `docker push ghcr.io/falkordb/...:rc-pr-<N>`
+# fails with:
+#
+#   denied: installation not allowed to Write organization package
+#
+# and every job that pulls the tag is skipped behind it. Nothing about the PR's
+# code is wrong and no re-run helps, so rust-pr.yml now skips that half for forks
+# and this workflow supplies it.
+#
+# ## Why `pull_request_target`, and what makes it safe
+#
+# `pull_request_target` evaluates the workflow file from the BASE branch and runs
+# with the base repo's token, which is what makes the GHCR push possible. The
+# well-known hazard is that it then builds fork-authored code — including a
+# fork-authored `build/runtime/Dockerfile` — while a writable token is in scope.
+#
+# Three things contain that:
+#
+#   1. The trigger is `labeled` only, never `synchronize`. A push cannot start
+#      this workflow; a human has to act after the diff exists.
+#   2. `gate` re-checks that the labeller has write/admin on this repo, so the
+#      label event alone is not the authority — someone with commit rights is.
+#      (Only such a person can apply a label in the first place; this is
+#      defence in depth against a label surviving a permission change.)
+#   3. `gate` pins the head SHA it saw and everything downstream builds THAT
+#      SHA. A push racing the label cannot substitute new code into this run.
+#
+# The label is deliberately not sticky: because only `labeled` fires, a later
+# push does NOT re-run this. Remove and re-add `action:ok-to-test` to test a new
+# head — and re-read the diff before you do, since that is the whole review step
+# this design rests on. Pay particular attention to build/**, .github/** and
+# tests/**: those execute, unlike graph/src changes which only run inside the
+# container under test.
+#
+# ## Consequences of a green run here
+#
+# A run publishes `rc-pr-<N>` tags to ghcr.io/falkordb from fork-authored source.
+# Those tags are PR scratch space — cleanup-rc-images.yml reaps them and nothing
+# promotes them to a release channel — but treat them as untrusted just the same.
+
+name: Rust PR (fork)
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - "main"
+      - "main-rs"
+      - "[0-9]*.[0-9]*"
+
+# One run per PR, same as rust-pr.yml. Distinct group so a fork run and the
+# `pull_request` run of the same PR never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap, unprivileged, and the only place trust is decided. Runs no PR code:
+  # there is deliberately no checkout here.
+  gate:
+    if: >-
+      github.event.label.name == 'action:ok-to-test' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pin.outputs.sha }}
+      file_changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Verify the labeller can authorise this
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.sender.login }}
+        run: |
+          set -euo pipefail
+          LEVEL=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq .permission)
+          echo "$ACTOR has '$LEVEL' on $REPO"
+          case "$LEVEL" in
+            admin|write|maintain) ;;
+            *) echo "::error::$ACTOR lacks write access; refusing to run fork CI"; exit 1 ;;
+          esac
+
+      # Pin the head this run is authorising. Everything downstream takes the
+      # SHA from here rather than re-reading the event, so a push landing while
+      # the build runs cannot swap in code the labeller never saw.
+      - name: Pin the reviewed head
+        id: pin
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "::notice::Building fork head $SHA"
+
+      # Same toolchain-change probe as rust-pr.yml's check-files, but resolved
+      # over the API instead of a working tree — this job must not check out
+      # fork code. The paths mirror that job's grep; keep them in step.
+      - name: Check whether the toolchain changed
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+          if echo "$FILES" | grep -qE '^(build/Dockerfile|build/libomp\.sh|build/graphblas/.*|graphblas\.sh|redisearch\.sh|\.github/workflows/build-toolchain\.yml)$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Rebuild the toolchain image at :pr-<N> when the fork touched build/**.
+  docker:
+    needs: gate
+    if: needs.gate.outputs.file_changed == 'true'
+    uses: ./.github/workflows/build-toolchain.yml
+    permissions:
+      contents: read
+      packages: write
+
+    with:
+      tag: pr-${{ github.event.pull_request.number }}
+
+  # The identical pipeline rust-pr.yml runs for same-repo PRs — one definition,
+  # so fork CI cannot drift from trunk CI.
+  rc-pipeline:
+    needs: [gate, docker]
+    if: ${{ !cancelled() && needs.gate.result == 'success' && (needs.docker.result == 'success' || needs.docker.result == 'skipped') }}
+    uses: ./.github/workflows/_rc-pipeline.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      commit_sha: ${{ needs.gate.outputs.head_sha }}
+      build_image: ${{ needs.gate.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
+    secrets: inherit

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -99,64 +99,34 @@ jobs:
     # build-toolchain.yml only uses the auto-injected GITHUB_TOKEN; no
     # custom secrets to forward, so we don't need `secrets: inherit`.
 
-  # Build the runtime image (rc-pr-<N>) once, push to GHCR. All flow / e2e test
-  # jobs below pull this image as a services container instead of dynamically
-  # loading a locally-built .so. When the toolchain was rebuilt this PR
-  # (build/Dockerfile changed), the runtime build uses the PR's toolchain too —
-  # so test feedback reflects the same image bytes main will publish on merge.
-  build-rc-image:
+  # The RC-image half of PR CI — the flavour image builds plus every test that
+  # consumes a published `rc-pr-<N>` tag. It lives in _rc-pipeline.yml because it
+  # needs `packages: write`, which a `pull_request` event raised from a fork does
+  # not grant: GitHub hands fork runs a read-only GITHUB_TOKEN no matter what the
+  # `permissions:` block asks for, so the GHCR push dies with "denied:
+  # installation not allowed to Write organization package" and every consumer of
+  # the tag is skipped behind it.
+  #
+  # Rather than show an external contributor six red X's for a permission they
+  # cannot be given, skip this half for fork PRs and run it from rust-pr-fork.yml
+  # instead, where a maintainer opts a *reviewed* head in via the
+  # `action:ok-to-test` label. The jobs that stay here only ever pull public
+  # images, so they still report normally on a fork PR — and between them
+  # `lint` and `coverage` already cover fmt, clippy, `cargo test -p graph`, the
+  # e2e/function/MVCC/concurrency suites and TCK. What a fork PR loses until the
+  # label goes on is the flow-test matrix and the asan / multi-arch image cells.
+  rc-pipeline:
     needs: [check-files, docker]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') }}
-    uses: ./.github/workflows/_build-flavour.yml
+    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/_rc-pipeline.yml
     permissions:
       contents: read
       packages: write
     with:
-      flavour: release
-      tag: rc-pr-${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number }}
       commit_sha: ${{ github.event.pull_request.head.sha }}
-      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"full","repo":"falkordb"},{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb-server"},{"arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","target":"full","repo":"falkordb"},{"arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","target":"server","repo":"falkordb-server"}]'
-      browser_tag: edge
       build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      # push_to_dockerhub left at default false — PR RC builds stay on GHCR.
-      # create_manifest defaults true (release is multi-arch).
-
-  # Build the asan instrumented runtime image (amd64-only). Single cell,
-  # no manifest needed (push directly to the bare tag).
-  build-rc-asan-image:
-    needs: [check-files, docker]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') }}
-    uses: ./.github/workflows/_build-flavour.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      flavour: a-sanitizer
-      # Note: asan image lives under the `falkordb` repo (not `falkordb-server`)
-      # — historical from when the asan image bundled the browser stage.
-      tag: rc-pr-${{ github.event.pull_request.number }}-asan
-      commit_sha: ${{ github.event.pull_request.head.sha }}
-      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb"}]'
-      dockerfile: build/runtime/Dockerfile.asan
-      build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      create_manifest: false
-
-  # Build the coverage-instrumented runtime image (amd64-only).
-  build-rc-coverage-image:
-    needs: [check-files, docker]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') }}
-    uses: ./.github/workflows/_build-flavour.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      flavour: coverage
-      tag: rc-pr-${{ github.event.pull_request.number }}-coverage
-      commit_sha: ${{ github.event.pull_request.head.sha }}
-      cells: '[{"arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","target":"server","repo":"falkordb-server"}]'
-      dockerfile: build/runtime/Dockerfile.coverage
-      build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      create_manifest: false
+    secrets: inherit
 
   lint:
     runs-on: ubuntu-latest
@@ -176,168 +146,6 @@ jobs:
       - name: Lint
         run: |
           CXX=clang++-22 cargo clippy --all-targets
-  test:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
-      # Mount the runner's docker socket so the "Capture service container
-      # logs on failure" step below can run `docker ps`/`docker logs` against
-      # the GHA service container. Without this the log-capture step is a
-      # silent no-op (and could mask the upload-artifact step).
-      options: --volume /var/run/docker.sock:/var/run/docker.sock
-    needs:
-      - check-files
-      - docker
-      - build-rc-image
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.build-rc-image.result == 'success' }}
-    permissions:
-      contents: read
-      packages: read
-    services:
-      falkordb:
-        image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ github.event.pull_request.number }}
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        ports: ["6379:6379"]
-        env:
-          # Empty FALKORDB_ARGS overrides the image's compiled-in default
-          # (MAX_QUEUED_QUERIES 25 ...) so the service starts with the
-          # module's true zero-config defaults; tests that need specific
-          # config bring it via GRAPH.CONFIG SET.
-          FALKORDB_ARGS: ""
-    env:
-      EXISTING_ENV: "1"
-      FALKORDB_HOST: falkordb
-      FALKORDB_PORT: "6379"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: rustup default stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          shared-key: "release"
-      # Cargo unit tests run against in-process code and don't touch redis.
-      - name: Run cargo unit tests
-        run: |
-          # Doctests are linked separately by rustdoc (which ignores RUSTFLAGS /
-          # .cargo rustflags), so they need the duplicate-symbol allowance for
-          # libredisearch_rs.a's bundled std via RUSTDOCFLAGS. Also disable release
-          # LTO for the test build: the embedded C/Rust archives carry no LLVM
-          # bitcode, so a release-LTO doctest fails with "Can't find section .llvmbc"
-          # (same reason the fuzz job sets CARGO_PROFILE_RELEASE_LTO=false).
-          CARGO_PROFILE_RELEASE_LTO=false RUSTDOCFLAGS="-C link-arg=-Wl,--allow-multiple-definition" cargo test --release -p graph
-      - name: Run pytest tests against the RC image
-        run: |
-          . /data/venv/bin/activate
-          pytest tests/test_e2e.py tests/test_functions.py tests/test_mvcc.py tests/test_concurrency.py -vv
-      - name: Run TCK tests against the RC image
-        run: |
-          . /data/venv/bin/activate
-          TCK_DONE=tck_done.txt pytest tests/tck/test_tck.py -s
-      # Capture the GHA service container's stdout/stderr so a failing run
-      # carries the redis lifecycle, module RedisModule_Log output, and any
-      # ASAN/LSan reports off the runner. The service container is named
-      # after its YAML key ("falkordb"); `docker logs` is run via the
-      # /var/run/docker.sock the runner shares with the job container.
-      - name: Capture service container logs on failure
-        if: failure()
-        run: |
-          mkdir -p tests/flow/logs
-          # Dump every container the runner can see — GHA service containers
-          # are named after their YAML key but a workflow-run prefix can show
-          # up too; iterating all containers is safer than matching by name.
-          for cid in $(docker ps -aq); do
-            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
-            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
-          done
-      - name: Upload logs on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: test-service-logs
-          path: tests/flow/logs/
-          if-no-files-found: ignore
-  flow-test-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      services_files: ${{ steps.set-matrix.outputs.services_files }}
-      spawn_files: ${{ steps.set-matrix.outputs.spawn_files }}
-      # Union of services_files + spawn_files for callers like coverage-flow
-      # that don't go through docker and just need every test file.
-      test_files: ${{ steps.set-matrix.outputs.test_files }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Generate test matrix
-        id: set-matrix
-        # tests/flow/test_matrix_split.py classifies each entry in
-        # flow_tests_done.txt: files whose Env() invocations never pass
-        # special flags (moduleArgs / useSlaves / enableDebugCommand /
-        # oss-cluster / shardsCount) go to services_files (cheap shared
-        # service); the rest go to spawn_files (private docker run per class).
-        run: |
-          python3 tests/flow/test_matrix_split.py >> $GITHUB_OUTPUT
-  # Per-flavour flow-test cells. Each `flow-<flavour>` block calls
-  # _flow-flavour.yml, which runs the services + spawn matrices for that
-  # one flavour. Calling the reusable workflow once per flavour gives each
-  # call its own 256-cell GHA matrix budget — splitting the otherwise
-  # over-the-limit (97 × multi-flavour × multi-arch) matrix into chunks.
-  # Adding a new flavour later = one more block here + one Dockerfile.<f> +
-  # one build-rc-<f>-image job.
-
-  flow-release:
-    needs: [check-files, docker, flow-test-matrix, build-rc-image]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-image.result == 'success' }}
-    uses: ./.github/workflows/_flow-flavour.yml
-    permissions:
-      contents: read
-      packages: read
-    with:
-      flavour: release
-      image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ github.event.pull_request.number }}
-      archs: '["amd64", "arm64"]'
-      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
-      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
-      build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      pr_number: ${{ github.event.pull_request.number }}
-    secrets: inherit
-
-  flow-asan:
-    needs: [check-files, docker, flow-test-matrix, build-rc-asan-image]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-asan-image.result == 'success' }}
-    uses: ./.github/workflows/_flow-flavour.yml
-    permissions:
-      contents: read
-      packages: read
-    with:
-      flavour: a-sanitizer
-      # Note: asan image lives under the `falkordb` repo (not `falkordb-server`)
-      # — historical from when the asan image bundled the browser stage.
-      image: ghcr.io/falkordb/falkordb:rc-pr-${{ github.event.pull_request.number }}-asan
-      archs: '["amd64"]'
-      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
-      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
-      build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      pr_number: ${{ github.event.pull_request.number }}
-      sanitizer_env: address
-    secrets: inherit
-
-  flow-coverage:
-    needs: [check-files, docker, flow-test-matrix, build-rc-coverage-image]
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-coverage-image.result == 'success' }}
-    uses: ./.github/workflows/_flow-flavour.yml
-    permissions:
-      contents: read
-      packages: read
-    with:
-      flavour: coverage
-      image: ghcr.io/falkordb/falkordb-server:rc-pr-${{ github.event.pull_request.number }}-coverage
-      archs: '["amd64"]'
-      services_files: ${{ needs.flow-test-matrix.outputs.services_files }}
-      spawn_files: ${{ needs.flow-test-matrix.outputs.spawn_files }}
-      build_image: ${{ needs.check-files.outputs.file_changed == 'true' && format('ghcr.io/falkordb/falkordb-build:pr-{0}', github.event.pull_request.number) || 'ghcr.io/falkordb/falkordb-build:latest' }}
-      pr_number: ${{ github.event.pull_request.number }}
-      collect_coverage: true
-    secrets: inherit
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

PR CI is unrunnable for external contributors, and has been for every fork PR the repo has received. #2396 is the live example: six `build-rc-*` cells fail and everything downstream is skipped, on every run, for a reason the author cannot act on.

The builds themselves succeed. The push does not:

```
#37 ERROR: failed to push ghcr.io/falkordb/falkordb-server:rc-pr-2396-x64:
           denied: installation not allowed to Write organization package
```

GitHub gives a `pull_request` raised from a fork a **read-only** `GITHUB_TOKEN`. The `permissions: packages: write` block in `_build-flavour.yml` asks for something the event withholds, so `docker push` of the `rc-pr-<N>` tag is denied — and `test`, `flow-release`, `flow-asan` and `flow-coverage` all consume that tag, so they skip behind it. Re-running never helps.

This splits the image-dependent half of PR CI out so it can be driven from a run that *does* have credentials.

## Changes

- **`_rc-pipeline.yml` (new)** — the half of PR CI that needs a published `rc-pr-<N>` tag: `build-rc-image`, `build-rc-asan-image`, `build-rc-coverage-image`, `test`, `flow-test-matrix`, `flow-release`, `flow-asan`, `flow-coverage`. Job bodies moved verbatim; the only edits are `github.event.*` → `inputs.*` and the checkout pinning below.
- **`rust-pr.yml`** — those eight jobs replaced by one `rc-pipeline` call, gated on `head.repo.full_name == github.repository`. Fork PRs now *skip* this half instead of failing it.
- **`rust-pr-fork.yml` (new)** — `pull_request_target`, `types: [labeled]`, label `action:ok-to-test`. Runs in the base repo's context, so the token can write packages, and calls the same `_rc-pipeline.yml`. One definition — fork CI cannot drift from trunk CI.
- **`_flow-flavour.yml`** — new optional `ref:` input, defaulting to today's behaviour.

## Why `pull_request_target` is safe here

It builds fork-authored code with a writable token in scope, which is the well-known hazard. Three things contain it:

1. The trigger is `labeled` only — never `synchronize`. A push cannot start this workflow; a human must act after the diff exists.
2. `gate` re-checks the labeller's write/admin access against the API, so the label event is not itself the authority.
3. `gate` pins the head SHA and the whole pipeline builds *that* SHA, so a push racing the label cannot substitute code the labeller never read.

The label is intentionally not sticky: a later push does not re-run this. Remove and re-add it to test a new head, re-reading the diff first — particularly `build/**`, `.github/**` and `tests/**`, which execute, unlike `graph/src` changes that only run inside the container under test.

## The subtle bug this avoids

`pull_request_target` checks out the **base branch** by default. Left alone, the flow cells would have run the base's tests against the PR's image and reported a confident, meaningless pass. Every checkout in `_rc-pipeline.yml` is pinned to `inputs.commit_sha`, and `_flow-flavour.yml` gained its `ref:` input for exactly this reason.

## Testing

- `actionlint` clean on all four files (the only findings repo-wide are pre-existing `ubuntu-slim` runner-label warnings in `agentics-maintenance.yml`).
- The eight moved jobs were diffed structurally against their originals after normalising `inputs.*` substitution: `build-rc-*` are byte-identical, and the only deltas in `test` / `flow-*` are the intended `ref:` + `persist-credentials: false` pins.
- Branch protection on `main` pins no required status checks (`contexts: []`), so the job renames (`test` → `rc-pipeline / test`) do not affect merge gating.
- End-to-end behaviour is only observable once this is on `main`, since `pull_request_target` resolves the workflow from the base branch. Suggested verification after merge: confirm a same-repo PR still runs the full matrix, then label #2396 and confirm the fork path publishes `rc-pr-2396` and goes green.

## Memory / Performance Impact

N/A — CI-only change. No engine, allocator or graph-object code is touched. Same job count and runner mix as before for same-repo PRs.

## Related Issues

Closes #2632

Unblocks #2396, which has been stuck on this since it opened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release-candidate validation for pull requests, including unit, integration, compatibility, AddressSanitizer, coverage, and flow tests.
  * Added secure validation support for pull requests originating from forks.
  * Added the ability to select a specific source commit for test runs.

* **Bug Fixes**
  * Improved pull-request testing reliability by pinning validation runs to the reviewed commit.
  * Added automatic service-log capture when validation fails.
  * Ensured toolchain images are rebuilt when dependency configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->