### PR TITLE
perf: keep the columnar aggregate path when a key or argument is computed

### DIFF
--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -45,7 +45,7 @@ use orx_tree::{Dyn, DynNode, DynTree, NodeIdx, NodeRef};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use thin_vec::{ThinVec, thin_vec};
+use thin_vec::ThinVec;
 
 /// Group-by accumulator map, keyed by the composite [`GroupKey`].
 ///
@@ -99,6 +99,18 @@ enum KeyExprKind {
     Variable(Variable),
     /// Property access: `GROUP BY n.age`
     Property { var: Variable, attr: Arc<String> },
+    /// Any other key expression, `GROUP BY n.id % 5` included.
+    ///
+    /// The same treatment `AggInputKind::Computed` gives an aggregate's input,
+    /// for the same reason: without it a single arithmetic key sent the *whole*
+    /// operator down `consume_input_per_row`, so the aggregate inputs lost
+    /// their bulk extraction too. Measured on `p.age` vs `p.age + 0` over
+    /// 10,000 rows — same data, same groups — that cost 15.96 M instructions
+    /// against 28.29 M.
+    Computed {
+        tree: QueryExpr<Variable>,
+        idx: NodeIdx<Dyn<ExprIR<Variable>>>,
+    },
 }
 
 /// How an aggregation input expression can be evaluated in bulk.
@@ -151,6 +163,14 @@ struct VectorizableAgg {
     /// per-group dedup state in [`Runtime::value_dedupers`], matching the
     /// per-row evaluator so the two paths stay consistent within a query.
     distinct_idx: Option<NodeIdx<Dyn<ExprIR<Variable>>>>,
+    /// Constant arguments after the first, for a multi-argument aggregation:
+    /// the `0.5` of `percentileDisc(n.score, 0.5)`.
+    ///
+    /// Only constants qualify. A row-dependent second argument would have to be
+    /// a column of its own, and no aggregation takes one — but more to the
+    /// point, `percentileDisc(x, n.p)` is not a meaningful aggregate, so the
+    /// per-row path stays the answer for it rather than a column nobody wants.
+    extra_args: Vec<Value>,
 }
 
 /// Full analysis of a vectorizable aggregate operator.
@@ -235,10 +255,19 @@ impl<'a> AggregateOp<'a> {
                             attr: attr.clone(),
                         });
                     } else {
-                        return None;
+                        key_kinds.push(KeyExprKind::Computed {
+                            tree: tree.clone(),
+                            idx: root.idx(),
+                        });
                     }
                 }
-                _ => return None,
+                // A key holding an aggregate is not a key; that shape belongs to
+                // the per-row path, which recurses to find the aggregates.
+                _ if subtree_has_aggregate(&root) => return None,
+                _ => key_kinds.push(KeyExprKind::Computed {
+                    tree: tree.clone(),
+                    idx: root.idx(),
+                }),
             }
         }
 
@@ -294,26 +323,27 @@ impl<'a> AggregateOp<'a> {
             let inner = distinct.child(0);
             let input = match inner.data() {
                 ExprIR::Variable(var) => AggInputKind::Variable(var.clone()),
-                ExprIR::Property(_) if inner.num_children() == 1 => {
-                    if !matches!(inner.child(0).data(), ExprIR::Variable(_)) {
-                        return None;
-                    }
-                    AggInputKind::Computed {
-                        tree: tree.clone(),
-                        idx: inner.idx(),
-                    }
-                }
-                _ => return None,
+                // Any other inner expression, `DISTINCT n.id % 100` included.
+                // Deduplication is per-value and happens after the column is
+                // built, so it does not care how the value was computed — the
+                // shape restriction here was never load-bearing.
+                _ if subtree_has_aggregate(&inner) => return None,
+                _ => AggInputKind::Computed {
+                    tree: tree.clone(),
+                    idx: inner.idx(),
+                },
             };
             return Some(VectorizableAgg {
                 func: func.clone(),
                 input: Some(input),
                 acc_var: acc_var.clone(),
                 distinct_idx: Some(distinct.idx()),
+                extra_args: Vec::new(),
             });
         }
 
         // Analyze the input argument (child 0).
