### PR TITLE
fix: register aof_rewrite for GRAPH_TYPE and GRAPHMETA_TYPE

### DIFF
--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -18,6 +18,7 @@
 //! RDB load (aux payload)   | graph_aux_load()   | Deserialize + register UDFs
 //! RDB save (per-key)       | graph_rdb_save()   | Encode graph to RDB stream
 //! RDB load (per-key)       | graph_rdb_load()   | Decode graph from RDB stream
+//! AOF rewrite (per-key)    | graph_aof_rewrite()| Emit GRAPH.RESTORE for no-preamble AOF
 //! ```
 //!
 //! ## UDF persistence
@@ -199,6 +200,69 @@ unsafe extern "C" fn graph_rdb_save(
         let graph = g.borrow();
         serializers::encoder::rdb_save_graph(rdb, &graph);
     }
+}
+
+/// AOF rewrite for `aof-use-rdb-preamble no`: emit one `GRAPH.RESTORE` that
+/// rebuilds the whole graph, using the same byte format `GRAPH.COPY` already
+/// replicates (`vec_save_graph` / `graph_restore`). Without this callback
+/// Redis calls a null `aof_rewrite` unconditionally and the rewrite child
+/// segfaults (#2710).
+///
+/// Virtual keys are skipped: they only exist to split one graph's RDB image
+/// across multiple Redis keys, and the primary key's `GRAPH.RESTORE` already
+/// reconstructs the whole graph, so emitting per virtual key would duplicate it.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn graph_aof_rewrite(
+    aof: *mut RedisModuleIO,
+    key: *mut raw::RedisModuleString,
+    value: *mut c_void,
+) {
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = raw::RedisModule_StringPtrLen.unwrap()(key, &raw mut len);
+        let key_name =
+            String::from_utf8_lossy(std::slice::from_raw_parts(ptr.cast(), len)).to_string();
+
+        if VKEY_STATE.lock().vkey_map.contains_key(&key_name) {
+            return;
+        }
+
+        // Direct encoding: use data_ptr() to bypass parking_lot RwLock, which
+        // deadlocks in the BGREWRITEAOF fork child for the same reason noted
+        // in graph_rdb_save above.
+        let graph_arc = &*(value.cast::<Arc<RwLock<ThreadedGraph>>>());
+        let tg: &ThreadedGraph = &*graph_arc.data_ptr();
+        let g = tg.graph.read();
+        let graph = g.borrow();
+        let payload = serializers::encoder::vec_save_graph(&graph);
+
+        let cmd = CString::new("GRAPH.RESTORE").unwrap();
+        let fmt = CString::new("sb").unwrap();
+        raw::RedisModule_EmitAOF.unwrap()(
+            aof,
+            cmd.as_ptr(),
+            fmt.as_ptr(),
+            key,
+            payload.as_ptr().cast::<std::os::raw::c_char>(),
+            payload.len(),
+        );
+    }
+}
+
+/// No-op AOF rewrite for graphmeta virtual keys.
+///
+/// Rust never creates graphmeta keys itself (see module doc); this exists so
+/// that if one from a loaded C RDB survives to an AOF rewrite, Redis calls a
+/// real (empty) callback instead of a null `aof_rewrite`, which segfaults the
+/// rewrite child (#2710). Same defensive stance `graphmeta_rdb_save` already
+/// takes.
+#[allow(clippy::missing_const_for_fn)]
+#[unsafe(no_mangle)]
+unsafe extern "C" fn graphmeta_aof_rewrite(
+    _aof: *mut RedisModuleIO,
+    _key: *mut raw::RedisModuleString,
+    _value: *mut c_void,
+) {
 }
 
 // ---------------------------------------------------------------------------
