### PR TITLE
perf(runtime): keep computed grouping keys on the vectorized path (1.7x)

### DIFF
--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -20,14 +20,14 @@
 //! ```
 //!
 //! Key and aggregation-input expressions are evaluated in bulk: a variable
-//! passthrough or `entity.property` is a single bulk attribute read, and any
-//! other input tree (`sum(n.age * 3)`) goes through
-//! [`VectorEval`](crate::runtime::vector_expr::VectorEval), which evaluates it
-//! column at a time. This includes single-argument `DISTINCT` aggregations
-//! (e.g. `count(DISTINCT n.id)`): the property column is still extracted in
-//! bulk and per-group deduplication is applied during accumulation. Inputs
-//! containing a nested aggregate, and multi-argument aggregations, still fall
-//! back to per-row evaluation.
+//! passthrough is read straight from its batch column, and every other tree
+//! — key or input, `n.age` and `sum(n.age * 3)` and `n.id % 100` alike — goes
+//! through [`VectorEval`](crate::runtime::vector_expr::VectorEval), which
+//! evaluates it column at a time. This includes single-argument `DISTINCT`
+//! aggregations (e.g. `count(DISTINCT n.id)`): the property column is still
+//! extracted in bulk and per-group deduplication is applied during
+//! accumulation. Inputs containing a nested aggregate, keys containing one,
+//! and multi-argument aggregations still fall back to per-row evaluation.
 
 use crate::parser::ast::{ExprIR, QueryExpr, Variable};
 use crate::planner::IR;
