### PR TITLE
perf: call a scalar function once per batch when all its arguments are constant

### DIFF
--- a/graph/src/runtime/vector_expr.rs
+++ b/graph/src/runtime/vector_expr.rs
@@ -563,6 +563,47 @@ impl<'a> VectorEval<'a> {
             columns.push(self.eval(&child, batch, rows)?);
         }
 
+        // Every argument one value shared by the whole batch means the answer
+        // is one value too — call the function once and hand back a `Scalar`
+        // rather than the same call `len` times into a materialized column.
+        //
+        // This composes, which is the point. In
+        // `split(replace(trim('  a,b,c  '), ',', ';'), ';')` the literal is a
+        // `Scalar`, so `trim` returns one, so `replace` sees a `Scalar` and
+        // returns one, and `split` likewise: the whole chain collapses to three
+        // calls per batch from three per row. Measured on the
+        // `split+trim+replace` benchmark row, 100 rows of exactly that:
+        // 3,578 instructions per row in `split` alone before this.
+        //
+        // Three guards, and only the first is load-bearing today.
+        //
+        // Requiring an argument is what actually keeps `rand()` and
+        // `randomUUID()` per row: they take none, so there would be nothing
+        // here to prove them constant from, and folding would hand every row
+        // in the batch one draw.
+        //
+        // `non_deterministic` is belt and braces on top of that. Every volatile
+        // function in the registry is zero-argument or is flagged only for its
+        // zero-argument "now" form — `date('2020-01-01')` answers the same
+        // thing however often it is asked — so removing this check changes no
+        // result today. It is here so that a volatile function which does take
+        // an argument (a seeded `rand`, a `now(tz)`) cannot be added later and
+        // silently start folding.
+        //
+        // The empty-batch check is the same kind of guard: operators drop empty
+        // batches before reaching this, so a call that would raise is not
+        // reached at zero rows either way. Stating it here keeps that a
+        // property of this function rather than of every caller.
+        if len > 0
+            && !func.non_deterministic
+            && !columns.is_empty()
+            && columns.iter().all(|c| matches!(c, ExprColumn::Scalar(_)))
+        {
+            let args: Vec<Value> = columns.iter().map(|c| c.get(0)).collect();
+            func.validate_args_type(&args)?;
+            return Ok(ExprColumn::Scalar(func.func.call(self.runtime, &args)?));
+        }
+
         let mut out = Vec::with_capacity(len);
         let mut args = Vec::with_capacity(columns.len());
         for i in 0..len {

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2804,3 +2804,74 @@ class testFunctionCallsFlow(FlowTestsBase):
     #
     #     res = self.graph.query("UNWIND range(1, 5) AS x RETURN prev(tostring(x) + tostring(x))")
     #     self.env.assertEqual(res.result_set, [[None], ['11'], ['22'], ['33'], ['44']])
+
+    def test95_constant_argument_functions_evaluate_once_per_batch(self):
+        # A scalar function whose every argument is one value shared by the
+        # whole batch is called once and broadcast, instead of once per row.
+        # The saving composes down a chain — in
+        # `split(replace(trim(...), ...), ...)` each call hands the next a
+        # shared value — so these check the answers are unchanged, per row and
+        # in aggregate, for the shapes that fold.
+        q = "UNWIND range(0, 4) AS i RETURN i, split(replace(trim('  a,b,c  '), ',', ';'), ';') AS v"
+        res = self.graph.query(q)
+        self.env.assertEqual([r[0] for r in res.result_set], [0, 1, 2, 3, 4])
+        for r in res.result_set:
+            self.env.assertEqual(r[1], ['a', 'b', 'c'])
+
+        # Folded into an aggregate, and mixed with a per-row value so the
+        # broadcast has to line up with real columns rather than replace them.
+        res = self.graph.query(
+            "UNWIND range(0, 99) AS i RETURN count(split('a;b;c', ';')), sum(i)")
+        self.env.assertEqual(res.result_set, [[100, 4950]])
+        res = self.graph.query(
+            "UNWIND range(0, 3) AS i RETURN i + size(split('a;b;c', ';')) AS n ORDER BY n")
+        self.env.assertEqual([r[0] for r in res.result_set], [3, 4, 5, 6])
+
+        # Nested one level under a function that does vary per row.
+        res = self.graph.query(
+            "UNWIND ['x', 'y'] AS s RETURN s + toUpper(trim(' q ')) AS v ORDER BY v")
+        self.env.assertEqual([r[0] for r in res.result_set], ['xQ', 'yQ'])
+
+    def test96_non_deterministic_functions_are_not_folded(self):
+        # The behaviour that makes test95 safe: a volatile function still
+        # varies per row. What stops these being folded is that they take no
+        # arguments, so there is nothing constant to fold from — not the
+        # `non_deterministic` flag, which is a second guard for volatile
+        # functions that might later take one. These pin the observable
+        # property; removing either guard alone does not move them, and that
+        # is worth knowing rather than assuming.
+        res = self.graph.query("UNWIND range(1, 200) AS i RETURN count(DISTINCT rand()) AS n")
+        self.env.assertGreater(res.result_set[0][0], 150)
+
+        res = self.graph.query("UNWIND range(1, 200) AS i RETURN count(DISTINCT randomUUID()) AS n")
+        self.env.assertEqual(res.result_set[0][0], 200)
+
+        # Two independent draws in one row must not collapse into each other.
+        res = self.graph.query(
+            "UNWIND range(1, 50) AS i WITH i WHERE rand() = rand() RETURN count(*) AS n")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
+        # `toString` of a random value is a deterministic function over a
+        # non-deterministic argument: the argument column is not scalar, so the
+        # outer call cannot fold either.
+        res = self.graph.query(
+            "UNWIND range(1, 200) AS i RETURN count(DISTINCT toString(randomUUID())) AS n")
+        self.env.assertEqual(res.result_set[0][0], 200)
+
+    def test97_folded_calls_keep_their_errors_and_empty_batches(self):
+        # Evaluating once must not move when an error is raised. A bad constant
+        # argument still fails the query...
+        try:
+            self.graph.query("UNWIND range(0, 9) AS i RETURN split(1, 2)")
+            self.env.assertTrue(False, depth=1)
+        except Exception as e:
+            self.env.assertContains("Type mismatch", str(e))
+
+        # ...and a batch with no rows still raises nothing. Operators drop
+        # empty batches before any expression is evaluated, so this holds with
+        # or without the row-count guard inside the fold; it is pinned because
+        # it is the behaviour callers depend on, whichever layer provides it.
+        res = self.graph.query("UNWIND [] AS i RETURN split(1, 2)")
+        self.env.assertEqual(res.result_set, [])
+        res = self.graph.query("MATCH (n:NoSuchLabel) RETURN split(1, 2)")
+        self.env.assertEqual(res.result_set, [])


### PR DESCRIPTION
Fixes #2714.

Sixth in the stack: #2686 → #2690 → #2691 → #2693 → this (#2685 has landed).

Fixes the worst instruction ratio in the benchmark — `split+trim+replace` at **2.83× C**.

## The cause

`VectorEval::eval_function` evaluated every scalar function once per row, even when each argument column was an `ExprColumn::Scalar` — one value already shared by the whole batch. So a constant subexpression cost exactly as much as a row-dependent one, and materialised a `Vec<Value>` of identical results on the way out.

The benchmark row is nothing but constants:

```cypher
UNWIND range(0, 99) AS i
RETURN count(split(replace(trim('  a,b,c  '), ',', ';'), ';'))
```

Marginal cost per row, each function measured against the same query with `count(1)` as the floor:

| function | instructions/row |
|---|---|
| `trim` | 813 |
| `toUpper` | 833 |
| `replace` | 1,107 |
| **`split`** | **3,578** |

`split` alone cost more than C's entire query (3,081/row). The implementation is not the problem — five allocations for three parts is reasonable — it was being called 100 times for one answer.

## Why fold in the evaluator rather than the planner

There is already a constant-folding pass in the optimizer, but it works through `GraphFn::pure_fn`, a `Runtime`-free form that only the temporal and map constructors provide. `trim`/`replace`/`split` have none, so it cannot reach them.

Folding here instead needs no new per-function plumbing and **composes**, which is the point: the literal is a `Scalar`, so `trim` returns one, so `replace` sees a `Scalar` and returns one, and `split` likewise. The chain collapses to three calls per batch from three per row. It also catches arguments that are scalar without being literals — a parameter, or anything upstream that folded.

## Measured

| row | before | after | | vs C before | vs C after |
|---|---|---|---|---|---|
| `split+trim+replace` | 871,972 | 227,062 | **3.84×** | 2.83× | **0.74×** |
| `UDF echo scalars` | 2,147,570 | 753,407 | **2.85×** | — | — |

Both stable to ±0.1% across three runs, with the `RETURN 1` control row at 171–175k against its 170,029 baseline — so that sweep is not load-inflated. Allocation on the target row drops to 1,581 B against C's 435,774 B.

`UDF echo scalars` is a bonus: user-defined functions called with constant arguments fold the same way.

## The two rows the gate flagged

Neither survived checking, and both are rows I had already characterised in the report's noise section.

`edge index lt range` read 1.37× off a median of three runs. Five consecutive runs on this build then gave 275,713 / 275,311 / 278,665 / 275,872 / 278,395 against a 276,105 baseline. That sweep's `RETURN 1` control was up 30%, which is precisely what `bench/README.md` says to treat as a void run.

`multi-type traverse` at 1.093× is the known bimodal row — 38.5M / 42.1M / 42.1M / 38.6M / 38.6M on one build, two clusters.

## On the guards

Being explicit, because two of the three are defensive rather than load-bearing and the code says so:

- **Requiring at least one argument is the guard that matters.** `rand()` and `randomUUID()` take none, so there is nothing here to prove them constant from, and folding would hand a whole batch a single draw.
- **`non_deterministic` changes no result today.** Every volatile function in the registry is zero-argument, or is flagged only for its zero-argument "now" form — `date('2020-01-01')` answers the same thing however often it is asked. The check is there so a volatile function that *does* take an argument (a seeded `rand`, a `now(tz)`) cannot be added later and silently start folding.
- **The empty-batch check is the same kind of guard.** Operators drop empty batches before reaching this, so a call that would raise is not reached at zero rows either way; stating it here keeps that a property of this function rather than of every caller.

I verified both of those by removing each and re-running, rather than assuming.

## Tests

Three in `tests/flow/test_function_calls.py`. They pin the observable behaviour and say so, rather than claiming to isolate the guards:

- **`test95_constant_argument_functions_evaluate_once_per_batch`** — the chain per row, folded into an aggregate, mixed with a per-row column so the broadcast has to line up with real data, and nested under a function that does vary per row.
- **`test96_non_deterministic_functions_are_not_folded`** — 200 rows of `rand()` yield >150 distinct values, `randomUUID()` yields exactly 200, two draws in one row don't collapse, and `toString(randomUUID())` doesn't fold either (its argument column isn't scalar). Documents that what stops these is the arity guard, not the flag.
- **`test97_folded_calls_keep_their_errors_and_empty_batches`** — a bad constant argument still fails the query; empty batches still raise nothing.

## Verification

- `cargo test -p graph` — 185 passed
- `./flow.sh` — **1488 passed, 0 failed**
- `pytest tests/test_e2e.py tests/test_functions.py` — 124 passed
- TCK — **2456 scenarios passed, 0 failed**
- full 66-query benchmark gated on instructions — no surviving regressions
- `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved evaluation speed for deterministic functions with constant arguments by evaluating them once per batch instead of once per row.

* **Bug Fixes**
  * Preserved nondeterministic function behavior.
  * Maintained existing error handling and empty-batch behavior for optimized evaluations.

* **Tests**
  * Added coverage for batch-level evaluation, nondeterministic functions, errors, and empty batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->