### PR TITLE
fix(path): A* optimality, pathCost hop-count, cost-aware k-shortest s…

### DIFF
--- a/src/algorithms/AStar.c
+++ b/src/algorithms/AStar.c
@@ -337,9 +337,18 @@ static bool AStarCtx_Run
 				double h;
 				if(!is_new) {
 					AStarLabel *nlabel = ac->records + (*nslot - 1);
-					if(nlabel->finalized || new_g >= nlabel->g_score) {
-						continue;
+					if(new_g >= nlabel->g_score) {
+						continue;  // not a strictly better route to 'nid'
 					}
+					// strictly better route found. if 'nid' was already
+					// finalized, REOPEN it: the haversine heuristic is only
+					// admissible, not necessarily consistent, when some nodes
+					// lack coordinates (h==0 there) -- so a node can be
+					// finalized at a non-optimal g. A* with an admissible
+					// heuristic stays optimal as long as such nodes are
+					// reopened and re-expanded. clearing 'finalized' lets the
+					// re-queued entry below be processed again.
+					nlabel->finalized = false;
 					h = nlabel->h;  // heuristic is fixed per node
 				} else {
 					// first discovery: compute and cache h(nid).
@@ -489,11 +498,15 @@ bool AStar_ShortestPath
 typedef struct {
 	Path   *path;    // the candidate path
 	double  weight;  // its total weight
+	double  cost;    // its total cost (secondary selection key; see comparator)
 } AStarCandidate;
 
 // candidate-heap comparator: the heap keeps the *greatest* element (per this
-// cmp) on top, so invert the natural order -- smallest weight (then shortest
-// path) becomes the top, i.e. the next path to accept.
+// cmp) on top, so invert the natural order -- the smallest under the
+// (weight, cost, length) lexicographic order becomes the top, i.e. the next
+// path to accept. mirrors proc_sp_paths' path_cmp; with cost_prop unspecified
+// (ATTRIBUTE_ID_NONE) every edge's cost is 1, so cost equals the hop count and
+// this collapses to the old (weight, length) order.
 static int _astar_cand_cmp
 (
 	const void *a,
@@ -505,6 +518,10 @@ static int _astar_cand_cmp
 
 	if(ca->weight != cb->weight) {
 		return (ca->weight < cb->weight) ? 1 : -1;
+	}
+
+	if(ca->cost != cb->cost) {
+		return (ca->cost < cb->cost) ? 1 : -1;
 	}
 
 	size_t la = Path_Len(ca->path);
@@ -593,6 +610,27 @@ static double _root_weight
 	return w;
 }
 
+// total cost of a whole path (sum of cost_prop over its edges, defaulting a
+// missing value to 1). secondary selection key only; ATTRIBUTE_ID_NONE yields
+// the hop count.
+static double _path_cost
+(
+	const Path *p,
+	AttributeID cost_prop
+) {
+	double c = 0;
+
+	uint ec = Path_EdgeCount(p);
+	for(uint j = 0; j < ec; j++) {
+		SIValue v = _get_value_or_default(
+				(GraphEntity *)Path_GetEdge(p, j),
+				cost_prop, SI_LongVal(1));
+		c += SI_GET_NUMERIC(v);
+	}
+
+	return c;
+}
+
 // build root(prev, i) ++ spur: prev's first i edges / i+1 nodes, then the spur
 // path (whose first node is prev.nodes[i], already included, so it is skipped).
 static Path *_concat
@@ -634,6 +672,7 @@ uint AStar_KShortestPaths
 	Tensor *relationMatrices,
 	int relationCount,
 	AttributeID weight_prop,
+	AttributeID cost_prop,
 	AttributeID lat_prop,
 	AttributeID lon_prop,
 	Path ***paths,
@@ -725,6 +764,7 @@ uint AStar_KShortestPaths
 				AStarCandidate *c = rm_malloc(sizeof(AStarCandidate));
 				c->path   = total;
 				c->weight = total_w;
+				c->cost   = _path_cost(total, cost_prop);
 				Heap_offer(&B, c);
 			} else {
 				Path_Free(total);  // already generated before

--- a/src/algorithms/AStar.h
+++ b/src/algorithms/AStar.h
@@ -31,8 +31,13 @@
 //
 // if dst, or any other node discovered during the search, is missing a
 // numeric latitudeProperty/longitudeProperty, its heuristic degrades to
-// 0 for that node -- still admissible, just locally equivalent to
-// Dijkstra rather than an error.
+// 0 for that node -- still admissible, just locally equivalent to Dijkstra
+// rather than an error. mixing coordinate-bearing and coordinate-less nodes
+// makes the heuristic admissible but not necessarily consistent, so the search
+// reopens (re-expands) an already-finalized node whenever a strictly shorter
+// route to it is found. this keeps the returned path optimal at the cost of a
+// few extra expansions on such graphs; when every node has coordinates the
+// heuristic is consistent and no reopening occurs.
 //
 // returns true and populates 'path' and 'weight' if 'dst' is reachable
 // from 'src'; returns false (leaving them untouched) otherwise.
@@ -64,7 +69,10 @@ bool AStar_ShortestPath
 // geographically-embedded graphs (road networks).
 //
 // same weightProp / lat/lon preconditions as AStar_ShortestPath. candidate
-// paths are deduplicated by a 64-bit hash of their edge-id sequence.
+// paths are deduplicated by a 64-bit hash of their edge-id sequence, and the k
+// paths are selected by the lexicographic order (weight, cost, length) -- see
+// Yen_KShortestPaths (yen.h) for the cost_prop semantics; pass
+// ATTRIBUTE_ID_NONE to leave it unspecified.
 //
 // returns the number of paths found (<= k; 0 if dst is unreachable). '*paths'
 // and '*weights' are set to newly allocated parallel array_t buffers (Path*
@@ -80,6 +88,7 @@ uint AStar_KShortestPaths
 	Tensor *relationMatrices,  // relation matrix per relationIDs entry
 	int relationCount,         // length of relationIDs
 	AttributeID weight_prop,   // weight attribute id
+	AttributeID cost_prop,     // secondary tie-break attribute, or NONE
 	AttributeID lat_prop,      // latitude attribute id, used for the heuristic
 	AttributeID lon_prop,      // longitude attribute id, used for the heuristic
 	Path ***paths,             // [output] array_t of Path*, ascending weight

--- a/src/algorithms/yen.c
+++ b/src/algorithms/yen.c
@@ -17,11 +17,17 @@
 typedef struct {
 	Path   *path;    // the candidate path
 	double  weight;  // its total weight
+	double  cost;    // its total cost (secondary selection key; see comparator)
 } YenCandidate;
 
 // candidate-heap comparator: the heap keeps the *greatest* element (per this
-// cmp) on top, so invert the natural order -- smallest weight (then shortest
-// path) becomes the top, i.e. the next path to accept.
+// cmp) on top, so invert the natural order -- the smallest under the
+// (weight, cost, length) lexicographic order becomes the top, i.e. the next
+// path to accept. this mirrors proc_sp_paths' path_cmp so the k paths selected
+// here are exactly the k smallest under the same total order the results are
+// then reported in. when no cost property is supplied every edge's cost
+// defaults to 1, so 'cost' equals the hop count and the cost key collapses
+// into the length key (no behavioural change for weight-only queries).
 static int _yen_cand_cmp
 (
 	const void *a,
@@ -33,6 +39,10 @@ static int _yen_cand_cmp
 
 	if(ca->weight != cb->weight) {
 		return (ca->weight < cb->weight) ? 1 : -1;
+	}
+
+	if(ca->cost != cb->cost) {
+		return (ca->cost < cb->cost) ? 1 : -1;
 	}
 
 	size_t la = Path_Len (ca->path);
@@ -125,6 +135,27 @@ static double _root_weight
 	return w;
 }
 
+// total cost of a whole path (sum of cost_prop over its edges, defaulting a
+// missing value to 1). used only as a secondary selection key; when cost_prop
+// is ATTRIBUTE_ID_NONE this returns the hop count.
+static double _path_cost
+(
+	const Path *p,
+	AttributeID cost_prop
+) {
+	double c = 0.0;
+
+	uint ec = Path_EdgeCount (p);
+	for(uint j = 0; j < ec; j++) {
+		SIValue v = _get_value_or_default(
+				(GraphEntity *) Path_GetEdge (p, j),
+				cost_prop, SI_LongVal(1));
+		c += SI_GET_NUMERIC(v);
+	}
+
+	return c;
+}
+
 // build root(prev, i) ++ spur: prev's first i edges/i+1 nodes, then the spur
 // path (whose first node is prev.nodes[i], already included, so it is skipped).
 static Path *_concat
@@ -175,6 +206,13 @@ static Path *_concat
 // produces, a false collision (which would drop a distinct path) is
 // astronomically unlikely.
 //
+// the k paths are selected by the lexicographic order (weight, cost, length),
+// where cost is the sum of 'cost_prop' over a path's edges (each missing value
+// defaulting to 1). pass ATTRIBUTE_ID_NONE for cost_prop to leave it
+// unspecified -- cost then equals the hop count and the cost key has no effect
+// beyond the length tie-break. this matches proc_sp_paths' path_cmp so the
+// selected set and the reported ordering agree.
+//
 // returns the number of paths found (<= k; 0 if dst is unreachable). '*paths'
 // and '*weights' are set to newly allocated parallel array_t buffers (Path*
 // and its total weight, ascending); the caller owns both arrays and each Path.
@@ -189,6 +227,7 @@ uint Yen_KShortestPaths
 	Tensor *relationMatrices,  // relation matrix per relationIDs entry
 	int relationCount,         // length of relationIDs
 	AttributeID weight_prop,   // weight attribute id
+	AttributeID cost_prop,     // secondary tie-break attribute, or NONE
 	Path ***paths,             // [output] array_t of Path*, ascending weight
 	double **weights           // [output] array_t of matching total weights
 ) {
@@ -280,6 +319,7 @@ uint Yen_KShortestPaths
 				YenCandidate *c = rm_malloc (sizeof(YenCandidate));
 				c->path   = total;
 				c->weight = total_w;
+				c->cost   = _path_cost (total, cost_prop);
 				Heap_offer(&B, c);
 			} else {
 				Path_Free(total);  // already generated before

--- a/src/algorithms/yen.h
+++ b/src/algorithms/yen.h
@@ -26,6 +26,12 @@
 // produces, a false collision (which would drop a distinct path) is
 // astronomically unlikely.
 //
+// the k paths are selected by the lexicographic order (weight, cost, length),
+// cost being the sum of 'cost_prop' over a path's edges (missing values default
+// to 1). pass ATTRIBUTE_ID_NONE for cost_prop to leave it unspecified: cost
+// then equals the hop count, so the cost key only refines the length tie-break
+// and weight-only queries are unaffected.
+//
 // returns the number of paths found (<= k; 0 if dst is unreachable). '*paths'
 // and '*weights' are set to newly allocated parallel array_t buffers (Path*
 // and its total weight, ascending); the caller owns both arrays and each Path.
@@ -40,6 +46,7 @@ uint Yen_KShortestPaths
 	Tensor *relationMatrices,  // relation matrix per relationIDs entry
 	int relationCount,         // length of relationIDs
 	AttributeID weight_prop,   // weight attribute id
+	AttributeID cost_prop,     // secondary tie-break attribute, or NONE
 	Path ***paths,             // [output] array_t of Path*, ascending weight
 	double **weights           // [output] array_t of matching total weights
 );

--- a/src/procedures/proc_astar_paths.c
+++ b/src/procedures/proc_astar_paths.c
@@ -306,10 +306,12 @@ static ProcedureResult Proc_AStarPathsInvoke
 		}
 	} else {
 		// k shortest loopless paths: Yen driven by A* spur searches.
+		// algo.AStar has no costProp; pass ATTRIBUTE_ID_NONE so cost defaults
+		// to hop count and selection stays (weight, length).
 		AStar_KShortestPaths(actx->g, src_id, dst_id, actx->path_count,
 				actx->dir, actx->relationIDs, actx->relationMatrices,
-				actx->relationCount, actx->weight_prop, actx->lat_prop,
-				actx->lon_prop, &actx->paths, &actx->weights);
+				actx->relationCount, actx->weight_prop, ATTRIBUTE_ID_NONE,
+				actx->lat_prop, actx->lon_prop, &actx->paths, &actx->weights);
 	}
 
 	return PROCEDURE_OK;