+        let mut extra_args: Vec<Value> = Vec::new();
         let input = if num_children == 1 {
             // No input args — this is count(*) / count() — only the accumulator var.
             None
@@ -343,9 +373,30 @@ impl<'a> AggregateOp<'a> {
                 }
             }
         } else {
-            // Multi-argument aggregation (e.g., percentileDisc(n.age, 0.5)).
-            // Fall back to per-row for these.
-            return None;
+            // Multi-argument aggregation: `percentileDisc(n.score, 0.5)`. The
+            // first argument is the column; the rest must be constants, which
+            // is what these functions take — a percentile is a property of the
+            // aggregate, not of a row.
+            for i in 1..num_children - 1 {
+                if !matches!(root.child(i).data(), ExprIR::Constant(_)) {
+                    return None;
+                }
+            }
+            for i in 1..num_children - 1 {
+                let ExprIR::Constant(v) = root.child(i).data() else {
+                    unreachable!("checked in the loop above");
+                };
+                extra_args.push(v.clone());
+            }
+            let arg = root.child(0);
+            match arg.data() {
+                ExprIR::Variable(var) => Some(AggInputKind::Variable(var.clone())),
+                _ if subtree_has_aggregate(&arg) => return None,
+                _ => Some(AggInputKind::Computed {
+                    tree: tree.clone(),
+                    idx: arg.idx(),
+                }),
+            }
         };
 
         Some(VectorizableAgg {
@@ -353,6 +404,7 @@ impl<'a> AggregateOp<'a> {
             input,
             acc_var: acc_var.clone(),
             distinct_idx: None,
+            extra_args,
         })
     }
 
@@ -469,6 +521,50 @@ impl<'a> AggregateOp<'a> {
                     } else {
                         &[]
                     };
+
+                    // A multi-argument aggregation cannot hand its whole column
+                    // to `batch_agg`, which reads the slice *as* the input
+                    // values and would take the trailing `0.5` for another
+                    // datum. It still belongs here rather than disqualifying the
+                    // operator: gating the fast path on every aggregate being
+                    // single-argument cost `agg in CALL` — six ordinary
+                    // aggregates beside one `percentileDisc` — the fast path for
+                    // all seven.
+                    if !agg.extra_args.is_empty() {
+                        let mut cur = prev;
+                        let mut per_value_err: Option<String> = None;
+                        for val in inputs {
+                            if matches!(val, Value::Null) {
+                                continue;
+                            }
+                            let mut args: ThinVec<Value> =
+                                ThinVec::with_capacity(1 + agg.extra_args.len());
+                            args.push(val.clone());
+                            args.extend(agg.extra_args.iter().cloned());
+                            let checked = agg
+                                .func
+                                .validate_args_type(&args)
+                                .and_then(|()| agg.func.validate_args_domain(&args));
+                            if let Err(e) = checked {
+                                per_value_err = Some(e);
+                                break;
+                            }
+                            match batch_fn(self.runtime, &args, 1, cur) {
+                                Ok(next) => cur = next,
+                                Err(e) => {
+                                    per_value_err = Some(e);
+                                    cur = Value::Null;
+                                    break;
+                                }
+                            }
+                        }
+                        acc.insert(&agg.acc_var, cur);
+                        if let Some(e) = per_value_err {
+                            batch_err = Some(e);
+                            break;
+                        }
+                        continue;
+                    }
                     // Validate each input — the per-row path runs validate_args_type
                     // before each call; without this, batch kernels relying on
                     // `unreachable!()` for unexpected types would panic on bad data
