### PR TITLE
fix(devcontainer): copy GraphBLAS assets and install OpenSSL headers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,7 @@ RUN apt install -y \
     libc++-22-dev \
     libc++abi-22-dev \
     libzstd-dev \
+    libssl-dev \
     python3-dev \
     python3-pip \
     python3-venv \
@@ -57,9 +58,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # Set working directory for build scripts
 WORKDIR /data
 
-# Copy build scripts, and the RediSearch submodule they build (git owns the pin;
+# Copy build scripts, GraphBLAS patch + PreJIT kernels, and the RediSearch submodule they build (git owns the pin;
 # redisearch.sh only builds what is checked out, so the source must be present)
 COPY graphblas.sh redisearch.sh /data/
+COPY build/graphblas /data/build/graphblas
 COPY deps/RediSearch /data/deps/RediSearch
 
 # Build and install GraphBLAS using project script


### PR DESCRIPTION
Fixes #2668 

## Summary

- Copy `build/graphblas` into the devcontainer so `graphblas.sh` can apply `GB_control.patch` and vendor PreJIT kernels.
- Install `libssl-dev` so RediSearch 8.6 hiredis can `find_package(OpenSSL)`.

## Testing

- [x] From repo root, with `git submodule update --init --recursive` already done: `docker build -f .devcontainer/Dockerfile .` completes past both `graphblas.sh` and `redisearch.sh`.
- [x] Confirm the image still has `/usr/local/lib/libgraphblas.a` and `/data/deps/RediSearch/bin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the development environment setup to support required secure-build tooling.
  * Updated build preparation so GraphBLAS resources are available automatically during development builds.
  * No changes were made to the application’s public behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->