### PR TITLE
perf(eval): dispatch boolean connectives without the stack machine

### DIFF
--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -406,6 +406,21 @@ impl<'a> ExprEval<'a> {
             ExprIR::Case { has_subject } => {
                 return self.eval_case(*has_subject, node, env, agg_group_key);
             }
+            // Boolean connectives are the backbone of `WHERE` clauses, and the
+            // per-row `Filter` fallback re-evaluates them for every row that
+            // the vectorized kernels can't serve (any `OR`/`NOT`, or a
+            // conjunction whose operands aren't all `var.attr <op> constant`).
+            //
+            // They short-circuit, so like `CASE` they were never able to use
+            // the eager stack machine in `eval_compound`: each arm there
+            // already recursed into `eval_node` directly and pushed exactly one
+            // value, leaving the two `SmallVec` scratch buffers, the node clone
+            // and the push/pop work loop as pure setup cost on the way in.
+            // Dispatching them here skips that entry overhead entirely.
+            ExprIR::And => return self.eval_and(node, env, agg_group_key),
+            ExprIR::Or => return self.eval_or(node, env, agg_group_key),
+            ExprIR::Not => return self.eval_not(node, env, agg_group_key),
+            ExprIR::Xor => return self.eval_xor(node, env, agg_group_key),
             // Fixed-arity operators, dispatched directly.
             //
             // `eval_compound` below is built to accumulate an arbitrary number
@@ -509,6 +524,93 @@ impl<'a> ExprEval<'a> {
         // ELSE is always the last child; the parser substitutes a null
         // constant when the query omits it.
         self.eval_node(&node.child(node.num_children() - 1), env, agg_group_key)
+    }
+
+    /// Evaluates `OR` over the children, short-circuiting on the first `true`.
+    ///
+    /// Cypher's three-valued logic: `true` wins outright, otherwise a `null`
+    /// operand makes the result `null`, and only an all-`false` list is `false`.
+    fn eval_or<R: RowView + ?Sized>(
+        &self,
+        node: &ExprNode<'_>,
+        env: Option<&R>,
+        agg_group_key: Option<u64>,
+    ) -> Result<Value, String> {
+        let mut is_null = false;
+        for child in node.children() {
+            match self.eval_node(&child, env, agg_group_key)? {
+                Value::Bool(true) => return Ok(Value::Bool(true)),
+                Value::Bool(false) => {}
+                Value::Null => is_null = true,
+                ir => return Err(format!("Type mismatch: expected Bool but was {ir:?}")),
+            }
+        }
+        Ok(if is_null {
+            Value::Null
+        } else {
+            Value::Bool(false)
+        })
+    }
+
+    /// Evaluates `AND` over the children, short-circuiting on the first `false`.
+    ///
+    /// Cypher's three-valued logic: `false` wins outright, otherwise a `null`
+    /// operand makes the result `null`, and only an all-`true` list is `true`.
+    fn eval_and<R: RowView + ?Sized>(
+        &self,
+        node: &ExprNode<'_>,
+        env: Option<&R>,
+        agg_group_key: Option<u64>,
+    ) -> Result<Value, String> {
+        let mut is_null = false;
+        for child in node.children() {
+            match self.eval_node(&child, env, agg_group_key)? {
+                Value::Bool(false) => return Ok(Value::Bool(false)),
+                Value::Bool(true) => {}
+                Value::Null => is_null = true,
+                ir => return Err(format!("Type mismatch: expected Bool but was {ir:?}")),
+            }
+        }
+        Ok(if is_null {
+            Value::Null
+        } else {
+            Value::Bool(true)
+        })
+    }
+
+    /// Evaluates `XOR` by folding the children, short-circuiting on `null`.
+    fn eval_xor<R: RowView + ?Sized>(
+        &self,
+        node: &ExprNode<'_>,
+        env: Option<&R>,
+        agg_group_key: Option<u64>,
+    ) -> Result<Value, String> {
+        let mut last = None;
+        for child in node.children() {
+            match self.eval_node(&child, env, agg_group_key)? {
+                Value::Bool(b) => last = Some(last.map_or(b, |l| logical_xor(l, b))),
+                Value::Null => return Ok(Value::Null),
+                ir => return Err(format!("Type mismatch: expected Bool but was {ir:?}")),
+            }
+        }
+        Ok(Value::Bool(last.unwrap_or(false)))
+    }
+
+    /// Evaluates `NOT`, propagating `null`.
+    fn eval_not<R: RowView + ?Sized>(
+        &self,
+        node: &ExprNode<'_>,
+        env: Option<&R>,
+        agg_group_key: Option<u64>,
+    ) -> Result<Value, String> {
+        match self.eval_node(&node.child(0), env, agg_group_key)? {
+            Value::Bool(b) => Ok(Value::Bool(!b)),
+            Value::Null => Ok(Value::Null),
+            v => Err(format!(
+                "Type mismatch: expected Boolean or Null but was {}",
+                v.name()
+            )),
+        }
     }
 
     /// Out-of-line continuation of [`eval_node`](Self::eval_node) for
@@ -619,86 +721,10 @@ impl<'a> ExprEval<'a> {
                         _ => res.push(Value::Bool(false)),
                     }
                 }