@@ -571,18 +667,50 @@ impl<'a> AggregateOp<'a> {
 
                     let prev = acc.take(&agg.acc_var).unwrap_or(Value::Null);
 
-                    let args = thin_vec![input_val, prev];
+                    // The call's inputs, without the accumulator: `[value]`, or
+                    // `[value, 0.5]` for a multi-argument aggregation.
+                    let mut inputs: ThinVec<Value> =
+                        ThinVec::with_capacity(1 + agg.extra_args.len());
+                    inputs.push(input_val);
+                    inputs.extend(agg.extra_args.iter().cloned());
 
-                    if let Err(e) = agg.func.validate_args_type(&args[..1]) {
+                    // Both checks, in the per-row path's order. `validate_args_domain`
+                    // was absent here while every aggregation reaching this loop was
+                    // single-argument and unconstrained; `percentileDisc(x, 1.2)` is
+                    // neither, and its kernel indexes by the percentile — so without
+                    // the domain check an out-of-range constant reached it and
+                    // crashed the server rather than raising.
+                    let checked = agg
+                        .func
+                        .validate_args_type(&inputs)
+                        .and_then(|()| agg.func.validate_args_domain(&inputs));
+                    if let Err(e) = checked {
                         // Restore the accumulator that was taken above.
-                        if let Some(prev_val) = args.into_iter().nth(1) {
-                            acc.insert(&agg.acc_var, prev_val);
-                        }
+                        acc.insert(&agg.acc_var, prev);
                         errors.push(e);
                         break;
                     }
 
-                    match agg.func.func.call(self.runtime, &args) {
+                    // Prefer `batch_agg`, for the reason `run_agg_expr` states:
+                    // it takes the accumulator as an owned `Value`, so `collect`
+                    // and the percentiles get a unique `Arc` and extend their
+                    // list in place. Pushing `prev` into `args` instead leaves
+                    // the accumulator behind a shared reference, and every row
+                    // deep-clones the whole list — O(n^2). Measured on
+                    // `percentileDisc(p.score, 0.5)` over 10,000 rows: 1,787 M
+                    // instructions that way against 26 M this way.
+                    let result = if let FnType::Aggregation {
+                        batch_agg: Some(batch_fn),
+                        ..
+                    } = &agg.func.fn_type
+                    {
+                        batch_fn(self.runtime, &inputs, 1, prev)
+                    } else {
+                        let mut args = inputs;
+                        args.push(prev);
+                        agg.func.func.call(self.runtime, &args)
+                    };
+                    match result {
                         Ok(new_val) => acc.insert(&agg.acc_var, new_val),
                         Err(e) => {
                             errors.push(e);
@@ -622,6 +750,18 @@ impl<'a> AggregateOp<'a> {
                     // int/float column, merging 9007199254740993 and
                     // 9007199254740992 into one group.
                     key_columns.push(runtime.materialize_node_property_values(&active_ids, attr));
+                }
+                KeyExprKind::Computed { tree, idx } => {
+                    // An evaluation error becomes `Err(())` — "this batch cannot
+                    // take the bulk path" — rather than being reported here. The
+                    // per-row path then re-evaluates and raises it, which keeps
+                    // one authority for the error's text and its ordering
+                    // relative to the other keys.
+                    key_columns.push(
+                        VectorEval::new(runtime)
+                            .eval_values(&tree.node(*idx), batch, active)
+                            .map_err(|_| ())?,
+                    );
                 }
             }
         }

--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -107,10 +107,17 @@ enum KeyExprKind {
     /// their bulk extraction too. Measured on `p.age` vs `p.age + 0` over
     /// 10,000 rows — same data, same groups — that cost 15.96 M instructions
     /// against 28.29 M.
-    Computed {
-        tree: QueryExpr<Variable>,
-        idx: NodeIdx<Dyn<ExprIR<Variable>>>,
-    },
+    Computed(ComputedExpr),
+}
+
+/// An expression [`VectorEval`] evaluates as a column, and where to start.
+///
+/// The tree is carried whole because a node index means nothing without it, and
+/// keys and aggregate inputs both need exactly this pair — they are the same
+/// idea reached from two directions.
+struct ComputedExpr {
+    tree: QueryExpr<Variable>,
+    idx: NodeIdx<Dyn<ExprIR<Variable>>>,
 }
 
 /// How an aggregation input expression can be evaluated in bulk.
@@ -131,10 +138,7 @@ enum AggInputKind {
     /// every other value, so `collect(row.t)` over map rows silently
     /// aggregated nothing. The variant is gone rather than fixed — one
     /// evaluator, nothing left to disagree with.
-    Computed {
-        tree: QueryExpr<Variable>,
-        idx: NodeIdx<Dyn<ExprIR<Variable>>>,
-    },
+    Computed(ComputedExpr),
 }
 
 /// True if `node`'s subtree contains an aggregate call.
@@ -171,6 +175,56 @@ struct VectorizableAgg {
     /// point, `percentileDisc(x, n.p)` is not a meaningful aggregate, so the
     /// per-row path stays the answer for it rather than a column nobody wants.
     extra_args: Vec<Value>,
+}
+
+impl VectorizableAgg {
+    /// The argument list for one input value: `[value]`, or `[value, 0.5]` for
+    /// a multi-argument aggregation, validated as the per-row path validates.
+    ///
+    /// `validate_args_domain` matters as much as the type check and used to be
+    /// missing here: every aggregation on this path was single-argument and
+    /// unconstrained until `percentileDisc` joined it, and its kernel indexes
+    /// by the percentile — so an out-of-range constant crashed the server
+    /// instead of raising.
+    fn args_for(
+        &self,
+        value: Value,
+    ) -> Result<ThinVec<Value>, String> {
+        let mut inputs: ThinVec<Value> = ThinVec::with_capacity(1 + self.extra_args.len());
+        inputs.push(value);
+        inputs.extend(self.extra_args.iter().cloned());
+        self.func.validate_args_type(&inputs)?;
+        self.func.validate_args_domain(&inputs)?;
+        Ok(inputs)
+    }
+
+    /// Fold `inputs` into the accumulator `prev`.
+    ///
+    /// Prefers `batch_agg`, for the reason `run_agg_expr` states: it takes the
+    /// accumulator as an owned `Value`, so `collect` and the percentiles get a
+    /// unique `Arc` and extend their list in place. Pushing `prev` into the
+    /// argument slice instead leaves the accumulator behind a shared
+    /// reference and every row deep-clones the whole list — O(n^2). Measured
+    /// on `percentileDisc(p.score, 0.5)` over 10,000 rows: 1,787 M
+    /// instructions that way against 26 M this way.
+    fn fold(
+        &self,
+        runtime: &Runtime,
+        inputs: ThinVec<Value>,
+        prev: Value,
+    ) -> Result<Value, String> {
+        if let FnType::Aggregation {
+            batch_agg: Some(batch_fn),
+            ..
+        } = &self.func.fn_type
+        {
+            batch_fn(runtime, &inputs, 1, prev)
+        } else {
+            let mut args = inputs;
+            args.push(prev);
+            self.func.func.call(runtime, &args)
+        }
+    }
 }
 
 /// Full analysis of a vectorizable aggregate operator.
@@ -255,19 +309,36 @@ impl<'a> AggregateOp<'a> {
                             attr: attr.clone(),
                         });
                     } else {
-                        key_kinds.push(KeyExprKind::Computed {
+                        key_kinds.push(KeyExprKind::Computed(ComputedExpr {
                             tree: tree.clone(),
                             idx: root.idx(),
-                        });
+                        }));
                     }
                 }
