### PR TITLE
perf: page the edge-endpoint index so a write copies a page, not the tier

### DIFF
--- a/bench/src/falkorbench/cli.py
+++ b/bench/src/falkorbench/cli.py
@@ -41,7 +41,21 @@ def _select(names: tuple[str, ...], *, cg_only: bool = False):
     missing = wanted - {q.name for q in chosen}
     if missing:
         raise click.ClickException(f"unknown queries: {sorted(missing)}")
-    return chosen
+    # Pull in whatever the chosen rows depend on, transitively. A row that
+    # measures against a graph an earlier row builds is meaningless without it,
+    # and silently so -- it reports a plausible number for the wrong graph.
+    by_name = {q.name: q for q in pool}
+    while True:
+        need = {n for q in chosen for n in q.needs} - {q.name for q in chosen}
+        if not need:
+            break
+        unknown = need - by_name.keys()
+        if unknown:
+            raise click.ClickException(f"unknown prerequisite queries: {sorted(unknown)}")
+        chosen += [by_name[n] for n in need]
+    # Back into suite order: a prerequisite has to run before its dependent.
+    order = {q.name: i for i, q in enumerate(pool)}
+    return sorted(chosen, key=lambda q: order[q.name])
 
 
 def common_options(fn):

--- a/bench/src/falkorbench/model.py
+++ b/bench/src/falkorbench/model.py
@@ -45,6 +45,11 @@ class Query(NamedTuple):
     cypher  the query text
     reps    override the default repeat count. The sized write queries set this
             so a 1M-row batch does not run 1000 times.
+    needs   names of rows that must run before this one for its number to mean
+            anything -- a row measured against a graph an earlier row builds.
+            `--` selection pulls these in; without that a named run measures the
+            same query against the setup graph and reports a plausible, wrong
+            result, the same way a `cg` row running dry measures a no-op.
     cg      runnable under callgrind: needs nothing beyond CG_SETUP's 1,000
             :Person / :KNOWS ring / 5,000 :Tmp, and does not drain a pool
             faster than it is refilled. Running dry does not fail loudly — it
@@ -56,6 +61,7 @@ class Query(NamedTuple):
     cypher: str
     reps: int | None = None
     cg: bool = False
+    needs: tuple[str, ...] = ()
 
     @property
     def command(self) -> str:

