### PR TITLE
devcontainer: set C.UTF-8 locale for Redis 8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CXX=clang++-22
 


### PR DESCRIPTION
Fixes #2670

Sets LANG and LC_ALL to C.UTF-8 in the devcontainer image so redis-server does not exit when the forwarded host locale (for example en_US.UTF-8) is missing.

## Test plan
- [x] Dockerfile-only change matching the workaround described in the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment locale support by configuring UTF-8 language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->