-                // A key holding an aggregate is not a key; that shape belongs to
-                // the per-row path, which recurses to find the aggregates.
+                // A key holding an aggregate is not a key; that shape belongs
+                // to the per-row path, which recurses to find the aggregates.
+                //
+                // Defence, not a live branch — and this was checked rather than
+                // assumed. Replacing all four `subtree_has_aggregate` guards in
+                // this file with `panic!` leaves the whole corpus green: 1,485
+                // flow tests, 124 e2e, 2,456 TCK scenarios, 187 unit tests.
+                // Nothing reaches them, for two separate reasons: the binder
+                // refuses an aggregate inside an aggregate ("Can't use
+                // aggregate functions inside of aggregate functions"), and an
+                // expression that merely *contains* one, like
+                // `g.v % max(g.v)`, is routed as an aggregation rather than a
+                // key, so it bails at the "root is not an aggregate" arm above.
+                //
+                // They stay because `analyze` is a syntactic check over an IR
+                // tree and the invariant it would be leaning on lives in
+                // another pass. Falling back costs the operator its columnar
+                // path and nothing else; the guard being wrong the other way
+                // would evaluate an aggregate per row inside a column build.
                 _ if subtree_has_aggregate(&root) => return None,
-                _ => key_kinds.push(KeyExprKind::Computed {
+                _ => key_kinds.push(KeyExprKind::Computed(ComputedExpr {
                     tree: tree.clone(),
                     idx: root.idx(),
-                }),
+                })),
             }
         }
 