--- a/src/procedures/proc_sp_paths.c
+++ b/src/procedures/proc_sp_paths.c
@@ -498,10 +498,10 @@ static double _sum_path_cost
 	const Path *p,
 	AttributeID cost_prop
 ) {
-	if(cost_prop == ATTRIBUTE_ID_NONE) {
-		return 0;
-	}
-
+	// sum costProp over the path's edges, defaulting a missing value to 1.
+	// when no costProp is given (cost_prop == ATTRIBUTE_ID_NONE) every edge
+	// contributes 1, so pathCost is the hop count -- matching what the
+	// exhaustive DFS reports, rather than 0.
 	double cost = 0;
 	uint edge_count = Path_EdgeCount (p);
 	for(uint i = 0; i < edge_count; i++) {
@@ -998,7 +998,7 @@ static ProcedureResult Proc_SPpathsInvoke
 				single_pair_ctx->path_count, single_pair_ctx->dir,
 				single_pair_ctx->relationIDs, single_pair_ctx->relationMatrices,
 				single_pair_ctx->relationCount, single_pair_ctx->weight_prop,
-				&paths, &weights) ;
+				single_pair_ctx->cost_prop, &paths, &weights) ;
 
 		// load results into the same max-heap Proc_SPpathsStep drains, exactly
 		// as SPpaths_k_minimal does, so downstream behavior is unchanged.