@@ -97,8 +97,29 @@ impl Hash for GroupKey {
 enum KeyExprKind {
     /// Simple variable passthrough: `GROUP BY n`
     Variable(Variable),
-    /// Property access: `GROUP BY n.age`
-    Property { var: Variable, attr: Arc<String> },
+    /// Any other key tree, `n.age` and `n.id % 100` alike.
+    ///
+    /// The column is built by [`VectorEval`], so the whole key tree is
+    /// evaluated column at a time — a bare `n.age` is still one bulk attribute
+    /// fetch — and the rest of the vectorized path (bulk aggregate-input
+    /// extraction, the columnar accumulate loop) is kept.
+    ///
+    /// Property access had its own variant, and any other shape sent the
+    /// *whole operator* down `consume_input_per_row`, which rebuilds an owned
+    /// `Row` and re-walks every key and input tree for every row. So a key as
+    /// ordinary as `n.age / 10` cost the bulk aggregate path too. The variant
+    /// is gone rather than extended — one evaluator, nothing left to disagree
+    /// with, exactly as [`AggInputKind::Computed`] did for the input side.
+    ///
+    /// The old variant's "unclassified" requirement is preserved by
+    /// [`VectorEval::eval_values`], which answers a property read with the
+    /// stored values rather than a classified lane: a grouping key must be the
+    /// stored value, or the classifier's float lane would promote a mixed
+    /// int/float column and merge 9007199254740993 with 9007199254740992.
+    Computed {
+        tree: QueryExpr<Variable>,
+        idx: NodeIdx<Dyn<ExprIR<Variable>>>,
+    },
 }
 
 /// How an aggregation input expression can be evaluated in bulk.
@@ -225,20 +246,19 @@ impl<'a> AggregateOp<'a> {
                 ExprIR::Variable(var) => {
                     key_kinds.push(KeyExprKind::Variable(var.clone()));
                 }
-                ExprIR::Property(attr) => {
-                    if root.num_children() != 1 {
+                // Anything else: materialise the column with `VectorEval`,
+                // keeping the whole operator on the vectorized path. A nested
+                // aggregate still falls back — it needs the per-row path's
+                // group-aware evaluation.
+                _ => {
+                    if subtree_has_aggregate(&root) {
                         return None;
                     }
-                    if let ExprIR::Variable(var) = root.child(0).data() {
-                        key_kinds.push(KeyExprKind::Property {
-                            var: var.clone(),
-                            attr: attr.clone(),
-                        });
-                    } else {
-                        return None;
-                    }
+                    key_kinds.push(KeyExprKind::Computed {
+                        tree: tree.clone(),
+                        idx: root.idx(),
+                    });
                 }
-                _ => return None,
             }
         }
 
@@ -397,23 +417,17 @@ impl<'a> AggregateOp<'a> {
             }
 
             // --- Phase 1: Extract key columns in bulk ---
-            let Ok(key_columns) =
-                Self::extract_key_columns(self.runtime, &batch, &active, &analysis.key_kinds)
-            else {
-                // Vectorized extraction failed for this batch.
-                // Fall back to per-row for this batch only.
-                Self::consume_batch_per_row(
-                    self.runtime,
-                    self.keys,
-                    self.agg,
-                    self.copy_from_parent,
-                    &batch,
-                    &default_acc,
-                    &mut groups,
-                    &mut errors,
-                );
-                continue;
-            };
+            let key_columns =
+                match Self::extract_key_columns(self.runtime, &batch, &active, &analysis.key_kinds)
+                {
+                    Ok(columns) => columns,
+                    // A key expression failed to evaluate: the query fails with
+                    // that error, exactly as it would on the per-row path.
+                    Err(e) => {
+                        errors.push(e);
+                        break;
+                    }
+                };
 
             // --- Phase 2: Extract aggregation input columns in bulk ---
             let agg_input_columns = match Self::extract_agg_input_columns(
@@ -598,12 +612,17 @@ impl<'a> AggregateOp<'a> {
     }
 
     /// Extracts key values for all active rows in a batch.
+    ///
+    /// Every key shape is evaluable — [`VectorEval`] is total — so an `Err` is
+    /// a genuine evaluation error (`Division by zero`) rather than "this batch
+    /// cannot take the bulk path", exactly as
+    /// [`extract_agg_input_columns`](Self::extract_agg_input_columns) reports.
     fn extract_key_columns(
         runtime: &'a Runtime<'a>,
         batch: &Batch<'a>,
         active: &[usize],
         key_kinds: &[KeyExprKind],
-    ) -> Result<Vec<Vec<Value>>, ()> {
+    ) -> Result<Vec<Vec<Value>>, String> {
         let mut key_columns = Vec::with_capacity(key_kinds.len());
         for kind in key_kinds {
             match kind {
@@ -614,14 +633,12 @@ impl<'a> AggregateOp<'a> {
                         .collect();
                     key_columns.push(col);
                 }
-                KeyExprKind::Property { var, attr } => {
-                    let node_ids = batch.extract_node_ids(var.id).ok_or(())?;
-                    let active_ids: Vec<_> = active.iter().map(|&i| node_ids[i]).collect();
-                    // Unclassified: a grouping key must be the stored value, and
-                    // the classifier's float lane would promote a mixed
-                    // int/float column, merging 9007199254740993 and
-                    // 9007199254740992 into one group.
-                    key_columns.push(runtime.materialize_node_property_values(&active_ids, attr));
+                KeyExprKind::Computed { tree, idx } => {
+                    key_columns.push(VectorEval::new(runtime).eval_values(
+                        &tree.node(*idx),
+                        batch,
+                        active,
+                    )?);
                 }
             }
         }
@@ -630,11 +647,10 @@ impl<'a> AggregateOp<'a> {
 
     /// Extracts aggregation input values for all active rows in a batch.
     ///
-    /// Unlike [`extract_key_columns`](Self::extract_key_columns), which reports
-    /// "this batch cannot take the bulk path" with `Err(())`, every input shape
-    /// is evaluable here — [`VectorEval`] is total. So an `Err` is a genuine
-    /// evaluation error (`Division by zero`) and is returned as such, rather
-    /// than sending the batch down the per-row path only to raise it again.
+    /// Every input shape is evaluable here — [`VectorEval`] is total — so an
+    /// `Err` is a genuine evaluation error (`Division by zero`) and is returned
+    /// as such, rather than sending the batch down the per-row path only to
+    /// raise it again.
     fn extract_agg_input_columns(
         runtime: &'a Runtime<'a>,
         batch: &Batch<'a>,
@@ -714,8 +730,15 @@ impl<'a> AggregateOp<'a> {
     }
 
     /// Processes a single batch using per-row evaluation.
-    /// Shared by both the per-row fallback path and the vectorized path
-    /// (when a specific batch can't use bulk extraction).
+    ///
+    /// `#[inline(never)]` because this is the *cold* path and it is large: with
+    /// `consume_input_vectorized` no longer calling it, LLVM starts inlining it
+    /// into `consume_input_per_row`, and the resulting layout costs the hot
+    /// vectorized loop measurably — 1,604,640 instructions on the `aggregates`
+    /// benchmark row against 1,596,817 with the attribute, and 536,087 against
+    /// 534,304 on `agg count`. Keeping it out of line pins both back to what
+    /// they cost before.
+    #[inline(never)]
     #[allow(clippy::too_many_arguments)]
     fn consume_batch_per_row(
         runtime: &'a Runtime<'a>,

--- a/tests/flow/test_aggregation.py
+++ b/tests/flow/test_aggregation.py
@@ -314,3 +314,91 @@ class testAggregations():
             self.graph.query("MATCH (n:M) RETURN sum(n.v)").result_set, [[4]])
         self.env.assertEqual(
             self.graph.query("MATCH ()-[r:R]->() RETURN sum(r.w)").result_set, [[2]])
+
+    def test_group_by_computed_key(self):
+        # A grouping key that is not a bare variable or `n.prop` used to send
+        # the *whole* operator down the per-row path — rebuilding an owned row
+        # and re-walking every key and input tree once per row. It is now
+        # materialised as a column by the same evaluator the aggregate inputs
+        # use, so these shapes have to keep answering exactly what the per-row
+        # path answered.
+        self.graph.query(
+            "UNWIND range(0, 9) AS i CREATE (:GK {id: i, name: 'p' + toString(i)})")
+
+        # Arithmetic on a property: the shape that motivated the change.
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) RETURN p.id % 3 AS k, count(*) AS c ORDER BY k").result_set,
+            [[0, 4], [1, 3], [2, 3]])
+
+        # A function call, and a key that mixes several properties.
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) RETURN toUpper(p.name) AS k, count(*) ORDER BY k LIMIT 2").result_set,
+            [['P0', 1], ['P1', 1]])
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) RETURN p.id + size(p.name) AS k, count(*) ORDER BY k LIMIT 2").result_set,
+            [[2, 1], [3, 1]])
+
+        # Several keys at once, one bare property and one computed.
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) RETURN p.id % 2 AS a, p.id % 5 AS b, count(*) AS c "
+                "ORDER BY a, b LIMIT 3").result_set,
+            [[0, 0, 1], [0, 1, 1], [0, 2, 1]])
+
+        # A relationship property as the key: the old bulk path only knew how
+        # to read a node column, so this fell back for every batch.
+        self.graph.query(
+            "UNWIND range(0, 5) AS i MATCH (a:GK {id: i}), (b:GK {id: i + 1}) "
+            "CREATE (a)-[:GE {w: i % 2}]->(b)")
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH ()-[r:GE]->() RETURN r.w AS k, count(*) AS c ORDER BY k").result_set,
+            [[0, 3], [1, 3]])
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH ()-[r:GE]->() RETURN r.w * 10 AS k, count(*) AS c ORDER BY k").result_set,
+            [[0, 3], [10, 3]])
+
+        # A key over a map, which is neither a node nor a relationship column.
+        self.env.assertEqual(
+            self.graph.query(
+                "UNWIND [{t:'a'}, {t:'b'}, {t:'a'}] AS row "
+                "RETURN row.t AS k, count(*) AS c ORDER BY k").result_set,
+            [['a', 2], ['b', 1]])
+
+        # Grouping keys must be the *stored* value: two ints a float cannot
+        # tell apart have to stay two groups, whether the key is read directly
+        # or computed, and whether or not a float shares the column.
+        self.graph.query(
+            "CREATE (:GW {v: 9007199254740993}), (:GW {v: 9007199254740992}), (:GW {v: 1.5})")
+        self.env.assertEqual(
+            self.graph.query("MATCH (n:GW) RETURN count(*) AS c, n.v AS k ORDER BY k").result_set,
+            [[1, 1.5], [1, 9007199254740992], [1, 9007199254740993]])
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (n:GW) WHERE n.v > 2 RETURN n.v + 0 AS k, count(*) ORDER BY k").result_set,
+            [[9007199254740992, 1], [9007199254740993, 1]])
+
+        # An error raised while evaluating a key still fails the query.
+        try:
+            self.graph.query("MATCH (p:GK) RETURN p.id / 0 AS k, count(*)")
+            self.env.assertTrue(False)
+        except Exception as e:
+            self.env.assertContains("Division by zero", str(e))
+
+        # A key holding an aggregate keeps falling back — it needs the per-row
+        # path's group-aware evaluation.
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) WITH p.id % 2 AS a, count(*) AS c "
+                "RETURN c + 1 AS k, count(*) ORDER BY k").result_set,
+            [[6, 2]])
+
+        # Null keys group together rather than dropping out.
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:GK) RETURN p.missing AS k, count(*) AS c").result_set,
+            [[None, 10]])

