### PR TITLE
perf(aggregate): stop allocating a grouping key per input row

### DIFF
--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -42,6 +42,7 @@ use crate::runtime::{
 };
 use ahash::RandomState;
 use orx_tree::{Dyn, DynNode, DynTree, NodeIdx, NodeRef};
+use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -61,11 +62,29 @@ type GroupMap = HashMap<GroupKey, (Row, Row), RandomState>;
 // GroupKey — collision-free composite grouping key
 // ---------------------------------------------------------------------------
 
+/// Backing store for a [`GroupKey`]'s values.
+///
+/// The key is rebuilt for *every input row* so it can be looked up in
+/// [`GroupMap`], but it is only retained for the first row of each group. With a
+/// `Vec` that was one malloc/free pair per row whose result was thrown away as
+/// soon as the group turned out to already exist: grouping 10k rows into 100
+/// groups paid 10k allocations to keep 100.
+///
+/// One inline slot, not two. Every extra slot widens the key unconditionally
+/// (`Value` is 16 bytes, so `SmallVec` measures 32 bytes at one slot and 48 at
+/// two, against `Vec`'s 24), and that width is carried by every group of every
+/// shape — including the empty key that *keyless* aggregation holds, which is
+/// the most common shape of all. One slot covers single-key grouping, which is
+/// where the allocations actually were; wider keys stay correct and merely keep
+/// allocating, spilling to the heap past the inline capacity exactly as the
+/// `Vec` always did.
+type GroupKeyVec = SmallVec<[Value; 1]>;
+
 /// A composite grouping key — a vector of evaluated key values.
 ///
 /// Uses `Value::hash` for bucket placement and `Value::eq` for collision
 /// resolution, eliminating the silent-merge bug of raw `u64` hash keys.