@@ -855,7 +919,7 @@ pub static GRAPH_TYPE: RedisType = RedisType::new(
         version: REDISMODULE_TYPE_METHOD_VERSION as u64,
         rdb_load: Some(graph_rdb_load),
         rdb_save: Some(graph_rdb_save),
-        aof_rewrite: None,
+        aof_rewrite: Some(graph_aof_rewrite),
         free: Some(graph_free),
 
         mem_usage: None,
@@ -949,7 +1013,7 @@ pub static GRAPHMETA_TYPE: RedisType = RedisType::new(
         version: REDISMODULE_TYPE_METHOD_VERSION as u64,
         rdb_load: Some(graphmeta_rdb_load),
         rdb_save: Some(graphmeta_rdb_save),
-        aof_rewrite: None,
+        aof_rewrite: Some(graphmeta_aof_rewrite),
         free: Some(graphmeta_free),
 
         mem_usage: None,

--- a/tests/flow/test_aof.py
+++ b/tests/flow/test_aof.py
@@ -10,9 +10,11 @@ class testAOFReplay():
         self.conn = self.env.getConnection()
 
     def tearDown(self):
-        # Leave AOF off for whatever runs next in this environment.
+        # Leave AOF off, and the preamble on its default, for whatever runs
+        # next in this environment.
         try:
             self.conn.config_set("appendonly", "no")
+            self.conn.config_set("aof-use-rdb-preamble", "yes")
         except Exception:
             pass
         self.conn.flushall()
@@ -70,5 +72,38 @@ class testAOFReplay():
 
         # ...and the graph came back through it, so the command really was replayed
         # rather than skipped.
+        result = graph.query("MATCH (n) RETURN count(n)")
+        self.env.assertEqual(result.result_set[0][0], 2)
+
+    def test02_bgrewriteaof_survives_without_rdb_preamble(self):
+        # With aof-use-rdb-preamble on (the default, test01's control) BGREWRITEAOF
+        # writes an RDB preamble and never calls the type's aof_rewrite callback.
+        # With it off, Redis rewrites every key as commands and calls
+        # aof_rewrite unconditionally. Neither engine registered one (#2710), so
+        # the rewrite forked a child that dereferenced a null function pointer
+        # and segfaulted every time, forever, since auto-aof-rewrite-percentage
+        # keeps re-triggering a rewrite that can never succeed.
+        self.conn.flushall()
+        self.conn.config_set("appendonly", "no")
+        self.conn.config_set("aof-use-rdb-preamble", "no")
+        self.conn.config_set("appendonly", "yes")
+        self._wait_for_aof_rewrite()
+
+        graph = self.db.select_graph(GRAPH_ID)
+        graph.query("CREATE (:P {n:1})")
+        graph.query("CREATE (:P {n:2})")
+
+        self.conn.execute_command("BGREWRITEAOF")
+        self._wait_for_aof_rewrite()
+
+        # The child that ran the rewrite must not have crashed.
+        self.env.assertTrue(self.conn.ping())
+        status = self.conn.info("persistence").get("aof_last_bgrewrite_status")
+        self.env.assertEqual(status, "ok")
+
+        # The rewritten AOF must actually reconstruct the graph, not just avoid
+        # crashing while producing an empty one.
+        self.conn.execute_command("DEBUG", "LOADAOF")
+        self.env.assertTrue(self.conn.ping())
         result = graph.query("MATCH (n) RETURN count(n)")
         self.env.assertEqual(result.result_set[0][0], 2)


### PR DESCRIPTION
## Cause

`GRAPH_TYPE` and `GRAPHMETA_TYPE` never registered `aof_rewrite`. With `aof-use-rdb-preamble yes` (default) this is invisible: `BGREWRITEAOF` emits an RDB preamble and never calls it. With `no`, Redis calls `aof_rewrite` unconditionally per key of that type. A null callback dereferences a null pointer, segfaulting the rewrite child. Since `auto-aof-rewrite-percentage` keeps re-triggering a rewrite that can never succeed, the server never recovers.

## Fix

`graph_aof_rewrite` emits one `GRAPH.RESTORE` per key via `RedisModule_EmitAOF`, reusing the byte format `GRAPH.COPY` already replicates (`vec_save_graph` / `graph_restore`). Virtual keys are skipped: they only exist to split one graph's RDB image across multiple keys, and the primary key's `GRAPH.RESTORE` already reconstructs the whole graph. `graphmeta_aof_rewrite` is a no-op, for the same defensive reason `graphmeta_rdb_save` already exists — Rust never creates graphmeta keys, but a loaded C RDB could carry one.

Fork-safety matches `graph_rdb_save`: encoding bypasses the `parking_lot` `RwLock` via `data_ptr()`, since a thread holding the write lock at fork time is gone in the child and a normal lock acquisition would deadlock.

## Verification

Built and tested inside `ghcr.io/falkordb/falkordb-build` (clang-22):

- `cargo build` / `cargo build --release`: pass
- `cargo fmt --all -- --check`: pass
- `CXX=clang++ cargo clippy --all-targets`: pass, no warnings
- New flow test `test02_bgrewriteaof_survives_without_rdb_preamble` plus the existing `test01`: 2/2 pass

`test02` sets `aof-use-rdb-preamble no`, writes two nodes, runs `BGREWRITEAOF`, and checks `aof_last_bgrewrite_status == ok` (no crash). It then runs `DEBUG LOADAOF` and re-queries the graph to confirm the rewritten AOF actually reconstructs it, not just avoids crashing while producing an empty one.

Fixes #2710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AOF rewriting when the RDB preamble is disabled, preventing crashes during `BGREWRITEAOF`.
  * Graph data is now correctly preserved and restored during AOF replay.
* **Tests**
  * Added coverage for AOF rewriting without the RDB preamble.
  * Ensured test configuration is reset after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->