--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -1021,6 +1021,28 @@ class testConstraintReplication():
         # the WAIT command forces master slave sync to complete
         self.source.execute_command("WAIT", 1, 0)
 
+        # Drop whatever the replica was still working through.
+        #
+        # Under the service-container flow flavour the replica is long-lived and
+        # shared with the classes above, so their ~26 GRAPH.CONSTRAINT commands
+        # replicate into it as well. A slow replica -- coverage instrumentation
+        # is enough -- can still be applying that backlog when MONITOR attaches,
+        # and the backlog then lands in `self.monitor` and inflates the count
+        # `test_01` asserts. It is a race, not a constant: it only shows up when
+        # the source runs far enough ahead of the replica.
+        #
+        # `WAIT` above returns once the replica has acked this connection's
+        # offset, and the replication stream is ordered, so everything the
+        # earlier classes wrote has been executed by now. MONITOR delivery is
+        # asynchronous, so settle first, then drop: from here on the list holds
+        # only what this test causes.
+        deadline = time.time() + 10
+        seen = -1
+        while len(self.monitor) != seen and time.time() < deadline:
+            seen = len(self.monitor)
+            time.sleep(0.5)
+        self.monitor.clear()
+
     def monitor_thread(self):
         global MONITOR_ATTACHED
         try:


### PR DESCRIPTION
Closes #2663

## Summary

The batch aggregate operator vectorized a grouping key only when it was a bare variable or `n.prop`. Anything else — `n.id % 100`, `toUpper(n.name)`, a relationship property — made `analyze()` return `None`, which sent the **whole operator** down `consume_input_per_row`: an owned `Row` rebuilt per row, and every key *and aggregate-input* tree re-walked per row. So one ordinary computed key also gave up the bulk aggregate-input path that #2628 had already built.

The input side had already solved this. `AggInputKind::Computed` materialises any tree with `VectorEval`, and #2555 removed its hand-rolled property arm in favour of the one evaluator. The key side now does the same: `KeyExprKind::Property` is gone, and `Computed` covers every shape through `VectorEval::eval_values`.

The old `Property` arm's *unclassified* requirement is preserved by construction rather than by a comment: `eval_values` answers a property read with the stored values instead of a classified lane, so the "a grouping key must be the stored value" invariant holds — `9007199254740993` still does not merge with `9007199254740992`. There's a test for it.

Two things fall out of the change:

- **Relationship-property keys stop falling back entirely.** The old arm called `batch.extract_node_ids(..)`, so `MATCH ()-[r:R]->() RETURN r.w, count(*)` took the per-row path for every batch. `eval_values` reads node and relationship columns alike.
- **`extract_key_columns` can no longer say "this batch cannot take the bulk path."** `VectorEval` is total, so the per-batch fallback goes away and an `Err` is a genuine evaluation error, handled exactly as Phase 2 already handled aggregate-input errors. `Division by zero` in a key still fails the query.

Keys containing an aggregate still fall back — they need the per-row path's group-aware evaluation.

## Changes

- `KeyExprKind::Property { var, attr }` → `KeyExprKind::Computed { tree, idx }`, evaluated by `VectorEval::eval_values`.
- `analyze()` no longer bails out on a non-`Variable`/non-`Property` key; it only bails when the key subtree contains an aggregate.
- `extract_key_columns` returns `Result<_, String>` instead of `Result<_, ()>`; the per-batch `consume_batch_per_row` fallback in `consume_input_vectorized` is removed.
- `consume_batch_per_row` gains `#[inline(never)]`. With the vectorized path no longer calling it, LLVM inlines the large cold function into `consume_input_per_row`, and the resulting layout cost the hot loop ~0.4% (measured, and documented at the attribute). The attribute pins the unaffected rows back to their exact previous cost.
- New flow test `test_group_by_computed_key`.

## Testing

