### PR TITLE
perf: answer n:Label as a column instead of a value per row

### DIFF
--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -38,7 +38,7 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_precision_loss)]
 use crate::{
-    graph::graph::{Graph, NodeId, RelationshipId},
+    graph::graph::{Graph, LabelId, NodeId, RelationshipId},
     identifier_limits::validate_identifier_len,
     index::indexer::{IndexOptions, IndexType, TextIndexOptions, VectorIndexOptions},
     parser::ast::{ExprIR, QueryExpr, Variable},
@@ -1680,21 +1680,48 @@ impl<'a> Runtime<'a> {
         id: NodeId,
         name: &str,
     ) -> bool {
-        let g = self.g.borrow();
         // A name the graph has never registered is on no node at all, not even
         // one this query just created: `CREATE (:L)` registers `L` before it
         // stages the label. Resolving a known name is a walk over the label
         // names — a handful of entries, no allocation.
-        let Some(label_id) = g.get_label_id(name) else {
+        let Some(label_id) = self.label_id(name) else {
             return false;
         };
+        self.node_has_label_id(id, label_id)
+    }
+
+    /// The registered id for a label name, or `None` when the graph has never
+    /// seen it.
+    ///
+    /// Split out so a caller testing the same label across many rows resolves
+    /// the name once instead of per row — see the `hasLabels` column kernel.
+    #[must_use]
+    pub fn label_id(
+        &self,
+        name: &str,
+    ) -> Option<LabelId> {
+        self.g.borrow().get_label_id(name)
+    }
+
+    /// [`Self::node_has_label`] with the name already resolved.
+    ///
+    /// Same three-way answer in the same order: a node this query deleted
+    /// answers from the labels captured at the delete, a label this query
+    /// staged answers from the staged state, and everything else is one bit of
+    /// the committed label matrix.
+    #[must_use]
+    pub fn node_has_label_id(
+        &self,
+        id: NodeId,
+        label_id: LabelId,
+    ) -> bool {
         if let Some(deleted) = self.deleted_nodes.borrow().get(&id) {
             return deleted.labels.contains(&label_id);
         }
         self.pending
             .borrow()
             .node_has_label(id, label_id)
-            .unwrap_or_else(|| g.node_has_label_id(id, label_id))
+            .unwrap_or_else(|| self.g.borrow().node_has_label_id(id, label_id))
     }
 
     pub fn get_node_attrs(

--- a/graph/src/runtime/vector_expr.rs
+++ b/graph/src/runtime/vector_expr.rs
@@ -259,6 +259,12 @@ impl<'a> VectorEval<'a> {
                         .children()
                         .any(|c| matches!(c.data(), ExprIR::Distinct)) =>
             {
+                if let Some(column) = (func.name == "hasLabels")
+                    .then(|| self.eval_has_labels(node, batch, rows))
+                    .flatten()
+                {
+                    return Ok(column);
+                }
                 self.eval_function(node, batch, rows)
             }
             _ => self.eval_per_row(node, batch, rows),
@@ -566,6 +572,88 @@ impl<'a> VectorEval<'a> {
             out.push(func.func.call(self.runtime, &args)?);
         }
         Ok(ExprColumn::Values(out))
+    }
+
+    /// `n:A:B` over a bound node column, as one boolean column.
+    ///
+    /// The generic function lane materializes a `Vec<Value>` of the operand and
+    /// another of the result — 32 bytes a row before the call — and re-resolves
+    /// every label *name* to its id on every row inside `hasLabels` itself. A
+    /// label test needs neither: the names resolve once for the batch, and each
+    /// row is then one bit of the label matrix written straight into a
+    /// `Bools` column. `MATCH (n) WHERE n:Person RETURN count(n)` allocated
+    /// 976 KB over 10k rows on the benchmark graph against 6 KB for the same
+    /// scan filtering on a property.
+    ///
+    /// `None` whenever the shape is not exactly that — an unbound or
+    /// heterogeneous operand column, or a label list that is not all string
+    /// constants — and the caller takes the generic lane, which stays the
+    /// definition of the answer.
+    ///
+    /// A name the graph has never registered is on no node, so an unresolvable
+    /// label makes the whole conjunction false for every row. That is the same
+    /// answer `Runtime::node_has_label` gives, reached without touching a
+    /// matrix.
+    fn eval_has_labels(
+        &self,
+        node: &ExprNode<'_>,
+        batch: &Batch<'_>,
+        rows: &[usize],
+    ) -> Option<ExprColumn> {
+        if node.num_children() != 2 {
+            return None;
+        }
+        let operand = node.child(0);
+        let ExprIR::Variable(var) = operand.data() else {
+            return None;
+        };
+        let Column::NodeIds(ids) = batch.column(var.id) else {
+            // `Unbound` is all-null and `Values` may hold nulls or non-nodes;
+            // both are the generic lane's business.
+            return None;
+        };
+
+        let list = node.child(1);
+        if !matches!(list.data(), ExprIR::List) || list.num_children() == 0 {
+            return None;
+        }
+        // Two passes, and the order matters. `hasLabels` type-checks every
+        // element of the list even once an earlier one has settled the answer,
+        // so `hasLabels(n, ['NeverUsed', 1])` is a type error and not `false`.
+        // Claiming the shape before checking the whole list would swallow that
+        // error, which `test11_label_predicate_against_pending_labels` pins.
+        let mut names = Vec::with_capacity(list.num_children());
+        for child in list.children() {
+            let ExprIR::Constant(Value::String(name)) = child.data() else {
+                return None;
+            };
+            names.push(name.clone());
+        }
+        let mut label_ids = Vec::with_capacity(names.len());
+        for name in &names {
+            match self.runtime.label_id(name) {
+                Some(id) => label_ids.push(id),
+                // Unregistered: on no node, so false everywhere with no
+                // per-row work at all.
+                None => {
+                    return Some(ExprColumn::Bools(
+                        vec![false; rows.len()],
+                        NullBitmap::none(rows.len()),
+                    ));
+                }
+            }
+        }
+
+        let mut out = Vec::with_capacity(rows.len());
+        for &row in rows {
+            let id = ids[row];
+            out.push(
+                label_ids
+                    .iter()
+                    .all(|&label| self.runtime.node_has_label_id(id, label)),
+            );
+        }
+        Some(ExprColumn::Bools(out, NullBitmap::none(rows.len())))
     }
 
     /// The universal fallback: evaluate this subtree once per row, through the

--- a/tests/flow/test_multi_label.py
+++ b/tests/flow/test_multi_label.py
@@ -329,3 +329,47 @@ class testMultiLabel():
         self.env.assertEqual(res.result_set, [])
         res = g.query("MATCH (n:E:F) WHERE n.v > 0 REMOVE n:F WITH n MATCH (m:E:F) WHERE m.v > 0 RETURN m.v")
         self.env.assertEqual(res.result_set, [])
+
+    def test12_label_predicate_column_kernel_matches_per_row(self):
+        """`n:Label` over a bound node column is answered by a column kernel:
+           the label names resolve once for the batch and each row is one bit of
+           the label matrix, instead of materializing a value per row and
+           re-resolving the name inside the function.
+
+           The kernel only claims the shape it recognises — a node column and a
+           list of string constants — and everything else stays on the generic
+           lane. These pin that both lanes give the same answer, over enough
+           rows to span more than one batch."""
+
+        g = self.db.select_graph('label_predicate_kernel')
+        g.query("UNWIND range(1, 3000) AS i CREATE (:A {i: i})")
+        g.query("UNWIND range(1, 1500) AS i CREATE (:A:B {i: i})")
+        g.query("UNWIND range(1, 700) AS i CREATE (:C {i: i})")
+
+        # the fast path: a bound node column, over several batches
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:A RETURN count(n)").result_set, [[4500]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:B RETURN count(n)").result_set, [[1500]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:A AND n:B RETURN count(n)").result_set, [[1500]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:A:B RETURN count(n)").result_set, [[1500]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE NOT n:A RETURN count(n)").result_set, [[700]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:A OR n:C RETURN count(n)").result_set, [[5200]])
+
+        # a label the graph never registered is on no node
+        self.env.assertEqual(g.query("MATCH (n) WHERE n:Nope RETURN count(n)").result_set, [[0]])
+        self.env.assertEqual(g.query("MATCH (n) WHERE NOT n:Nope RETURN count(n)").result_set, [[5200]])
+
+        # combined with a property predicate, which takes its own column lane
+        self.env.assertEqual(
+            g.query("MATCH (n) WHERE n:A AND n.i <= 10 RETURN count(n)").result_set, [[20]])
+
+        # the kernel must agree with the projection of the same predicate
+        res = g.query("MATCH (n:A) WHERE n.i = 1 RETURN n:A, n:B, n:C ORDER BY n:B")
+        self.env.assertEqual(res.result_set, [[True, False, False], [True, True, False]])
+
+        # fallback: an unmatched OPTIONAL MATCH leaves a null, not a node column
+        res = g.query("OPTIONAL MATCH (n:Nope) RETURN n:A")
+        self.env.assertEqual(res.result_set, [[None]])
+
+        # fallback: a null node mixed in with real ones stays three-valued
+        res = g.query("MATCH (n:C) WITH n LIMIT 1 OPTIONAL MATCH (m:Nope) RETURN n:C, m:C")
+        self.env.assertEqual(res.result_set, [[True, None]])


### PR DESCRIPTION
Fixes #2684

Targets `main`. First of the memory-allocation rows; see the note at the bottom on why this is one PR rather than a stack.

## The problem

A label predicate over a scan allocated in proportion to the rows scanned:

| query | allocated |
|---|---|
| `MATCH (n) RETURN count(n)` | 5,983 B |
| `MATCH (n) WHERE n.id < 5 RETURN count(n)` | 6,726 B |
| **`MATCH (n) WHERE n:Person RETURN count(n)`** | **976,643 B** |

`n:Person` arrives as `hasLabels(n, ['Person'])`, and a `FuncInvocation` takes the generic column lane: a `Vec<Value>` for the operand, another for the result — 32 bytes a row before the call — and then `hasLabels` re-resolves each label *name* to its id on **every row**.

It is not the matrix read: `WHERE n:NoSuchLabel`, which returns before touching a matrix, costs 962,285 B too.

## The fix

A column kernel, in the spirit of the comparison kernels already in `vectorized.rs`: resolve the names once for the batch, then write one matrix bit per row straight into an `ExprColumn::Bools`.

| query | before | after |
|---|---|---|
| `WHERE n:Person` | 976,643 | **12,517** |
| `label predicate` (bench row) | 990,144 | **1,789** |
| `WHERE NOT n:Person` | 974,038 | **8,352** |
| `WHERE n:Person OR n:Doc` | 1,009,747 | **8,191** |

Against C on the bench row: **allocated bytes 2.29x → 0.004x**, and dropping the per-row name resolution moves instructions as well, **1.19x → 0.30x**.

## Scope of the claim

The kernel claims only the shape it recognises — a bound `NodeIds` column and a list of string constants — and everything else stays on the generic lane, which remains the definition of the answer. An `Unbound` or `Values` operand column (unmatched `OPTIONAL MATCH`, a null mixed with real nodes) is not a `NodeIds` column, so three-valued logic is untouched.

## Two details worth the reading time

**Validation order.** `hasLabels` type-checks every element of the list even once an earlier one has settled the answer, so `hasLabels(n, ['NeverUsed', 1])` is a type error and not `false`. My first version resolved names in one pass and short-circuited on the first unregistered label, which swallowed that error — the **existing** `test11_label_predicate_against_pending_labels` caught it. Hence two passes, validate before resolve, with the reason recorded in the code.

**Where the answer comes from.** `Runtime::node_has_label` is split into `label_id` + `node_has_label_id` so the kernel resolves once and still goes through the same three-way cascade as the per-row path — a node this query deleted, a label it staged, then the committed matrix. The name-resolving wrapper is unchanged for its existing callers.

## Tests

`test12` pins both lanes agreeing over more than one batch, the unregistered label, combination with a property predicate, projection use, and the `OPTIONAL MATCH` null fallbacks. Existing label-semantics tests pass unchanged.

Full flow suite **1480/1480**, 183 unit tests, fmt clean, clippy back to the 2 pre-existing warnings.

## Why this is one PR, not six

The six allocation rows do not share two or three causes — I measured, and two of my grouping hypotheses were wrong:

- **Not the "all types" path.** `WCC all types` (2.95 MB) ≈ `WCC typed` (2.94 MB) ≈ `WCC null` (2.96 MB); `WCC labeled` is *higher* at 3.72 MB.
- **Not the index.** For the create-then-delete edge rows the *unindexed* variant (`TREL`, 705 KB) costs more than indexed `SIMILAR` (445 KB) or `UREL` (246 KB).

And `id eq join` turns out to be a `Value Hash Join`, so its allocation is in the join rather than expression evaluation — unchanged by this PR (3.34x → 3.35x), as expected.

So the remaining five rows are at least three separate investigations, and I would rather land the one that is diagnosed than ship speculative changes to memory behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved label predicate evaluation for faster results, especially across large datasets and batches.
  - Added support for efficient checks involving single, combined, negated, and unregistered labels.

- **Bug Fixes**
  - Preserved correct label behavior for deleted nodes, staged changes, unmatched optional matches, and combined property predicates.
  - Ensured optimized evaluation matches standard row-by-row results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->