### PR TITLE
refactor(index): one type for index documents, not three hand-rolled copies

### DIFF
--- a/graph/src/effects/v3/apply.rs
+++ b/graph/src/effects/v3/apply.rs
@@ -25,7 +25,7 @@ use crate::{
     entity_type::EntityType,
     graph::graph::{Graph, TypeId},
     index::{IndexType, indexer::IndexOptions},
-    runtime::{runtime::map_to_index_options, value::Value},
+    runtime::{pending::IndexDocs, runtime::map_to_index_options, value::Value},
 };
 use roaring::RoaringTreemap;
 use rustc_hash::FxHashMap;
@@ -161,10 +161,9 @@ impl std::fmt::Display for LocalName {
 /// Index bookkeeping that accumulates across a buffer and is committed once.
 #[derive(Default)]
 struct IndexOps {
-    add_docs: FxHashMap<u64, RoaringTreemap>,
-    remove_docs: FxHashMap<u64, RoaringTreemap>,
-    add_edge_docs: FxHashMap<u64, RoaringTreemap>,
-    remove_edge_docs: FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
+    /// The same type the write path collects into, rather than a second set of
+    /// four maps that has to agree with it by inspection.
+    docs: IndexDocs,
     touched: bool,
     /// The first never-used node id as of **before** this buffer, and the ids
     /// this buffer has created so far.
@@ -214,8 +213,8 @@ pub fn apply_effects(
         apply_record(g, record?, &mut ops)?;
     }
 
-    g.commit_index(&mut ops.add_docs, &mut ops.remove_docs);
-    g.commit_edge_index(&mut ops.add_edge_docs, &mut ops.remove_edge_docs);
+    g.commit_index(&mut ops.docs.node_adds, &mut ops.docs.node_removes);
+    g.commit_edge_index(&mut ops.docs.edge_adds, &mut ops.docs.edge_removes);
     if ops.touched {
         g.populate_indexes_sync();
     }
@@ -281,11 +280,11 @@ fn apply_record(
             let ids = ids.to_vec();
             if !labels.is_empty() {
                 let label_ids = checked_label_ids(g, &labels)?;
-                g.set_node_labels_product(&ids, &label_ids, &mut ops.add_docs, true);
+                g.set_node_labels_product(&ids, &label_ids, &mut ops.docs.node_adds, true);
             }
             if !attr_ids.is_empty() {
                 check_attr_shape(g, &ids, &attr_ids, &rows)?;
-                g.set_nodes_attributes_rows(&ids, &attr_ids, &rows, &mut ops.add_docs)?;
+                g.set_nodes_attributes_rows(&ids, &attr_ids, &rows, &mut ops.docs.node_adds)?;
             }
             Ok(())
         }
@@ -306,7 +305,7 @@ fn apply_record(
 
             if !attr_ids.is_empty() {
                 let map = attr_map(g, &ids, &attr_ids, &rows)?;
-                g.set_relationships_attributes(&map, &mut ops.add_edge_docs)?;
+                g.set_relationships_attributes(&map, &mut ops.docs.edge_adds)?;
             }
             Ok(())
         }
@@ -326,13 +325,13 @@ fn apply_record(
             match entity {
                 EntityType::Node => {
                     check_attr_shape(g, &ids, &attr_ids, &rows)?;
-                    g.set_nodes_attributes_rows(&ids, &attr_ids, &rows, &mut ops.add_docs)?;
+                    g.set_nodes_attributes_rows(&ids, &attr_ids, &rows, &mut ops.docs.node_adds)?;
                 }
                 EntityType::Relationship => {
                     // Edges still go through the map form; only the node store
                     // has the row-major entry point so far.
                     let map = attr_map(g, &ids, &attr_ids, &rows)?;
-                    g.set_relationships_attributes(&map, &mut ops.add_edge_docs)?;
+                    g.set_relationships_attributes(&map, &mut ops.docs.edge_adds)?;
                 }
             }
             Ok(())
@@ -341,7 +340,12 @@ fn apply_record(
         Record::Labels { add, ids, labels } => {
             let label_ids = checked_label_ids(g, &labels)?;
             if add {
-                g.set_node_labels_product(&ids.to_vec(), &label_ids, &mut ops.add_docs, false);
+                g.set_node_labels_product(
+                    &ids.to_vec(),
+                    &label_ids,
+                    &mut ops.docs.node_adds,
+                    false,
+                );
             } else {
                 // Removal still takes the expanded pairs; only the add path has
                 // been given the compact form so far.
@@ -353,7 +357,7 @@ fn apply_record(
                         cols.push(lid);
                     }
                 }
-                g.remove_nodes_labels(&rows, &cols, &mut ops.remove_docs);
+                g.remove_nodes_labels(&rows, &cols, &mut ops.docs.node_removes);
             }
             Ok(())
         }
@@ -366,7 +370,7 @@ fn apply_record(
             // range — the one shape that has no vector to hand over.
             let nodes: RoaringTreemap = ids.iter().collect();
             verify_deletable(g, &nodes, ops)?;
-            g.delete_nodes(&nodes, &mut ops.remove_docs)?;
+            g.delete_nodes(&nodes, &mut ops.docs.node_removes)?;
             // Deleting releases the id back to the bin, so a *later* record in
             // this same buffer may legitimately create it again: a multi-commit
             // query (`CREATE (n) WITH n DELETE n WITH 1 AS z CREATE ()`) commits
@@ -379,7 +383,7 @@ fn apply_record(
 
         Record::DeleteEdge { ids, .. } => {
             let edges: RoaringTreemap = ids.iter().collect();
-            g.delete_relationships(&edges, &mut ops.remove_edge_docs)?;
+            g.delete_relationships(&edges, &mut ops.docs.edge_removes)?;
             Ok(())
         }
 

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -246,13 +246,6 @@ pub struct MemoryUsageReport {
 ///
 /// The Graph is `Send + Sync` but not internally synchronized. Use [`MvccGraph`]
 /// for concurrent access with proper read/write isolation.
-/// Sentinel for an empty/deleted slot in [`Graph::edge_endpoints`].
-///
-/// Equals `compound_key(u32::MAX, u32::MAX)`, which would only collide with a
-/// real edge whose endpoints are both node id `u32::MAX` (4.29 billion) — not
-/// reachable in practice, since the tensor compound key caps node ids at u32.
-const EDGE_NO_ENDPOINT: u64 = u64::MAX;
-
 /// A relationship removed by [`Graph::delete_relationships`] or
 /// [`Graph::delete_implicit_edges`]: its id, **its type**, and its endpoints.
 ///

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -24,7 +24,7 @@
 //!
 //! On error or ROLLBACK, the Pending is simply dropped without applying.
 
-use std::{cell::RefCell, ops::BitOrAssign, sync::Arc};
+use std::{cell::RefCell, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
@@ -155,24 +155,12 @@ pub struct Pending {
     pub(crate) set_labels: FxHashMap<u64, Vec<u64>>,
     /// Labels to remove: node_id → [label_ids]
     pub(crate) remove_labels: FxHashMap<u64, Vec<u64>>,
-    /// Documents to add to indexes (keyed by label id)
-    pub(crate) index_add_docs: FxHashMap<u64, RoaringTreemap>,
-    /// Documents to remove from indexes (keyed by label id)
-    pub(crate) index_remove_docs: FxHashMap<u64, RoaringTreemap>,
-    /// Edge documents to add to indexes (keyed by relationship type id)
-    pub(crate) index_add_edge_docs: FxHashMap<u64, RoaringTreemap>,
-    /// Edge documents to remove from indexes: `type_id → { edge_id → (src, dst) }`.
-    /// `(src, dst)` is captured at deletion time — the edge is gone
-    /// from the tensor by the time `commit_edge_index` runs so the
-    /// 24-byte RediSearch key must be reconstructable from here.
-    pub(crate) index_remove_edge_docs: FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
-    /// Deferred index operations — accumulated across commit cycles,
-    /// applied only after the full query succeeds so that a failed
-    /// query never leaves stale entries in RediSearch.
-    pub(crate) deferred_index_adds: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) deferred_index_removes: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) deferred_edge_index_adds: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) deferred_edge_index_removes: FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
+    /// Index documents this `Commit` produced.
+    pub(crate) index_docs: IndexDocs,
+    /// Index documents accumulated across the query's commits, applied only
+    /// once the whole query succeeds so a failed one never leaves stale
+    /// entries in RediSearch.
+    pub(crate) deferred_docs: IndexDocs,
     /// Union of every index document this query has published, accumulated across
     /// all of its `Commit`s, so a later failure can resync them against committed
     /// state (see [`Self::resync_published_indexes`]).
@@ -180,7 +168,7 @@ pub struct Pending {
     /// Deliberately **not** reset by [`Self::clear`], which runs after every
     /// `Commit`: the undo has to cover the whole query, not just the last `Commit`.
     /// Per-query state — `Pending` belongs to one `Runtime`.
-    published: DeferredIndexes,
+    published: IndexDocs,
     /// Schema baseline: number of labels when the current commit window started.
     pub(crate) schema_label_count: usize,
     /// Schema baseline: number of relationship types when the current commit window started.
@@ -191,17 +179,68 @@ pub struct Pending {
     pub(crate) schema_rel_attr_count: usize,
 }
 
-/// One `Commit`'s index document changes, collected while applying `pending` and
-/// written to RediSearch as a batch.
+/// Edge documents to remove, keyed by relationship type: `type_id -> { edge_id
+/// -> (src, dst) }`.
+///
+/// The endpoints ride along because they are captured at deletion time — the
+/// edge is gone from the tensor by the time the 24-byte RediSearch key has to
+/// be rebuilt, so they cannot be looked up again.
+pub type EdgeDocRemovals = FxHashMap<u64, FxHashMap<u64, (u64, u64)>>;
+
+/// The index documents a unit of work produced, in both directions and for
+/// both entity kinds.
+///
+/// One type rather than four parallel maps, and used for both the per-commit
+/// set and the deferred one it folds into. They have to stay in
+/// correspondence — a document added to the wrong half is a stale RediSearch
+/// entry that nothing later notices — and four loose fields on `Pending` made
+/// that the caller's job at every site.
 #[derive(Default)]
-pub struct DeferredIndexes {
-    pub(crate) node_adds: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) node_removes: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) edge_adds: FxHashMap<u64, RoaringTreemap>,
-    pub(crate) edge_removes: FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
+pub struct IndexDocs {
+    /// Node documents to add, keyed by label id.
+    pub node_adds: FxHashMap<u64, RoaringTreemap>,
+    /// Node documents to remove, keyed by label id.
+    pub node_removes: FxHashMap<u64, RoaringTreemap>,
+    /// Edge documents to add, keyed by relationship type id.
+    pub edge_adds: FxHashMap<u64, RoaringTreemap>,
+    /// Edge documents to remove — see [`EdgeDocRemovals`].
+    pub edge_removes: EdgeDocRemovals,
 }
 
-impl DeferredIndexes {
+impl IndexDocs {
+    /// True when nothing was produced, so a caller can skip the work of
+    /// publishing an empty set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.node_adds.is_empty()
+            && self.node_removes.is_empty()
+            && self.edge_adds.is_empty()
+            && self.edge_removes.is_empty()
+    }
+
+    /// Fold `other` in, leaving it empty.
+    ///
+    /// Replaces four hand-written loops that folded a commit's documents into
+    /// the query's deferred set — one per map, each a chance to fold the wrong
+    /// pair together.
+    pub fn absorb(
+        &mut self,
+        other: &mut Self,
+    ) {
+        for (slot, ids) in other.node_adds.drain() {
+            *self.node_adds.entry(slot).or_default() |= ids;
+        }
+        for (slot, ids) in other.node_removes.drain() {
+            *self.node_removes.entry(slot).or_default() |= ids;
+        }
+        for (slot, ids) in other.edge_adds.drain() {
+            *self.edge_adds.entry(slot).or_default() |= ids;
+        }
+        for (slot, ids) in other.edge_removes.drain() {
+            self.edge_removes.entry(slot).or_default().extend(ids);
+        }
+    }
+
     /// Fold `other` in, for accumulating everything one query published.
     fn merge(
         &mut self,
@@ -285,15 +324,9 @@ impl Pending {
             existing_relationships_attrs: FxHashMap::default(),
             set_labels: FxHashMap::default(),
             remove_labels: FxHashMap::default(),
-            index_add_docs: FxHashMap::default(),
-            index_remove_docs: FxHashMap::default(),
-            index_add_edge_docs: FxHashMap::default(),
-            index_remove_edge_docs: FxHashMap::default(),
-            published: DeferredIndexes::default(),
-            deferred_index_adds: FxHashMap::default(),
-            deferred_index_removes: FxHashMap::default(),
-            deferred_edge_index_adds: FxHashMap::default(),
-            deferred_edge_index_removes: FxHashMap::default(),
+            index_docs: IndexDocs::default(),
+            published: IndexDocs::default(),
+            deferred_docs: IndexDocs::default(),
             schema_label_count: 0,
             schema_rel_type_count: 0,
             schema_node_attr_count: 0,
@@ -965,14 +998,18 @@ impl Pending {
                 .set_labels
                 .keys()
                 .all(|id| self.created_nodes.contains(*id));
-            g.borrow_mut()
-                .set_nodes_labels_bulk(&rows, &cols, &mut self.index_add_docs, all_new);
+            g.borrow_mut().set_nodes_labels_bulk(
+                &rows,
+                &cols,
+                &mut self.index_docs.node_adds,
+                all_new,
+            );
         }
         if !self.remove_labels.is_empty() {
             let (rows, cols) = flatten_label_map(&self.remove_labels);
             stats.borrow_mut().labels_removed += rows.len();
             g.borrow_mut()
-                .remove_nodes_labels(&rows, &cols, &mut self.index_remove_docs);
+                .remove_nodes_labels(&rows, &cols, &mut self.index_docs.node_removes);
         }
         if !self.new_nodes_attrs.is_empty() || !self.existing_nodes_attrs.is_empty() {
             let mut g = g.borrow_mut();
@@ -980,13 +1017,15 @@ impl Pending {
                 let nset = g.import_node_attrs(
                     &self.new_nodes_attrs,
                     &self.set_labels,
-                    &mut self.index_add_docs,
+                    &mut self.index_docs.node_adds,
                 );
                 stats.borrow_mut().properties_set += nset;
             }
             if !self.existing_nodes_attrs.is_empty() {
-                let (nremoved, nset) =
-                    g.set_nodes_attributes(&self.existing_nodes_attrs, &mut self.index_add_docs)?;
+                let (nremoved, nset) = g.set_nodes_attributes(
+                    &self.existing_nodes_attrs,
+                    &mut self.index_docs.node_adds,
+                )?;
                 let mut s = stats.borrow_mut();
                 s.properties_set += nset;
                 s.properties_removed += nremoved;
@@ -999,14 +1038,14 @@ impl Pending {
             if !self.new_relationships_attrs.is_empty() {
                 let nset = g.import_relationship_attrs(
                     &self.new_relationships_attrs,
-                    &mut self.index_add_edge_docs,
+                    &mut self.index_docs.edge_adds,
                 );
                 stats.borrow_mut().properties_set += nset;
             }
             if !self.existing_relationships_attrs.is_empty() {
                 let (nremoved, nset) = g.set_relationships_attributes(
                     &self.existing_relationships_attrs,
-                    &mut self.index_add_edge_docs,
+                    &mut self.index_docs.edge_adds,
                 )?;
                 let mut s = stats.borrow_mut();
                 s.properties_set += nset;
@@ -1017,7 +1056,7 @@ impl Pending {
             stats.borrow_mut().nodes_deleted += self.deleted_nodes.len();
             self.deleted_node_labels = g
                 .borrow_mut()
-                .delete_nodes(&self.deleted_nodes, &mut self.index_remove_docs)?;
+                .delete_nodes(&self.deleted_nodes, &mut self.index_docs.node_removes)?;
         }
         // Take relationship deletions BEFORE implicit edge processing
         // so we can pass them to delete_implicit_edges for dedup.
@@ -1031,7 +1070,7 @@ impl Pending {
             let implicit_edges = g.borrow_mut().delete_implicit_edges(
                 &self.deleted_nodes,
                 &explicit_rels,
-                &mut self.index_remove_edge_docs,
+                &mut self.index_docs.edge_removes,
             )?;
             let count = implicit_edges.len();
             stats.borrow_mut().relationships_deleted += count;
@@ -1044,7 +1083,7 @@ impl Pending {
         if !explicit_rels.is_empty() {
             let endpoints = g
                 .borrow_mut()
-                .delete_relationships(&explicit_rels, &mut self.index_remove_edge_docs)?;
+                .delete_relationships(&explicit_rels, &mut self.index_docs.edge_removes)?;
             // Use the actually-removed relationships (delete_relationships skips
             // stale/missing ids) for stats and effects/constraint bookkeeping.
             stats.borrow_mut().relationships_deleted += endpoints.len();
@@ -1062,31 +1101,8 @@ impl Pending {
         // the full query succeeds to avoid stale RediSearch entries on
         // rollback.
 
-        // Accumulate index operations into deferred fields.
-        for (k, v) in self.index_add_docs.drain() {
-            self.deferred_index_adds
-                .entry(k)
-                .or_default()
-                .bitor_assign(&v);
-        }
-        for (k, v) in self.index_remove_docs.drain() {
-            self.deferred_index_removes
-                .entry(k)
-                .or_default()
-                .bitor_assign(&v);
-        }
-        for (k, v) in self.index_add_edge_docs.drain() {
-            self.deferred_edge_index_adds
-                .entry(k)
-                .or_default()
-                .bitor_assign(&v);
-        }
-        for (k, v) in self.index_remove_edge_docs.drain() {
-            self.deferred_edge_index_removes
-                .entry(k)
-                .or_default()
-                .extend(v);
-        }
+        // Accumulate this commit's documents into the query's deferred set.
+        self.deferred_docs.absorb(&mut self.index_docs);
 
         Ok(())
     }
@@ -1326,13 +1342,8 @@ impl Pending {
     }
 
     /// Take the accumulated index document changes, leaving pending empty.
-    pub fn take_deferred_indexes(&mut self) -> DeferredIndexes {
-        DeferredIndexes {
-            node_adds: std::mem::take(&mut self.deferred_index_adds),
-            node_removes: std::mem::take(&mut self.deferred_index_removes),
-            edge_adds: std::mem::take(&mut self.deferred_edge_index_adds),
-            edge_removes: std::mem::take(&mut self.deferred_edge_index_removes),
-        }
+    pub fn take_deferred_indexes(&mut self) -> IndexDocs {
+        std::mem::take(&mut self.deferred_docs)
     }
 
     /// Undo the index documents earlier `Commit`s published, after this query
@@ -1464,10 +1475,10 @@ impl Pending {
         self.deleted_relationships.clear();
         self.deleted_endpoints.clear();
         self.deleted_node_labels.clear();
-        self.index_add_docs.clear();
-        self.index_remove_docs.clear();
-        self.index_add_edge_docs.clear();
-        self.index_remove_edge_docs.clear();
+        self.index_docs.node_adds.clear();
+        self.index_docs.node_removes.clear();
+        self.index_docs.edge_adds.clear();
+        self.index_docs.edge_removes.clear();
     }
 
     /// Returns the number of effects (operations) tracked in this Pending.

--- a/src/commands/effect.rs
+++ b/src/commands/effect.rs
@@ -26,6 +26,7 @@ use graph::{
     entity_type::EntityType,
     graph::graph::{Graph, TypeId},
     index::IndexType,
+    runtime::pending::{EdgeDocRemovals, IndexDocs},
     runtime::value::Value,
 };
 use parking_lot::RwLock;
@@ -125,11 +126,8 @@ fn apply_effects(
         return Err(format!("unsupported effects version: {version}"));
     }
 
-    let mut index_add_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
-    let mut index_remove_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
-    let mut index_add_edge_docs: FxHashMap<u64, RoaringTreemap> = FxHashMap::default();
-    let mut index_remove_edge_docs: FxHashMap<u64, FxHashMap<u64, (u64, u64)>> =
-        FxHashMap::default();
+    // The same type the write path and the v3 applier collect into.
+    let mut docs = IndexDocs::default();
     let mut has_index_ops = false;
 
     // Entity effects reference labels, relationship types, and attributes by
@@ -160,13 +158,13 @@ fn apply_effects(
         // effects still take hold in stream order. Only one batch is ever
         // non-empty: starting one flushes the other.
         match effect_type {
-            EFFECT_DELETE_EDGE => flush_del_nodes(g, &mut del_nodes, &mut index_remove_docs)?,
+            EFFECT_DELETE_EDGE => flush_del_nodes(g, &mut del_nodes, &mut docs.node_removes)?,
             EFFECT_DELETE_NODE => {
-                flush_del_edges(g, &mut del_edges, &mut index_remove_edge_docs)?;
+                flush_del_edges(g, &mut del_edges, &mut docs.edge_removes)?;
             }
             _ => {
-                flush_del_edges(g, &mut del_edges, &mut index_remove_edge_docs)?;
-                flush_del_nodes(g, &mut del_nodes, &mut index_remove_docs)?;
+                flush_del_edges(g, &mut del_edges, &mut docs.edge_removes)?;
+                flush_del_nodes(g, &mut del_nodes, &mut docs.node_removes)?;
             }
         }
 
@@ -195,7 +193,7 @@ fn apply_effects(
 
                 // Apply labels
                 if label_count > 0 {
-                    g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut index_add_docs, true);
+                    g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut docs.node_adds, true);
                 }
 
                 // Attributes
@@ -204,7 +202,7 @@ fn apply_effects(
                     let attrs = read_attrs(buf, &mut offset, attr_count, node_attr_count)?;
                     let mut attr_map = FxHashMap::default();
                     attr_map.insert(node_id_raw, attrs);
-                    g.set_nodes_attributes(&attr_map, &mut index_add_docs)?;
+                    g.set_nodes_attributes(&attr_map, &mut docs.node_adds)?;
                 }
             }
 
@@ -230,7 +228,7 @@ fn apply_effects(
                     let attrs = read_attrs(buf, &mut offset, attr_count, rel_attr_count)?;
                     let mut attr_map = FxHashMap::default();
                     attr_map.insert(rel_id_raw, attrs);
-                    g.set_relationships_attributes(&attr_map, &mut index_add_edge_docs)?;
+                    g.set_relationships_attributes(&attr_map, &mut docs.edge_adds)?;
                 }
             }
 
@@ -240,7 +238,7 @@ fn apply_effects(
                 let attrs = read_attrs(buf, &mut offset, attr_count, node_attr_count)?;
                 let mut attr_map = FxHashMap::default();
                 attr_map.insert(node_id, attrs);
-                g.set_nodes_attributes(&attr_map, &mut index_add_docs)?;
+                g.set_nodes_attributes(&attr_map, &mut docs.node_adds)?;
             }
 
             EFFECT_UPDATE_EDGE => {
@@ -249,7 +247,7 @@ fn apply_effects(
                 let attrs = read_attrs(buf, &mut offset, attr_count, rel_attr_count)?;
                 let mut attr_map = FxHashMap::default();
                 attr_map.insert(rel_id, attrs);
-                g.set_relationships_attributes(&attr_map, &mut index_add_edge_docs)?;
+                g.set_relationships_attributes(&attr_map, &mut docs.edge_adds)?;
             }
 
             EFFECT_SET_LABELS => {
@@ -265,7 +263,7 @@ fn apply_effects(
                     label_rows.push(node_id);
                     label_cols.push(label_id as u64);
                 }
-                g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut index_add_docs, false);
+                g.set_nodes_labels_bulk(&label_rows, &label_cols, &mut docs.node_adds, false);
             }
 
             EFFECT_REMOVE_LABELS => {
@@ -281,7 +279,7 @@ fn apply_effects(
                     label_rows.push(node_id);
                     label_cols.push(label_id as u64);
                 }
-                g.remove_nodes_labels(&label_rows, &label_cols, &mut index_remove_docs);
+                g.remove_nodes_labels(&label_rows, &label_cols, &mut docs.node_removes);
             }
 
             EFFECT_DELETE_NODE => {
@@ -364,11 +362,11 @@ fn apply_effects(
         }
     }
 
-    flush_del_edges(g, &mut del_edges, &mut index_remove_edge_docs)?;
-    flush_del_nodes(g, &mut del_nodes, &mut index_remove_docs)?;
+    flush_del_edges(g, &mut del_edges, &mut docs.edge_removes)?;
+    flush_del_nodes(g, &mut del_nodes, &mut docs.node_removes)?;
 
-    g.commit_index(&mut index_add_docs, &mut index_remove_docs);
-    g.commit_edge_index(&mut index_add_edge_docs, &mut index_remove_edge_docs);
+    g.commit_index(&mut docs.node_adds, &mut docs.node_removes);
+    g.commit_edge_index(&mut docs.edge_adds, &mut docs.edge_removes);
 
     if has_index_ops {
         g.populate_indexes_sync();
@@ -381,12 +379,12 @@ fn apply_effects(
 fn flush_del_nodes(
     g: &mut Graph,
     nodes: &mut RoaringTreemap,
-    index_remove_docs: &mut FxHashMap<u64, RoaringTreemap>,
+    removals: &mut FxHashMap<u64, RoaringTreemap>,
 ) -> Result<(), String> {
     if nodes.is_empty() {
         return Ok(());
     }
-    g.delete_nodes(nodes, index_remove_docs)?;
+    g.delete_nodes(nodes, removals)?;
     nodes.clear();
     Ok(())
 }
@@ -395,12 +393,12 @@ fn flush_del_nodes(
 fn flush_del_edges(
     g: &mut Graph,
     rels: &mut RoaringTreemap,
-    index_remove_edge_docs: &mut FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
+    removals: &mut EdgeDocRemovals,
 ) -> Result<(), String> {
     if rels.is_empty() {
         return Ok(());
     }
-    g.delete_relationships(rels, index_remove_edge_docs)?;
+    g.delete_relationships(rels, removals)?;
     rels.clear();
     Ok(())
 }


### PR DESCRIPTION
**Folded into #2570**, where the commit now sits alongside the codec. GitHub marked this merged because the fast-forward put its head commit into the base branch — nothing was squashed or lost.

This was sized as a major refactor because review comment #04 read like one, and the reference count backed that up: ~68 mentions in `pending.rs` and ~35 in `graph.rs`. The plan was for it to sit between the functional PR and the tests, so a hundred-site change would not be reviewed alongside replication behaviour.

It turned out to be **+137 / −131 across four files**, because the type already existed. `DeferredIndexes` had exactly the four fields and a `merge` doing exactly what `Pending`'s four hand-written fold loops did — it simply was not used for storage. So the work was "use the type we have", not "introduce one", and the reference count was mostly the *same four names* repeated rather than a hundred places each needing a decision.

At that size it does not earn a PR of its own, and separating it costs more in stack maintenance than it buys in reviewability. The stack is four PRs, not five.

See #2700 for the full record.
