### PR TITLE
fix: DELETE of an edge created in the same query on a recycled id

### DIFF
--- a/graph/src/runtime/ops/delete.rs
+++ b/graph/src/runtime/ops/delete.rs
@@ -474,7 +474,18 @@ impl Runtime<'_> {
             Value::Relationship(rel) => {
                 if self.pending.borrow().is_relationship_deleted(*rel) {
                     // Already pending deletion, nothing to do
-                } else if !self.g.borrow().is_relationship_deleted(*rel) {
+                } else if self.pending.borrow().is_relationship_created(*rel)
+                    || !self.g.borrow().is_relationship_deleted(*rel)
+                {
+                    // A pending-created edge is deletable even though the
+                    // committed graph still lists its id as deleted: ids are
+                    // recycled, and `reserve_relationship` hands one out while
+                    // leaving it in that set until commit, so the id reads as
+                    // deleted for the whole life of the pending create. Testing
+                    // only the committed flag skipped such an edge and left its
+                    // create standing, so the edge survived the query that
+                    // deleted it.
+                    //
                     // Snapshot attrs BEFORE marking as deleted so pending data
                     // is still accessible via get_relationship_attrs.
                     let type_name = self.get_relationship_type(*rel).unwrap();

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -1,4 +1,5 @@
 from common import *
+from index_utils import wait_for_indices_to_sync
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../..')
 
@@ -556,6 +557,82 @@ class testGraphDeletionFlow(FlowTestsBase):
         # regression: property access on labeled result must not hit undefined attribute
         res = self.graph.query("MATCH (x:BOO) WHERE x.id = 0 RETURN x")
         self.env.assertEqual(res.result_set, [])
+
+    def test26_delete_recycled_pending_edge(self):
+        # Deleting an edge that was created in the same query must delete it,
+        # including when the create was handed a recycled edge id.
+        #
+        # reserve_relationship() hands out an id from the graph's deleted set
+        # without clearing it there, so for the whole life of the pending create
+        # the id still reads as deleted. DELETE used to test only that flag and
+        # so skipped the edge, leaving the create standing: the edge survived the
+        # very query that deleted it. Ids are only recycled once something has
+        # been deleted, which is why the first iteration below used to pass and
+        # every later one leaked.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:P {id: 1}), (:P {id: 2})")
+
+        for i in range(6):
+            res = self.graph.query("""
+                MATCH (a:P {id: 1}), (b:P {id: 2})
+                CREATE (a)-[r:R {uid: 999}]->(b)
+                DELETE r"""
+            )
+            self.env.assertEqual(res.relationships_created, 1)
+            self.env.assertEqual(res.relationships_deleted, 1)
+
+            res = self.graph.query("MATCH ()-[r:R]->() RETURN count(r)")
+            self.env.assertEqual(res.result_set[0][0], 0)
+
+    def test27_delete_recycled_pending_edge_unique_constraint(self):
+        # The leak above was silent until a unique constraint made it fatal: the
+        # surviving edge kept its property, so the next execution of the same
+        # query failed to create its edge at all.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:P {id: 1}), (:P {id: 2})")
+        self.graph.query("CREATE INDEX FOR ()-[r:R]-() ON (r.uid)")
+        self.conn.execute_command(
+            "GRAPH.CONSTRAINT", "CREATE", self.graph.name,
+            "UNIQUE", "RELATIONSHIP", "R", "PROPERTIES", "1", "uid")
+        wait_for_indices_to_sync(self.graph)
+
+        for i in range(6):
+            res = self.graph.query("""
+                MATCH (a:P {id: 1}), (b:P {id: 2})
+                CREATE (a)-[r:R {uid: 999}]->(b)
+                DELETE r"""
+            )
+            self.env.assertEqual(res.relationships_created, 1)
+            self.env.assertEqual(res.relationships_deleted, 1)
+
+        res = self.graph.query("MATCH ()-[r:R]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
+    def test28_delete_subset_of_recycled_pending_edges(self):
+        # Same recycled-id path, but only one of two created edges is deleted —
+        # guards against a fix that cancels every pending create indiscriminately.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:P {id: 1}), (:P {id: 2})")
+
+        # warm the free list so the ids below are recycled rather than fresh
+        self.graph.query("""
+            MATCH (a:P {id: 1}), (b:P {id: 2})
+            CREATE (a)-[r:R]->(b)
+            DELETE r""")
+
+        res = self.graph.query("""
+            MATCH (a:P {id: 1}), (b:P {id: 2})
+            CREATE (a)-[r1:R {n: 1}]->(b), (a)-[r2:R {n: 2}]->(b)
+            DELETE r1"""
+        )
+        self.env.assertEqual(res.relationships_created, 2)
+        self.env.assertEqual(res.relationships_deleted, 1)
+
+        res = self.graph.query("MATCH ()-[r:R]->() RETURN r.n")
+        self.env.assertEqual(res.result_set, [[2]])
 
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -577,8 +577,16 @@ class testGraphDeletionFlow(FlowTestsBase):
             res = self.graph.query("""
                 MATCH (a:P {id: 1}), (b:P {id: 2})
                 CREATE (a)-[r:R {uid: 999}]->(b)
-                DELETE r"""
+                DELETE r
+                RETURN id(r)"""
             )
+            # The id pins the precondition. On the first pass nothing has been
+            # freed yet so id 0 is fresh; from the second on it comes back off
+            # the free list, which is the case that used to leak. Asserting it
+            # stays 0 is what keeps this test exercising a recycled id — were
+            # reclamation to stop, the ids would climb and this would fail
+            # rather than quietly testing the already-working fresh-id path.
+            self.env.assertEqual(res.result_set, [[0]])
             self.env.assertEqual(res.relationships_created, 1)
             self.env.assertEqual(res.relationships_deleted, 1)
 
@@ -602,8 +610,10 @@ class testGraphDeletionFlow(FlowTestsBase):
             res = self.graph.query("""
                 MATCH (a:P {id: 1}), (b:P {id: 2})
                 CREATE (a)-[r:R {uid: 999}]->(b)
-                DELETE r"""
+                DELETE r
+                RETURN id(r)"""
             )
+            self.env.assertEqual(res.result_set, [[0]])
             self.env.assertEqual(res.relationships_created, 1)
             self.env.assertEqual(res.relationships_deleted, 1)
 
@@ -626,13 +636,53 @@ class testGraphDeletionFlow(FlowTestsBase):
         res = self.graph.query("""
             MATCH (a:P {id: 1}), (b:P {id: 2})
             CREATE (a)-[r1:R {n: 1}]->(b), (a)-[r2:R {n: 2}]->(b)
-            DELETE r1"""
+            DELETE r1
+            RETURN id(r1), id(r2)"""
         )
+        # r1 takes the one id on the free list, r2 is allocated fresh — so the
+        # edge being deleted is precisely the recycled one, and the edge that
+        # must survive is not.
+        self.env.assertEqual(res.result_set, [[0, 1]])
         self.env.assertEqual(res.relationships_created, 2)
         self.env.assertEqual(res.relationships_deleted, 1)
 
-        res = self.graph.query("MATCH ()-[r:R]->() RETURN r.n")
-        self.env.assertEqual(res.result_set, [[2]])
+        res = self.graph.query("MATCH ()-[r:R]->() RETURN id(r), r.n")
+        self.env.assertEqual(res.result_set, [[1, 2]])
+
+    def test29_delete_recycled_pending_node_and_edge(self):
+        # Coverage of the node-cascade path with every id reclaimed rather than
+        # fresh: both endpoints and the edge come back off the free lists.
+        #
+        # Unlike test26-test28 this one passes with or without the relationship
+        # fix, and deliberately stays here saying so. Deleting the nodes cascades
+        # through `remove_pending_relationships_for_node`, which cancels the
+        # edge's pending create outright, so the edge never reaches the
+        # relationship arm of `delete_entity` and the recycled-id bug cannot
+        # bite. What it does pin is that this cascade keeps handling recycled
+        # node *and* edge ids correctly, which is the neighbouring path.
+        self.graph.delete()
+
+        # warm both free lists
+        self.graph.query("CREATE (a:P {t: 0})-[r:R {t: 0}]->(b:P {t: 0})")
+        self.graph.query("MATCH (a:P)-[r:R]->(b:P) DELETE a, r, b")
+
+        for i in range(3):
+            res = self.graph.query("""
+                CREATE (a:P {t: 1})-[r:R {t: 2}]->(b:P {t: 3})
+                WITH a, r, b
+                DELETE a, r, b
+                RETURN id(a), id(r), id(b)"""
+            )
+            self.env.assertEqual(res.result_set, [[0, 0, 1]])
+            self.env.assertEqual(res.nodes_created, 2)
+            self.env.assertEqual(res.nodes_deleted, 2)
+            self.env.assertEqual(res.relationships_created, 1)
+            self.env.assertEqual(res.relationships_deleted, 1)
+
+            res = self.graph.query("MATCH (n) RETURN count(n)")
+            self.env.assertEqual(res.result_set[0][0], 0)
+            res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+            self.env.assertEqual(res.result_set[0][0], 0)
 
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):


### PR DESCRIPTION
Fixes #2644

**Stack 1/3** — base of the stack, targets `main`.

`MATCH (a),(b) CREATE (a)-[r:R]->(b) DELETE r` left the edge in the graph on every execution after the first, **silently** — the reply just omitted the `Relationships deleted` line. The C engine deletes it correctly.

## Cause

`reserve_relationship` recycles ids by selecting one out of the graph's deleted-relationship set and **leaves it there** until commit, so for the whole life of a pending create the id still reads as deleted. The relationship arm of `delete_entity` tested only that committed flag:

```rust
if pending.is_relationship_deleted(rel) {
} else if !g.is_relationship_deleted(rel) { ...delete... }
```

An edge created on a recycled id matched neither arm, so the delete became a no-op and the pending create committed. The node arm has always handled this via an explicit `is_node_created` branch; the relationship arm had no equivalent.

That is also why the bug alternated: a fresh id is not in the deleted set, so the first create-then-delete worked and freed its id; the next reused that id and leaked; the leak meant nothing was freed, so the one after allocated fresh and worked again.

## Repro (no constraints needed)

```
CREATE (:P {id:1}), (:P {id:2})
# then 5x: MATCH (a:P {id:1}),(b:P {id:2}) CREATE (a)-[r:R {uid:999}]->(b) DELETE r
run 1: created=1 deleted=1   Cached execution: 0
run 2: created=1 deleted=     Cached execution: 1   <-- leaked
run 3: created=1 deleted=1
run 4: created=1 deleted=     <-- leaked
MATCH ()-[r:R]->() RETURN count(r)  ->  2      # expected 0
```

The same eight commands on the C module leave `0`.

## Fix

Accept a pending-created edge in the guard. Nothing else changes: the existing path already marks the edge deleted and lets commit apply create-then-delete, which nets to nothing and reports `Relationships created: 1` / `Relationships deleted: 1` — matching C exactly. `delete_relationships_bulk` already routed pending-created edges here for this treatment, so the bulk path is fixed by the same change.

## How it was found

The benchmark suite measured `urel create delete` at **1,729 instructions**, far below the ~162k `RETURN 1` floor — the graph's `UREL.uid` unique constraint turned the leaked edge into a hard `unique constraint violation` on every later execution, so the harness was timing an error reply. After this fix that row is a real measurement again (768,202 instructions).

## Tests

Three regression tests in `test_graph_deletion.py` (bare, under a unique constraint, and deleting only one of two created edges). All three fail on `main` and pass here. Full flow suite green apart from known parallelism flakes that pass in isolation; 177 unit tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed deletion of relationships created and removed within the same query when recycled relationship IDs are used.
  - Ensured pending relationships are deleted correctly with unique constraints, multiple relationships, and cascading node deletion.

- **Tests**
  - Added regression coverage for repeated create/delete operations, deleting selected pending relationships, unique-constraint scenarios, and cascading deletion of recycled nodes and relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
