### PR TITLE
perf: keep a hash-join build slot inline instead of a Vec per key

### DIFF
--- a/graph/src/runtime/ops/value_hash_join.rs
+++ b/graph/src/runtime/ops/value_hash_join.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 use ahash::RandomState;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
+use smallvec::{SmallVec, smallvec};
 
 use crate::parser::ast::{QueryExpr, Variable};
 use crate::planner::IR;
@@ -55,7 +56,15 @@ pub(crate) struct RightRowRef {
 
 /// One hash bucket's worth of build-side rows that share the same key value,
 /// kept as positions so probe can re-check exact key equality after a hash hit.
-pub(crate) type BuildSlot = Vec<RightRowRef>;
+///
+/// Inline capacity 1, because the overwhelmingly common case is a key that
+/// appears once. A `Vec` here is a heap allocation per *distinct key* to hold a
+/// single 8-byte position, and joins on near-unique keys are exactly the shape
+/// that produces one per row. Measured on a 10,000-row build side: 1,646,215
+/// bytes allocated when every key was distinct, against 12,423 when the same
+/// rows carried only five distinct keys. Duplicate keys spill to the heap as
+/// before.
+pub(crate) type BuildSlot = SmallVec<[RightRowRef; 1]>;
 
 /// General-path build/probe table: `seeded_hash(Value) -> [(key, right rows)]`.
 /// The per-bucket `Vec` resolves hash collisions; exact `Value` equality is
@@ -133,7 +142,7 @@ fn insert_value(
     let bucket = table.entry(hash_value(&key)).or_default();
     match bucket.iter_mut().find(|(k, _)| *k == key) {
         Some((_, refs)) => refs.push(slot),
-        None => bucket.push((key, vec![slot])),
+        None => bucket.push((key, smallvec![slot])),
     }
 }
 

--- a/tests/flow/test_hashjoin.py
+++ b/tests/flow/test_hashjoin.py
@@ -97,3 +97,41 @@ class testHashJoin(FlowTestsBase):
         actual_result = self.graph.query(q)
         self.env.assertEqual(actual_result.result_set, [[1, 1024], [2, 1]])
 
+    def test_unique_and_duplicate_keys(self):
+        """The build side keeps one slot per distinct key, inline for the common
+           case of a key that appears once and spilling to the heap only for
+           duplicates. Both have to answer identically, so this joins against a
+           near-unique key and a heavily duplicated one over the same rows, and
+           spans more than one batch either way.
+
+           The inline case used to be a heap allocation per distinct key: over a
+           10,000-row build side, 1,646,215 bytes allocated when every key was
+           distinct against 12,423 when the same rows carried five."""
+
+        g = self.graph
+        n = 3000
+        g.query(f"UNWIND range(1, {n}) AS i CREATE (:R {{uniq: i, few: i % 5}})")
+        g.query("CREATE (:L {k: 7}), (:L {k: 2}), (:L {k: 999999})")
+
+        # unique keys: one build slot each, matched one at a time
+        res = g.query("MATCH (l:L) MATCH (r:R) WHERE r.uniq = l.k RETURN l.k, count(r) ORDER BY l.k")
+        self.env.assertEqual(res.result_set, [[2, 1], [7, 1]])
+
+        # duplicated keys: one slot holding many rows
+        res = g.query("MATCH (l:L) MATCH (r:R) WHERE r.few = l.k RETURN l.k, count(r) ORDER BY l.k")
+        self.env.assertEqual(res.result_set, [[2, n // 5]])
+
+        # a key on no build row joins nothing
+        res = g.query("MATCH (l:L) MATCH (r:R) WHERE r.uniq = 999999 RETURN count(r)")
+        self.env.assertEqual(res.result_set, [[0]])
+
+        # NULL never joins, on either side
+        g.query("CREATE (:L {k: null})")
+        res = g.query("MATCH (l:L) MATCH (r:R) WHERE r.uniq = l.k RETURN count(r)")
+        self.env.assertEqual(res.result_set, [[2]])
+
+        # a non-integer key promotes the table off the integer fast path and
+        # must still agree
+        g.query(f"UNWIND range(1, {n}) AS i CREATE (:S {{k: toString(i)}})")
+        res = g.query("MATCH (s:S) MATCH (t:S) WHERE s.k = t.k RETURN count(s)")
+        self.env.assertEqual(res.result_set, [[n]])


### PR DESCRIPTION
Fixes #2688

**Stack 3/3** — targets #2686, which targets #2685. Review those first.

## The problem

`id eq join` allocated **3.34x** the C engine (1,590,165 B against 476,381) and ran 2.08x its instructions.

The cost is per **distinct key**, not per row. Holding the build side at 10,000 rows and varying only how many distinct join keys those rows carry:

| distinct keys | allocated |
|---|---|
| 10,000 | **1,646,215 B** |
| 5 | **12,423 B** |

132x, for the same rows. `BuildSlot` was `Vec<RightRowRef>`, so the table held a heap `Vec` for every distinct key — and a key appearing once stores a single 8-byte position in it. Joining on an id is precisely the near-unique case, so it allocated once per row.

## The fix

`SmallVec<[RightRowRef; 1]>` keeps that single position inline. Duplicates spill to the heap exactly as before, and `smallvec` was already a dependency of this crate.

| row | metric | before | after |
|---|---|---|---|
| `id eq join` | instructions | 2.08x | **1.41x** |
| `id eq join` | allocated | 3.34x | **2.67x** |
| `hash join` | instructions | 0.66x | **0.56x** |
| `hash join` | allocated | 0.26x | **0.20x** |
| `correlated hash join` | instructions | 0.95x | **0.91x** |

Instructions move because 10,000 malloc/free pairs are instructions too, and **every** hash join benefits rather than only the row that surfaced it.

## Correcting the issue I filed

#2688 guessed that the cause was the build side always being the *larger* input, and proposed choosing the build side by size. That was wrong, and it is worth saying so plainly: C runs this query with the **identical plan** — Value Hash Join, index scan left, label scan right — and still allocates a third as much. Input ordering was never the problem, so the planner change #2688 suggested is not needed.

## What is left

About 130 bytes per distinct key, and it is linear — 137, 129 and 113 bytes/key at 1k, 10k and 50k build rows. That is the map entry itself (an 8-byte key beside a 24-byte `SmallVec`) plus the rehash doubling of growing a table to N entries with no capacity known up front.

C reaches ~48 bytes/row by building a flat array, sorting it and binary searching rather than hashing. Closing that gap means rewriting build and probe, which also touches NULL handling, the promotion to the `Value` table, and the deliberate hash-flooding defence (`JOIN_HASH_SEED`) — so it belongs in its own change rather than bundled here.

## Tests

`test_unique_and_duplicate_keys` joins the same rows on a near-unique key and on a heavily duplicated one, spanning more than one batch either way, and covers a key present on no build row, `NULL` on the probe side, and a string key that promotes the table off the integer fast path.

Verified it catches a regression: against a build that keeps only the first row per key, it fails.

1480/1480 flow tests, 183 unit tests, fmt clean, clippy unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory efficiency for hash joins while preserving existing matching behavior.
  * Confirmed correct hash-join results for unique and duplicate keys, missing keys, NULL values, non-integer keys, and data spanning multiple batches.

* **Tests**
  * Added coverage for hash joins with varied key distributions and larger build-side inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->