### PR TITLE
bench: order the sized rows by magnitude so the creates measure creates

### DIFF
--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -580,20 +580,26 @@ QUERIES = [
     # which would slow every full-graph query measured after them.
     # "write N" is the mixed create+delete round-trip; the "create N" /
     # "delete N" pairs measure the two halves separately.
+    # Ordered by the amount of churn each row causes, ascending, so no row is
+    # preceded by one an order of magnitude larger. Grouping the mixed
+    # "write N" rows ahead of the create/delete pairs instead put `create 100`
+    # and `create 10k` directly after `write 1m`, and a write costs more while
+    # the engine still carries a large deletion: creating a single node costs
+    # 0.05 ms after a 10k delete and 0.69 ms after a 1M one. Those two rows were
+    # measuring recovery from `write 1m` rather than the cost of a create, and
+    # read as a 4.4x / 3.0x regression against C that a fresh graph does not
+    # show (there Rust is at 1.28x and 0.74x).
     Q("write 1",             True,  "UNWIND range(1, 1) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 1000),
     Q("write 10",            True,  "UNWIND range(1, 10) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 1000),
     Q("write 100",           True,  "UNWIND range(1, 100) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 500),
-    Q("write 1k",            True,  "UNWIND range(1, 1000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 200),
-    Q("write 10k",           True,  "UNWIND range(1, 10000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 50),
-    Q("write 100k",          True,  "UNWIND range(1, 100000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 10),
-    Q("write 1m",            True,  "UNWIND range(1, 1000000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 2),
-    # The pure create/delete pairs accumulate up to reps*N entities before the
-    # delete row drains them, inflating capacity even further — keep them
-    # after the mixed "write N" rows so those keep a stable context.
     Q("create 100",          True,  "UNWIND range(1, 100) AS i CREATE (:Tmp {x: i})", 500),
     Q("delete 100",          True,  "MATCH (t:Tmp) WITH t LIMIT 100 DELETE t", 500),
+    Q("write 1k",            True,  "UNWIND range(1, 1000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 200),
+    Q("write 10k",           True,  "UNWIND range(1, 10000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 50),
     Q("create 10k",          True,  "UNWIND range(1, 10000) AS i CREATE (:Tmp {x: i})", 50),
     Q("delete 10k",          True,  "MATCH (t:Tmp) WITH t LIMIT 10000 DELETE t", 50),
+    Q("write 100k",          True,  "UNWIND range(1, 100000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 10),
+    Q("write 1m",            True,  "UNWIND range(1, 1000000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 2),
 ]
 
 # Expected-error queries: run only in --once (coverage) mode, never timed.

--- a/bench/tests/test_queries.py
+++ b/bench/tests/test_queries.py
@@ -38,6 +38,33 @@ class TestQuerySet:
         # Everything from the first sized write query onward must also be sized.
         assert sized_idx == list(range(first_sized, len(qs.QUERIES)))
 
+    def test_sized_write_queries_ascend_in_magnitude(self):
+        """No sized row may be preceded by one an order of magnitude larger.
+
+        A write costs more while the engine still carries a large deletion:
+        creating one node measured 0.05 ms after a 10k delete and 0.69 ms after
+        a 1M one. With the create/delete pairs grouped after the mixed rows,
+        `create 100` ran directly after `write 1m` and measured recovery from it
+        rather than the cost of a create -- 4.4x C, where a fresh graph shows
+        1.28x. Ascending order keeps each row's context comparable to its own
+        size, and only a test keeps it that way; the previous ordering rule was
+        a comment and drifted.
+        """
+        sized = [
+            q.name
+            for q in qs.QUERIES
+            if any(q.name.startswith(p) for p in ("write ", "create ", "delete "))
+            and q.name.split()[-1][0].isdigit()
+        ]
+        suffix = {"": 1, "k": 1_000, "m": 1_000_000}
+
+        def magnitude(name: str) -> int:
+            n = name.split()[-1]
+            return int(n.rstrip("km")) * suffix[n[-1] if n[-1] in "km" else ""]
+
+        sizes = [magnitude(n) for n in sized]
+        assert sizes == sorted(sizes), f"sized rows must ascend in magnitude, got {sized}"
+
     def test_reps_are_positive_when_set(self):
         for q in qs.QUERIES:
             assert q.reps is None or q.reps > 0, q.name


### PR DESCRIPTION
Fixes #2673

**Stack 2/2** — targets #2674. Review that one first. Benchmark-harness only; no engine code.

`create 100` and `create 10k` reported **4.4x** and **3.0x** the C engine. A fresh graph shows neither — there Rust runs a 100-node create at **1.28x** and a 10k-node create at **0.74x**, ahead of C. The gap was context, not code.

## Cause

The sized block grouped the mixed `write N` rows first and the create/delete pairs after, so `create 100` ran directly after `write 1m`. A write costs more while the engine still carries a large deletion — every write query snapshots the graph, and that snapshot scales with the deleted-id set and the capacity a big delete leaves behind. Creating a **single** node:

| preceding delete | 10k | 100k | 500k | 1M |
|---|---|---|---|---|
| first write | 0.51 ms | 0.70 ms | 1.45 ms | 2.56 ms |
| steady state | 0.05 ms | 0.13 ms | 0.37 ms | **0.69 ms** |

13x for one node, and the steady state never recovers. Reads are unaffected (0.095 ms) — only writes pay.

## Fix

Order the block by magnitude, so no row is preceded by one an order larger:

```
write 1, write 10, write 100, create 100, delete 100,
write 1k, write 10k, create 10k, delete 10k,
write 100k, write 1m
```

Measured (3 reps, median):

| row | before | after |
|---|---|---|
| `create 100` | 4.36x | **2.47x** |
| `create 10k` | 3.03x | 2.95x |
| every `write N` row | — | within noise |
| suite total instr vs C | 0.613x | 0.613x |

**`create 10k` barely moves, and that is expected** — it now follows `write 10k`, which churns 500k nodes at 50 reps under any ordering. What is left in both rows is the snapshot cost itself, which is separate work. This PR does not claim to fix that; it stops the two rows from misattributing it to the create path.

## On the ordering it replaces

The old grouping had a stated reason — keep the create/delete pairs after the mixed rows so those keep a stable context. But it traded one row's context for another's, and the rows it protected are the ones that churn most heavily anyway. Ascending order gives every row a context comparable to its own size, and the measurements above show the `write N` rows lose nothing by it.

## Test

The new ordering has a test rather than a comment — the module docstring already records that the `write N`-last rule "was enforced only by a comment" and drifted. Verified red/green: restoring the grouped order fails `test_sized_write_queries_ascend_in_magnitude`. 96 bench tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered benchmark write scenarios by ascending workload size for clearer, more consistent execution.

* **Tests**
  * Added coverage to verify that sized write, create, and delete scenarios remain ordered by magnitude.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->