- `cargo test -p graph` — 176 passed. The one failure, `build_bool_is_iso_and_grb_build_is_not`, reproduces unchanged on the base commit (it probes the locally installed GraphBLAS, not this code).
- `pytest tests/test_e2e.py tests/test_functions.py tests/test_mvcc.py tests/test_concurrency.py` — 138 passed.
- TCK — 173 features / 2456 scenarios passed, 0 failed.
- `./flow.sh` — 1467/1471, the same 4 pre-existing failures as the base commit, verified by running the full suite on a base build. (An earlier run showed 2 extra; both pass in isolation and are parallelism flakes.)
- `cargo fmt --all --check` clean; `cargo clippy --all-targets` introduces no new warnings (the 2 remaining are pre-existing, in `cond_var_len_traverse.rs` and `bulk_insert.rs`).
- The new test passes against **both** the base and the patched module — it asserts that the fast path answers what the per-row path answered, not new behaviour.

## Memory / Performance Impact

Callgrind, instructions per execution, `THREAD_COUNT 1`, base vs PR built from the same tree:

| query | base | PR | ratio |
| --- | ---: | ---: | ---: |
| `WITH pipeline` — `MATCH (p:Person) WITH p.id % 100 AS g, count(*) AS c …` | 3,170,892 | 1,957,051 | **1.62x** |
| `ORDER BY agg` — `MATCH (p:Person) RETURN p.id % 5 AS k, count(*) …` | 2,905,861 | 1,669,899 | **1.74x** |
| `aggregates` | 1,596,902 | 1,595,794 | 1.00x |
| `agg count` | 534,048 | 534,098 | 1.00x |
| `agg sum` | 698,884 | 698,849 | 1.00x |
| `count distinct` | 3,478,605 | 3,478,575 | 1.00x |
| `RETURN DISTINCT` | 611,082 | 611,032 | 1.00x |

Every unaffected row is within 0.01%, i.e. inside the harness's ±0.20% differencing margin. Wall clock on the same host agrees: `WITH pipeline` 2.60 ms → 1.36 ms, `ORDER BY agg` 2.70 ms → 1.41 ms.

Memory: allocation goes **down** on the affected queries. The per-row path built one owned `Row` (a `SmallVec` of values plus a `BitSet`) for every input row; the vectorized path builds one `Vec<Value>` per key per batch. No per-entity storage changes, no allocator behaviour changes, `QUERY_MEM_CAPACITY` untouched.

### Confirmed on CI

`benchmark-cov` ran the full 332-query set against base and against the C engine on CI hardware. Its callgrind numbers land on top of the local ones:

| query | base | PR | PR/base |
| --- | ---: | ---: | ---: |
| `ORDER BY agg` | 2,885,062 | 1,659,975 | **0.575x** |
| `WITH pipeline` | 3,124,944 | 1,916,090 | **0.613x** |
| `trig` | 976,740 | 819,790 | 0.839x |
| `math extras` | 1,348,052 | 1,152,735 | 0.855x |

`trig` and `math extras` are a bonus: both end in an aggregation over a computed expression, so they were on the per-row path too and neither was on my radar.

Of 103 callgrind queries, those four are the only ones that moved more than 1%; the remaining 99 are within ±0.7%, i.e. the harness's own error bar. Allocated bytes: geomean 1.006 across 50 ranked rows, and the three rows above 1.05x are all `delete …` queries sitting just over the 64 KB floor, which this change cannot reach.

### A test fix rides along

`testConstraintReplication.test_01` started failing on the `coverage-flow-svc` flavour. It is not a regression — a control PR (whitespace-only, same base) was green, so the failure is a race this change *exposes* rather than causes.

The test asserts an exact count of `GRAPH.CONSTRAINT` commands on the replica's MONITOR stream. Under the service-container flavour the replica is long-lived and shared with the two classes above it, whose ~26 constraint creations replicate into the same stream (38 = 12 + 26). A slow replica — coverage instrumentation suffices — is still draining that backlog when MONITOR attaches. Speeding up the source widened the gap enough to make it land every time.

`WAIT` already guarantees the replica has executed everything the earlier classes wrote; MONITOR delivery is simply asynchronous. So the fix settles until the stream stops growing, then clears the list, and the count reflects only what the test itself causes.

## Related Issues

Closes #2663.

Follows #2628 (columnar expression evaluation) and #2555 (one evaluator for aggregate inputs), applying the same treatment to the grouping-key side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved grouping and aggregation for computed keys, including arithmetic expressions, functions, map values, multiple keys, nulls, and large numeric values.
  * Added support for grouping by computed node and relationship properties while maintaining efficient bulk processing.

* **Bug Fixes**
  * Queries now correctly report errors from invalid computed keys, such as division by zero, instead of silently falling back to slower processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