--- a/tests/flow/test_astar.py
+++ b/tests/flow/test_astar.py
@@ -585,3 +585,47 @@ class testAStar(FlowTestsBase):
         for rd in ("outgoing", "incoming", "both"):
             self._astar_vs_sppaths(g, 0, 3, 1,   rel_dir=rd, rel_types=["AR", "AS"])
             self._astar_vs_sppaths(g, 0, 3, 100, rel_dir=rd, rel_types=["AR", "AS"])
+
+    def test17_astar_inconsistent_heuristic_reopens(self):
+        # mixing coordinate-bearing and coordinate-less nodes makes the
+        # haversine heuristic admissible but NOT consistent, so a finalized
+        # node must be reopened when a strictly shorter route to it appears --
+        # otherwise A* returns a suboptimal path.
+        #
+        # graph (weights, all in "metres" so h stays admissible):
+        #   S -[5]-> P            P has NO coordinates -> h(P) = 0
+        #   S -[1]-> Q -[1]-> P   Q is ~50 m from T   -> h(Q) ~= 50
+        #   P -[99]-> T
+        # P is popped/finalized early at g=5 (f = 5 + 0); Q pops later
+        # (f = 1 + ~50) and only then exposes the g=2 route to P. Without
+        # reopening, A* keeps P at g=5 and returns S-P-T = 104; the optimum is
+        # S-Q-P-T = 101, which Dijkstra (algo.SPpaths) always finds.
+        g = self.db.select_graph("astar_reopen")
+        g.query("""
+            CREATE (s:AK {id:0, lat:37.00001, lon:-122.0}),
+                   (q:AK {id:1, lat:37.00045, lon:-122.0}),
+                   (p:AK {id:2}),
+                   (t:AK {id:3, lat:37.0, lon:-122.0}),
+                   (s)-[:AE {weight:1}]->(q),
+                   (s)-[:AE {weight:5}]->(p),
+                   (q)-[:AE {weight:1}]->(p),
+                   (p)-[:AE {weight:99}]->(t)
+        """)
+
+        astar = g.query("""
+            MATCH (u:AK {id:0}), (v:AK {id:3})
+            CALL algo.AStar({sourceNode:u, targetNode:v, weightProp:'weight',
+                latitudeProperty:'lat', longitudeProperty:'lon'})
+            YIELD pathWeight RETURN pathWeight
+        """)
+        sp = g.query("""
+            MATCH (u:AK {id:0}), (v:AK {id:3})
+            CALL algo.SPpaths({sourceNode:u, targetNode:v, weightProp:'weight',
+                pathCount:1})
+            YIELD pathWeight RETURN pathWeight
+        """)
+
+        self.env.assertEquals(len(astar.result_set), 1)
+        self.env.assertAlmostEqual(astar.result_set[0][0], 101, delta=1e-9)
+        self.env.assertAlmostEqual(astar.result_set[0][0],
+                                   sp.result_set[0][0], delta=1e-9)