--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -600,6 +600,28 @@ QUERIES = [
     Q("delete 10k",          True,  "MATCH (t:Tmp) WITH t LIMIT 10000 DELETE t", 50),
     Q("write 100k",          True,  "UNWIND range(1, 100000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 10),
     Q("write 1m",            True,  "UNWIND range(1, 1000000) AS i CREATE (t:Tmp {x: i}) WITH t DELETE t", 2),
+
+    # ---- one write against a large EDGE population -------------------------
+    # Every sized row above creates and deletes *nodes*, so the edge count
+    # stays at SETUP's ~10k for the whole run and no row in the suite is
+    # sensitive to the cost of a write scaling with |E|. That hid #2687, where
+    # the edge-endpoint index was copied whole on the first edge mutation of
+    # every write transaction: 2,676,794 bytes allocated to create one edge
+    # against 200k of them, against 52,454 once paged. On this graph the same
+    # bug is worth 40 KB, so the suite read it as a 9% row.
+    #
+    # `edge create at 200k` measures the same create/delete round-trip as
+    # `urel create delete`, three orders of magnitude further up the edge count.
+    # It DEPENDS on `bulk edges 200k` having run first: a name-filtered run that
+    # picks it alone measures it at 10k edges instead, quietly and without
+    # failing, exactly as `delete 100` depends on `create 100`. The pairing is
+    # held by a test.
+    #
+    # Both go last so the 200k edges cannot shift any other row, and the
+    # measured row follows a large *create* rather than a large delete, so it
+    # is not reading recovery from `write 1m` the way `create 100` once did.
+    Q("bulk edges 200k",     True,  "UNWIND range(1, 200000) AS i CREATE (:Wide)-[:WIDE]->(:Wide)", 1),
+    Q("edge create at 200k", True,  "MATCH (a:Person {id: 1}), (b:Person {id: 2}) CREATE (a)-[r:WIDEX]->(b) WITH r DELETE r", 100),
 ]
 
 # Expected-error queries: run only in --once (coverage) mode, never timed.

--- a/bench/src/falkorbench/queries.py
+++ b/bench/src/falkorbench/queries.py
@@ -612,16 +612,16 @@ QUERIES = [
     #
     # `edge create at 200k` measures the same create/delete round-trip as
     # `urel create delete`, three orders of magnitude further up the edge count.
-    # It DEPENDS on `bulk edges 200k` having run first: a name-filtered run that
-    # picks it alone measures it at 10k edges instead, quietly and without
-    # failing, exactly as `delete 100` depends on `create 100`. The pairing is
-    # held by a test.
+    # It DEPENDS on `bulk edges 200k` having run first, which `needs=` declares
+    # so that selecting it by name pulls the builder in. Without that a named
+    # run measures it at 10k edges instead, quietly and without failing.
     #
     # Both go last so the 200k edges cannot shift any other row, and the
     # measured row follows a large *create* rather than a large delete, so it
     # is not reading recovery from `write 1m` the way `create 100` once did.
     Q("bulk edges 200k",     True,  "UNWIND range(1, 200000) AS i CREATE (:Wide)-[:WIDE]->(:Wide)", 1),
-    Q("edge create at 200k", True,  "MATCH (a:Person {id: 1}), (b:Person {id: 2}) CREATE (a)-[r:WIDEX]->(b) WITH r DELETE r", 100),
+    Q("edge create at 200k", True,  "MATCH (a:Person {id: 1}), (b:Person {id: 2}) CREATE (a)-[r:WIDEX]->(b) WITH r DELETE r", 100,
+      needs=("bulk edges 200k",)),
 ]
 
 # Expected-error queries: run only in --once (coverage) mode, never timed.

--- a/bench/tests/test_queries.py
+++ b/bench/tests/test_queries.py
@@ -24,19 +24,29 @@ class TestQuerySet:
         for q in qs.QUERIES:
             assert q.cypher.strip(), q.name
 
-    def test_sized_write_queries_stay_last(self):
-        """They inflate node capacity / matrix dimension to max(N), which would
-        slow every full-graph query measured after them."""
+    def test_graph_inflating_queries_stay_last(self):
+        """The suite ends in one block of rows that grow the graph for good.
+
+        The sized writes inflate node capacity and matrix dimension to max(N);
+        the two edge rows add 200k edges. Either would slow every full-graph
+        query measured after them, so the property to hold is that the tail is
+        *entirely* that block -- not that every row in it is a sized write.
+        `bulk edges 200k` and `edge create at 200k` belong to it by what they do
+        to the graph rather than by their names, so they are named here.
+        """
         sized_prefixes = ("write ", "create ", "delete ")
-        sized_idx = [
-            i
-            for i, q in enumerate(qs.QUERIES)
-            if any(q.name.startswith(p) for p in sized_prefixes) and q.name.split()[-1][0].isdigit()
-        ]
-        assert sized_idx, "expected to find the sized write queries"
-        first_sized = min(sized_idx)
-        # Everything from the first sized write query onward must also be sized.
-        assert sized_idx == list(range(first_sized, len(qs.QUERIES)))
+        edge_rows = ("bulk edges 200k", "edge create at 200k")
+
+        def inflating(q) -> bool:
+            return q.name in edge_rows or (
+                any(q.name.startswith(p) for p in sized_prefixes)
+                and q.name.split()[-1][0].isdigit()
+            )
+
+        idx = [i for i, q in enumerate(qs.QUERIES) if inflating(q)]
+        assert idx, "expected to find the graph-inflating queries"
+        # Everything from the first one onward must also inflate the graph.
+        assert idx == list(range(min(idx), len(qs.QUERIES)))
 
     def test_sized_write_queries_ascend_in_magnitude(self):
         """No sized row may be preceded by one an order of magnitude larger.
@@ -64,6 +74,40 @@ class TestQuerySet:
 
         sizes = [magnitude(n) for n in sized]
         assert sizes == sorted(sizes), f"sized rows must ascend in magnitude, got {sized}"
+
+    def test_large_edge_row_follows_its_builder(self):
+        """`edge create at 200k` is meaningless unless the bulk row ran first.
+
+        It measures a write against a large edge population, which only exists
+        because `bulk edges 200k` built it. Selected alone -- or reordered ahead
+        of the builder -- it measures the same write at SETUP's ~10k edges and
+        reports a number that looks fine, the same way a `cg` row running dry
+        quietly measures a no-op. Nothing else in the suite is sensitive to |E|,
+        so there is no second row to catch the mistake.
+        """
+        names = [q.name for q in qs.QUERIES]
+        assert "bulk edges 200k" in names
+        assert "edge create at 200k" in names
+        assert names.index("bulk edges 200k") < names.index("edge create at 200k")
+
+    def test_sized_row_guard_ignores_the_edge_rows(self):
+        """The ascending-magnitude rule is about node churn, not these two.
+
+        `test_sized_write_queries_ascend_in_magnitude` collects rows by name
+        shape, and `... 200k` after `write 1m` would look like a violation. They
+        are exempt because the rule exists to stop a row measuring recovery from
+        a larger *deletion*, and the builder in front of these creates without
+        deleting. This pins the exemption to the naming rather than leaving it
+        to chance if a row is renamed.
+        """
+        sized = [
+            q.name
+            for q in qs.QUERIES
+            if any(q.name.startswith(p) for p in ("write ", "create ", "delete "))
+            and q.name.split()[-1][0].isdigit()
+        ]
+        assert "edge create at 200k" not in sized
+        assert "bulk edges 200k" not in sized
 
     def test_reps_are_positive_when_set(self):
         for q in qs.QUERIES:

--- a/bench/tests/test_queries.py
+++ b/bench/tests/test_queries.py
@@ -90,6 +90,44 @@ class TestQuerySet:
         assert "edge create at 200k" in names
         assert names.index("bulk edges 200k") < names.index("edge create at 200k")
 
+        # Declared, not just ordered: selection has to pull the builder in.
+        measured = next(q for q in qs.QUERIES if q.name == "edge create at 200k")
+        assert "bulk edges 200k" in measured.needs
+
+    def test_named_selection_pulls_in_prerequisites(self):
+        """Selecting the measured row alone must still run its builder.
+
+        `_select` keeps only what is named, so without `needs` a run picking
+        `edge create at 200k` measures the same write against SETUP's ~10k edges
+        and reports a plausible, wrong number -- the failure mode has no symptom.
+        """
+        from falkorbench.cli import _select
+
+        chosen = [q.name for q in _select(("edge create at 200k",))]
+        assert chosen == ["bulk edges 200k", "edge create at 200k"]
+
+        # And an unrelated selection is not dragged into building 200k edges.
+        assert [q.name for q in _select(("RETURN 1",))] == ["RETURN 1"]
+
+    def test_edge_rows_come_after_the_sized_writes(self):
+        """The edge rows must not slip in front of `write 1m`.
+
+        `test_graph_inflating_queries_stay_last` only proves the inflating rows
+        form a tail; it still passes with the edge rows first. They would then
+        run straight after the 1M-node delete and measure recovery from it
+        rather than an edge write -- the confound the ascending-magnitude rule
+        exists to prevent.
+        """
+        names = [q.name for q in qs.QUERIES]
+        sized_last = max(
+            i
+            for i, q in enumerate(qs.QUERIES)
+            if any(q.name.startswith(p) for p in ("write ", "create ", "delete "))
+            and q.name.split()[-1][0].isdigit()
+        )
+        assert names.index("bulk edges 200k") > sized_last
+        assert names.index("edge create at 200k") > sized_last
+
     def test_sized_row_guard_ignores_the_edge_rows(self):
         """The ascending-magnitude rule is about node churn, not these two.
 

--- a/graph/src/graph/endpoint_index.rs
+++ b/graph/src/graph/endpoint_index.rs
@@ -124,14 +124,169 @@ impl Endpoint for u64 {
 }
 
 /// One slot per edge id, in a fixed field type.
-type Slots<T> = Vec<(T, T)>;
+/// The largest a page grows to. A write copies at most one page, so this bounds
+/// the copy-on-write cost: 4096 slots is 16 KB of `(u16, u16)` and 64 KB of
+/// `(u64, u64)`, against 16 bytes of page pointer per page.
+const PAGE_SLOTS: usize = 4096;
 
-/// Bytes one slot of a tier costs, taken from the layout the compiler chose
-/// rather than a literal that has to be kept in step with it. `(U24, U24)` is 6
-/// bytes only because `U24` is `[u8; 3]` and so alignment 1; a field type that
-/// gained alignment would otherwise make `GRAPH.MEMORY` drift silently.
-const fn slot_bytes<T>(_: &Slots<T>) -> usize {
-    size_of::<(T, T)>()
+/// A tier's slots, in pages that are shared individually.
+///
+/// One flat `Vec` behind the tier's `Arc` was the whole cost this type exists to
+/// avoid: see [`Tier`]. Sharing the pages rather than the vector means the write
+/// that follows a snapshot copies the page it lands in instead of every edge in
+/// the tier, and appends touch only the last one.
+///
+/// Every page but the last holds exactly `PAGE_SLOTS` slots, which keeps
+/// addressing to a shift and a mask. **The last page is only as long as the tier
+/// needs**, doubling as it fills. That matters more than it sounds: a fixed
+/// `PAGE_SLOTS` tail cost every graph holding a single edge a whole page, which
+/// measured at **+20.4 KB per graph** against a flat `Vec` — 27% of the
+/// per-graph footprint, on a server that may hold thousands of small graphs, in
+/// exchange for a win that only appears on large ones. Sizing the tail removes
+/// that floor and keeps the bound, because the copy is still one page.
+type Page<T> = Arc<[(T, T)]>;
+
+struct Paged<T> {
+    pages: Vec<Page<T>>,
+    len: usize,
+}
+
+impl<T> Clone for Paged<T> {
+    /// Clones the page *pointers*, not the slots — the point of the type.
+    fn clone(&self) -> Self {
+        Self {
+            pages: self.pages.clone(),
+            len: self.len,
+        }
+    }
+}
+
+impl<T> Default for Paged<T> {
+    fn default() -> Self {
+        Self {
+            pages: Vec::new(),
+            len: 0,
+        }
+    }
+}
+
+/// A page of `slots` empty slots.
+///
+/// `Arc<[_]>` rather than `Arc<Vec<_>>` so the slots live *inline* in the `Arc`
+/// allocation: a `Vec` behind an `Arc` costs the read path a second dependent
+/// load to reach them, and a bounds check against a length it also has to load.
+fn empty_page<T: Endpoint>(slots: usize) -> Page<T> {
+    Arc::from(vec![(T::EMPTY, T::EMPTY); slots])
+}
+
+impl<T: Endpoint> Paged<T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The slot at `at`, which must be within `len`.
+    fn at(
+        &self,
+        at: usize,
+    ) -> (T, T) {
+        self.pages[at / PAGE_SLOTS][at % PAGE_SLOTS]
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (T, T)> + '_ {
+        (0..self.len).map(|i| self.at(i))
+    }
+
+    /// Bytes actually allocated, tail page included at its real length.
+    fn allocated_bytes(&self) -> usize {
+        self.pages.iter().map(|p| p.len()).sum::<usize>() * size_of::<(T, T)>()
+    }
+
+    /// Bytes the *used* slots occupy, which is what a per-edge figure wants.
+    /// Taken from the layout the compiler chose rather than a literal that has
+    /// to be kept in step with it: `(U24, U24)` is 6 bytes only because `U24` is
+    /// `[u8; 3]` and so alignment 1, and a field type that gained alignment
+    /// would otherwise make `GRAPH.MEMORY` drift silently.
+    fn used_bytes(&self) -> usize {
+        self.len * size_of::<(T, T)>()
+    }
+
+    /// Replace page `p` with a longer one, empty past what it already held.
+    fn regrow(
+        &mut self,
+        p: usize,
+        slots: usize,
+    ) {
+        let mut next = vec![(T::EMPTY, T::EMPTY); slots];
+        let held = self.pages[p].len().min(slots);
+        next[..held].copy_from_slice(&self.pages[p][..held]);
+        self.pages[p] = Arc::from(next);
+    }
+
+    /// Make the pages address at least `slots` positions.
+    ///
+    /// Only the last page may be short, so a page about to stop being last is
+    /// filled out to `PAGE_SLOTS` first. The tail then doubles rather than
+    /// growing by the shortfall, which keeps appending amortised.
+    fn ensure_pages(
+        &mut self,
+        slots: usize,
+    ) {
+        if slots == 0 {
+            return;
+        }
+        let want = slots.div_ceil(PAGE_SLOTS);
+        let tail = slots - (want - 1) * PAGE_SLOTS;
+
+        if self.pages.len() < want {
+            if let Some(last) = self.pages.len().checked_sub(1)
+                && self.pages[last].len() < PAGE_SLOTS
+            {
+                self.regrow(last, PAGE_SLOTS);
+            }
+            while self.pages.len() + 1 < want {
+                self.pages.push(empty_page(PAGE_SLOTS));
+            }
+            self.pages.push(empty_page(tail));
+            return;
+        }
+
+        let last = want - 1;
+        if self.pages[last].len() < tail {
+            let grown = tail.max(self.pages[last].len() * 2).min(PAGE_SLOTS);
+            self.regrow(last, grown);
+        }
+    }
+
+    /// The page holding `at`, unshared so it can be written.
+    ///
+    /// This is `Arc::make_mut` by hand, because that does not exist for an
+    /// unsized `Arc<[_]>`. `get_mut` returning `None` is the same test
+    /// `make_mut` makes — unique in both strong and weak counts — so a page a
+    /// snapshot still holds is copied here, and only that page.
+    fn page_mut(
+        &mut self,
+        at: usize,
+    ) -> &mut [(T, T)] {
+        let p = at / PAGE_SLOTS;
+        if Arc::get_mut(&mut self.pages[p]).is_none() {
+            self.pages[p] = Arc::from(self.pages[p].to_vec());
+        }
+        Arc::get_mut(&mut self.pages[p]).expect("unique after the copy above")
+    }
+
+    fn push(
+        &mut self,
+        value: (T, T),
+    ) {
+        self.ensure_pages(self.len + 1);
+        let at = self.len;
+        self.page_mut(at)[at % PAGE_SLOTS] = value;
+        self.len += 1;
+    }
 }
 
 /// A tier, shared between MVCC versions until one of them writes to it.
@@ -147,7 +302,7 @@ const fn slot_bytes<T>(_: &Slots<T>) -> usize {
 /// tiers are history and are not touched. Holding each behind its own `Arc`
 /// means a version clones only the tier it writes to, and the history stays
 /// shared.
-type Tier<T> = Option<Arc<Slots<T>>>;
+type Tier<T> = Option<Arc<Paged<T>>>;
 
 /// `edge_id -> (src, dst)`, split into contiguous id ranges by field width.
 ///
@@ -167,28 +322,32 @@ pub struct EndpointIndex {
 /// something else at the new width.
 fn promote<A: Endpoint, B: Endpoint>(
     from: &mut Tier<A>,
-    into: &mut Slots<B>,
+    into: &mut Paged<B>,
 ) {
     let Some(old) = from.take() else { return };
     // Reuse the buffer when this version owns it outright; a version that still
-    // shares it with a snapshot has to copy.
+    // shares it with a snapshot has to copy. Only the page pointers are cloned
+    // here — the slots are read out below either way.
     let old = Arc::try_unwrap(old).unwrap_or_else(|shared| (*shared).clone());
     if old.is_empty() {
         return;
     }
-    let mut merged: Slots<B> = Vec::with_capacity(old.len() + into.len());
-    merged.extend(old.into_iter().map(|(s, d)| {
-        if s.vacant() && d.vacant() {
+    let mut merged: Paged<B> = Paged::default();
+    merged.ensure_pages(old.len() + into.len());
+    for (s, d) in old.iter() {
+        merged.push(if s.vacant() && d.vacant() {
             (B::EMPTY, B::EMPTY)
         } else {
             (B::put(s.get()), B::put(d.get()))
-        }
-    }));
-    merged.append(into);
+        });
+    }
+    for i in 0..into.len() {
+        merged.push(into.at(i));
+    }
     *into = merged;
 }
 
-/// Run `$body` for each tier in id order, with `$v` bound to `&Option<Slots<_>>`.
+/// Run `$body` for each tier in id order, with `$v` bound to `&Option<Paged<_>>`.
 macro_rules! each_tier {
     ($self:expr, |$v:ident| $body:block) => {{
         {
@@ -254,7 +413,7 @@ impl EndpointIndex {
     pub fn memory_usage(&self) -> usize {
         let mut n = 0;
         each_tier!(self, |v| {
-            n += v.as_ref().map_or(0, |v| v.capacity() * slot_bytes(v));
+            n += v.as_ref().map_or(0, |v| v.allocated_bytes());
         });
         n
     }
@@ -268,7 +427,7 @@ impl EndpointIndex {
         }
         let mut bytes = 0;
         each_tier!(self, |v| {
-            bytes += v.as_ref().map_or(0, |v| v.len() * slot_bytes(v));
+            bytes += v.as_ref().map_or(0, |v| v.used_bytes());
         });
         bytes as f64 / n as f64
     }
@@ -291,7 +450,7 @@ impl EndpointIndex {
         each_tier!(self, |v| {
             if let Some(v) = v {
                 if slot < v.len() {
-                    let (s, d) = v[slot];
+                    let (s, d) = v.at(slot);
                     return if s.vacant() && d.vacant() {
                         None
                     } else {
@@ -497,6 +656,24 @@ impl EndpointIndex {
         }
     }
 
+    /// The identity of each page backing the `u16` tier.
+    ///
+    /// Pointers, not contents: whether two versions *share* a page is exactly
+    /// what the copy-on-write bound is about, and it is invisible in anything
+    /// derived from the slots or from the page count.
+    #[cfg(test)]
+    fn w16_page_ids(&self) -> Vec<usize> {
+        self.w16
+            .as_ref()
+            .map(|t| {
+                t.pages
+                    .iter()
+                    .map(|p| Arc::as_ptr(p).cast::<()>() as usize)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Tombstone `edge_id`'s slot. Vectors never shrink, as before.
     pub fn clear(
         &mut self,
@@ -537,13 +714,14 @@ trait TierOps {
     );
 }
 
-impl<T: Endpoint> TierOps for Slots<T> {
+impl<T: Endpoint> TierOps for Paged<T> {
     fn grow_to(
         &mut self,
         len: usize,
     ) {
-        if len > self.len() {
-            self.resize(len, (T::EMPTY, T::EMPTY));
+        if len > self.len {
+            self.ensure_pages(len);
+            self.len = len;
         }
     }
     fn put(
@@ -552,24 +730,32 @@ impl<T: Endpoint> TierOps for Slots<T> {
         src: u64,
         dst: u64,
     ) {
-        self[at] = (T::put(src), T::put(dst));
+        // One page copies here if a snapshot still shares it, not the tier.
+        self.page_mut(at)[at % PAGE_SLOTS] = (T::put(src), T::put(dst));
     }
     fn vacate(
         &mut self,
         at: usize,
     ) {
-        if let Some(s) = self.get_mut(at) {
-            *s = (T::EMPTY, T::EMPTY);
+        if at < self.len {
+            self.page_mut(at)[at % PAGE_SLOTS] = (T::EMPTY, T::EMPTY);
         }
     }
     fn len(&self) -> usize {
-        Vec::len(self)
+        self.len
     }
     fn reserve_exact(
         &mut self,
         extra: usize,
     ) {
-        Vec::reserve_exact(self, extra);
+        // `saturating_sub` because the page count is only ever *at least* what
+        // the logical length needs: a caller reserving less than is already
+        // allocated asks for nothing, not for a wrapped-around capacity.
+        self.pages.reserve_exact(
+            (self.len + extra)
+                .div_ceil(PAGE_SLOTS)
+                .saturating_sub(self.pages.len()),
+        );
     }
 }
 
@@ -753,12 +939,265 @@ mod tests {
             "preparing should never be narrower than growing edge by edge"
         );
     }
+
+    /// A deterministic xorshift, so a failure here is reproducible rather than
+    /// a Heisenbug that vanishes on re-run.
+    fn xorshift(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+
+    /// Endpoint values chosen to sit exactly on the tier boundaries, where the
+    /// empty-slot sentinel of each width lives. `65_535` is `u16::EMPTY`, so an
+    /// edge with that endpoint must be held one tier wider or it would read
+    /// back as a deleted slot.
+    const BOUNDARIES: [u64; 8] = [
+        0,
+        65_534,
+        65_535,
+        16_777_214,
+        16_777_215,
+        4_294_967_294,
+        4_294_967_295,
+        4_294_967_296,
+    ];
+
+    /// Random `set`/`clear`/snapshot sequences must agree with a flat
+    /// `Vec<Option<(src, dst)>>` that models nothing but the observable answer.
+    ///
+    /// The paging exists to make an MVCC version cheap, which means the slots a
+    /// version reads are reached through page pointers it may share with a
+    /// snapshot. A wrong `Arc::make_mut` there does not fail loudly: it writes
+    /// through into a snapshot's page, or drops a write into a copy nobody
+    /// reads, and the index quietly returns the wrong endpoints for an edge.
+    /// So the sequence takes snapshots as it goes and checks every one of them
+    /// at the end, against the model as it stood when the snapshot was taken.
+    #[test]
+    fn random_edits_and_snapshots_agree_with_a_flat_reference() {
+        let mut state = 0x2545_F491_4F6C_DD1D_u64;
+        let mut ix = EndpointIndex::default();
+        let mut model: Vec<Option<(u64, u64)>> = Vec::new();
+        let mut snapshots: Vec<(EndpointIndex, Vec<Option<(u64, u64)>>)> = Vec::new();
+        let mut writes = 0u32;
+        let mut clears = 0u32;
+
+        for _ in 0..40_000 {
+            let r = xorshift(&mut state);
+            // Ids dense enough to reuse slots and to cross page boundaries
+            // repeatedly: several pages' worth at every width.
+            let id = r % 9_000;
+            match (r >> 21) & 7 {
+                0..=4 => {
+                    // Half the endpoints land on a tier boundary; the rest are
+                    // spread across the four widths so promotion happens in
+                    // every direction the tiers allow.
+                    let (src, dst) = if r & 1 == 0 {
+                        (
+                            BOUNDARIES[((r >> 40) % 8) as usize],
+                            BOUNDARIES[((r >> 44) % 8) as usize],
+                        )
+                    } else {
+                        let cap = [60_000_u64, 16_000_000, 4_000_000_000, u64::MAX / 2]
+                            [((r >> 40) % 4) as usize];
+                        ((r >> 3) % cap, (r >> 25) % cap)
+                    };
+                    ix.set(id, src, dst);
+                    if model.len() <= id as usize {
+                        model.resize(id as usize + 1, None);
+                    }
+                    model[id as usize] = Some((src, dst));
+                    writes += 1;
+                }
+                5 | 6 => {
+                    ix.clear(id);
+                    if (id as usize) < model.len() {
+                        model[id as usize] = None;
+                    }
+                    clears += 1;
+                }
+                _ => {
+                    // A version, so the *next* write reaches a shared page and
+                    // has to copy it rather than scribble on this snapshot.
+                    snapshots.push((ix.clone(), model.clone()));
+                }
+            }
+        }
+
+        // The sequence has to have actually exercised all three, or the test
+        // asserts agreement about nothing.
+        assert!(writes > 10_000, "writes: {writes}");
+        assert!(clears > 5_000, "clears: {clears}");
+        assert!(snapshots.len() > 1_000, "snapshots: {}", snapshots.len());
+
+        let check = |ix: &EndpointIndex, model: &[Option<(u64, u64)>], what: &str| {
+            for id in 0..9_000u64 {
+                let want = model.get(id as usize).copied().flatten();
+                assert_eq!(ix.get(id), want, "{what}: edge {id}");
+            }
+        };
+        check(&ix, &model, "live");
+        for (i, (snap, snap_model)) in snapshots.iter().enumerate() {
+            check(snap, snap_model, &format!("snapshot {i}"));
+        }
+    }
+
+    /// A small tier allocates the slots it uses, not a whole page.
+    ///
+    /// The first cut of the paged layout gave every page exactly `PAGE_SLOTS`
+    /// slots, tail included, so a graph holding a single edge paid a whole page
+    /// for it: **+20.4 KB per graph** measured against a flat `Vec` over 200
+    /// graphs, 27% of the per-graph footprint, on a server that may hold
+    /// thousands of small graphs. That is the wrong trade for a copy-on-write
+    /// win that only shows up on large ones, so the tail page is sized to the
+    /// tier and this keeps it that way.
+    #[test]
+    fn a_small_tier_does_not_allocate_a_whole_page() {
+        for edges in [1_u64, 10, 100] {
+            let mut ix = EndpointIndex::default();
+            for e in 0..edges {
+                ix.set(e, e % 60_000, (e + 1) % 60_000);
+            }
+            // 4 bytes a slot in the `u16` tier, so the used bytes are the floor
+            // and a doubling tail is the ceiling.
+            let used = usize::try_from(edges).unwrap() * 4;
+            let allocated = ix.memory_usage();
+            assert!(
+                allocated < 4 * used.max(64),
+                "{edges} edges allocated {allocated} bytes for {used} bytes of slots"
+            );
+        }
+
+        // And the bound still holds once the tier is genuinely large: whole
+        // pages then, so allocation tracks the edges rather than the page size.
+        let mut ix = EndpointIndex::default();
+        for e in 0..50_000u64 {
+            ix.set(e, e % 60_000, (e + 1) % 60_000);
+        }
+        let allocated = ix.memory_usage();
+        assert!(
+            (200_000..280_000).contains(&allocated),
+            "50k edges at 4 bytes a slot allocated {allocated} bytes"
+        );
+    }
+
+    /// The whole point, as a bound rather than a benchmark: the first write
+    /// after a version must leave every page but one shared with the snapshot.
+    ///
+    /// Stated as page *identity* rather than bytes. A deep copy of the pages
+    /// produces an index of exactly the same size and the same page count — so
+    /// `memory_usage`, and anything else computed from the slots, cannot tell
+    /// the two apart. Sharing is only observable in the pointers.
+    #[test]
+    fn a_version_that_writes_one_edge_copies_one_page() {
+        let mut ix = EndpointIndex::default();
+        for e in 0..200_000u64 {
+            ix.set(e, e % 60_000, (e + 1) % 60_000);
+        }
+        let before = ix.w16_page_ids();
+        assert!(
+            before.len() > 40,
+            "want many pages to share: {}",
+            before.len()
+        );
+
+        // The committed snapshot stays alive, so the version's first write
+        // reaches `Arc::make_mut` with a refcount above one — the deep-copy
+        // case this type exists to bound.
+        let mut version = ix.clone();
+        version.set(0, 1, 2);
+
+        let after = version.w16_page_ids();
+        assert_eq!(after.len(), before.len(), "a write should not add pages");
+        let copied = after.iter().zip(&before).filter(|(a, b)| a != b).count();
+        assert_eq!(
+            copied,
+            1,
+            "a one-edge version copied {copied} of {} pages",
+            before.len()
+        );
+
+        // And the copy is a copy: the snapshot still reads what it always did.
+        assert_eq!(ix.get(0), Some((0, 1)));
+        assert_eq!(version.get(0), Some((1, 2)));
+    }
 }
 
 #[cfg(test)]
 mod cow_bench {
     use super::EndpointIndex;
     use crate::graph::graphblas::instr::read_instr;
+
+    /// What paging costs the read path.
+    ///
+    /// `get` used to be one bounds-checked load from a flat vector; a page
+    /// lookup makes it a shift, a mask, a load of the page pointer and a second
+    /// bounds check. Instructions will show that; the thing instructions cannot
+    /// show is the extra indirection's cache behaviour, so this reports time as
+    /// well, for a sequential scan and for random access over an index far
+    /// larger than L2.
+    ///
+    /// Run with:
+    ///   cargo test --release -p graph get_cost -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn get_cost_of_paging() {
+        use std::time::Instant;
+
+        let edges = 10_000_000u64;
+        let mut ix = EndpointIndex::default();
+        for e in 0..edges {
+            ix.set(e, e % 60_000, (e + 1) % 60_000);
+        }
+
+        // Sequential: every page pointer is used 4096 times in a row.
+        let i0 = read_instr();
+        let t0 = Instant::now();
+        let mut acc = 0u64;
+        for e in 0..edges {
+            if let Some((s, d)) = ix.get(e) {
+                acc = acc.wrapping_add(s ^ d);
+            }
+        }
+        let seq_t = t0.elapsed();
+        let seq_i = read_instr().zip(i0).map(|(a, b)| a - b);
+        std::hint::black_box(acc);
+
+        // Random: the page-pointer array is 8 bytes per 4096 slots, so for this
+        // index it is ~20 KB and stays cached even when the slots do not. That
+        // is the case where an extra indirection would hurt if it were going to.
+        let reps = 10_000_000u64;
+        let mut state = 0x9E37_79B9_7F4A_7C15_u64;
+        let i1 = read_instr();
+        let t1 = Instant::now();
+        let mut acc2 = 0u64;
+        for _ in 0..reps {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            if let Some((s, d)) = ix.get(state % edges) {
+                acc2 = acc2.wrapping_add(s ^ d);
+            }
+        }
+        let rnd_t = t1.elapsed();
+        let rnd_i = read_instr().zip(i1).map(|(a, b)| a - b);
+        std::hint::black_box(acc2);
+
+        let per = |i: Option<u64>, n: u64| {
+            i.map_or("n/a".to_string(), |v| format!("{:.2}", v as f64 / n as f64))
+        };
+        println!(
+            "  sequential {edges} gets   {} instr/get   {:.1} ns/get",
+            per(seq_i, edges),
+            seq_t.as_nanos() as f64 / edges as f64
+        );
+        println!(
+            "  random     {reps} gets   {} instr/get   {:.1} ns/get",
+            per(rnd_i, reps),
+            rnd_t.as_nanos() as f64 / reps as f64
+        );
+    }
 
     /// What an MVCC version costs when the writer touches one edge.
     ///

--- a/graph/src/graph/endpoint_index.rs
+++ b/graph/src/graph/endpoint_index.rs
@@ -214,16 +214,38 @@ impl<T: Endpoint> Paged<T> {
         self.len * size_of::<(T, T)>()
     }
 
-    /// Replace page `p` with a longer one, empty past what it already held.
+    /// Replace `page` with a longer one, empty past what it already held.
     fn regrow(
-        &mut self,
-        p: usize,
+        page: &mut Page<T>,
         slots: usize,
     ) {
         let mut next = vec![(T::EMPTY, T::EMPTY); slots];
-        let held = self.pages[p].len().min(slots);
-        next[..held].copy_from_slice(&self.pages[p][..held]);
-        self.pages[p] = Arc::from(next);
+        let held = page.len().min(slots);
+        next[..held].copy_from_slice(&page[..held]);
+        *page = Arc::from(next);
+    }
+
+    /// Build a tier of exactly `len` slots from `it`, one allocation per page.
+    ///
+    /// `promote` used to `push` each slot, which re-derived the page index and
+    /// re-checked the page count for every element of a tier it had already
+    /// sized. Filling each page from the iterator instead makes promotion one
+    /// `extend` per page.
+    fn from_slots<I: Iterator<Item = (T, T)>>(
+        mut it: I,
+        len: usize,
+    ) -> Self {
+        let mut pages = Vec::with_capacity(len.div_ceil(PAGE_SLOTS));
+        let mut left = len;
+        while left > 0 {
+            let n = left.min(PAGE_SLOTS);
+            let mut page: Vec<(T, T)> = Vec::with_capacity(n);
+            page.extend(it.by_ref().take(n));
+            debug_assert_eq!(page.len(), n, "iterator shorter than the stated length");
+            pages.push(Arc::from(page));
+            left -= n;
+        }
+        Self { pages, len }
     }
 
     /// Make the pages address at least `slots` positions.
@@ -242,22 +264,23 @@ impl<T: Endpoint> Paged<T> {
         let tail = slots - (want - 1) * PAGE_SLOTS;
 
         if self.pages.len() < want {
-            if let Some(last) = self.pages.len().checked_sub(1)
-                && self.pages[last].len() < PAGE_SLOTS
+            // The page that is about to stop being last has to be full first.
+            if let Some(last) = self.pages.last_mut()
+                && last.len() < PAGE_SLOTS
             {
-                self.regrow(last, PAGE_SLOTS);
+                Self::regrow(last, PAGE_SLOTS);
             }
-            while self.pages.len() + 1 < want {
-                self.pages.push(empty_page(PAGE_SLOTS));
-            }
+            // Grows only: this branch is `pages.len() < want`, so `want - 1` is
+            // never below the current length and `resize_with` cannot truncate.
+            self.pages.resize_with(want - 1, || empty_page(PAGE_SLOTS));
             self.pages.push(empty_page(tail));
             return;
         }
 
-        let last = want - 1;
-        if self.pages[last].len() < tail {
-            let grown = tail.max(self.pages[last].len() * 2).min(PAGE_SLOTS);
-            self.regrow(last, grown);
+        let last = self.pages.last_mut().expect("want >= 1, so a page exists");
+        if last.len() < tail {
+            let grown = tail.max(last.len() * 2).min(PAGE_SLOTS);
+            Self::regrow(last, grown);
         }
     }
 
@@ -276,16 +299,6 @@ impl<T: Endpoint> Paged<T> {
             self.pages[p] = Arc::from(self.pages[p].to_vec());
         }
         Arc::get_mut(&mut self.pages[p]).expect("unique after the copy above")
-    }
-
-    fn push(
-        &mut self,
-        value: (T, T),
-    ) {
-        self.ensure_pages(self.len + 1);
-        let at = self.len;
-        self.page_mut(at)[at % PAGE_SLOTS] = value;
-        self.len += 1;
     }
 }
 
@@ -332,19 +345,20 @@ fn promote<A: Endpoint, B: Endpoint>(
     if old.is_empty() {
         return;
     }
-    let mut merged: Paged<B> = Paged::default();
-    merged.ensure_pages(old.len() + into.len());
-    for (s, d) in old.iter() {
-        merged.push(if s.vacant() && d.vacant() {
+    // A slot is empty only when *both* endpoints are — `EMPTY` is a sentinel
+    // value of the field type, so a live edge may legitimately hold it in one
+    // endpoint. Widening reads through `get`/`put`, which would turn a narrow
+    // tier's sentinel into a real id at the wider width, so an empty slot is
+    // carried across as the wider tier's own sentinel instead.
+    let widened = old.iter().map(|(s, d)| {
+        if s.vacant() && d.vacant() {
             (B::EMPTY, B::EMPTY)
         } else {
             (B::put(s.get()), B::put(d.get()))
-        });
-    }
-    for i in 0..into.len() {
-        merged.push(into.at(i));
-    }
-    *into = merged;
+        }
+    });
+    let total = old.len() + into.len();
+    *into = Paged::from_slots(widened.chain((0..into.len()).map(|i| into.at(i))), total);
 }
 
 /// Run `$body` for each tier in id order, with `$v` bound to `&Option<Paged<_>>`.
@@ -761,7 +775,7 @@ impl<T: Endpoint> TierOps for Paged<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Endpoint, EndpointIndex, U24};
+    use super::{Endpoint, EndpointIndex, PAGE_SLOTS, U24};
 
     /// Each width has to keep its all-ones value spare, or a legitimate pair
     /// reads back as a deleted slot. The boundaries are where an off-by-one
@@ -1043,6 +1057,41 @@ mod tests {
         }
     }
 
+    /// Promotion across a page boundary.
+    ///
+    /// `from_slots` fills whole `PAGE_SLOTS` pages and `at` divides by the same
+    /// constant; a mistake in either is invisible while the promoted tier fits
+    /// in one page, which is true of every other test in this file. Halving the
+    /// page size inside `from_slots` passes all of them and fails this.
+    #[test]
+    fn promoting_a_tier_larger_than_a_page_preserves_every_slot() {
+        let n = u64::try_from(PAGE_SLOTS * 2 + 37).unwrap();
+        let mut ix = EndpointIndex::default();
+        for e in 0..n {
+            ix.set(e, e % 60_000, (e + 1) % 60_000);
+        }
+        // A tombstone in the first page and one past the boundary, so the
+        // empty-slot carry is exercised on both sides of it.
+        let past = u64::try_from(PAGE_SLOTS).unwrap() + 11;
+        ix.clear(5);
+        ix.clear(past);
+
+        // Reusing a low id with endpoints too wide for `u16` promotes the
+        // whole tier into `u32`, rewriting every slot at the new width.
+        ix.set(1, 5_000_000_000, 5_000_000_001);
+
+        assert_eq!(ix.get(1), Some((5_000_000_000, 5_000_000_001)));
+        assert_eq!(ix.get(5), None, "tombstone before the page boundary");
+        assert_eq!(ix.get(past), None, "tombstone after the page boundary");
+        for e in (0..n).filter(|e| *e != 1 && *e != 5 && *e != past) {
+            assert_eq!(
+                ix.get(e),
+                Some((e % 60_000, (e + 1) % 60_000)),
+                "edge {e} did not survive promotion"
+            );
+        }
+    }
+
     /// A small tier allocates the slots it uses, not a whole page.
     ///
     /// The first cut of the paged layout gave every page exactly `PAGE_SLOTS`
@@ -1164,7 +1213,7 @@ mod cow_bench {
         let seq_i = read_instr().zip(i0).map(|(a, b)| a - b);
         std::hint::black_box(acc);
 
-        // Random: the page-pointer array is 8 bytes per 4096 slots, so for this
+        // Random: the page-pointer array is 16 bytes per 4096 slots, so for this
         // index it is ~20 KB and stays cached even when the slots do not. That
         // is the case where an extra indirection would hurt if it were going to.
         let reps = 10_000_000u64;


### PR DESCRIPTION
Fixes #2687. Now the base of the stack: #2693 → #2712 sit on top.

## What this is worth on the benchmark

Leading with this, because an earlier version of this PR quoted two rows at −9.5% and −16.8% and left the impression the suite barely moves. It moves more than that, and one row I had simply never measured is the strongest result here. Allocated bytes, median of three runs per side against current `main`, with `RETURN 1` as a control:

| row | main | this PR | saved | |
|---|---|---|---|---|
| `create edge` | 98,557 B | 2,647 B | −95,910 | **37×** |
| `delete edge` | 242,977 B | 193,924 B | −49,052 | 1.3× |
| `urel create delete` | 250,635 B | 201,632 B | −49,003 | 1.2× |
| `delete indexed edge` | 447,919 B | 398,765 B | −49,153 | 1.1× |

Three of those save the *same* ~49,000 bytes, which is the tier copy: 10,109 edges × 4 bytes = 40,436 B plus overhead. That constant is the signature of the bug. `create edge` saves about twice that and is left with almost nothing.

**Instructions do not move on any existing row** — `create edge` 0.978, `delete indexed edge` 0.997, `delete edge` 0.998, `urel create delete` 1.000, against a `RETURN 1` control at 1.003. So on the suite as it stood, this is an allocation fix and buys no CPU.

## Why the suite understates it, and the row that fixes that

Every sized write row creates and deletes *nodes*, so the edge count stays at SETUP's ~10,109 for the whole run. Nothing in the suite was sensitive to a write cost that scales with |E| — which is exactly what this bug was. On a 10k-edge graph the copy is 40 KB, so an unbounded O(E) term read as a 9% row.

The second commit adds `edge create at 200k`: the same create/delete round-trip as `urel create delete`, three orders of magnitude further up the edge count. Median of three, spread under 1% on either side:

| | main | this PR | |
|---|---|---|---|
| instructions | 1,531,279 | 1,006,373 | **−34%** |
| cycles | 575,222 | 365,749 | −36% |
| allocated bytes | 3,300,520 | 716,449 | **4.6×** |

That is the first *instruction* difference the suite shows for this fix at all.

## The bug

`EndpointIndex` holds each width tier behind its own `Arc`, so an MVCC version clones only the tier it writes to. That was already a deliberate optimisation — and on a real graph it does nothing, because almost every write appends, appends land in the widest tier, and that tier holds almost every edge. "Copy one tier" was still "copy the whole index", O(E) per write transaction, paid before the write touched anything. The tier's own doc comment already described the cost.

`cargo test --release -p graph cow_cost -- --ignored --nocapture`, a benchmark already in the file written for exactly this:

| edges | before | after | |
|---|---|---|---|
| 100,000 | 19,545 instr | 8,533 | |
| 1,000,000 | 116,721 instr | 8,460 | |
| 10,000,000 | 1,251,891 instr | 10,976 | **114×** |

Linear before, flat after. End to end, bytes allocated by a single-edge `CREATE` against a graph already holding N edges (median of three; the first call at each size carries a one-time transient):

| existing edges | before | after |
|---|---|---|
| 0 | 135,518 B | 52,930 B |
| 50,000 | 708,713 B | 53,152 B |
| 200,000 | 2,676,794 B | **52,454 B** |

## Every page but the last is `PAGE_SLOTS`; the last is sized to the tier

The first cut of this made *every* page exactly `PAGE_SLOTS` slots, tail included. That is the obvious layout and it was the wrong one: a graph holding a single edge paid a whole page for it. `used_memory` over 200 graphs:

| | flat `Vec` | full pages | sized tail |
|---|---|---|---|
| 200 graphs × 10 edges | 77,669 B/graph | **98,302** | 77,842 |
| 200 graphs × 1 edge | 75,587 B/graph | **96,027** | 75,556 |
| nodes only, no edges | 47,679 B/graph | 47,502 | 47,458 |

**+20.4 KB per graph** with at least one edge — 27% of the per-graph footprint — on a server that may hold thousands of small graphs, bought for a win that only appears on large ones. The nodes-only row is the control that pins it to this index. Against the project's "no per-entity overhead" bar that was not shippable, and no benchmark could have caught it because the suite uses one graph.

Sizing the tail page removes the floor completely and keeps the bound, because a write still copies at most one page. The tail doubles as it fills, so appending stays amortised, and only the last page is ever short — which keeps addressing a shift and a mask.

Pages are `Arc<[(T, T)]>` rather than `Arc<Vec<_>>` so the slots live inline in the allocation: a `Vec` behind an `Arc` costs the read path a second dependent load to reach them. The cost of the slice form is that `Arc::make_mut` does not exist for an unsized `[_]`, so copy-on-write is written out by hand — `Arc::get_mut` returning `None` is the same uniqueness test `make_mut` makes.

## What it costs

`get` was one bounds-checked load from a flat vector; a page lookup adds a shift, a mask, a dependent load of the page pointer and a bounds check against a length the fat pointer carries. Over a 10 M-edge index:

| access | before | full pages | sized tail |
|---|---|---|---|
| sequential | 0.5 ns, 17 instr | 1.6 ns, 40 | 1.8 ns, 45 |
| random | 5.5 ns, 21 instr | 9.3 ns, 44 | 9.9 ns, 48 |

4 instructions worse than the fixed-array layout, which could check against a constant — paid deliberately to delete the 20.4 KB floor.

In a query it is 0.2–0.3%. `get` is reached only when a relationship is *materialised* — serialised into a reply, `startNode`/`endNode`, path building, delete — never in a traversal's inner loop. Over 50,000 materialised relationships:

| query | paged | flat | |
|---|---|---|---|
| `count(startNode(r))` | 299,026,874 | 298,363,602 | +0.22% |
| `count(endNode(r))` | 298,768,709 | 297,922,017 | +0.28% |
| `count(r)` (never calls `get`) | 2,086,611 | 2,094,647 | 1.00× |

The control matters: `count(r)` does not materialise edges and shows no difference, which is what pins the delta to the lookup. Both figures are true — the microbenchmark isolates `get`, so 13 extra instructions on a 21-instruction operation is 2.3×; materialising a relationship costs ~5,980 instructions, so the same 13 are 0.2%.

Restoring the pre-paging read cost exactly would need the copy-on-write to happen below userspace — `mmap` MAP_PRIVATE over a shared backing, where reads are a plain flat indexed load and a write faults so the kernel copies a 4 KB page. That is the only design giving both, and it is a lot of platform-specific machinery for 0.2%.

## Tests

Three, each mutation-checked:

- **`random_edits_and_snapshots_agree_with_a_flat_reference`** — 40,000 random `set`/`clear`/snapshot steps against a plain `Vec<Option<(u64, u64)>>` model, every snapshot checked against the model as it stood when taken. A hand-written copy-on-write is silent when wrong — it writes through into a snapshot's page, or drops a write into a copy nobody reads — so skipping the copy in `page_mut` fails this at `snapshot 1: edge 23`.
- **`a_version_that_writes_one_edge_copies_one_page`** — asserts page *identity*, not bytes. My first version of this test asserted a byte delta and was vacuous: a deep copy of the pages yields the same size and the same page count, so sharing is invisible in anything derived from the slots. Skipping the copy fails it with `copied 0 of 49 pages`.
- **`a_small_tier_does_not_allocate_a_whole_page`** — pins the floor at 1, 10 and 100 edges, and checks a 50k-edge tier still allocates in proportion to edges. Making the tail a full page again fails it with `1 edges allocated 16384 bytes for 4 bytes of slots`.

Plus `get_cost_of_paging`, an ignored benchmark beside the existing `cow_cost_of_a_version`, so the read-path cost stays measurable rather than remembered.

## Verification

- `cargo test -p graph` — 186 passed
- `./flow.sh` — 1488 passed, 0 failed
- `pytest tests/test_mvcc.py tests/test_concurrency.py` — 14 passed
- `bench/tests` — 98 passed
- `cargo fmt --all -- --check` clean; clippy adds no new warnings

`test12_load_large_graph` and `test_slowlog` each flaked once on host load during this work; both fail identically on the parent branch with no paging at all, and both pass on retry.

No format change: this is an in-memory index, rebuilt on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved endpoint index memory efficiency when creating snapshots.
  * Reduced the amount of data copied during index updates, improving write performance for large indexes.
  * Improved memory usage accounting for endpoint indexes.
* **Reliability**
  * Improved consistency of indexed data across updates and snapshots.
  * Benchmark selections now automatically include required prerequisite operations.
  * Improved ordering of graph-building benchmark operations for more reliable performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->