### PR TITLE
perf: lend LAGraph the adjacency matrix instead of duplicating it

### DIFF
--- a/graph/src/runtime/functions/algo_procedures.rs
+++ b/graph/src/runtime/functions/algo_procedures.rs
@@ -355,20 +355,36 @@ fn parse_config(args: &[Value]) -> Result<OrderMap<Arc<String>, Value>, String> 
     }
 }
 
-/// Create an LAGraph_Graph from a raw GrB_Matrix.
-/// The graph takes ownership of the matrix pointer—caller must NOT free it
-/// after this call.
+/// Create an `LAGraph_Graph` over `adj`.
+///
+/// `borrowed` says who owns the matrix handle afterwards, and it decides one
+/// thing only: what happens to `adj` if `LAGraph_New` fails.
+///
+/// * `borrowed = false` — LAGraph takes the handle. The caller must not free
+///   it, and must tear the graph down with
+///   [`delete_lagraph_graph_maybe_borrowed`] passing `false`. On failure
+///   `LAGraph_New` has not taken the handle, so this frees it rather than leak
+///   a matrix nothing else refers to.
+/// * `borrowed = true` — the caller keeps the handle (typically inside a
+///   `Matrix` that will free it) and lends it for the graph's lifetime. Nothing
+///   is freed here on failure, because the caller's owner still holds it, and
+///   the teardown must detach `G->A` first.
 unsafe fn create_lagraph_graph(
     adj: crate::graph::graphblas::GrB_Matrix,
     kind: LAGraph_Kind,
+    borrowed: bool,
 ) -> Result<LAGraph_Graph, String> {
     let mut g: LAGraph_Graph = null_mut();
     let mut msg = new_msg();
     let mut adj_mut = adj;
     let info = lagraph_bindings::LAGraph_New(&raw mut g, &raw mut adj_mut, kind, msg.as_mut_ptr());
     if info != 0 {
-        // LAGraph_New did not take ownership; free the matrix to avoid a leak.
-        crate::graph::graphblas::GrB_Matrix_free(&raw mut adj_mut);
+        // `LAGraph_New` only fails before taking the matrix, so the handle is
+        // still live here. Free it when this call owned it; leave it alone when
+        // it was lent, or the caller's owner would double-free.
+        if !borrowed {
+            crate::graph::graphblas::GrB_Matrix_free(&raw mut adj_mut);
+        }
         return Err(format!("LAGraph_New failed: {info}"));
     }
     if g.is_null() {
@@ -381,27 +397,6 @@ unsafe fn create_lagraph_graph(
 unsafe fn delete_lagraph_graph(g: &mut LAGraph_Graph) {
     let mut msg = new_msg();
     lagraph_bindings::LAGraph_Delete(g, msg.as_mut_ptr());
-}
-
-/// Create an LAGraph_Graph that borrows `adj`: the caller keeps ownership of
-/// the matrix and must free the graph with [`delete_lagraph_graph_borrowed`].
-/// `LAGraph_New` only fails before taking the matrix, so the error path never
-/// leaves the handle inside a graph.
-unsafe fn create_lagraph_graph_borrowed(
-    adj: crate::graph::graphblas::GrB_Matrix,
-    kind: LAGraph_Kind,
-) -> Result<LAGraph_Graph, String> {
-    let mut g: LAGraph_Graph = null_mut();
-    let mut msg = new_msg();
-    let mut adj_mut = adj;
-    let info = lagraph_bindings::LAGraph_New(&raw mut g, &raw mut adj_mut, kind, msg.as_mut_ptr());
-    if info != 0 {
-        return Err(format!("LAGraph_New failed: {info}"));
-    }
-    if g.is_null() {
-        return Err(String::from("LAGraph_New returned null graph"));
-    }
-    Ok(g)
 }
 
 /// Free an LAGraph_Graph whose adjacency matrix is borrowed: detach `G->A`
@@ -756,11 +751,8 @@ fn register_pagerank(funcs: &mut Functions) {
                 };
 
                 let borrowed = owned_adj.is_some();
-                let mut lag_g = if borrowed {
-                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
-                } else {
-                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
-                };
+                let mut lag_g =
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED, borrowed)?;
 
                 // Cache AT and OutDegree (required for PageRank)
                 let mut msg = new_msg();
@@ -867,11 +859,8 @@ fn register_wcc(funcs: &mut Functions) {
                 };
 
                 let borrowed = owned_adj.is_some();
-                let mut lag_g = if borrowed {
-                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
-                } else {
-                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
-                };
+                let mut lag_g =
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED, borrowed)?;
 
                 // Cache symmetric structure
                 let mut msg = new_msg();
@@ -987,11 +976,8 @@ fn register_betweenness(funcs: &mut Functions) {
                 };
 
                 let borrowed = owned_adj.is_some();
-                let mut lag_g = if borrowed {
-                    create_lagraph_graph_borrowed(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
-                } else {
-                    create_lagraph_graph(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
-                };
+                let mut lag_g =
+                    create_lagraph_graph(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED, borrowed)?;
 
                 let mut msg = new_msg();
                 lagraph_bindings::LAGraph_Cached_AT(lag_g, msg.as_mut_ptr());
@@ -1115,9 +1101,10 @@ fn register_bfs(funcs: &mut Functions) {
                 // to LAGraph instead of duplicating it; the borrowed delete
                 // detaches `G->A` so only the `Matrix` wrapper frees it.
                 let compact_source = u64::from(source_id);
-                let mut lag_g = create_lagraph_graph_borrowed(
+                let mut lag_g = create_lagraph_graph(
                     adj.inner(),
                     LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED,
+                    true,
                 )?;
 
                 let mut msg = new_msg();
@@ -1280,11 +1267,8 @@ fn register_cdlp(funcs: &mut Functions) {
                 };
 
                 let borrowed = owned_adj.is_some();
-                let mut lag_g = if borrowed {
-                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
-                } else {
-                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
-                };
+                let mut lag_g =
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED, borrowed)?;
 
                 let mut msg = new_msg();
                 let lag_g_ref = lag_g.as_mut().ok_or_else(|| String::from("LAGraph graph pointer is null"))?;
@@ -2780,6 +2764,7 @@ fn register_harmonic_centrality(funcs: &mut Functions) {
                 let mut lag_g = create_lagraph_graph(
                     compact_adj,
                     LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED,
+                    false,
                 )?;
 
                 let mut msg = new_msg();
@@ -3223,6 +3208,7 @@ fn register_maxflow(funcs: &mut Functions) {
                 let mut lag_g = create_lagraph_graph(
                     cap_mtx,
                     LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED,
+                    false,
                 )?;
                 let mut msg = new_msg();
                 lagraph_bindings::LAGraph_Cached_AT(lag_g, msg.as_mut_ptr());

--- a/graph/src/runtime/functions/algo_procedures.rs
+++ b/graph/src/runtime/functions/algo_procedures.rs
@@ -413,6 +413,23 @@ unsafe fn delete_lagraph_graph_borrowed(g: &mut LAGraph_Graph) {
     delete_lagraph_graph(g);
 }
 
+/// Free an `LAGraph_Graph` whose adjacency matrix may be borrowed.
+///
+/// The procedures below take one of two paths: the unfiltered path lends
+/// LAGraph the matrix it just built and keeps the `Matrix` wrapper that frees
+/// it, while the compact path hands over a raw matrix nothing else owns. This
+/// picks the matching teardown so the handle is freed exactly once.
+unsafe fn delete_lagraph_graph_maybe_borrowed(
+    g: &mut LAGraph_Graph,
+    borrowed: bool,
+) {
+    if borrowed {
+        delete_lagraph_graph_borrowed(g);
+    } else {
+        delete_lagraph_graph(g);
+    }
+}
+
 /// Extract GrB_Vector entries as (index, f64) pairs.
 unsafe fn extract_vector_f64(v: crate::graph::graphblas::GrB_Vector) -> Vec<(u64, f64)> {
     use crate::graph::graphblas::{GrB_Index, GrB_Vector_extractTuples_FP64, GrB_Vector_nvals};
@@ -705,7 +722,7 @@ fn register_pagerank(funcs: &mut Functions) {
 
             unsafe {
                 use crate::graph::graphblas::{
-                    lagraph_bindings, GrB_Matrix, GrB_Matrix_dup, GrB_Matrix_resize, GrB_Vector,
+                    lagraph_bindings, GrB_Matrix, GrB_Matrix_resize, GrB_Vector,
                     GrB_Vector_free,
                 };
 
@@ -716,10 +733,16 @@ fn register_pagerank(funcs: &mut Functions) {
                     .as_ref()
                     .is_none_or(|lbl| g.label_node_count(lbl.as_str()) == g.node_count());
 
+                // Holds the adjacency matrix on the paths that lend it to LAGraph;
+                // `None` on the compact path, whose matrix LAGraph owns.
+                let mut owned_adj: Option<crate::graph::graphblas::matrix::Matrix<bool>> = None;
                 let (lag_adj, compact_to_id): (GrB_Matrix, Option<Vec<u64>>) = if use_unfiltered {
+                    // `adj` is freshly built and uniquely owned, so lend its handle to
+                    // LAGraph rather than duplicating it; the borrowed delete detaches
+                    // `G->A` so only the `Matrix` wrapper frees it.
                     let adj = g.build_adjacency_matrix(&rel_types);
-                    let mut raw_adj: GrB_Matrix = std::ptr::null_mut();
-                    GrB_Matrix_dup(&raw mut raw_adj, adj.inner());
+                    let raw_adj: GrB_Matrix = adj.inner();
+                    owned_adj = Some(adj);
                     let n = g.node_count() + g.deleted_nodes_count();
                     GrB_Matrix_resize(raw_adj, n, n);
                     (raw_adj, None)
@@ -732,7 +755,12 @@ fn register_pagerank(funcs: &mut Functions) {
                     (lag_adj, Some(compact_to_id))
                 };
 
-                let mut lag_g = create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?;
+                let borrowed = owned_adj.is_some();
+                let mut lag_g = if borrowed {
+                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
+                } else {
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
+                };
 
                 // Cache AT and OutDegree (required for PageRank)
                 let mut msg = new_msg();
@@ -753,7 +781,7 @@ fn register_pagerank(funcs: &mut Functions) {
                 );
 
                 if info != 0 {
-                    delete_lagraph_graph(&mut lag_g);
+                    delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
                     return Err(format!("LAGr_PageRank failed: {info}"));
                 }
 
@@ -762,7 +790,7 @@ fn register_pagerank(funcs: &mut Functions) {
 
                 // Free LAGraph resources
                 GrB_Vector_free(&raw mut centrality);
-                delete_lagraph_graph(&mut lag_g);
+                delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
 
                 let has_deleted = g.deleted_nodes_count() != 0;
                 let mut node_ids = Vec::with_capacity(entries.len());
@@ -809,15 +837,21 @@ fn register_wcc(funcs: &mut Functions) {
 
             unsafe {
                 use crate::graph::graphblas::{
-                    lagraph_bindings, GrB_Matrix, GrB_Matrix_dup, GrB_Matrix_resize, GrB_Vector,
+                    lagraph_bindings, GrB_Matrix, GrB_Matrix_resize, GrB_Vector,
                     GrB_Vector_free,
                 };
 
                 // Match C implementation fast path for unfiltered run.
+                // Holds the adjacency matrix on the paths that lend it to LAGraph;
+                // `None` on the compact path, whose matrix LAGraph owns.
+                let mut owned_adj: Option<crate::graph::graphblas::matrix::Matrix<bool>> = None;
                 let (lag_adj, compact_to_id): (GrB_Matrix, Option<Vec<u64>>) = if node_labels.is_empty() {
+                    // `adj` is freshly built and uniquely owned, so lend its handle to
+                    // LAGraph rather than duplicating it; the borrowed delete detaches
+                    // `G->A` so only the `Matrix` wrapper frees it.
                     let adj = g.build_symmetric_adjacency_matrix(&rel_types);
-                    let mut raw_adj: GrB_Matrix = std::ptr::null_mut();
-                    GrB_Matrix_dup(&raw mut raw_adj, adj.inner());
+                    let raw_adj: GrB_Matrix = adj.inner();
+                    owned_adj = Some(adj);
                     let n = g.node_count() + g.deleted_nodes_count();
                     GrB_Matrix_resize(raw_adj, n, n);
                     (raw_adj, None)
@@ -832,7 +866,12 @@ fn register_wcc(funcs: &mut Functions) {
                     (lag_adj, Some(compact_to_id))
                 };
 
-                let mut lag_g = create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?;
+                let borrowed = owned_adj.is_some();
+                let mut lag_g = if borrowed {
+                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
+                } else {
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
+                };
 
                 // Cache symmetric structure
                 let mut msg = new_msg();
@@ -848,7 +887,7 @@ fn register_wcc(funcs: &mut Functions) {
                 );
 
                 if info != 0 {
-                    delete_lagraph_graph(&mut lag_g);
+                    delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
                     return Err(format!("LAGr_ConnectedComponents failed: {info}"));
                 }
 
@@ -869,7 +908,7 @@ fn register_wcc(funcs: &mut Functions) {
                 }
 
                 GrB_Vector_free(&raw mut component);
-                delete_lagraph_graph(&mut lag_g);
+                delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
 
                 Ok(Batch::from_columns([
                     Column::NodeIds(node_ids),
@@ -921,15 +960,21 @@ fn register_betweenness(funcs: &mut Functions) {
 
             unsafe {
                 use crate::graph::graphblas::{
-                    lagraph_bindings, GrB_Matrix, GrB_Matrix_dup, GrB_Matrix_resize, GrB_Vector,
+                    lagraph_bindings, GrB_Matrix, GrB_Matrix_resize, GrB_Vector,
                     GrB_Vector_free,
                 };
 
                 // Match C implementation fast path for unfiltered run.
+                // Holds the adjacency matrix on the paths that lend it to LAGraph;
+                // `None` on the compact path, whose matrix LAGraph owns.
+                let mut owned_adj: Option<crate::graph::graphblas::matrix::Matrix<bool>> = None;
                 let (compact_adj, compact_to_id): (GrB_Matrix, Option<Vec<u64>>) = if node_labels.is_empty() {
+                    // `adj` is freshly built and uniquely owned, so lend its handle to
+                    // LAGraph rather than duplicating it; the borrowed delete detaches
+                    // `G->A` so only the `Matrix` wrapper frees it.
                     let adj = g.build_adjacency_matrix(&rel_types);
-                    let mut raw_adj: GrB_Matrix = std::ptr::null_mut();
-                    GrB_Matrix_dup(&raw mut raw_adj, adj.inner());
+                    let raw_adj: GrB_Matrix = adj.inner();
+                    owned_adj = Some(adj);
                     let n = g.node_count() + g.deleted_nodes_count();
                     GrB_Matrix_resize(raw_adj, n, n);
                     (raw_adj, None)
@@ -941,7 +986,12 @@ fn register_betweenness(funcs: &mut Functions) {
                     (compact_adj, Some(compact_to_id))
                 };
 
-                let mut lag_g = create_lagraph_graph(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?;
+                let borrowed = owned_adj.is_some();
+                let mut lag_g = if borrowed {
+                    create_lagraph_graph_borrowed(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
+                } else {
+                    create_lagraph_graph(compact_adj, LAGraph_Kind::LAGraph_ADJACENCY_DIRECTED)?
+                };
 
                 let mut msg = new_msg();
                 lagraph_bindings::LAGraph_Cached_AT(lag_g, msg.as_mut_ptr());
@@ -985,14 +1035,14 @@ fn register_betweenness(funcs: &mut Functions) {
                 );
 
                 if info != 0 {
-                    delete_lagraph_graph(&mut lag_g);
+                    delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
                     return Err(format!("LAGr_Betweenness failed: {info}"));
                 }
 
                 let entries = extract_vector_f64(centrality);
 
                 GrB_Vector_free(&raw mut centrality);
-                delete_lagraph_graph(&mut lag_g);
+                delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
 
                 // All compact indices map to valid nodes (already label-filtered)
                 let mut node_ids = Vec::with_capacity(entries.len());
@@ -1200,15 +1250,21 @@ fn register_cdlp(funcs: &mut Functions) {
 
             unsafe {
                 use crate::graph::graphblas::{
-                    GrB_Matrix, GrB_Matrix_dup, GrB_Matrix_resize, GrB_Vector, lagraphx_bindings,
+                    GrB_Matrix, GrB_Matrix_resize, GrB_Vector, lagraphx_bindings,
                     GrB_Vector_free,
                 };
 
                 // Match C implementation fast path for unfiltered run.
+                // Holds the adjacency matrix on the paths that lend it to LAGraph;
+                // `None` on the compact path, whose matrix LAGraph owns.
+                let mut owned_adj: Option<crate::graph::graphblas::matrix::Matrix<bool>> = None;
                 let (lag_adj, compact_to_id): (GrB_Matrix, Option<Vec<u64>>) = if node_labels.is_empty() {
+                    // `adj` is freshly built and uniquely owned, so lend its handle to
+                    // LAGraph rather than duplicating it; the borrowed delete detaches
+                    // `G->A` so only the `Matrix` wrapper frees it.
                     let adj = g.build_symmetric_adjacency_matrix(&rel_types);
-                    let mut raw_adj: GrB_Matrix = std::ptr::null_mut();
-                    GrB_Matrix_dup(&raw mut raw_adj, adj.inner());
+                    let raw_adj: GrB_Matrix = adj.inner();
+                    owned_adj = Some(adj);
                     let n = g.node_count() + g.deleted_nodes_count();
                     GrB_Matrix_resize(raw_adj, n, n);
                     (raw_adj, None)
@@ -1223,7 +1279,12 @@ fn register_cdlp(funcs: &mut Functions) {
                     (lag_adj, Some(compact_to_id))
                 };
 
-                let mut lag_g = create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?;
+                let borrowed = owned_adj.is_some();
+                let mut lag_g = if borrowed {
+                    create_lagraph_graph_borrowed(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
+                } else {
+                    create_lagraph_graph(lag_adj, LAGraph_Kind::LAGraph_ADJACENCY_UNDIRECTED)?
+                };
 
                 let mut msg = new_msg();
                 let lag_g_ref = lag_g.as_mut().ok_or_else(|| String::from("LAGraph graph pointer is null"))?;
@@ -1238,7 +1299,7 @@ fn register_cdlp(funcs: &mut Functions) {
                 );
 
                 if info != 0 {
-                    delete_lagraph_graph(&mut lag_g);
+                    delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
                     return Err(format!("LAGraph_cdlp failed: {info}"));
                 }
 
@@ -1259,7 +1320,7 @@ fn register_cdlp(funcs: &mut Functions) {
                 }
 
                 GrB_Vector_free(&raw mut cdlp);
-                delete_lagraph_graph(&mut lag_g);
+                delete_lagraph_graph_maybe_borrowed(&mut lag_g, borrowed);
 
                 Ok(Batch::from_columns([
                     Column::NodeIds(node_ids),


### PR DESCRIPTION
Fixes #2715.

Second in the stack, now targeting `main` (#2685 has landed).

A modest fix plus a diagnosis that matters more than the fix.

## The fix

Four algorithm procedures built an owned adjacency matrix and then immediately `GrB_Matrix_dup`'d it, because `Matrix::inner` documents that its caller must not free the handle while LAGraph frees every matrix it is given. The original was dropped one line later, so the copy existed purely to satisfy ownership.

The file already had the answer: `create_lagraph_graph_borrowed` / `delete_lagraph_graph_borrowed`, which detach `G->A` before deleting so LAGraph does not free a caller-owned handle. `algo.BFS` has used them since they were added, with a comment saying exactly why. These four now do too — they keep the `Matrix` wrapper alive for the call and lend its handle. No `mem::forget`, no ownership-transfer helper, no unsafe added.

Each of these procedures has two paths that differ in ownership: the unfiltered path lends a matrix it built, the compact path hands over a raw matrix nothing else owns. `owned_adj` records which, and `delete_lagraph_graph_maybe_borrowed` picks the matching teardown so the handle is freed exactly once.

Getting that wrong is a double free rather than a leak, and it did go wrong once while writing this: `algo.betweenness` briefly lent its matrix while still using the owning teardown. The compiler caught it — `owned_adj` assigned but never read — and the four sites are now checked against each other by an explicit audit rather than by eye.

| | before | after |
|---|---|---|
| `algo.WCC({})` | 2,945,862 | 2,818,862 |
| `algo.WCC({relationshipTypes:[…]})` | 2,936,717 | 2,774,328 |
| `algo.labelPropagation` | 2,860,348 | 2,698,694 |

About 5%. Worth having, but not the story.

## The diagnosis

These procedures allocate in proportion to the node **id space**, not to live nodes — and **both engines do**:

| graph with 10,463 live nodes | Rust | C |
|---|---|---|
| fresh | 2.77 MB | 2.76 MB |
| after 500k nodes created + deleted | **67.4 MB** | **42.6 MB** |

24x on Rust, 15x on C, for the same 10,463 live nodes, because `n = node_count + deleted_nodes_count` sizes the matrix by every id slot ever used. The benchmark measures `WCC all types` after its write rows, which is why that row reads 1.57x C — and 67.4/42.6 is 1.58x, the same number.

So the row's ratio is not this dup, and it is not the "all types" path either (`WCC all types` 2.95 MB ≈ `WCC typed` 2.94 MB ≈ `WCC null` 2.96 MB; `WCC labeled` is *higher* at 3.72 MB).

The remaining Rust-vs-C gap is that the symmetric closure builds **three** matrices over that id space — `build_adjacency_matrix`, its transpose, and their sum — where a `GrB_transpose` accumulating onto the first would need one. That is a separate change with its own aliasing risk, and the shared O(id-space) behaviour underneath is a design question for both engines rather than a Rust defect.

## Tests

59 tests across `test_wcc`, `test_bfs`, `test_cdlp`, `test_pagerank`, `test_procedures` and `test_path_algorithms` pass. WCC still reports 10,463 nodes in 363 components; `pageRank` and `betweenness` still return 10,463. 183 unit tests, fmt clean, clippy at the 2 pre-existing warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved execution efficiency for PageRank, WCC, Betweenness, and label propagation procedures by reducing unnecessary graph data duplication.
  * Optimized graph-based processing for BFS, Harmonic Centrality, and Max Flow through more appropriate resource ownership handling.
* **Reliability**
  * Improved graph resource management to prevent duplicate cleanup and ensure resources are released correctly across successful and failed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