-struct GroupKey(Vec<Value>);
+struct GroupKey(GroupKeyVec);
 
 impl PartialEq for GroupKey {
     fn eq(
@@ -378,7 +397,7 @@ impl<'a> AggregateOp<'a> {
         // Pre-insert default group for keyless aggregation.
         if self.keys.is_empty() {
             let key_env = Row::new();
-            groups.insert(GroupKey(vec![]), (key_env, default_acc.clone()));
+            groups.insert(GroupKey(GroupKeyVec::new()), (key_env, default_acc.clone()));
         }
 
         for batch_result in child {
@@ -452,7 +471,7 @@ impl<'a> AggregateOp<'a> {
                         )
                 })
             {
-                let entry = groups.get_mut(&GroupKey(vec![])).unwrap();
+                let entry = groups.get_mut(&GroupKey(GroupKeyVec::new())).unwrap();
                 let acc = &mut entry.1;
                 let mut batch_err: Option<String> = None;
                 for (agg_idx, agg) in analysis.agg_kinds.iter().enumerate() {
@@ -509,7 +528,7 @@ impl<'a> AggregateOp<'a> {
             }
 
             for row_idx in 0..num_active {
-                let key_values: Vec<Value> =
+                let key_values: GroupKeyVec =
                     key_columns.iter().map(|col| col[row_idx].clone()).collect();
                 let group_key = GroupKey(key_values);
 
@@ -686,7 +705,7 @@ impl<'a> AggregateOp<'a> {
         // Pre-insert default group for keyless aggregation.
         if self.keys.is_empty() {
             let key_env = Row::new();
-            groups.insert(GroupKey(vec![]), (key_env, default_acc.clone()));
+            groups.insert(GroupKey(GroupKeyVec::new()), (key_env, default_acc.clone()));
         }
 
         for batch_result in child {
@@ -730,7 +749,7 @@ impl<'a> AggregateOp<'a> {
         for row in batch.active_indices() {
             let vars = BatchRow::new(batch, row).to_owned_row();
             let (key_values, key_env) = match (|| {
-                let mut key_values = Vec::with_capacity(keys.len());
+                let mut key_values = GroupKeyVec::with_capacity(keys.len());
                 let mut key_env = Row::new();
                 for (name, tree) in keys {
                     let value = ExprEval::from_runtime(runtime).eval(
@@ -748,7 +767,7 @@ impl<'a> AggregateOp<'a> {
                         key_env.insert(new_var, val.clone());
                     }
                 }
-                Ok::<(Vec<Value>, Row), String>((key_values, key_env))
+                Ok::<(GroupKeyVec, Row), String>((key_values, key_env))
             })() {
                 Ok(kv) => kv,
                 Err(e) => {


### PR DESCRIPTION
## Summary

The vectorized aggregate grouping loop allocated a `Vec<Value>` for **every input row** just to probe the group map, then dropped it the moment the group turned out to already exist. Only the first row of each group ever keeps its key, so grouping 10k rows into 100 groups paid 10k malloc/free pairs to retain 100.

`GroupKey` is now backed by a `SmallVec` with one inline slot, so single-key grouping — the shape that had the allocations — probes the map without touching the allocator.

```rust
for row_idx in 0..num_active {
    let key_values: Vec<Value> =                            // one malloc per row,
        key_columns.iter().map(|col| col[row_idx].clone()).collect();
    let group_key = GroupKey(key_values);

    let entry = groups.entry(group_key).or_insert_with(|| { // ...freed right here
```

**Why one inline slot and not two.** `Value` is 16 bytes, so the key measures 32 bytes at one inline slot and 48 at two, against `Vec`'s 24. That width is carried by every group of every shape — including the empty key held by *keyless* aggregation (`count(*)`, `sum(...)`), the most common shape of all. Measured under callgrind, `[Value; 2]` gave back about a fifth of the win for exactly that reason (`WITH pipeline` -6.6% instead of -7.6%). One slot covers single-key grouping, which is where the allocations actually were.

Wider keys are unchanged in behaviour — `SmallVec` spills to the heap past the inline capacity, exactly as the `Vec` always did.

## Changes

- `graph/src/runtime/ops/aggregate.rs`: `GroupKey(Vec<Value>)` → `GroupKey(SmallVec<[Value; 1]>)` via a new `GroupKeyVec` alias, and the five construction sites updated to match. `smallvec` was already a direct dependency of the `graph` crate, so no dependency change.

Behaviour is identical: `GroupKey`'s hand-written `Hash`/`PartialEq` iterate the values and are unaffected by the backing container.

## Testing

| suite | result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `CXX=clang++ cargo clippy --all-targets` | 0 errors |
| `cargo test -p graph` | 182 passed, 1 pre-existing failure¹ |
| `pytest tests/test_e2e.py tests/test_functions.py tests/test_mvcc.py tests/test_concurrency.py` | 138 passed |
| TCK (`tck_done.txt`) | 173 features, **2456 scenarios passed, 0 failed** |
| flow `test_aggregation` / `test_distinct` / `test_with_clause` | 11 / 10 / 12 passed, 0 failed |
| flow (full suite) | 1442 passed, 5 pre-existing failures² |

¹ `graph::graphblas::matrix::tests::build_bool_is_iso_and_grb_build_is_not` — asserts an upstream GraphBLAS property; fails identically on a clean tree here (locally installed GraphBLAS version).
² `test_replication_states`, `test_replication::test_bulk_replication`, `test_function_calls::test92/93/94` — all verified failing identically on a clean baseline build.

## Memory / Performance Impact

Callgrind, instructions per execution, `THREAD_COUNT 1`, `--n1 5 --n2 25`:

| query | base | this PR | Δ |
|---|---:|---:|---:|
| `WITH pipeline` — `MATCH (p:Person) WITH p.id % 100 AS g, count(*) AS c WHERE c > 50 …` | 3,175,918 | 2,933,251 | **−7.6%** |
| `ORDER BY agg` — `MATCH (p:Person) RETURN p.id % 5 AS k, count(*) …` | 2,906,770 | 2,684,633 | **−7.6%** |

Both group 10,000 rows.

**Noise floor.** Non-grouping rows move within ±0.7% between the two builds — `index lookup` +0.31% and `id seek` +0.55%, neither of which enters this code at all, so that band is build-layout drift rather than a real effect. The keyless aggregate rows (`aggregates` +0.76%, `label scan + count` +0.66%) sit inside the same band, and structurally cannot regress here: keyless aggregation with batch kernels takes the fast path above this loop and constructs one key per *batch*, not per row. The −7.6% on the grouped queries is an order of magnitude above that floor and reproduced across repeat runs.

Memory: no per-entity overhead. The 8 extra bytes per key are transient query state bounded by group cardinality, and are offset by removing one heap allocation per input row.

## Related Issues

Closes #2709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced memory overhead when storing grouping keys during aggregation.
  - Improved efficiency for both vectorized and per-row aggregation processing.
  - Preserved existing aggregation behavior, results, and grouping logic across all processing paths.
  - No changes are expected to aggregation outputs or grouping semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
