### PR TITLE
perf: reuse one iterator pair per type when cascading deleted nodes' edges

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -2465,27 +2465,37 @@ impl Graph {
         for type_idx in 0..self.relationship_matrices.len() {
             let mut rels: Vec<(u64, u64, u64)> = Vec::new();
 
-            // Collect all edges for deleted nodes from this tensor
-            for node_id in deleted_nodes {
-                // Outgoing edges
-                for (src, dst, edge_id) in
-                    self.relationship_matrices[type_idx].iter(node_id, node_id, false)
-                {
-                    if !explicit_rels.contains(edge_id) {
-                        rels.push((edge_id, src, dst));
+            // Collect all edges for deleted nodes from this tensor.
+            //
+            // One iterator pair for the whole type, re-seeked per node, rather
+            // than a fresh pair per node: building one allocates a
+            // `GxB_Iterator` per layer and waits the tensor, so per-node
+            // construction cost scales with the deleted set and the number of
+            // relationship types while having nothing to do with how many edges
+            // those nodes actually have. Deleting a million edgeless nodes over
+            // six types built twelve million iterators to yield nothing.
+            {
+                let tensor = &self.relationship_matrices[type_idx];
+                let mut outgoing = tensor.iter(0, 0, false);
+                let mut incoming = tensor.iter(0, 0, true);
+                for node_id in deleted_nodes {
+                    outgoing.seek(node_id, node_id);
+                    for (src, dst, edge_id) in &mut outgoing {
+                        if !explicit_rels.contains(edge_id) {
+                            rels.push((edge_id, src, dst));
+                        }
                     }
-                }
-                // Incoming edges — skip if source is also a deleted node
-                // (those edges are already collected from the source's
-                // outgoing iteration), and skip self-loops already found above.
-                for (src, dst, edge_id) in
-                    self.relationship_matrices[type_idx].iter(node_id, node_id, true)
-                {
-                    if src != node_id
-                        && !deleted_nodes.contains(src)
-                        && !explicit_rels.contains(edge_id)
-                    {
-                        rels.push((edge_id, src, dst));
+                    // Incoming edges — skip if source is also a deleted node
+                    // (those edges are already collected from the source's
+                    // outgoing iteration), and skip self-loops already found above.
+                    incoming.seek(node_id, node_id);
+                    for (src, dst, edge_id) in &mut incoming {
+                        if src != node_id
+                            && !deleted_nodes.contains(src)
+                            && !explicit_rels.contains(edge_id)
+                        {
+                            rels.push((edge_id, src, dst));
+                        }
                     }
                 }
             }

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -1694,6 +1694,31 @@ impl<'a> Iter<'a> {
             buf_pos: 0,
         }
     }
+
+    /// Re-seek to a new row range, reusing the underlying GraphBLAS iterators
+    /// instead of allocating a fresh pair.
+    ///
+    /// The mirror of [`versioned_matrix::Iter::seek`], for callers that scan
+    /// many single-row ranges of the same tensor. Building an `Iter` allocates
+    /// a `GxB_Iterator` per layer and, on the forward side, waits the tensor
+    /// first, so doing it per row makes the scan cost far more than the rows
+    /// it visits.
+    ///
+    /// The buffered multi-edge ids belong to the pair the iterator was sitting
+    /// on, so they are dropped here — after a seek the next `next()` must start
+    /// from the new range.
+    pub fn seek(
+        &mut self,
+        min_row: u64,
+        max_row: u64,
+    ) {
+        match &mut self.base {
+            BaseIter::Forward(it) => it.seek(min_row, max_row),
+            BaseIter::Backward(it) => it.seek(min_row, max_row),
+        }
+        self.buf.clear();
+        self.buf_pos = 0;
+    }
 }
 
 impl Iterator for Iter<'_> {

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -801,6 +801,55 @@ class testGraphDeletionFlow(FlowTestsBase):
         )
         self.env.assertEqual(res.result_set, [[9, "E", 2]])
 
+    def test36_implicit_edge_cascade_across_types_and_directions(self):
+        # `delete_implicit_edges` reuses one iterator pair per relationship type
+        # and re-seeks it for each deleted node, instead of building a fresh pair
+        # per node. A seek that failed to reposition would still find the first
+        # node's edges and silently miss the rest, which reads as a large speedup
+        # rather than as a failure — so this pins the cascade over many nodes and
+        # over every type and direction.
+        self.graph.delete()
+
+        # one hub carrying both directions of four types, plus a self-loop
+        self.graph.query("CREATE (h:Hub {n: 0})")
+        for t in range(1, 5):
+            self.graph.query(f"MATCH (h:Hub) CREATE (h)-[:T{t} {{w: {t}}}]->(:Out {{n: {t}}})")
+            self.graph.query(f"MATCH (h:Hub) CREATE (:In {{n: {t}}})-[:T{t} {{w: {t}}}]->(h)")
+        self.graph.query("MATCH (h:Hub) CREATE (h)-[:T1 {w: 99}]->(h)")
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 9)
+
+        res = self.graph.query("MATCH (h:Hub) DELETE h")
+        self.env.assertEqual(res.nodes_deleted, 1)
+        self.env.assertEqual(res.relationships_deleted, 9)
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+        # the far endpoints survive
+        res = self.graph.query("MATCH (n) RETURN count(n)")
+        self.env.assertEqual(res.result_set[0][0], 8)
+
+    def test37_implicit_edge_cascade_over_many_nodes(self):
+        # The same cascade spanning more nodes than one runtime batch, with each
+        # node's edges reachable only by re-seeking the shared iterator.
+        self.graph.delete()
+
+        n = 5000
+        self.graph.query(f"UNWIND range(1, {n}) AS i CREATE (:H2 {{i: i}})-[:TA]->(:E1 {{i: i}})")
+        self.graph.query(
+            f"UNWIND range(1, {n}) AS i MATCH (h:H2 {{i: i}}) CREATE (:E2 {{i: i}})-[:TB]->(h)")
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 2 * n)
+
+        res = self.graph.query("MATCH (h:H2) DELETE h")
+        self.env.assertEqual(res.nodes_deleted, n)
+        self.env.assertEqual(res.relationships_deleted, 2 * n)
+
+        res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()


### PR DESCRIPTION
Fixes #2672

**Stack 1/2** — base of the stack, targets `main`.

`write 1m` ran at **2.58x** the C engine, the largest absolute gap left in the benchmark.

## Cause

`Graph::delete_implicit_edges` built a fresh iterator per deleted node per relationship type:

```rust
for type_idx in 0..relationship_matrices.len() {   // 6 types
    for node_id in deleted_nodes {                  // 1M
        ...[type_idx].iter(node_id, node_id, false)
        ...[type_idx].iter(node_id, node_id, true)
```

~12 million iterator constructions for `Tmp` nodes with **no edges at all**. Each allocates a `GxB_Iterator` per layer and, on the forward side, waits the tensor first — so cost tracked the deleted set and the type count, neither related to how many edges those nodes carry.

A symbolicated profile put `delete_implicit_edges` at **37.5% inclusive** against a query thread that was 53% of the profile (~71% of real query work), with the leaves being pure iterator churn: `Iter::new`, `Iter::seek`, `GB_calloc_memory`, `GB_Context_data_arena`, `GxB_Iterator_free`.

Isolated confirmation — 200k **edgeless** nodes, varying only relationship-type count:

| rel types | 1 | 2 | 4 | 8 |
|---|---|---|---|---|
| before | 145.4 | 197.8 | 266.4 | 417.6 ms |
| **after** | **117.3** | **119.9** | **129.9** | **152.0** ms |

Per-type slope falls from ~39 ms to ~5 ms.

## Fix

`versioned_matrix::Iter` already supports `seek` for this exact reason — `CondTraverseOp` uses it to amortize allocation across per-row scans. This gives `tensor::Iter` the same and hoists the pair out of the node loop: one forward and one backward iterator per type, re-seeked per node.

The access pattern is **unchanged** — a sparse deletion still visits only its own rows rather than scanning the graph, so there is no shape of workload this makes worse.

## Benchmark (3 reps, median, vs the same C module)

| row | before | after |
|---|---|---|
| `write 1m` | 2.58x | **0.79x** |
| `write 100k` | 0.87x | **0.26x** |
| `write 10k` | 0.85x | **0.25x** |
| `write 1k` | 0.87x | **0.25x** |
| `delete 10k` | 0.76x | **0.27x** |
| `delete 100` | 1.15x | **0.77x** |
| **suite total instr vs C** | **1.671x** | **0.613x** |

`write 1m` goes from 56.8B to 17.4B instructions and now beats C.

## Correctness

A speedup this large on a delete path is indistinguishable from a bug that stops deleting, so the tests pin the **cascade**, not the timing:

- `test36` — every direction and type off one hub, including a self-loop (9 edges, all must cascade)
- `test37` — the same cascade over more nodes than one runtime batch (5000 nodes, 10000 edges), where a seek that failed to reposition would find the first node's edges and silently miss the rest

Full flow suite **1477/1477**, 183 unit tests, fmt clean, clippy at the 2 pre-existing warnings.

`create 100` / `create 10k` are untouched here (4.36x / 3.03x) — separate cause, see #2673 and the snapshot-cost work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved efficiency when removing implicit relationships across many deleted nodes.
  * Large-scale graph deletions now reuse relationship scanning resources for faster processing.

* **Bug Fixes**
  * Strengthened handling of cascading edge removal across relationship types, directions, self-loops, and large node sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->