@@ -327,11 +398,15 @@ impl<'a> AggregateOp<'a> {
                 // Deduplication is per-value and happens after the column is
                 // built, so it does not care how the value was computed — the
                 // shape restriction here was never load-bearing.
+                //
+                // The aggregate guard is defence, not a live branch — see the
+                // key guard in `analyze` for the evidence and the reasoning.
+                // Same for the two below.
                 _ if subtree_has_aggregate(&inner) => return None,
-                _ => AggInputKind::Computed {
+                _ => AggInputKind::Computed(ComputedExpr {
                     tree: tree.clone(),
                     idx: inner.idx(),
-                },
+                }),
             };
             return Some(VectorizableAgg {
                 func: func.clone(),
@@ -366,10 +441,10 @@ impl<'a> AggregateOp<'a> {
                     if subtree_has_aggregate(&arg) {
                         return None;
                     }
-                    Some(AggInputKind::Computed {
+                    Some(AggInputKind::Computed(ComputedExpr {
                         tree: tree.clone(),
                         idx: arg.idx(),
-                    })
+                    }))
                 }
             }
         } else {
@@ -377,14 +452,13 @@ impl<'a> AggregateOp<'a> {
             // first argument is the column; the rest must be constants, which
             // is what these functions take — a percentile is a property of the
             // aggregate, not of a row.
-            for i in 1..num_children - 1 {
-                if !matches!(root.child(i).data(), ExprIR::Constant(_)) {
-                    return None;
-                }
-            }
+            // One pass: `extra_args` is local, so pushing before a later
+            // argument turns out non-constant costs nothing — it is dropped
+            // with the `None`. Validating in a separate loop first only bought
+            // an `unreachable!`.
             for i in 1..num_children - 1 {
                 let ExprIR::Constant(v) = root.child(i).data() else {
-                    unreachable!("checked in the loop above");
+                    return None;
                 };
                 extra_args.push(v.clone());
             }
@@ -392,10 +466,10 @@ impl<'a> AggregateOp<'a> {
             match arg.data() {
                 ExprIR::Variable(var) => Some(AggInputKind::Variable(var.clone())),
                 _ if subtree_has_aggregate(&arg) => return None,
-                _ => Some(AggInputKind::Computed {
+                _ => Some(AggInputKind::Computed(ComputedExpr {
                     tree: tree.clone(),
                     idx: arg.idx(),
-                }),
+                })),
             }
         };
 
@@ -537,19 +611,10 @@ impl<'a> AggregateOp<'a> {
                             if matches!(val, Value::Null) {
                                 continue;
                             }
-                            let mut args: ThinVec<Value> =
-                                ThinVec::with_capacity(1 + agg.extra_args.len());
-                            args.push(val.clone());
-                            args.extend(agg.extra_args.iter().cloned());
-                            let checked = agg
-                                .func
-                                .validate_args_type(&args)
-                                .and_then(|()| agg.func.validate_args_domain(&args));
-                            if let Err(e) = checked {
-                                per_value_err = Some(e);
-                                break;
-                            }
-                            match batch_fn(self.runtime, &args, 1, cur) {
+                            match agg
+                                .args_for(val.clone())
+                                .and_then(|args| agg.fold(self.runtime, args, cur))
+                            {
                                 Ok(next) => cur = next,
                                 Err(e) => {
                                     per_value_err = Some(e);
@@ -667,50 +732,18 @@ impl<'a> AggregateOp<'a> {
 
                     let prev = acc.take(&agg.acc_var).unwrap_or(Value::Null);
 
-                    // The call's inputs, without the accumulator: `[value]`, or
-                    // `[value, 0.5]` for a multi-argument aggregation.
-                    let mut inputs: ThinVec<Value> =
-                        ThinVec::with_capacity(1 + agg.extra_args.len());
-                    inputs.push(input_val);
-                    inputs.extend(agg.extra_args.iter().cloned());
-
-                    // Both checks, in the per-row path's order. `validate_args_domain`
-                    // was absent here while every aggregation reaching this loop was
-                    // single-argument and unconstrained; `percentileDisc(x, 1.2)` is
-                    // neither, and its kernel indexes by the percentile — so without
-                    // the domain check an out-of-range constant reached it and
-                    // crashed the server rather than raising.
-                    let checked = agg
-                        .func
-                        .validate_args_type(&inputs)
-                        .and_then(|()| agg.func.validate_args_domain(&inputs));
-                    if let Err(e) = checked {
-                        // Restore the accumulator that was taken above.
-                        acc.insert(&agg.acc_var, prev);
-                        errors.push(e);
-                        break;
-                    }
-
-                    // Prefer `batch_agg`, for the reason `run_agg_expr` states:
-                    // it takes the accumulator as an owned `Value`, so `collect`
-                    // and the percentiles get a unique `Arc` and extend their
-                    // list in place. Pushing `prev` into `args` instead leaves
-                    // the accumulator behind a shared reference, and every row
-                    // deep-clones the whole list — O(n^2). Measured on
-                    // `percentileDisc(p.score, 0.5)` over 10,000 rows: 1,787 M
-                    // instructions that way against 26 M this way.
-                    let result = if let FnType::Aggregation {
-                        batch_agg: Some(batch_fn),
-                        ..
-                    } = &agg.func.fn_type
-                    {
-                        batch_fn(self.runtime, &inputs, 1, prev)
-                    } else {
-                        let mut args = inputs;
-                        args.push(prev);
-                        agg.func.func.call(self.runtime, &args)
+                    // Validate before the fold, so a bad argument puts the
+                    // accumulator back rather than leaving the slot empty.
+                    let inputs = match agg.args_for(input_val) {
+                        Ok(inputs) => inputs,
+                        Err(e) => {
+                            acc.insert(&agg.acc_var, prev);
+                            errors.push(e);
+                            break;
+                        }
                     };
-                    match result {
+
+                    match agg.fold(self.runtime, inputs, prev) {
                         Ok(new_val) => acc.insert(&agg.acc_var, new_val),
                         Err(e) => {
                             errors.push(e);
@@ -751,7 +784,7 @@ impl<'a> AggregateOp<'a> {
                     // 9007199254740992 into one group.
                     key_columns.push(runtime.materialize_node_property_values(&active_ids, attr));
                 }
-                KeyExprKind::Computed { tree, idx } => {
+                KeyExprKind::Computed(ComputedExpr { tree, idx }) => {
                     // An evaluation error becomes `Err(())` — "this batch cannot
                     // take the bulk path" — rather than being reported here. The
                     // per-row path then re-evaluates and raises it, which keeps
@@ -795,7 +828,7 @@ impl<'a> AggregateOp<'a> {
                         .collect();
                     agg_columns.push(col);
                 }
-                Some(AggInputKind::Computed { tree, idx }) => {
+                Some(AggInputKind::Computed(ComputedExpr { tree, idx })) => {
                     // Evaluated columnarly: `sum(n.age * 3)` costs one bulk
                     // attribute fetch and one pass per operator, where the
                     // per-row path re-walked the tree — and re-read the

--- a/tests/flow/test_aggregation.py
+++ b/tests/flow/test_aggregation.py
@@ -314,3 +314,110 @@ class testAggregations():
             self.graph.query("MATCH (n:M) RETURN sum(n.v)").result_set, [[4]])
         self.env.assertEqual(
             self.graph.query("MATCH ()-[r:R]->() RETURN sum(r.w)").result_set, [[2]])
+
+    def test_computed_group_key_matches_a_precomputed_one(self):
+        # A grouping key that is not a bare variable or property used to send
+        # the *whole* aggregate operator down the per-row path — aggregate
+        # inputs losing their bulk extraction along with it. The oracle for the
+        # columnar key is the same key computed in a `WITH`, which reaches the
+        # aggregate as a plain variable and so takes the path that always
+        # existed. The two must agree on values, on grouping, and on order.
+        self.graph.delete()
+        self.graph.query(
+            "UNWIND range(0, 99) AS i CREATE (:K {i: i, s: toString(i % 7)})")
+
+        for key in ["k.i % 5", "k.i / 10", "k.s + '!'", "toUpper(k.s)",
+                    "k.i % 5 + k.i % 3", "abs(k.i - 50)", "[k.i % 4]",
+                    "k.missing", "k.i % 2 = 0"]:
+            direct = self.graph.query(
+                f"MATCH (k:K) RETURN {key} AS g, count(*) AS c ORDER BY c, g").result_set
+            oracle = self.graph.query(
+                f"MATCH (k:K) WITH {key} AS g RETURN g, count(*) AS c ORDER BY c, g").result_set
+            self.env.assertEqual(direct, oracle)
+
+        # Two keys, one of each kind, and an aggregate input that is itself a
+        # computed column: the paths compose or they do not.
+        direct = self.graph.query(
+            "MATCH (k:K) RETURN k.i % 3 AS a, k.s AS b, sum(k.i * 2) AS t ORDER BY a, b").result_set
+        oracle = self.graph.query(
+            "MATCH (k:K) WITH k, k.i % 3 AS a RETURN a, k.s AS b, sum(k.i * 2) AS t ORDER BY a, b").result_set
+        self.env.assertEqual(direct, oracle)
+
+    def test_computed_group_key_keeps_integers_exact(self):
+        # The bulk key extractor deliberately avoids the column classifier's
+        # float lane, because promoting a mixed int/float column would round
+        # 9007199254740993 to 9007199254740992 and merge two distinct groups
+        # into one. The computed-key path has to hold that line too: the float
+        # in this graph is what makes the column mixed.
+        self.graph.delete()
+        self.graph.query(
+            "CREATE (:P {v: 9007199254740993}), (:P {v: 9007199254740992}), (:P {v: 1.5})")
+
+        expected = [[1.5, 1], [9007199254740992, 1], [9007199254740993, 1]]
+        self.env.assertEqual(
+            self.graph.query(
+                "MATCH (p:P) RETURN p.v + 0 AS k, count(*) ORDER BY k").result_set,
+            expected)
+        # And the two big keys are still integers, not floats that happen to
+        # print without a fraction.
+        types = self.graph.query(
+            "MATCH (p:P) RETURN p.v + 0 AS k, count(*) ORDER BY k").result_set
+        self.env.assertEqual([type(r[0]) for r in types], [float, int, int])
+
+    def test_distinct_over_a_computed_argument(self):
+        # `DISTINCT <expr>` used to be restricted to a bare variable or
+        # property; anything else fell back. Deduplication happens per value
+        # after the column is built, so the shape of the expression that built
+        # it cannot matter — these check that it does not.
+        self.graph.delete()
+        self.graph.query("UNWIND range(0, 99) AS i CREATE (:D {i: i})")
+
+        self.env.assertEqual(
+            self.graph.query("MATCH (d:D) RETURN count(DISTINCT d.i % 10)").result_set,
+            [[10]])
+        self.env.assertEqual(
+            self.graph.query("MATCH (d:D) RETURN size(collect(DISTINCT d.i % 4))").result_set,
+            [[4]])
+        self.env.assertEqual(
+            self.graph.query("MATCH (d:D) RETURN sum(DISTINCT d.i % 3)").result_set,
+            [[3]])
+        # Grouped, so the dedup state is per group and not shared across them.
+        direct = self.graph.query(
+            "MATCH (d:D) RETURN d.i % 2 AS g, count(DISTINCT d.i % 10) AS c ORDER BY g").result_set
+        self.env.assertEqual(direct, [[0, 5], [1, 5]])
+        # Null never accumulates, distinct or not.
+        self.env.assertEqual(
+            self.graph.query("MATCH (d:D) RETURN count(DISTINCT d.missing)").result_set,
+            [[0]])
+
+    def test_multi_argument_aggregation_validates_its_constant(self):
+        # `percentileDisc(x, 0.5)` is the multi-argument shape. Bringing it onto
+        # the columnar path meant carrying the trailing constant through the
+        # accumulate loop, and that loop checked argument *types* but not their
+        # *domain* — so an out-of-range percentile reached a kernel that indexes
+        # by it and crashed the server. These are the cases that crashed.
+        self.graph.delete()
+        self.graph.query("UNWIND range(1, 5) AS i CREATE (:Q {v: i})")
+
+        self.env.assertEqual(
+            self.graph.query("MATCH (q:Q) RETURN percentileDisc(q.v, 0.5)").result_set, [[3]])
+        self.env.assertEqual(
+            self.graph.query("MATCH (q:Q) RETURN percentileCont(q.v, 0.25)").result_set, [[2]])
+        # A computed first argument, and a grouped form.
+        self.env.assertEqual(
+            self.graph.query("MATCH (q:Q) RETURN percentileDisc(q.v * 2, 0.5)").result_set, [[6]])
+        direct = self.graph.query(
+            "MATCH (q:Q) RETURN q.v % 2 AS g, percentileDisc(q.v, 1.0) AS p ORDER BY g").result_set
+        self.env.assertEqual(direct, [[0, 4], [1, 5]])
+
+        for bad, msg in [("1.2", "must be a number in the range 0.0 to 1.0"),
+                         ("-0.5", "must be a number in the range 0.0 to 1.0"),
+                         ("null", "Type mismatch")]:
+            try:
+                self.graph.query(f"MATCH (q:Q) RETURN percentileDisc(q.v, {bad})")
+                self.env.assertTrue(False, depth=1)
+            except Exception as e:
+                self.env.assertContains(msg, str(e))
+        # The server is still there — the point of the domain check.
+        self.env.assertEqual(
+            self.graph.query("MATCH (q:Q) RETURN count(*)").result_set, [[5]])


### PR DESCRIPTION
Fixes #2716.

Fifth in the stack: #2686 → #2690 → #2691 → this (#2685 has landed).

## One cause behind five rows

`AggregateOp::analyze` whitelists a few expression shapes and drops the **whole** operator to `consume_input_per_row` when anything falls outside one. So a single arithmetic grouping key also costs the *aggregate inputs* their bulk extraction — the fallback is per-operator, not per-expression.

Aggregate inputs already had a `Computed` variant that keeps the columnar path (#2555). Keys, `DISTINCT` arguments and multi-argument aggregations never got one. That is the whole defect; this PR gives them one.

Isolated with a control that changes nothing but the shape — `p.age` vs `p.age + 0` as the grouping key, same data, same groups, same output:

| key | instructions (10,000 rows) |
|---|---|
| `p.age` | 15,964,859 |
| `p.age + 0` | 28,289,118 |

`ORDER BY` contributes nothing to that (15,967,319 with it, 15,964,859 without) — the gap is entirely the key expression. Normalised per row it is ~1,230 instructions, and the reported gaps vs C land on the same number: `ORDER BY agg` 1,201/row, `WITH pipeline` 1,223/row, `percentileDisc` 1,375/row. That is what made these one cause rather than five.

## The three gates opened

- a key that is not a bare variable or property — `p.id % 5 AS k`
- `DISTINCT` over anything but a variable or property — `DISTINCT p.id % 100`
- a multi-argument aggregation — `percentileDisc(p.score, 0.5)`, whose trailing arguments must be constants (a percentile is a property of the aggregate, not of a row)

## Measured

| query | before | after | | vs C before | vs C after |
|---|---|---|---|---|---|
| `count distinct` | 36,229,836 | 7,581,527 | **4.78×** | 1.93× | **0.40×** |
| `distinct aggs` | 2,546,681 | 697,044 | **3.65×** | 1.71× | **0.47×** |
| `ORDER BY agg` | 28,081,096 | 16,840,004 | 1.67× | 1.72× | **1.03×** |
| `WITH pipeline` | 28,462,989 | 17,238,694 | 1.65× | 1.74× | **1.05×** |
| `percentileCont` | 26,363,056 | 16,180,036 | 1.63× | 2.05× | **1.26×** |
| `percentileDisc` | 26,363,832 | 16,181,396 | 1.63× | 2.05× | **1.26×** |

Four of the six now beat C; the two percentiles close from 2.05× to 1.26×. `WITH pipeline` and `distinct aggs` were not on the original list — they turned out to share the cause.

## Two bugs found on the way

Both were latent in code this change newly routes traffic through, and both were caught by measurement rather than by reading:

**A server crash.** The general accumulate loop validated argument *types* but not their *domain* — which was harmless while every aggregation reaching it was single-argument and unconstrained. `percentileDisc(x, 1.2)` is constrained, and its kernel indexes by the percentile: out of range it crashed the server rather than raising. `tests/test_e2e.py::test_percentile_disc_edge_cases` caught it.

**A 67× regression.** That loop pushed the accumulator into a shared `args` slice and called `func.call`, where `run_agg_expr` deliberately prefers `batch_agg` in order to pass it *owned*. Behind a shared reference, every row deep-clones the whole accumulated list — O(n²). Vectorizing percentile through that path made it **1,787 M instructions**, 67× worse than the per-row path it replaced. Only the full benchmark sweep showed it; the tests were all green. Fixed by preferring `batch_agg` here too, as the per-row path documents.

Multi-argument aggregations also stay *inside* the keyless batch fast path rather than disqualifying the operator from it. My first guard excluded the whole operator, which cost `agg in CALL` — six ordinary aggregates beside one `percentileDisc` — the fast path for all seven.

## What this does not fix

Stated because it was measured, not assumed:

- **`collect DISTINCT`** (35.79 M, 2.13× C) is **unchanged**. Its aggregate is not at the root of its tree — `size(collect(DISTINCT p.age))` — so the operator still needs the per-row path's recursion to find it. Confirmed as the same cause by the same kind of control: `collect(DISTINCT p.age)` costs 6.78 M against 35.91 M for `size(collect(DISTINCT p.age))`, a 5.3× difference from the wrapper alone. Fixing it means applying the outer expression per group at finalize time, which is a structural change to a different part of the operator, so it is not bundled here.
- **`agg in CALL`** is **1.7% worse** (15.06 M → 15.33 M; stable to ±0.01 M over three runs, so real rather than noise). Its inner aggregate imports a variable, so it never took the fast path; it runs 100 times over a handful of rows each, and columnar setup does not amortise at that size. Its 1.83× gap is dominated by per-invocation overhead, not by this cause — so it did not belong to the cluster after all.

## Tests

Four new tests in `tests/flow/test_aggregation.py`, each mutation-checked:

- **`test_computed_group_key_matches_a_precomputed_one`** — nine key shapes, each compared against the same key computed in a `WITH`, which reaches the aggregate as a plain variable and so takes the path that always existed. A real oracle rather than hardcoded expectations. Pointing the computed key at the wrong subtree node fails 6 of 15 tests.
- **`test_computed_group_key_keeps_integers_exact`** — the bulk key extractor deliberately avoids the column classifier's float lane, because promoting a mixed int/float column would round 9007199254740993 to 9007199254740992 and merge two distinct groups. Verified the computed-key path holds that line (it does — the column stays per-element typed), and pinned it, including the Python types of the returned keys.
- **`test_distinct_over_a_computed_argument`** — grouped and ungrouped, plus null handling. Dropping `distinct_idx` fails it.
- **`test_multi_argument_aggregation_validates_its_constant`** — the values, and the three arguments that crashed the server. Removing the domain check fails it.

## Verification

- `cargo test -p graph` — 185 passed
- `./flow.sh` — **1485 passed, 0 failed**
- `pytest tests/test_e2e.py tests/test_functions.py` — 124 passed
- TCK — **2456 scenarios passed, 0 failed**
- full 66-query benchmark gated on instructions — **no regressions**, worst row 1.00×
- `cargo fmt --all -- --check` clean; clippy adds no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggregations now support computed grouping expressions, such as arithmetic expressions in `GROUP BY`.
  * `DISTINCT` can be applied to computed expressions.
  * Multi-argument aggregations, including percentile calculations, are supported for improved performance.

* **Bug Fixes**
  * Invalid percentile values are now validated safely, preventing server crashes.
  * Grouping produces consistent results when mixing integer and floating-point values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->