-                ExprIR::Or => {
-                    let mut is_null = false;
-                    let mut found = false;
-                    for child in node.children() {
-                        match self.eval_node(&child, env, agg_group_key)? {
-                            Value::Bool(true) => {
-                                found = true;
-                                res.push(Value::Bool(true));
-                                break;
-                            }
-                            Value::Bool(false) => {}
-                            Value::Null => is_null = true,
-                            ir => {
-                                return Err(format!("Type mismatch: expected Bool but was {ir:?}"));
-                            }
-                        }
-                    }
-                    if !found {
-                        if is_null {
-                            res.push(Value::Null);
-                        } else {
-                            res.push(Value::Bool(false));
-                        }
-                    }
-                }
-                ExprIR::Xor => {
-                    let mut last = None;
-                    let mut found = false;
-                    for child in node.children() {
-                        match self.eval_node(&child, env, agg_group_key)? {
-                            Value::Bool(b) => last = Some(last.map_or(b, |l| logical_xor(l, b))),
-                            Value::Null => {
-                                found = true;
-                                res.push(Value::Null);
-                                break;
-                            }
-                            ir => {
-                                return Err(format!("Type mismatch: expected Bool but was {ir:?}"));
-                            }
-                        }
-                    }
-                    if !found {
-                        res.push(Value::Bool(last.unwrap_or(false)));
-                    }
-                }
-                ExprIR::And => {
-                    let mut is_null = false;
-                    let mut found = false;
-                    for child in node.children() {
-                        match self.eval_node(&child, env, agg_group_key)? {
-                            Value::Bool(false) => {
-                                found = true;
-                                res.push(Value::Bool(false));
-                                break;
-                            }
-                            Value::Bool(true) => {}
-                            Value::Null => is_null = true,
-                            ir => {
-                                return Err(format!("Type mismatch: expected Bool but was {ir:?}"));
-                            }
-                        }
-                    }
-                    if !found {
-                        if is_null {
-                            res.push(Value::Null);
-                        } else {
-                            res.push(Value::Bool(true));
-                        }
-                    }
-                }
-                ExprIR::Not => match self.eval_node(&node.child(0), env, agg_group_key)? {
-                    Value::Bool(b) => res.push(Value::Bool(!b)),
-                    Value::Null => res.push(Value::Null),
-                    v => {
-                        return Err(format!(
-                            "Type mismatch: expected Boolean or Null but was {}",
-                            v.name()
-                        ));
-                    }
-                },
+                ExprIR::Or => res.push(self.eval_or(&node, env, agg_group_key)?),
+                ExprIR::Xor => res.push(self.eval_xor(&node, env, agg_group_key)?),
+                ExprIR::And => res.push(self.eval_and(&node, env, agg_group_key)?),
+                ExprIR::Not => res.push(self.eval_not(&node, env, agg_group_key)?),
                 ExprIR::Negate => match self.eval_node(&node.child(0), env, agg_group_key)? {
                     Value::Int(i) => res.push(Value::Int(i.checked_neg().ok_or_else(|| {
                         String::from("ArgumentError: integer overflow in unary minus")


### PR DESCRIPTION
## Summary

`AND`, `OR`, `XOR` and `NOT` fell through `eval_node` into `eval_compound`, the eager post-order stack machine. Its prologue builds two `SmallVec` scratch buffers, clones the node to seed the stack, and enters a push/pop work loop before a single operand is touched.

That machinery exists to accumulate an arbitrary number of operands. The boolean connectives short-circuit, so they could never use it — and never did: each arm inside `eval_compound` already recursed into `eval_node` directly and pushed exactly one value. The entry cost was pure overhead, quantified in the neighbouring comment at ~1,600 instructions, which is why `CASE` already has an early-return arm. The boolean operators were just never given the same treatment.

This matters because it is the per-row `Filter` fallback path. `FilterOp`'s vectorized kernels only serve `Single` and `Conjunction` predicates of the form `var.attr <op> constant`, so any `OR`, any `NOT`, and any conjunction over functions or two variables is re-evaluated per row through here.

## Changes

- Extracted `eval_or`, `eval_and`, `eval_xor` and `eval_not` helpers in `graph/src/runtime/eval.rs`, mirroring the existing `eval_case` pattern.
- Dispatched all four from `eval_node`'s early-return section, so they never enter `eval_compound`.
- Kept the `eval_compound` arms, because a `List` child can still reach them (`RETURN [a AND b]`), but they now delegate to the same helpers — so each operator's three-valued logic is defined once instead of twice.

No behaviour change: each helper preserves its arm's Cypher three-valued semantics exactly (`true` wins for `OR`, `false` wins for `AND`, `null` propagates, non-boolean operands raise the same messages).

## Testing

- `cargo test -p graph --lib` — 177 passed.
- `pytest tests/test_e2e.py tests/test_functions.py` — 124 passed, including `test_xor`, which asserts all 27 three-valued `a XOR b XOR c` combinations.
- TCK — 2,456 scenarios passed, 0 failed. The `expressions/boolean` subset alone is 150 scenarios / 483 steps, all passing.
- Flow tests — 1,025 passed. Five failures in `test_results`, `test_pending_queries_limit` and `test_access_del_entity` reproduce identically on a baseline build of `main`, so they are pre-existing and unrelated.
- `cargo fmt --all --check` and `CXX=clang++ cargo clippy --all-targets` both clean.

## Memory / Performance Impact

No allocation change — both scratch buffers were stack-inline `SmallVec`s, so this removes setup instructions, not heap traffic.

Exact instruction counts per execution via `bench callgrind` (±0.2%), re-measured after rebasing onto `main` (`c2c462b`), from two release builds differing only in this commit:

| query | before | after | delta |
| --- | ---: | ---: | ---: |
| `boolean ops` | 374,627 | 330,714 | **−11.7%** |
| `OR mixed filter` | 1,964,709 | 1,836,199 | **−6.5%** |
| `NOT pattern` | 284,127 | 284,166 | +0.0% |
| `filter scan` | 640,597 | 640,467 | −0.0% |
| `pattern OR filter` | 4,336,949 | 4,337,297 | +0.0% |

The three flat rows are deliberate controls that never reach this code, and none regressed: `NOT pattern` is rewritten to an anti-semi-apply by the planner, `filter scan` is served by the vectorized conjunction kernel, and `pattern OR filter` is dominated by pattern evaluation.

## Related Issues

Closes #2637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved evaluation speed for boolean logic operations.
  * Preserved existing three-valued logic and short-circuiting behavior for `And`, `Or`, `Not`, and `Xor`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->