### PR TITLE
feat(AStar): add heuristicScale to fix time-weighted A* optimality

### DIFF
--- a/src/algorithms/AStar.c
+++ b/src/algorithms/AStar.c
@@ -76,16 +76,23 @@ static inline bool _get_node_latlon
 }
 
 // admissible heuristic: haversine distance from 'id' to the fixed goal
-// (dst_lat, dst_lon), or 0 if dst's coordinates were never resolved or
-// 'id' itself lacks a numeric lat/lon -- either case degrades gracefully
-// to Dijkstra-like behavior for the affected node rather than erroring
-// mid-search.
+// (dst_lat, dst_lon) scaled into the weight's units by 'heur_scale', or 0 if
+// dst's coordinates were never resolved or 'id' itself lacks a numeric lat/lon
+// -- either case degrades gracefully to Dijkstra-like behavior for the affected
+// node rather than erroring mid-search.
+//
+// 'heur_scale' converts raw meters to the weightProp's units and MUST be a
+// lower bound on the weight accrued per meter of straight-line progress for the
+// heuristic to stay admissible (see AStar.h). e.g. weightProp == distance in
+// meters -> heur_scale == 1; weightProp == travel time in hours -> heur_scale
+// == 1 / (max_speed in meters-per-hour).
 static inline double _heuristic
 (
 	Graph *g,
 	NodeID id,
 	AttributeID lat_prop,
 	AttributeID lon_prop,
+	double heur_scale,
 	bool dst_has_coords,
 	double dst_lat,
 	double dst_lon
@@ -99,7 +106,7 @@ static inline double _heuristic
 		return 0;
 	}
 
-	return _haversine_meters(lat, lon, dst_lat, dst_lon);
+	return heur_scale * _haversine_meters(lat, lon, dst_lat, dst_lon);
 }
 
 // per-node search record used by the A* search below (best-known cost g, cached
@@ -137,6 +144,7 @@ typedef struct AStarCtx {
 	AttributeID     weight_prop;       // weight attribute id
 	AttributeID     lat_prop;          // latitude attribute id (heuristic)
 	AttributeID     lon_prop;          // longitude attribute id (heuristic)
+	double          heur_scale;        // meters -> weight-units heuristic scale
 
 	// expansion directions derived from 'dir', computed once at construction
 	int             ndirs;
@@ -161,7 +169,8 @@ static AStarCtx *AStarCtx_New
 	int relationCount,
 	AttributeID weight_prop,
 	AttributeID lat_prop,
-	AttributeID lon_prop
+	AttributeID lon_prop,
+	double heur_scale
 ) {
 	AStarCtx *ac = rm_calloc(1, sizeof(AStarCtx));
 
@@ -173,6 +182,7 @@ static AStarCtx *AStarCtx_New
 	ac->weight_prop      = weight_prop;
 	ac->lat_prop         = lat_prop;
 	ac->lon_prop         = lon_prop;
+	ac->heur_scale       = heur_scale;
 
 	ac->ndirs = 0;
 	if(dir == GRAPH_EDGE_DIR_OUTGOING || dir == GRAPH_EDGE_DIR_BOTH) {
@@ -228,15 +238,17 @@ static bool AStarCtx_Run
 	// resolve dst's coordinates once, up front: every heuristic evaluation
 	// during this search targets this fixed goal. if dst has no numeric
 	// lat/lon, the heuristic degrades to 0 for the entire search (i.e. plain
-	// Dijkstra) rather than erroring.
+	// Dijkstra) rather than erroring. a non-positive heur_scale also disables
+	// the heuristic graph-wide (h == 0 -> plain Dijkstra), so skip the lookup.
 	double dst_lat = 0;
 	double dst_lon = 0;
 	bool dst_has_coords = (ac->weight_prop != ATTRIBUTE_ID_NONE) &&
+			(ac->heur_scale > 0)                                 &&
 			_get_node_latlon(ac->g, dst_id, ac->lat_prop, ac->lon_prop, &dst_lat, &dst_lon);
 
 	// seed the source: g_score 0, priority f = 0 + h(src).
 	double src_h = _heuristic(ac->g, src_id, ac->lat_prop, ac->lon_prop,
-			dst_has_coords, dst_lat, dst_lon);
+			ac->heur_scale, dst_has_coords, dst_lat, dst_lon);
 	AStarLabel src_label =
 		{ .parent = src_id, .g_score = 0, .h = src_h, .finalized = false };
 
@@ -344,7 +356,7 @@ static bool AStarCtx_Run
 				} else {
 					// first discovery: compute and cache h(nid).
 					h = _heuristic(ac->g, nid, ac->lat_prop, ac->lon_prop,
-							dst_has_coords, dst_lat, dst_lon);
+							ac->heur_scale, dst_has_coords, dst_lat, dst_lon);
 					AStarLabel fresh = { .h = h, .finalized = false };
 					arr_append(ac->records, fresh);
 					*nslot = arr_len(ac->records);
