### PR TITLE
fix(ksp): skip redundant dst lookup in landmark mode; test long route

### DIFF
--- a/src/algorithms/AStar.c
+++ b/src/algorithms/AStar.c
@@ -283,14 +283,15 @@ static bool AStarCtx_Run
 
 	bool single_source = (dst_id == (NodeID)INVALID_ENTITY_ID);
 
-	// resolve dst's coordinates once, up front: every heuristic evaluation
-	// during this search targets this fixed goal. if dst has no numeric lat/lon,
-	// heur_scale is non-positive, this is a single-source sweep, or a landmark
-	// potential is driving h, the haversine term degrades to 0 -- the potential
-	// branch in _astar_node_h ignores these anyway.
+	// resolve dst's coordinates once, up front: every haversine evaluation during
+	// this search targets this fixed goal. skip the lookup entirely when the
+	// haversine term can't contribute -- a single-source sweep, a landmark
+	// potential driving h (its branch in _astar_node_h ignores coords), no weight
+	// prop, or a non-positive scale -- and, finally, when dst has no numeric lat/lon.
 	double dst_lat = 0;
 	double dst_lon = 0;
 	bool dst_has_coords = !single_source                          &&
+			(ac->potential == NULL)                              &&
 			(ac->weight_prop != ATTRIBUTE_ID_NONE)               &&
 			(ac->heur_scale > 0)                                 &&
 			_get_node_latlon (&dst_lat, &dst_lon,

--- a/tests/flow/test_astar.py
+++ b/tests/flow/test_astar.py
@@ -676,3 +676,62 @@ class testAStar(FlowTestsBase):
         self.env.assertEquals(astar_k, sp_k)
         # both routes are found (weights 2 and 20)
         self.env.assertEquals(sorted(w for _, w in astar_k), [2, 20])
+
+    def test19_astar_k_shortest_long_route_landmark(self):
+        # Exercise the landmark-potential branch in AStar_KShortestPaths, which
+        # only engages when k > 1 AND the first shortest path is >= 200 hops
+        # (ASTAR_LANDMARK_MIN_HOPS): a reverse Dijkstra sweep from dst becomes
+        # the A* heuristic driving every spur. Every other test here uses short
+        # graphs and never reaches it, so this guards that path -- the sweep
+        # build, ac->potential reuse across spurs, and its teardown -- plus the
+        # k-shortest correctness/order it produces.
+        #
+        # A 210-hop spine (the unique cheapest route, clearing the 200-hop gate)
+        # with three node-distinct 2-hop detours of increasing surcharge gives a
+        # well-ordered, distinct-weight k-shortest set. Coordinates are colocated
+        # so the haversine heuristic is 0 (admissible) and the landmark machinery
+        # -- not the geographic heuristic -- is what's under test.
+        #
+        # NOTE algo.SPpaths(pathCount>1) routes through this SAME
+        # AStar_KShortestPaths driver (coords off, heur_scale 0), so it fires the
+        # identical landmark path -- it is NOT an independent oracle for it. The
+        # authoritative check here is therefore the k-shortest WEIGHTS, which are
+        # known by construction; _astar_vs_sppaths additionally confirms the A*
+        # (heuristic-on) and SPpaths (heuristic-off) entry points agree.
+        g = self.db.select_graph("astar_landmark_long")
+        # nodes 0..210 form the spine; 211/212/213 are detour waypoints
+        g.query("UNWIND range(0, 213) AS x "
+                "CREATE (:AK {id: x, lat: 37.0, lon: -122.0})")
+
+        spine = [(i, i + 1, 1.0) for i in range(210)]        # 210 hops, weight 210
+        # each detour reroutes one spine hop through a waypoint: +1 hop, and a
+        # distinct surcharge over the direct edge so the top-k weights are unique
+        detours = [
+            (10, 211, 11, 0.60),   # surcharge 2*0.60 - 1 = 0.20
+            (50, 212, 51, 0.65),   # surcharge 0.30
+            (90, 213, 91, 0.70),   # surcharge 0.40
+        ]
+        edges = list(spine)
+        for a, mid, b, w in detours:
+            edges += [(a, mid, w), (mid, b, w)]
+        rows = ", ".join(f"[{u}, {v}, {w}]" for u, v, w in edges)
+        g.query(f"""
+            UNWIND [{rows}] AS e
+            MATCH (a:AK {{id: e[0]}}), (b:AK {{id: e[1]}})
+            CREATE (a)-[:AE {{weight: e[2]}}]->(b)
+        """)
+
+        # the k cheapest weights are fixed by construction: the 210.0 spine, then
+        # each single detour's surcharge (0.20, 0.30, 0.40) -- an oracle that does
+        # not depend on either engine
+        expected = [210.0, 210.2, 210.3, 210.4]
+        for k in (1, 2, 3, 4):
+            rowset = self._astar_vs_sppaths(g, 0, 210, k)   # asserts A* == SPpaths
+            self.env.assertEquals(len(rowset), k)
+            got = sorted(w for _, w in rowset)
+            for a, b in zip(got, expected[:k]):
+                self.env.assertAlmostEqual(a, b, delta=1e-6)
+            # the shortest route is the full 210-hop spine, so the landmark gate
+            # (p0 >= 200 hops) fires for every k > 1 case above
+            shortest = min(rowset, key=lambda r: r[1])
+            self.env.assertEquals(len(shortest[0]) - 1, 210)


### PR DESCRIPTION
Follow-up to the merged A* goal-directed k-shortest work (#2720), addressing two Copilot review comments left on that PR:

- AStarCtx_Run resolved dst_has_coords (a Graph_GetNode + lat/lon reads) on every spur search even when a landmark potential drives h -- where _astar_node_h ignores the coordinates entirely. Gate the lookup with `ac->potential == NULL` so it is skipped in that mode. Behavior is unchanged (the value was unused there); it just drops wasted per-spur work.

- Add test19_astar_k_shortest_long_route_landmark: builds a 210-hop route (clears the 200-hop ASTAR_LANDMARK_MIN_HOPS gate) with k>1 to exercise the reverse-sweep / ac->potential path that existing short-graph tests never reach; asserts the k-shortest weights against an oracle fixed by graph construction. algo.SPpaths shares this same driver, so it cannot be the independent oracle for the landmark path itself.

(The third comment -- a stale yen.c reference -- is already resolved on master.)