--- a/tests/flow/test_path_algorithms.py
+++ b/tests/flow/test_path_algorithms.py
@@ -1231,3 +1231,64 @@ class testAllShortestPaths():
                 f"targetNode:v, weightProp:'w', relDirection:'{rd}', "
                 f"pathCount:100, relTypes:['R','S','R']}}) {ret}")
             self.env.assertEquals(dup, distinct)
+
+    def test29_fastpath_pathcost_hopcount_without_costprop(self):
+        # with no costProp, pathCost is the hop count (each edge defaults to 1),
+        # matching the exhaustive DFS -- not 0. Verify across all three fast
+        # paths (pathCount 1 / 0 / >1).
+        g = self.db.select_graph("fp_costhops")
+        g.query("""
+            CREATE (a:V {id:0}), (b:V {id:1}), (c:V {id:2}),
+                   (a)-[:R {w:1}]->(b), (b)-[:R {w:1}]->(c),
+                   (a)-[:R {w:5}]->(c)
+        """)
+        for pc in (1, 0, 3):
+            r = g.query(f"""
+                MATCH (u:V {{id:0}}), (v:V {{id:2}})
+                CALL algo.SPpaths({{sourceNode:u, targetNode:v, weightProp:'w',
+                  pathCount:{pc}}}) YIELD path, pathCost
+                RETURN length(path) AS hops, pathCost
+            """)
+            self.env.assertTrue(len(r.result_set) > 0)
+            for hops, cost in r.result_set:
+                # pathCost == number of edges on the path (hop count)
+                self.env.assertEquals(cost, float(hops))
+
+    def test30_kshortest_costprop_tiebreak(self):
+        # among equal-weight paths the k-shortest fast path (Yen) must select by
+        # (weight, cost, length) -- preferring lower cost -- matching the DFS,
+        # not pick a tie arbitrarily by length. three s->t routes:
+        #   P1: s-c-t  weight 3, cost 0   (cheapest weight)
+        #   P2: s-a-t  weight 5, cost 1   } equal weight, differ only on cost
+        #   P3: s-b-t  weight 5, cost 100 }
+        # with k=2 the result must be {P1, P2}; the cost-100 tie (P3) is excluded.
+        g = self.db.select_graph("fp_cost_tie")
+        g.query("""
+            CREATE (s:V {id:0}), (a:V {id:1}), (b:V {id:2}),
+                   (c:V {id:3}), (t:V {id:4}),
+                   (s)-[:R {w:1, c:0}]->(c),   (c)-[:R {w:2, c:0}]->(t),
+                   (s)-[:R {w:2, c:1}]->(a),   (a)-[:R {w:3, c:0}]->(t),
+                   (s)-[:R {w:2, c:100}]->(b), (b)-[:R {w:3, c:0}]->(t)
+        """)
+
+        def rows(dfs):
+            extra = ", maxLen:1000" if dfs else ""
+            r = g.query(f"""
+                MATCH (u:V {{id:0}}), (v:V {{id:4}})
+                CALL algo.SPpaths({{sourceNode:u, targetNode:v, weightProp:'w',
+                  costProp:'c', pathCount:2{extra}}})
+                YIELD path, pathWeight, pathCost
+                RETURN [n IN nodes(path)|n.id] AS ids, pathWeight, pathCost
+                ORDER BY pathWeight, pathCost
+            """)
+            return [(tuple(x[0]), x[1], x[2]) for x in r.result_set]
+
+        fast = rows(dfs=False)
+        dfs  = rows(dfs=True)
+
+        ids = set(t[0] for t in fast)
+        self.env.assertEquals(len(fast), 2)
+        self.env.assertContains((0, 1, 4), ids)       # P2 (cost 1) kept
+        self.env.assertNotContains((0, 2, 4), ids)    # P3 (cost 100) excluded
+        # selection agrees with the DFS
+        self.env.assertEquals(fast, dfs)


### PR DESCRIPTION
…election

Addresses three post-merge review findings on the Yen/A*/all-shortest work:

1. A* returned suboptimal paths when only some nodes have lat/lon: the haversine heuristic is admissible but inconsistent across coordinate / coordinate-less nodes, and AStarCtx_Run never reopened finalized nodes. Now a strictly shorter g to an already-finalized node reopens and re-expands it, restoring optimality; all-coords graphs stay consistent so no reopening occurs.

2. algo.SPpaths pathCost regressed to 0 without costProp for the accelerated pathCount:0 / pathCount>1 paths (the DFS reported hop count). _sum_path_cost now sums a default of 1 per edge, so pathCost is the hop count without costProp -- matching the DFS -- across all pathCount values.

3. The Yen fast path selected k paths by (weight, length), ignoring costProp, diverging from the DFS among equal-weight ties. Thread cost_prop (may be ATTRIBUTE_ID_NONE) into Yen_KShortestPaths / AStar_KShortestPaths and select by (weight, cost, length) -- matching path_cmp so selection and reported order agree. Without costProp, cost == hop count == length, so weight-only queries are unaffected.

Adds regression tests: test_astar test17 (reopen), test_path_algorithms test29 (pathCost hop count) and test30 (cost tie-break).