@@ -456,14 +468,15 @@ bool AStar_ShortestPath
 	int relationCount,
 	AttributeID weight_prop,
 	AttributeID lat_prop,
-	AttributeID lon_prop
+	AttributeID lon_prop,
+	double heur_scale
 ) {
 	ASSERT(g      != NULL);
 	ASSERT(path   != NULL);
 	ASSERT(weight != NULL);
 
 	AStarCtx *ac = AStarCtx_New(g, dir, relationIDs, relationMatrices,
-			relationCount, weight_prop, lat_prop, lon_prop);
+			relationCount, weight_prop, lat_prop, lon_prop, heur_scale);
 
 	bool found = AStarCtx_Run(ac, src_id, dst_id, NULL, NULL);
 
@@ -636,6 +649,7 @@ uint AStar_KShortestPaths
 	AttributeID weight_prop,
 	AttributeID lat_prop,
 	AttributeID lon_prop,
+	double heur_scale,
 	Path ***paths,
 	double **weights
 ) {
@@ -655,7 +669,7 @@ uint AStar_KShortestPaths
 	}
 
 	AStarCtx *ac = AStarCtx_New(g, dir, relationIDs, relationMatrices,
-			relationCount, weight_prop, lat_prop, lon_prop);
+			relationCount, weight_prop, lat_prop, lon_prop, heur_scale);
 
 	// A[0]: the global shortest path. if dst is unreachable there are none.
 	if(!AStarCtx_Run(ac, src, dst, NULL, NULL)) {

--- a/src/algorithms/AStar.h
+++ b/src/algorithms/AStar.h
@@ -19,15 +19,24 @@
 // ASSUMES weightProp is non-negative for every edge (same as Dijkstra,
 // same rationale, not enforced -- see Dijkstra.h).
 //
-// ASSUMES weightProp is expressed in the same units as the haversine
-// heuristic (meters) for the heuristic to remain admissible (never
-// overestimate the true remaining cost to dst) and therefore for A* to
-// guarantee an optimal result. If weightProp represents something else
-// (time, hop count, an abstract cost), the heuristic may overestimate
-// and A* can return a suboptimal (but still structurally valid) path.
-// This is a caller responsibility, not enforced at runtime -- mirrors
+// The haversine heuristic is computed in meters; 'heur_scale' converts it
+// into weightProp's units. For A* to remain admissible (never overestimate
+// the true remaining cost to dst, and therefore guarantee an optimal result)
+// heur_scale MUST be a lower bound on the weight accrued per meter of
+// straight-line progress across every edge:
+//   weightProp == distance in meters      -> heur_scale == 1
+//   weightProp == travel time (e.g hours) -> heur_scale == 1 / max_speed
+//                                            (max_speed in meters per hour)
+//   weightProp == hop count / abstract    -> heur_scale == 0 (h == 0, i.e.
+//                                            plain Dijkstra; any other value
+//                                            has no meaningful meter relation)
+// A heur_scale larger than that lower bound makes the heuristic inadmissible,
+// so A* can return a suboptimal (but still structurally valid) path; a
+// heur_scale <= 0 disables the heuristic (plain Dijkstra, always optimal).
+// Picking it is a caller responsibility, not enforced at runtime -- mirrors
 // how Dijkstra.c documents but does not enforce its non-negative-weight
-// precondition.
+// precondition. When unsure, underestimate: a smaller heur_scale only costs
+// extra exploration, never correctness.
 //
 // if dst, or any other node discovered during the search, is missing a
 // numeric latitudeProperty/longitudeProperty, its heuristic degrades to
@@ -54,7 +63,8 @@ bool AStar_ShortestPath
 	int relationCount,         // length of relationIDs
 	AttributeID weight_prop,   // weight attribute id
 	AttributeID lat_prop,      // latitude attribute id, used for the heuristic
-	AttributeID lon_prop       // longitude attribute id, used for the heuristic
+	AttributeID lon_prop,      // longitude attribute id, used for the heuristic
+	double heur_scale          // meters -> weightProp units heuristic scale
 );
 
 // find up to 'k' shortest loopless paths from src to dst by ascending weight,
