### PR TITLE
fix(runtime): handle negative ID range bounds

### DIFF
--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -1307,11 +1307,21 @@ impl<'a> Runtime<'a> {
                 let idx = expr.root().idx();
                 super::eval::ExprEval::from_runtime(this).eval(expr, idx, Some(vars), None)
             }? {
-                Value::Int(id) => id as u64,
+                Value::Int(id) => id,
                 _ => {
                     return Err(String::from("Node ID must be an integer"));
                 }
             };
+            // IDs are non-negative: negative equality/upper bounds cannot match,
+            // while negative lower bounds are trivially satisfied.
+            if id < 0 {
+                match op {
+                    ExprIR::Eq | ExprIR::Lt | ExprIR::Le => return Ok(None),
+                    ExprIR::Gt | ExprIR::Ge => continue,
+                    _ => unreachable!(),
+                }
+            }
+            let id = id as u64;
             match op {
                 ExprIR::Eq => {
                     if id < min || id > max {

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -231,6 +231,28 @@ class testNodeByIDFlow(FlowTestsBase):
         resultsetB = self.graph.query(query).result_set
         self.env.assertEqual(resultsetA, resultsetB)
 
+    def test_negative_id_bounds(self):
+        queries = [
+            ("MATCH (n) WHERE ID(n) < 0 RETURN count(*)", "NodeByIdSeek", 0),
+            ("MATCH (n) WHERE ID(n) < -5 RETURN count(*)", "NodeByIdSeek", 0),
+            ("MATCH (n) WHERE ID(n) <= -1 RETURN count(*)", "NodeByIdSeek", 0),
+            ("MATCH (n) WHERE ID(n) = -1 RETURN count(*)", "NodeByIdSeek", 0),
+            ("MATCH (n) WHERE ID(n) > -5 RETURN count(*)", "NodeByIdSeek", 10),
+            ("MATCH (n) WHERE ID(n) >= -5 RETURN count(*)", "NodeByIdSeek", 10),
+            ("MATCH (n) WHERE ID(n) < 3 AND ID(n) > 5 RETURN count(*)", "NodeByIdSeek", 0),
+            ("MATCH (n) WHERE ID(n) < 1 RETURN count(*)", "NodeByIdSeek", 1),
+            ("MATCH (n) WHERE ID(n) <= 0 RETURN count(*)", "NodeByIdSeek", 1),
+            ("MATCH (n:person) WHERE ID(n) <= -1 RETURN count(*)", "Node By Label and ID Scan", 0),
+            ("MATCH (n:person) WHERE ID(n) >= -5 RETURN count(*)", "Node By Label and ID Scan", 10),
+            ("MATCH (n:person) WHERE ID(n) = -1 RETURN count(*)", "Node By Label and ID Scan", 0),
+            ("MATCH (n:person) WHERE ID(n) <= 0 RETURN count(*)", "Node By Label and ID Scan", 1),
+        ]
+
+        for query, op, expected_count in queries:
+            self.env.assertContains(op, str(self.graph.explain(query)))
+            result = self.graph.query(query).result_set
+            self.env.assertEqual(result, [[expected_count]])
+
     # Try to fetch none existing entities by ID(s).
     def test_for_none_existing_entity_ids(self):
         # Try to fetch an entity with a none existing ID.


### PR DESCRIPTION
## Summary

Recovers **#2285** ("Fix negative ID range bounds" by @BhavayChopra), which was closed accidentally and **cannot be reopened by GitHub**.

PR #2285 was cut from the old `main-rs` branch (its parent commit `d975d677` is exactly the tip of `refs/heads/main-rs`). During the Rust-engine migration (#2279) `main` was recreated as an unrelated history, so `git merge-base` finds **no common ancestor** between the two. GitHub's reopen validation rejects it outright:

> The `BhavayChopra:codex/fix-negative-id-bounds` branch has no history in common with `FalkorDB:main`.

There is no API workaround. This PR therefore replays the original commit onto current `main` via `git cherry-pick`, which applied **cleanly with no conflicts** and **preserves @BhavayChopra as the commit author**. Full credit for the fix belongs to them.

The bug is still present and unfixed on current `main`.

### The bug

`graph/src/runtime/runtime.rs:1310` folded the node ID into an unsigned type before any range reasoning:

```rust
Value::Int(id) => id as u64,
```

A negative `i64` wraps to a huge `u64` (`-1` → `18446744073709551615`), so ID range bounds are computed against a garbage value. Concretely, on a graph with IDs `0..9`:

| Query | Expected | Actual on `main` |
|---|---|---|
| `WHERE id(n) > -1` | 10 | 0 |
| `WHERE id(n) >= -5` | 10 | 0 |
| `WHERE id(n) < -1` | 0 | 10 |
| `WHERE id(n) <= -1` | 0 | 10 |

Both **false negatives** (silently dropping every matching node) and **false positives** (returning nodes that don't satisfy the predicate).

## Changes

- `graph/src/runtime/runtime.rs` — keep the evaluated ID as `i64` and short-circuit on negatives *before* casting. Since entity IDs are non-negative by construction, a negative bound is decidable without touching the range:
  - `Eq` / `Lt` / `Le` → unsatisfiable, `return Ok(None)`
  - `Gt` / `Ge` → trivially satisfied, `continue` (bound contributes nothing)

  The `as u64` cast now happens only on a value proven non-negative.
- `tests/flow/test_node_by_id.py` — new `test_negative_id_bounds` covering 13 query/operator/expected-count cases, asserting both the result count **and** the chosen execution op (`NodeByIdSeek`, `Node By Label and ID Scan`) so a future planner regression can't silently mask the fix.

## Testing

Verified locally against a release build (`cargo build --release`):

```
$ RELEASE=1 VERBOSE=0 TEST="tests/flow/test_node_by_id" ./flow.sh
	test_node_by_id:testNodeByIDFlow.test_for_none_existing_entity_ids:	[PASS]
	test_node_by_id:testNodeByIDFlow.test_get_nodes:                  	[PASS]
	test_node_by_id:testNodeByIDFlow.test_negative_id_bounds:         	[PASS]
	test_node_by_id:testNodeByIDFlow.test_node_by_id_scan_reset:      	[PASS]
Total Tests Run: 4, Total Tests Failed: 0, Total Tests Passed: 4
```

**Regression-guard confirmed.** I reverted *only* the `runtime.rs` hunk (restoring the file from `origin/main`), rebuilt, and re-ran the same suite — the new test fails on **6 of its 13 cases**, exactly the negative-bound rows in the table above:

```
	❌  (FAIL):	[[10]] == [[0]]	test_node_by_id.py:254   # id(n) > -1  and  id(n) >= -N
	❌  (FAIL):	[[0]] == [[10]]	test_node_by_id.py:254   # id(n) < -1  and  id(n) <= -N
Total Tests Run: 4, Total Tests Failed: 1, Total Tests Passed: 3
```

So the test genuinely exercises the fixed code path rather than passing vacuously.

Also clean: `cargo check -p graph`, `cargo fmt --all -- --check`, `CXX=clang++ cargo clippy -p graph` (the one remaining warning is pre-existing in `cond_var_len_traverse.rs`, an untouched file).

## Memory / Performance Impact

None. The change is a sign test on a value already held in a register, evaluated once per ID-bound predicate at range-construction time — not per row, and not inside any traversal or iterator loop. No allocation, no change to graph object ownership or lifetime. Generated code for the non-negative path is identical apart from the branch.

## Related Issues

Closes #2648

Recovers #2285. Original fix authored by @BhavayChopra.
