### PR TITLE
perf: snapshot a deleted node's edges from its own adjacency, not a full scan

### DIFF
--- a/graph/src/runtime/ops/delete.rs
+++ b/graph/src/runtime/ops/delete.rs
@@ -211,36 +211,31 @@ impl Runtime<'_> {
             return Ok(());
         }
 
-        // Snapshot implicit-edge type/attrs only when a later clause may
-        // reference them. The actual cascade delete and effects/replication
-        // bookkeeping is handled at commit time by `delete_implicit_edges`,
-        // which is O(E) once instead of O(E) per batch.
+        // Snapshot the edges the deleted nodes carry, for later clauses that can
+        // still reference them. The actual cascade delete and effects bookkeeping
+        // happens at commit time in `delete_implicit_edges`.
+        //
+        // Ask each node for its own edges. This used to be one pass over every
+        // relationship tensor, which reads all E edges however few nodes are being
+        // deleted — and `DELETE` runs a batch at a time, so it was O(E) *per
+        // batch*: deleting 100k nodes of a 100k-node, 100k-edge graph scanned the
+        // whole graph ~98 times, and a two-node `CREATE ... DELETE ... RETURN`
+        // scaled with the size of an otherwise untouched graph (0.135 ms with no
+        // edges, 1.39 ms with 80k). Row-bounded lookups are O(degree), and measured
+        // faster at every size, including deleting the entire graph (252 -> 113 ms).
         if snapshot {
-            // Build a set of committed IDs for O(1) lookups
-            let committed_set: std::collections::HashSet<NodeId> =
-                committed.iter().copied().collect();
-            let g = self.g.borrow();
-            let n = g.node_cap();
-            for tensor in g.relationship_matrices_iter() {
-                for (src, dest, rel_id) in tensor.iter(0, n, false) {
-                    let src_node: NodeId = src.into();
-                    let dest_node: NodeId = dest.into();
-                    let rel: RelationshipId = rel_id.into();
-                    let src_deleted = committed_set.contains(&src_node);
-                    let dest_deleted = committed_set.contains(&dest_node);
-                    if !src_deleted && !dest_deleted {
-                        continue;
-                    }
-                    // Skip if other endpoint is already pending-deleted
-                    if !src_deleted && self.pending.borrow().is_node_deleted(src_node) {
-                        continue;
-                    }
-                    if !dest_deleted && self.pending.borrow().is_node_deleted(dest_node) {
+            for &id in &committed {
+                let incident: Vec<(NodeId, NodeId, RelationshipId)> =
+                    self.g.borrow().get_node_relationships(id).collect();
+                for (src, dst, rel) in incident {
+                    // An edge between two deleted nodes is reached from both ends,
+                    // and one already snapshotted by an earlier batch must keep
+                    // that snapshot — it holds the pre-delete data.
+                    if self.deleted_relationships.borrow().contains_key(&rel) {
                         continue;
                     }
                     let type_name = self.get_relationship_type(rel).unwrap();
                     let attrs = self.get_relationship_attrs(rel);
-                    let (src, dst) = (src_node, dest_node);
                     self.deleted_relationships
                         .borrow_mut()
                         .insert(rel, DeletedRelationship::new(src, dst, type_name, attrs));

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -684,6 +684,123 @@ class testGraphDeletionFlow(FlowTestsBase):
             res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
             self.env.assertEqual(res.result_set[0][0], 0)
 
+    def test30_deleted_edges_readable_after_node_delete(self):
+        # Deleting a node has to snapshot the edges it carried so later clauses
+        # can still read them. This pins that snapshot while the mechanism that
+        # collects it changes from a full scan of every relationship tensor to a
+        # per-node adjacency lookup.
+        #
+        # The edge here sits between two nodes that are both deleted, so it is
+        # reachable from either end and must still be reported exactly once with
+        # its pre-delete property.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:A {n: 1})-[:R {w: 7}]->(:B {n: 2})")
+
+        res = self.graph.query("""
+            MATCH (a:A)-[r:R]->(b:B)
+            DELETE a, b
+            RETURN r.w, type(r), startNode(r).n, endNode(r).n"""
+        )
+        self.env.assertEqual(res.result_set, [[7, "R", 1, 2]])
+        self.env.assertEqual(res.nodes_deleted, 2)
+        self.env.assertEqual(res.relationships_deleted, 1)
+
+        res = self.graph.query("MATCH (n) RETURN count(n)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
+    def test31_deleted_edges_readable_across_batches(self):
+        # Same snapshot, but over more rows than one runtime batch (1024), so the
+        # delete runs as several batches and an edge may be snapshotted by one
+        # batch and revisited by a later one. Every edge must still come back
+        # with its own property.
+        self.graph.delete()
+
+        n = 2500
+        self.graph.query(f"""
+            UNWIND range(1, {n}) AS i
+            CREATE (:Src {{i: i}})-[:E {{i: i}}]->(:Dst {{i: i}})"""
+        )
+
+        res = self.graph.query("MATCH (a:Src)-[r:E]->(b:Dst) DELETE a, b RETURN sum(r.i), count(r)")
+        self.env.assertEqual(res.result_set, [[n * (n + 1) // 2, n]])
+        self.env.assertEqual(res.nodes_deleted, 2 * n)
+        self.env.assertEqual(res.relationships_deleted, n)
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
+    def test32_detach_delete_snapshots_only_incident_edges(self):
+        # Unrelated edges must be left alone. The scan this replaces filtered a
+        # full pass by endpoint membership; a per-node lookup has to reach exactly
+        # the same edge set.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:Keep {n: 1})-[:K {w: 1}]->(:Keep {n: 2})")
+        self.graph.query("CREATE (:Drop {n: 3})-[:D {w: 2}]->(:Other {n: 4})")
+
+        res = self.graph.query("MATCH (d:Drop) DETACH DELETE d RETURN d.n")
+        self.env.assertEqual(res.result_set, [[3]])
+        self.env.assertEqual(res.relationships_deleted, 1)
+
+        # the untouched edge and both its endpoints survive
+        res = self.graph.query("MATCH (a:Keep)-[r:K]->(b:Keep) RETURN a.n, r.w, b.n")
+        self.env.assertEqual(res.result_set, [[1, 1, 2]])
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 1)
+        res = self.graph.query("MATCH (o:Other) RETURN o.n")
+        self.env.assertEqual(res.result_set, [[4]])
+
+    def test33_delete_node_that_is_only_an_edge_destination(self):
+        # The deleted node is the *destination* of its edge, never the source. A
+        # per-node lookup that followed only outgoing rows would find nothing
+        # here and silently leave the edge behind.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:Live {n: 1})-[:E {w: 9}]->(:Sink {n: 2})")
+
+        res = self.graph.query("MATCH (s:Sink) DETACH DELETE s RETURN s.n")
+        self.env.assertEqual(res.result_set, [[2]])
+        self.env.assertEqual(res.relationships_deleted, 1)
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+        # the surviving source keeps no dangling degree
+        res = self.graph.query("MATCH (l:Live) RETURN l.n, outdegree(l)")
+        self.env.assertEqual(res.result_set, [[1, 0]])
+
+    def test34_edge_props_readable_when_only_destination_deleted(self):
+        # This is the case the snapshot exists for: the edge is read *after* the
+        # node it hangs off is deleted, and the deleted node is the edge's
+        # destination. The snapshot is collected per deleted node, so a lookup
+        # that followed only outgoing rows would never see this edge and the
+        # RETURN would come back empty instead of carrying its property.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:Live {n: 1})-[:E {w: 9}]->(:Sink {n: 2})")
+
+        res = self.graph.query("""
+            MATCH (l:Live)-[r:E]->(s:Sink)
+            DELETE s
+            RETURN r.w, type(r), startNode(r).n"""
+        )
+        self.env.assertEqual(res.result_set, [[9, "E", 1]])
+
+    def test35_edge_props_readable_when_only_source_deleted(self):
+        # The mirror of test34, so neither direction can be dropped.
+        self.graph.delete()
+
+        self.graph.query("CREATE (:Live {n: 1})-[:E {w: 9}]->(:Sink {n: 2})")
+
+        res = self.graph.query("""
+            MATCH (l:Live)-[r:E]->(s:Sink)
+            DELETE l
+            RETURN r.w, type(r), endNode(r).n"""
+        )
+        self.env.assertEqual(res.result_set, [[9, "E", 2]])
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()


### PR DESCRIPTION
Fixes #2646

**Stack 3/3** — targets #2641. Review #2640 and #2641 first.

`delete returning`, `delete return entities`, `pending degree` and `multi-label write` all ran at **5.3-7.2x** the C engine — the tightest cluster of regressions in the suite, and all four on one cause.

## Cause

When `DELETE` has to snapshot deleted entities for a later clause to read, `delete_nodes_bulk` found the edges hanging off those nodes by walking **every relationship tensor across the whole node capacity** and keeping rows whose endpoints were being deleted. That reads all E edges however few nodes are being deleted, so a query touching three entities scaled with the size of an otherwise untouched graph:

| graph edges | 0 | 5,000 | 20,000 | 80,000 |
|---|---|---|---|---|
| `delete returning` | 0.135 | 0.207 | 0.471 | **1.391** |
| `multi-label write` | 0.071 | 0.175 | 0.463 | **1.343** |

(ms, p50)

Worse, `DELETE` runs a batch of rows at a time and the scan sat inside the per-batch path — the comment directly above it noted the commit-time cascade is "O(E) once instead of O(E) per batch" while the scan below did exactly the per-batch thing. Deleting 100k nodes of a 100k-node, 100k-edge graph scanned the whole graph ~98 times.

## Fix

`get_node_relationships` already answers this question row-bounded, in O(degree), and is what the per-entity path uses. Use it here too. The duplicate cases the scan handled with endpoint bookkeeping — an edge between two deleted nodes reached from both ends, and one already snapshotted by an earlier batch — are handled by keeping the first snapshot, which is the one holding pre-delete data.

| graph edges | 0 | 5,000 | 20,000 | 80,000 |
|---|---|---|---|---|
| `delete returning` | 0.135 | 0.095 | 0.095 | **0.103** |
| `multi-label write` | 0.071 | 0.063 | 0.071 | **0.063** |

Flat, as it should be.

**No threshold to fall back to the scan.** Because deletes are batched, the scan is never the cheaper option on a graph large enough for the difference to matter, and measurement agrees even at the extreme of deleting everything — 1k/10k/50k/100k nodes of 100k with a RETURN went 2.96/26.9/130.9/252.3 ms to **1.40/12.2/60.9/112.7 ms**. I initially added a threshold and removed it once the numbers showed the scan branch had no win to protect.

## Harness result (this PR, on top of the stack)

| row | before/C | after/C |
|---|---|---|
| `delete returning` | 7.17x | **1.86x** |
| `delete return entities` | 6.59x | **1.77x** |
| `pending degree` | 6.64x | **1.63x** |
| `multi-label write` | 5.30x | **0.93x** |

## Tests

The tests pin the snapshot itself rather than the deletion, which happens at commit time and was never in question: reading an edge's properties after deleting the node on **either** end of it, an edge between two deleted nodes, a delete spanning more rows than one batch, and unrelated edges left untouched.

Worth noting: my first three tests all had the deleted node as the edge *source*, so a direction bug would have slipped through — a mutant restricting the lookup to outgoing edges passed all of them. `test34`/`test35` were added for that and the mutant hangs on `test34`, so the direction is genuinely held down. All 40 tests in `test_graph_deletion.py` pass. Tests are numbered from 30 to leave room for the `test29` added to #2640.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edge properties remain readable after deleting connected nodes, including with `DELETE` and `DETACH DELETE`.
  * Fixed behavior across large, multi-batch operations.
  * Preserved correct results when deleting only an edge’s source or destination node.
  * Prevented unrelated edges from being affected by node deletion.

* **Tests**
  * Added coverage for node deletion, edge-property access, and multi-batch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->