@@ -82,6 +92,7 @@ uint AStar_KShortestPaths
 	AttributeID weight_prop,   // weight attribute id
 	AttributeID lat_prop,      // latitude attribute id, used for the heuristic
 	AttributeID lon_prop,      // longitude attribute id, used for the heuristic
+	double heur_scale,         // meters -> weightProp units heuristic scale
 	Path ***paths,             // [output] array_t of Path*, ascending weight
 	double **weights           // [output] array_t of matching total weights
 );

--- a/src/procedures/proc_astar_paths.c
+++ b/src/procedures/proc_astar_paths.c
@@ -21,8 +21,14 @@
 //                   weightProp: 'weight',
 //                   latitudeProperty: 'lat',
 //                   longitudeProperty: 'lon',
+//                   heuristicScale: 1.0,
 //                   pathCount: 3}) YIELD path, pathWeight
 // RETURN path, pathWeight
+//
+// heuristicScale (optional, default 1.0) scales the haversine heuristic
+// (meters) into weightProp's units and must be a non-negative lower bound on
+// the weight per meter for A* to stay optimal: 1.0 for a distance-in-meters
+// weight, 1/max_speed for a travel-time weight (see AStar.h).
 
 typedef struct {
 	Node src;                    // source node
@@ -38,6 +44,7 @@ typedef struct {
 	AttributeID weight_prop;     // weight attribute id
 	AttributeID lat_prop;        // latitude attribute id (required)
 	AttributeID lon_prop;        // longitude attribute id (required)
+	double heur_scale;           // meters -> weightProp units heuristic scale
 	uint64_t path_count;         // number of paths to return (>= 1)
 	Path **paths;                // result paths (array_t, ascending weight)
 	double *weights;             // parallel total weights (array_t)
@@ -111,6 +118,7 @@ static bool validate_config
 	SIValue weight_prop;    // weight attribute name
 	SIValue lat_prop;       // latitude attribute name
 	SIValue lon_prop;       // longitude attribute name
+	SIValue heur_scale;     // meters -> weightProp units heuristic scale
 	SIValue path_count;     // # of paths to return
 
 	bool start_exists         = MAP_GET(config, "sourceNode",        start);
@@ -120,6 +128,7 @@ static bool validate_config
 	bool weight_prop_exists   = MAP_GET(config, "weightProp",        weight_prop);
 	bool lat_prop_exists      = MAP_GET(config, "latitudeProperty",  lat_prop);
 	bool lon_prop_exists      = MAP_GET(config, "longitudeProperty", lon_prop);
+	bool heur_scale_exists    = MAP_GET(config, "heuristicScale",    heur_scale);
 	bool path_count_exists    = MAP_GET(config, "pathCount",         path_count);
 
 	if(!start_exists || !end_exists) {
@@ -233,6 +242,27 @@ static bool validate_config
 		ctx->weight_prop = GraphContext_GetAttributeID(gc, weight_prop.stringval);
 	}
 
+	// heuristicScale converts the haversine heuristic (meters) into weightProp's
+	// units. It must be a non-negative lower bound on the weight accrued per
+	// meter of straight-line progress for A* to stay admissible (see AStar.h);
+	// e.g. 1 when weightProp is a distance in meters, or 1/max_speed when it is
+	// travel time. Defaults to 1 (weightProp assumed to be a distance in meters,
+	// the historical A* contract).
+	ctx->heur_scale = 1.0;
+
+	if(heur_scale_exists) {
+		if(!(SI_TYPE(heur_scale) & SI_NUMERIC)) {
+			ErrorCtx_SetError(EMSG_MUST_BE, "heuristicScale", "a number");
+			return false;
+		}
+		double s = SI_GET_NUMERIC(heur_scale);
+		if(s < 0) {
+			ErrorCtx_SetError(EMSG_MUST_BE, "heuristicScale", "a non-negative number");
+			return false;
+		}
+		ctx->heur_scale = s;
+	}
+
 	if(path_count_exists) {
 		if(SI_TYPE(path_count) != T_INT64) {
 			ErrorCtx_SetError(EMSG_MUST_BE, "pathCount", "integer");
@@ -296,7 +326,7 @@ static ProcedureResult Proc_AStarPathsInvoke
 		bool found = AStar_ShortestPath(&path, &weight, actx->g, src_id, dst_id,
 				actx->dir, actx->relationIDs, actx->relationMatrices,
 				actx->relationCount, actx->weight_prop, actx->lat_prop,
-				actx->lon_prop);
+				actx->lon_prop, actx->heur_scale);
 
 		actx->paths   = arr_new(Path *, found ? 1 : 0);
 		actx->weights = arr_new(double, found ? 1 : 0);
@@ -309,7 +339,7 @@ static ProcedureResult Proc_AStarPathsInvoke
 		AStar_KShortestPaths(actx->g, src_id, dst_id, actx->path_count,
 				actx->dir, actx->relationIDs, actx->relationMatrices,
 				actx->relationCount, actx->weight_prop, actx->lat_prop,
-				actx->lon_prop, &actx->paths, &actx->weights);
+				actx->lon_prop, actx->heur_scale, &actx->paths, &actx->weights);
 	}
 
 	return PROCEDURE_OK;

--- a/tests/flow/test_astar.py
+++ b/tests/flow/test_astar.py
@@ -585,3 +585,94 @@ class testAStar(FlowTestsBase):
         for rd in ("outgoing", "incoming", "both"):
             self._astar_vs_sppaths(g, 0, 3, 1,   rel_dir=rd, rel_types=["AR", "AS"])
             self._astar_vs_sppaths(g, 0, 3, 100, rel_dir=rd, rel_types=["AR", "AS"])
+
+    def test17_astar_heuristic_scale_validation(self):
+        # heuristicScale must be a non-negative number.
+        g = self.db.select_graph("astar_heur_scale_validations")
+        g.query("""CREATE (:AK {id: 0, lat: 37.0, lon: -122.0}),
+                           (:AK {id: 1, lat: 37.1, lon: -122.0})""")
+
+        for bad, msg in (("'x'", "heuristicScale must be a number"),
+                         ("true", "heuristicScale must be a number"),
+                         ("-0.5", "heuristicScale must be a non-negative number"),
+                         ("-1",   "heuristicScale must be a non-negative number")):
+            query = f"""MATCH (n:AK {{id: 0}}), (m:AK {{id: 1}})
+                CALL algo.AStar({{sourceNode: n, targetNode: m,
+                    latitudeProperty: 'lat', longitudeProperty: 'lon',
+                    weightProp: 'weight', heuristicScale: {bad}}})
+                YIELD path RETURN path"""
+            try:
+                g.query(query)
+                self.env.assertTrue(False)  # should have raised
+            except redis.exceptions.ResponseError as e:
+                self.env.assertContains(msg, str(e))
+
+    def test18_astar_heuristic_scale_semantics(self):
+        # A time-weighted graph where the weight (travel time) is decoupled
+        # from geographic distance, so the raw haversine-meters heuristic
+        # (heuristicScale defaulting to 1) is grossly inadmissible.
+        #
+        #   S -[t=10]-> A -[t=10]-> T   (A sits between S and T -> small h)
+        #   S -[t= 1]-> B -[t= 1]-> T   (B detours north -> larger h)
+        #
+        # The true fastest S->T route is S-B-T (time 2), but with a meters
+        # heuristic A is geographically nearer T, so A* finalizes T via the
+        # slow S-A-T route (time 20) before ever expanding B. Scaling the
+        # heuristic into the weight's (time) units restores optimality; a
+        # scale of 0 disables the heuristic entirely (== Dijkstra).
+        g = self.db.select_graph("astar_heur_scale")
+        g.query("""
+            CREATE (s:AK {id: 0, lat: 0.0,  lon: 0.0}),
+                   (a:AK {id: 1, lat: 0.0,  lon: 0.01}),
+                   (b:AK {id: 2, lat: 0.01, lon: 0.0}),
+                   (t:AK {id: 3, lat: 0.0,  lon: 0.02}),
+                   (s)-[:AE {weight: 10}]->(a),
+                   (a)-[:AE {weight: 10}]->(t),
+                   (s)-[:AE {weight: 1}]->(b),
+                   (b)-[:AE {weight: 1}]->(t)
+        """)
+
+        def astar_weight(extra):
+            r = g.query(f"""
+                MATCH (n:AK {{id: 0}}), (m:AK {{id: 3}})
+                CALL algo.AStar({{sourceNode: n, targetNode: m, weightProp: 'weight',
+                    latitudeProperty: 'lat', longitudeProperty: 'lon'{extra}}})
+                YIELD pathWeight RETURN pathWeight""")
+            return r.result_set[0][0]
+
+        # trusted oracle: Dijkstra -> the true optimum is 2 (S-B-T)
+        dij = g.query("""
+            MATCH (n:AK {id: 0}), (m:AK {id: 3})
+            CALL algo.SPpaths({sourceNode: n, targetNode: m,
+                weightProp: 'weight', pathCount: 1})
+            YIELD pathWeight RETURN pathWeight""").result_set[0][0]
+        self.env.assertAlmostEqual(dij, 2, delta=1e-9)
+
+        # default heuristicScale (== 1): meters heuristic is inadmissible here,
+        # so A* returns the suboptimal S-A-T route (time 20). This documents
+        # the pre-fix behavior and that the default is unchanged.
+        self.env.assertAlmostEqual(astar_weight(""), 20, delta=1e-9)
+        self.env.assertAlmostEqual(astar_weight(", heuristicScale: 1.0"), 20, delta=1e-9)
+
+        # admissible scale (<= min edge weight/length ~= 4e-4 s/m here) and the
+        # heuristic-disabling scale 0 both recover the true optimum.
+        self.env.assertAlmostEqual(astar_weight(", heuristicScale: 0.0001"), 2, delta=1e-9)
+        self.env.assertAlmostEqual(astar_weight(", heuristicScale: 0"), 2, delta=1e-9)
+
+        # the same holds for K-shortest: with an admissible scale A*-Yen must
+        # return the exact same path set/weights as Dijkstra-Yen.
+        def k_ids_weights(call):
+            r = g.query(f"""
+                MATCH (n:AK {{id: 0}}), (m:AK {{id: 3}})
+                {call} YIELD path, pathWeight
+                RETURN [nd IN nodes(path) | nd.id] AS ids, pathWeight""")
+            return sorted((tuple(row[0]), round(row[1], 6)) for row in r.result_set)
+
+        astar_k = k_ids_weights("""CALL algo.AStar({sourceNode: n, targetNode: m,
+            weightProp: 'weight', latitudeProperty: 'lat', longitudeProperty: 'lon',
+            heuristicScale: 0.0001, pathCount: 2})""")
+        sp_k = k_ids_weights("""CALL algo.SPpaths({sourceNode: n, targetNode: m,
+            weightProp: 'weight', pathCount: 2})""")
+        self.env.assertEquals(astar_k, sp_k)
+        # both routes are found (weights 2 and 20)
+        self.env.assertEquals(sorted(w for _, w in astar_k), [2, 20])


### PR DESCRIPTION
algo.AStar's heuristic is the haversine great-circle distance in meters, which is only admissible when weightProp is also a distance in meters. When the weight is travel time (e.g. drivetimeHours), meters grossly overestimate the remaining cost, so f = g + h is dominated by h and A* degenerates into greedy best-first search -- fast but returning suboptimal paths (observed ~1.6x too long on the Swedish road network, matching a prospect report).

Add an optional heuristicScale argument (double, default 1.0) that converts the haversine meters into weightProp's units:

    h(n) = heuristicScale * haversine_meters(n, dst)

It must be a non-negative lower bound on the weight accrued per meter of straight-line progress to keep A* admissible (and therefore optimal):
  * distance in meters -> heuristicScale = 1 (the default, unchanged behavior)
  * travel time        -> heuristicScale = 1 / max_speed
  * 0                  -> heuristic disabled (== Dijkstra, always optimal)

On 50 random Swedish-road-network pairs with a drivetime weight, A* went from 48/50 suboptimal (default meters heuristic) to 0/50 with heuristicScale = 1/120000, matching Dijkstra and an independent scipy oracle exactly while still running ~2.2x faster than Dijkstra. Mirrors pgRouting pgr_aStar's `factor` parameter.