### PR TITLE
refactor(effects/v3): apply models the id space instead of guessing at it

### DIFF
--- a/graph/src/effects/error.rs
+++ b/graph/src/effects/error.rs
@@ -158,30 +158,87 @@ pub enum ApplyError {
         id: i64,
     },
 
-    /// A `CREATE_NODE` names an id that is neither in this replica's recycle
-    /// bin nor past the first id it has never allocated — so it is already live
-    /// here.
+    /// A create names an id that is neither in this replica's recycle bin nor
+    /// past the first id it has never allocated — so it is already live here.
+    /// `kind` says which entity: nodes and relationships are checked the same
+    /// way, against the same [`crate::graph::id_space::IdSpace`].
     ///
-    /// Node ids are not carried by any record that could report a disagreement
-    /// about them: the next fresh id is derived from `node_count` and the bin,
-    /// and `create_nodes` removes ids from the bin whether or not they were in
-    /// it. Left unchecked, a drift stays invisible until the replica is
-    /// promoted and hands out an id that is already in use.
+    /// Ids are not carried by any record that could report a disagreement about
+    /// them: the next fresh id is derived from the entity's count and its bin,
+    /// and the create removes ids from the bin whether or not they were in it.
+    /// Left unchecked, a drift stays invisible until the replica is promoted and
+    /// hands out an id that is already in use.
     #[error(
-        "effects buffer creates node {id}, which is already live on this replica          (recycle bin holds {bin} ids, first unallocated id {first_unallocated}). The two engines          have diverged; the buffer was not applied."
+        "effects buffer creates {kind} {id}, which is already live on this replica (the \
+         boundary it was judged against is {first_unallocated}). The two engines have \
+         diverged; the buffer was not applied."
     )]
-    NodeAlreadyLive {
+    AlreadyLive {
+        kind: &'static str,
         id: u64,
-        bin: u64,
         first_unallocated: u64,
     },
 
-    /// A `DELETE_NODE` names an id this replica does not hold live — either it
-    /// is already in the recycle bin, or it was never allocated.
+    /// A delete names an id this replica does not hold live — either it is
+    /// already in the recycle bin, or it was never allocated. `kind` says which
+    /// entity: nodes and relationships are checked the same way, against the same
+    /// [`crate::graph::id_space::IdSpace`].
     #[error(
-        "effects buffer deletes node {id}, which is not live on this replica          ({reason}). The two engines have diverged; the buffer was not applied."
+        "effects buffer deletes {kind} {id}, which is not live on this replica ({reason}). \
+         The two engines have diverged; the buffer was not applied."
     )]
-    NodeNotLive { id: u64, reason: &'static str },
+    NotLive {
+        kind: &'static str,
+        id: u64,
+        reason: &'static str,
+    },
+
+    /// A record names an id with nothing past it.
+    ///
+    /// `u64::MAX` cannot be created: there is no boundary above it, and a master
+    /// that had genuinely handed out 2^64 ids would have exhausted memory long
+    /// before reaching the top.
+    #[error(
+        "effects buffer creates {kind} {id}, which is past the end of the id space. \
+         The two engines have diverged; the buffer was not applied."
+    )]
+    IdPastEndOfSpace { kind: &'static str, id: u64 },
+
+    /// The batch left ids allocated between the boundary it started from and the
+    /// highest id it created, without creating them.
+    ///
+    /// An allocator hands out the lowest free id, so it cannot reach an id
+    /// without having handed out everything below it. A buffer that leaves a
+    /// hole was not produced by one — the likeliest cause is a replica that has
+    /// missed a buffer, and accepting it would leave an id space the master does
+    /// not have.
+    #[error(
+        "effects buffer allocated {kind} ids {entry_bound}..={highest} but created only \
+         {created} of them. The two engines have diverged; the buffer was not applied."
+    )]
+    IdsHaveAHole {
+        kind: &'static str,
+        entry_bound: u64,
+        highest: u64,
+        created: u64,
+    },
+
+    /// The graph's own id boundary for `kind` is not where the ids it was given
+    /// put it.
+    ///
+    /// The entity's count is an independent counter, so the same id applied twice
+    /// moves it twice while the set of ids does not change. This is the only
+    /// place anything checks that counter against a value not derived from it.
+    #[error(
+        "effects buffer left this replica's {kind} id boundary at {graph_bound}, but the \
+         ids it carried put it at {expected}. The two engines have diverged; the buffer \
+         was not applied."
+    )]
+    CountMiscounted {
+        kind: &'static str,
+        graph_bound: u64,
+        expected: u64,
+    },
 
     /// A schema id the local dictionary does not hold.
     ///

--- a/graph/src/effects/v3/apply.rs
+++ b/graph/src/effects/v3/apply.rs
@@ -26,7 +26,10 @@ use crate::{
         AttrRef, INDEX_FLD_FULLTEXT, INDEX_FLD_VECTOR, Record, entity_tag, open_payload,
     },
     entity_type::EntityType,
-    graph::graph::{Graph, NodeOpError, TypeId},
+    graph::{
+        graph::{Graph, NodeOpError, TypeId},
+        id_space::{IdSpace, IdSpaceError},
+    },
     index::{IndexType, indexer::IndexOptions},
     runtime::{pending::IndexDocs, value::Value},
 };
@@ -34,7 +37,6 @@ use crate::{
 // wrote it, so the error lives beside `DecodeError`. Re-exported because
 // this is where callers have always found it.
 pub use crate::effects::error::{ApplyError, LocalName};
-use roaring::RoaringTreemap;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
@@ -44,30 +46,23 @@ impl From<String> for ApplyError {
     }
 }
 
-/// Index bookkeeping that accumulates across a buffer and is committed once.
-#[derive(Default)]
-struct IndexOps {
+/// What accumulates across a buffer and is settled once, at the end.
+struct BufferOps {
     /// The same type the write path collects into, rather than a second set of
     /// four maps that has to agree with it by inspection.
     docs: IndexDocs,
-    /// The first never-used node id as of **before** this buffer, and the ids
-    /// this buffer has created so far.
+    /// The node id space this buffer is building.
     ///
-    /// Both are needed because the id space is only dense *between* buffers,
-    /// not within one: records are emitted grouped by shape, so a buffer can
-    /// create ids 500..600 before it creates 0..500, and mid-buffer
-    /// `node_count` is a count rather than a bound. Judging an id against the
-    /// mark as it was on entry, plus what this buffer has already added, is
-    /// stable under that reordering.
-    ///
-    /// `Graph::first_unallocated_node_id` rather than `max_node_id() + 1`: the latter
-    /// has a 0 sentinel for an empty graph, which reads as "id 0 was handed
-    /// out" and rejects the first create of id 0.
-    entry_unallocated: u64,
-    /// The ids this buffer has created and not since deleted. A delete removes
-    /// its ids again, because the allocator may hand a freed id back within the
-    /// same buffer.
-    created_here: RoaringTreemap,
+    /// Held here rather than on the graph because its lifetime is the buffer's,
+    /// and a buffer is a thing only this file knows about. What the graph does
+    /// know is how to maintain one: `create_nodes` and `delete_nodes` take it and
+    /// feed it themselves, so nothing here can create a node and forget to
+    /// account for it — and nothing can be handed a graph without saying what to
+    /// do about validation, because the argument is not optional to supply.
+    nodes: IdSpace,
+    /// And the relationship one. Same type, same checks — the id spaces are two
+    /// counted ranges with recycle bins, and nothing about the invariant differs.
+    edges: IdSpace,
 }
 
 /// Apply a whole `GRAPH.EFFECT` payload.
@@ -89,14 +84,26 @@ pub fn apply_effects(
     // be read; `open_payload` owns that plaintext and the records borrow from it.
     let payload = open_payload(buf)?;
 
-    let mut ops = IndexOps {
-        entry_unallocated: g.first_unallocated_node_id(),
-        ..IndexOps::default()
+    let mut ops = BufferOps {
+        docs: IndexDocs::default(),
+        nodes: IdSpace::at(g.node_id_bound()),
+        edges: IdSpace::at(g.relationship_id_bound()),
     };
 
     for record in payload.records() {
         apply_record(g, record?, &mut ops)?;
     }
+
+    // Only now: records are grouped by shape rather than ordered by id, so the
+    // id space is legitimately fragmented partway through a buffer and only has
+    // to be whole at the end. A buffer that fails earlier never reaches this,
+    // which is right — it has not finished building the thing being checked.
+    ops.nodes
+        .verify(g.node_id_bound())
+        .map_err(|e| id_space_error_map("node", e))?;
+    ops.edges
+        .verify(g.relationship_id_bound())
+        .map_err(|e| id_space_error_map("relationship", e))?;
 
     g.commit_index(&mut ops.docs.node_adds, &mut ops.docs.node_removes);
     g.commit_edge_index(&mut ops.docs.edge_adds, &mut ops.docs.edge_removes);
@@ -104,29 +111,72 @@ pub fn apply_effects(
 }
 
 /// A refusal from a bulk node operation, as the divergence it is.
+///
+/// Two arms, and only one of them is really the graph's: whatever it reported
+/// while doing the work. Every judgement about liveness belongs to
+/// [`IdSpace`] — it decides, and its refusals arrive wrapped, to be unwrapped
+/// straight back into the rendering [`id_space_error_map`] gives them.
 fn node_op(
+    kind: &'static str,
     e: NodeOpError,
-    ops: &IndexOps,
-    bin: u64,
 ) -> ApplyError {
     match e {
-        NodeOpError::AlreadyLive(id) => ApplyError::NodeAlreadyLive {
+        NodeOpError::Graph(e) => ApplyError::Graph(e),
+        NodeOpError::IdSpace(e) => id_space_error_map(kind, e),
+    }
+}
+
+/// A refusal from the id-space check, as the divergence it is.
+///
+/// The graph states these in its own terms — it knows nothing of buffers or of a
+/// peer engine — so the wording that names both sides is added here, where there
+/// is a peer to name.
+fn id_space_error_map(
+    kind: &'static str,
+    e: IdSpaceError,
+) -> ApplyError {
+    match e {
+        IdSpaceError::AlreadyLive { id, entry_bound } => ApplyError::AlreadyLive {
+            kind,
             id,
-            bin,
-            first_unallocated: ops.entry_unallocated,
+            first_unallocated: entry_bound,
         },
-        NodeOpError::AlreadyRecycled(id) => ApplyError::NodeNotLive {
+        IdSpaceError::AlreadyRecycled(id) => ApplyError::NotLive {
+            kind,
             id,
             reason: "it is already in the recycle bin",
         },
-        NodeOpError::Graph(e) => ApplyError::Graph(e),
+        IdSpaceError::NeverCreated(id) => ApplyError::NotLive {
+            kind,
+            id,
+            reason: "it was never allocated here",
+        },
+        IdSpaceError::Hole {
+            entry_bound,
+            highest,
+            created,
+        } => ApplyError::IdsHaveAHole {
+            kind,
+            entry_bound,
+            highest,
+            created,
+        },
+        IdSpaceError::Miscounted {
+            graph_bound,
+            expected,
+        } => ApplyError::CountMiscounted {
+            kind,
+            graph_bound,
+            expected,
+        },
+        IdSpaceError::IdOutOfRange(id) => ApplyError::IdPastEndOfSpace { kind, id },
     }
 }
 
 fn apply_record(
     g: &mut Graph,
     record: Record,
-    ops: &mut IndexOps,
+    ops: &mut BufferOps,
 ) -> Result<(), ApplyError> {
     match record {
         Record::AddSchema {
@@ -172,23 +222,12 @@ fn apply_record(
             rows,
         } => {
             let nodes = ids.to_roaring();
-            // Only what the graph cannot know: an id this *buffer* already
-            // claimed. It is live in the graph by now, but the mark below is
-            // frozen at buffer entry and so cannot see it.
-            if let Some(twice) = (&nodes & &ops.created_here).min() {
-                return Err(ApplyError::NodeAlreadyLive {
-                    id: twice,
-                    bin: g.deleted_nodes_count(),
-                    first_unallocated: ops.entry_unallocated,
-                });
-            }
-            g.add_reserved_node_count(ids.len() as u64);
-            // The graph refuses rather than double-counting, so there is no
-            // separate check here to keep in step with it.
-            let bin = g.deleted_nodes_count();
-            g.create_nodes(&nodes, ops.entry_unallocated)
-                .map_err(|e| node_op(e, ops, bin))?;
-            ops.created_here |= &nodes;
+            // No reservation to make: these ids came from the master, not from
+            // this graph's allocator. The graph refuses rather than
+            // double-counting, so there is no separate check here to keep in step
+            // with it either.
+            g.create_nodes(&nodes, &mut ops.nodes)
+                .map_err(|e| node_op("node", e))?;
 
             // The graph's bulk APIs take `&[u64]`, so the ids are materialized
             // once here rather than per call.
@@ -226,14 +265,14 @@ fn apply_record(
             rows,
         } => {
             let type_name = resolve_type(g, relation_id)?;
-            g.add_reserved_relationship_count(ids.len() as u64);
             // `&[u64]` for the bulk APIs; materialized once each.
             let (ids, src, dst): (Vec<u64>, Vec<u64>, Vec<u64>) = (
                 ids.iter().collect(),
                 src.iter().collect(),
                 dst.iter().collect(),
             );
-            g.create_relationships_bulk(&type_name, &src, &dst, &ids);
+            g.create_relationships_bulk(&type_name, &src, &dst, &ids, Some(&mut ops.edges))
+                .map_err(|e| node_op("relationship", e))?;
 
             if !attr_ids.is_empty() {
                 let map = attr_map(g, &ids, &attr_ids, &rows)?;
@@ -319,35 +358,20 @@ fn apply_record(
             // `Vec<u64>` first, and a delete-by-label arrives as a consecutive
             // range — the one shape that has no vector to hand over.
             let nodes = ids.to_roaring();
-            // Only what the graph cannot know: at or above the mark frozen at
-            // buffer entry and not created by this buffer means it was never
-            // allocated here at all. The second half matters because a buffer
-            // may legitimately create a node and then delete it.
-            if let Some(id) = (&nodes - &ops.created_here)
-                .max()
-                .filter(|&id| id >= ops.entry_unallocated)
-            {
-                return Err(ApplyError::NodeNotLive {
-                    id,
-                    reason: "it was never allocated here",
-                });
-            }
-            let bin = g.deleted_nodes_count();
-            g.delete_nodes(&nodes, &mut ops.docs.node_removes)
-                .map_err(|e| node_op(e, ops, bin))?;
-            // Deleting releases the id back to the bin, so a *later* record in
-            // this same buffer may legitimately create it again: a multi-commit
-            // query (`CREATE (n) WITH n DELETE n WITH 1 AS z CREATE ()`) commits
-            // three times into one buffer, and the allocator recycles the freed
-            // id on the third. Leaving it in `created_here` makes that a
-            // false `NodeAlreadyLive` and discards the whole payload.
-            ops.created_here -= &nodes;
+            // Two ways a delete can name something that is not live, and the
+            // graph answers one of them by itself: an id already in the recycle
+            // bin. The other — at or above the boundary this buffer started from
+            // and never created by it, so nothing has ever held it — needs the
+            // batch, which is why it is handed over here.
+            g.delete_nodes(&nodes, &mut ops.docs.node_removes, Some(&ops.nodes))
+                .map_err(|e| node_op("node", e))?;
             Ok(())
         }
 
         Record::DeleteEdge { ids, .. } => {
             let edges = ids.to_roaring();
-            g.delete_relationships(&edges, &mut ops.docs.edge_removes)?;
+            g.delete_relationships(&edges, &mut ops.docs.edge_removes, Some(&ops.edges))
+                .map_err(|e| node_op("relationship", e))?;
             Ok(())
         }
 
@@ -887,7 +911,14 @@ mod tests {
         .encode(&mut buf);
         let err = apply_effects(&mut g, &buf).expect_err("must refuse");
         assert!(
-            matches!(err, ApplyError::NodeAlreadyLive { id: 1, .. }),
+            matches!(
+                err,
+                ApplyError::AlreadyLive {
+                    kind: "node",
+                    id: 1,
+                    ..
+                }
+            ),
             "{err}"
         );
         assert_eq!(g.node_count(), 3, "the buffer must not have been applied");
@@ -895,8 +926,12 @@ mod tests {
 
     #[test]
     fn one_buffer_claiming_an_id_twice_aborts() {
-        // Neither record's ids were live on entry, so that boundary alone
-        // cannot see this. It is still divergence.
+        // Neither record's ids were live on entry, so the entry boundary alone
+        // cannot see this — id 1 is above it and reads as fresh both times. What
+        // sees it is the intersection with what the buffer has already created,
+        // and because the recycle bin has been removed from the candidates first,
+        // it does not fire on the legitimate delete-then-recreate that
+        // `a_buffer_may_create_delete_and_recreate_the_same_id` covers.
         let mut g = graph();
         let mut buf = new_buffer();
         Record::CreateNode {
@@ -915,15 +950,30 @@ mod tests {
         .encode(&mut buf);
         let err = apply_effects(&mut g, &buf).expect_err("must refuse");
         assert!(
-            matches!(err, ApplyError::NodeAlreadyLive { id: 1, .. }),
+            matches!(
+                err,
+                ApplyError::AlreadyLive {
+                    kind: "node",
+                    id: 1,
+                    ..
+                }
+            ),
             "{err}"
+        );
+        assert_eq!(
+            g.node_count(),
+            2,
+            "refused at the record, so the second one applied nothing"
         );
     }
 
     #[test]
     fn a_buffer_may_create_a_node_and_then_delete_it() {
-        // The false positive the `created_here` set exists to avoid: the id is
-        // past the entry mark, so it looks never-allocated to the delete check.
+        // The false positive the delete check has to avoid: id 1 is at or above
+        // the boundary the buffer started from, so "never allocated here" is what
+        // it looks like to anything that only knows that boundary. What makes it
+        // legitimate is that this buffer created it, which is exactly what the
+        // ingested set remembers.
         let mut g = graph();
         let mut buf = new_buffer();
         Record::CreateNode {
@@ -959,7 +1009,14 @@ mod tests {
         write_delete(&mut buf, &IdList::from([1]), &[]);
         let err = apply_effects(&mut g, &buf).expect_err("must refuse a double delete");
         assert!(
-            matches!(err, ApplyError::NodeNotLive { id: 1, .. }),
+            matches!(
+                err,
+                ApplyError::NotLive {
+                    kind: "node",
+                    id: 1,
+                    ..
+                }
+            ),
             "{err}"
         );
     }
@@ -981,7 +1038,14 @@ mod tests {
         write_delete(&mut buf, &IdList::from([99]), &[]);
         let err = apply_effects(&mut g, &buf).expect_err("must refuse");
         assert!(
-            matches!(err, ApplyError::NodeNotLive { id: 99, .. }),
+            matches!(
+                err,
+                ApplyError::NotLive {
+                    kind: "node",
+                    id: 99,
+                    ..
+                }
+            ),
             "{err}"
         );
     }
@@ -1133,10 +1197,14 @@ mod tests {
         .encode(&mut buf);
         apply_effects(&mut g, &buf).expect("a recycled id must apply");
 
-        // Fresh: past anything ever handed out.
+        // Fresh: the next id never handed out. Id 3 rather than an arbitrary
+        // high one — a master allocates the lowest free id, so it cannot reach
+        // 99 without having handed out everything below it, and a buffer that
+        // claims otherwise is divergence rather than a fresh create. That case
+        // is `a_buffer_that_jumps_the_bound_is_refused`.
         let mut buf = new_buffer();
         Record::CreateNode {
-            ids: IdList::from([99]),
+            ids: IdList::from([3]),
             labels: vec![],
             attr_ids: vec![],
             rows: vec![],
@@ -1149,7 +1217,159 @@ mod tests {
         write_delete(&mut buf, &IdList::from([0]), &[]);
         let err = apply_effects(&mut g, &buf).expect_err("must refuse");
         assert!(
-            matches!(err, ApplyError::NodeNotLive { id: 0, .. }),
+            matches!(
+                err,
+                ApplyError::NotLive {
+                    kind: "node",
+                    id: 0,
+                    ..
+                }
+            ),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_buffer_that_jumps_the_bound_is_refused() {
+        // Creating id 9 on a graph that has handed out nothing leaves 0..8
+        // allocated and never created. No master produces that: it allocates the
+        // lowest free id, so reaching 9 means it created everything below, and a
+        // replica that accepted this would hold an id space its master does not
+        // have. Refused as the divergence it is, and the whole buffer is dropped.
+        let mut g = graph();
+        let mut buf = new_buffer();
+        Record::CreateNode {
+            ids: IdList::from([9]),
+            labels: vec![],
+            attr_ids: vec![],
+            rows: vec![],
+        }
+        .encode(&mut buf);
+        let err = apply_effects(&mut g, &buf).expect_err("must refuse");
+        assert!(
+            matches!(
+                err,
+                ApplyError::IdsHaveAHole {
+                    kind: "node",
+                    entry_bound: 0,
+                    highest: 9,
+                    created: 1,
+                }
+            ),
+            "{err}"
+        );
+    }
+
+    /// A buffer that creates two nodes and one edge between them, as setup.
+    fn edge_setup(buf: &mut Vec<u8>) {
+        Record::AddSchema {
+            schema_type: EntityType::Relationship,
+            id: 0,
+            name: "R".to_owned(),
+        }
+        .encode(buf);
+        Record::CreateNode {
+            ids: IdList::from([0, 1]),
+            labels: vec![],
+            attr_ids: vec![],
+            rows: vec![],
+        }
+        .encode(buf);
+    }
+
+    fn write_create_edge(
+        buf: &mut Vec<u8>,
+        edge_ids: &[u64],
+    ) {
+        Record::CreateEdge {
+            ids: edge_ids.iter().copied().collect(),
+            relation_id: 0,
+            src: std::iter::repeat_n(0u64, edge_ids.len()).collect(),
+            dst: std::iter::repeat_n(1u64, edge_ids.len()).collect(),
+            attr_ids: vec![],
+            rows: vec![],
+        }
+        .encode(buf);
+    }
+
+    #[test]
+    fn an_edge_id_claimed_twice_in_one_buffer_aborts() {
+        // Edges get the same id space as nodes. Before they did, this buffer was
+        // applied without complaint and the replica's edge ids drifted from the
+        // master's — invisible until a promotion, because edges enumerate from
+        // the tensor rather than from a counter, so a wrong count cannot fuse two
+        // of them the way it fuses two nodes.
+        let mut g = graph();
+        let mut buf = new_buffer();
+        edge_setup(&mut buf);
+        write_create_edge(&mut buf, &[0, 1]);
+        write_create_edge(&mut buf, &[1, 2]);
+
+        let err = apply_effects(&mut g, &buf).expect_err("edge 1 is claimed twice");
+        assert!(
+            matches!(
+                err,
+                ApplyError::AlreadyLive {
+                    kind: "relationship",
+                    id: 1,
+                    ..
+                }
+            ),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_edge_buffer_that_jumps_the_bound_is_refused() {
+        // The replica-missed-a-buffer case, on the edge side: reaching edge id 9
+        // means the master handed out 0..8, and this replica was told about none
+        // of them.
+        let mut g = graph();
+        let mut buf = new_buffer();
+        edge_setup(&mut buf);
+        write_create_edge(&mut buf, &[9]);
+
+        let err = apply_effects(&mut g, &buf).expect_err("must refuse");
+        assert!(
+            matches!(
+                err,
+                ApplyError::IdsHaveAHole {
+                    kind: "relationship",
+                    entry_bound: 0,
+                    highest: 9,
+                    created: 1,
+                }
+            ),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn deleting_an_edge_never_allocated_aborts_the_buffer() {
+        let mut g = graph();
+        let mut buf = new_buffer();
+        edge_setup(&mut buf);
+        write_create_edge(&mut buf, &[0]);
+        apply_effects(&mut g, &buf).expect("setup must apply");
+
+        let mut buf = new_buffer();
+        Record::DeleteEdge {
+            ids: IdList::from([7]),
+            relation_id: 0,
+            src: IdList::from([0]),
+            dst: IdList::from([1]),
+        }
+        .encode(&mut buf);
+        let err = apply_effects(&mut g, &buf).expect_err("edge 7 was never allocated");
+        assert!(
+            matches!(
+                err,
+                ApplyError::NotLive {
+                    kind: "relationship",
+                    id: 7,
+                    ..
+                }
+            ),
             "{err}"
         );
     }
@@ -1159,9 +1379,11 @@ mod tests {
         // A multi-commit query commits into *one* buffer, and the id allocator
         // recycles a freed id across commits, so `C(0) · D(0) · C(0)` is what
         // `CREATE (n) WITH n DELETE n WITH 1 AS z CREATE ()` actually ships.
-        // Before the delete released it from `created_here` this tripped
-        // `NodeAlreadyLive` and the replica discarded all three commits,
-        // leaving the master with a node the replica never got.
+        //
+        // This is why the ingested set does not shrink on a delete: id 0 was
+        // handed out once, and the recreate is the allocator reusing it rather
+        // than the buffer claiming it twice. A set that dropped it on the delete
+        // would have to decide which of those it was looking at, and cannot.
         let mut g = graph();
         let mut buf = new_buffer();
         Record::CreateNode {

--- a/graph/src/effects/v3/test_aux.rs
+++ b/graph/src/effects/v3/test_aux.rs
@@ -62,8 +62,9 @@ pub(crate) fn with_edge(
     id: u64,
 ) {
     let mut graph = g.borrow_mut();
-    graph.add_reserved_relationship_count(1);
-    graph.create_relationships_bulk(&Arc::new(type_name.to_owned()), &[0], &[1], &[id]);
+    graph
+        .create_relationships_bulk(&Arc::new(type_name.to_owned()), &[0], &[1], &[id], None)
+        .expect("no batch, nothing to refuse");
 }
 
 /// One live node, labelled.

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -79,6 +79,7 @@ use lru::LruCache;
 use orx_tree::DynTree;
 use parking_lot::{Mutex, MutexGuard};
 use roaring::RoaringTreemap;
+use thiserror::Error;
 
 use crate::{
     entity_type::EntityType,
@@ -92,6 +93,7 @@ use crate::{
             tensor::Tensor,
             versioned_matrix::{self, VersionedMatrix},
         },
+        id_space::{IdSpace, IdSpaceError},
     },
     index::{
         Field,
@@ -269,28 +271,19 @@ pub struct DeletedEdge {
 /// Typed rather than a `String` because the effects apply path renders these
 /// into a divergence report an operator reads, and "which id, and which of the
 /// two ways it was wrong" is the whole content of that report.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum NodeOpError {
-    /// Already handed out and not freed, so creating it would double-count
-    /// `node_count` and shift every later fresh id.
-    AlreadyLive(u64),
-    /// Already in the recycle bin, so it is not live to delete.
-    AlreadyRecycled(u64),
     /// Anything the graph itself reported while doing the work.
+    #[error("{0}")]
     Graph(String),
-}
 
-impl std::fmt::Display for NodeOpError {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        match self {
-            Self::AlreadyLive(id) => write!(f, "node {id} is already live"),
-            Self::AlreadyRecycled(id) => write!(f, "node {id} is already in the recycle bin"),
-            Self::Graph(e) => f.write_str(e),
-        }
-    }
+    /// The ids do not fit the graph's id space. Every judgement about whether a
+    /// node is live is made there rather than here — see
+    /// [`crate::graph::id_space`] — because half of it needs a batch and half of
+    /// it needs only the recycle bin, and splitting them across two types is how
+    /// the two halves drift apart.
+    #[error(transparent)]
+    IdSpace(#[from] IdSpaceError),
 }
 
 impl From<String> for NodeOpError {
@@ -1403,11 +1396,30 @@ impl Graph {
         self.attrs_name.get_index_of(attr)
     }
 
+    /// Give back `n` of a reservation counter, without wrapping.
+    ///
+    /// The counter says how many ids are outstanding, so consuming more than
+    /// were reserved is a bookkeeping bug — and an unchecked `-=` would wrap it
+    /// to something near `u64::MAX` in release, at which point `reserve_nodes`
+    /// believes the whole recycle bin is spoken for and hands out only fresh
+    /// ids forever. Loud in tests, harmless in release.
+    fn dec_reserved(
+        &self,
+        counter: u64,
+        n: u64,
+    ) -> u64 {
+        debug_assert!(
+            counter >= n,
+            "consuming {n} reservations of {counter} outstanding"
+        );
+        counter.saturating_sub(n)
+    }
+
     pub fn return_node_id(
         &mut self,
         id: NodeId,
     ) {
-        self.reserved_node_count -= 1;
+        self.reserved_node_count = self.dec_reserved(self.reserved_node_count, 1);
         self.deleted_nodes.insert(id.into());
     }
 
@@ -1415,7 +1427,7 @@ impl Graph {
         &mut self,
         id: RelationshipId,
     ) {
-        self.reserved_relationship_count -= 1;
+        self.reserved_relationship_count = self.dec_reserved(self.reserved_relationship_count, 1);
         self.deleted_relationships.insert(id.into());
     }
 
@@ -1437,9 +1449,11 @@ impl Graph {
 
     /// Reserve `n` node ids without choosing which.
     ///
-    /// The effects apply path takes the ids from the primary, so it needs the
-    /// counter moved but not an allocation — and it knows `n` up front, so it
-    /// should not have to say so one at a time.
+    /// No production caller left. The effects apply path used this to fake a
+    /// reservation it never made, so that `create_nodes` had something to
+    /// decrement; the reservation is consumed by
+    /// [`Self::create_allocated_nodes`] now, which is the only path that makes
+    /// one. Kept for tests that stand a graph up by hand.
     pub const fn add_reserved_node_count(
         &mut self,
         n: u64,
@@ -1484,35 +1498,12 @@ impl Graph {
         Ok(ids)
     }
 
-    /// Delete every node in `nodes`, or refuse and change nothing.
-    ///
-    /// # Errors
-    ///
-    /// [`NodeOpError::AlreadyRecycled`] for the lowest id already in the bin —
-    /// the half of "is this node live" only the bin can answer. The other half,
-    /// whether an id was ever allocated *here*, needs a mark frozen before the
-    /// caller's batch plus the ids that batch has itself created, and neither
-    /// is something this graph has a concept of; `apply_effects` keeps that.
-    ///
-    /// Refusing rather than proceeding, because the body subtracts from
-    /// `node_count` unconditionally and a delete of an already-freed id
-    /// underflowed it.
-    fn refuse_undeletable(
-        &self,
-        nodes: &RoaringTreemap,
-    ) -> Result<(), NodeOpError> {
-        match (nodes & &self.deleted_nodes).min() {
-            Some(id) => Err(NodeOpError::AlreadyRecycled(id)),
-            None => Ok(()),
-        }
-    }
-
     /// Create nodes this graph's own allocator issued.
     ///
     /// Unchecked, and it has to be. `return_node_id` puts a *cancelled
     /// reservation* into the recycle bin while `node_count` has not moved, so
-    /// mid-transaction `first_unallocated_node_id()` counts an id that was
-    /// never live and overstates the boundary. `CREATE (a)-[:R]->(b) DELETE b`
+    /// mid-transaction the boundary `node_count + deleted_nodes.len()` counts
+    /// an id that was never live and overstates itself. `CREATE (a)-[:R]->(b) DELETE b`
     /// reaches exactly that: b's id goes to the bin, the boundary becomes 1,
     /// and the checked form then rejects a's id 0 as already live — a
     /// legitimate query refused.
@@ -1524,43 +1515,98 @@ impl Graph {
     ///
     /// The underlying flaw is that `reserved_node_count` is a count standing in
     /// for a set — see the follow-up replacing it with an exact reservation.
+    ///
+    /// The counterpart is [`Self::create_nodes`], for ids that did *not* come
+    /// from this allocator. Two entry points rather than one with an optional
+    /// check, because the difference is which question is being asked, and a
+    /// caller that has to decide between them cannot express "checked, but
+    /// against nothing".
     pub fn create_allocated_nodes(
         &mut self,
         nodes: &RoaringTreemap,
     ) {
-        let _ = self.create_nodes(nodes, 0);
+        // Consuming the reservation is this path's, not the mutation's. Ids that
+        // arrive from somewhere else — an effects buffer — were never reserved
+        // here, and making the mutation decrement unconditionally forced that
+        // caller to fake a reservation first purely so the counter had something
+        // to give back.
+        self.reserved_node_count = self.dec_reserved(self.reserved_node_count, nodes.len());
+        self.mark_nodes_live(nodes);
     }
 
-    /// Create every node in `nodes`, or refuse and change nothing.
+    /// Where the node id space ends: ids below were handed out, ids at or above
+    /// never were. True as stated only between batches, where the space is dense
+    /// — which is exactly when an [`IdSpace`] is opened against it.
+    #[must_use]
+    pub fn node_id_bound(&self) -> u64 {
+        self.node_count + self.deleted_nodes.len()
+    }
+
+    /// The same for relationships.
+    #[must_use]
+    pub fn relationship_id_bound(&self) -> u64 {
+        self.relationship_count + self.deleted_relationships.len()
+    }
+
+    /// Create every node in `nodes` as part of a batch, or refuse and change
+    /// nothing.
+    ///
+    /// The batch is required rather than optional because it is the only thing
+    /// that can say what "already live" means here. Records inside one effects
+    /// buffer are grouped by shape rather than ordered by id, so a create of
+    /// 500..600 may precede one of 0..500; judged against a boundary this graph
+    /// derives, the second is rejected — the derived boundary has advanced to
+    /// 100 — even though the buffer is legitimate. The batch carries the boundary
+    /// as it stood before any of that, which is the only one the whole buffer can
+    /// be judged against.
+    ///
+    /// Reading the boundary off the batch rather than taking it as a parameter of
+    /// its own is what stops a caller handing over a boundary that disagrees with
+    /// the batch it is handing over with it.
+    ///
+    /// A caller with no batch wants [`Self::create_allocated_nodes`], which is a
+    /// different question rather than this one with a piece missing: its ids came
+    /// from the allocator, so there is nothing to check.
     ///
     /// # Errors
     ///
-    /// [`NodeOpError::AlreadyLive`] for the lowest id it cannot create — one
-    /// already handed out and not freed. Refusing is the point: the body below adds to `node_count` and
-    /// subtracts from `reserved_node_count` unconditionally, so an already-live
-    /// id used to double-count silently and shift every later fresh id. A
-    /// caller cannot forget the check when the operation itself is the check.
+    /// [`IdSpaceError::AlreadyLive`], wrapped, for the lowest id it cannot
+    /// create — one already handed out and not freed. Refusing is the point:
+    /// [`Self::mark_nodes_live`] moves the counters unconditionally, so an
+    /// already-live id used to double-count silently and shift every later fresh
+    /// id. A caller cannot forget the check when the operation itself is the
+    /// check.
     ///
-    /// `first_unallocated` is the caller's rather than [`Self::first_unallocated_node_id`],
-    /// and it has to be: records inside one effects buffer are grouped by shape
-    /// rather than ordered by id, so a create of 500..600 may precede one of
-    /// 0..500. Judged against this graph's *live* mark, the second of those is
-    /// rejected — the mark has already advanced to 100 — even though the buffer
-    /// is legitimate. `apply_effects` freezes the mark at buffer entry for that
-    /// reason and passes it here.
+    /// [`NodeOpError::IdSpace`] if the ids do not fit the batch — see
+    /// [`crate::graph::id_space`].
     pub fn create_nodes(
         &mut self,
         nodes: &RoaringTreemap,
-        first_unallocated: u64,
+        id_space: &mut IdSpace,
     ) -> Result<(), NodeOpError> {
-        if let Some(live) = (nodes - &self.deleted_nodes)
-            .min()
-            .filter(|&id| id < first_unallocated)
-        {
-            return Err(NodeOpError::AlreadyLive(live));
-        }
+        // One call, checked and recorded together. The bin is this graph's half
+        // of "is it live" and it is handed over; the boundary is the batch's, and
+        // the batch keeps it. An id reaches the graph through this function or
+        // not at all, so nothing that creates a node can be added later and
+        // forget to account for it.
+        id_space.record_created(nodes, &self.deleted_nodes)?;
+        self.mark_nodes_live(nodes);
+        Ok(())
+    }
+
+    /// Move `nodes` from reserved to live, and size the matrices to hold them.
+    ///
+    /// What the two create paths have in common is this and only this — they
+    /// differ in what they check *before* it, not in what they do. Factoring the
+    /// check instead meant a boundary parameter with `0` standing for "do not
+    /// check", which is a value pretending to be a mode: it made the unchecked
+    /// path return a `Result` that could not be anything but `Ok`, and left the
+    /// reader to work out why.
+    fn mark_nodes_live(
+        &mut self,
+        nodes: &RoaringTreemap,
+    ) {
         self.node_count += nodes.len();
-        self.reserved_node_count -= nodes.len();
         self.deleted_nodes -= nodes;
 
         // Ensure capacity covers the highest node ID (effects replay may
@@ -1574,7 +1620,6 @@ impl Graph {
         }
 
         self.resize();
-        Ok(())
     }
 
     #[must_use]
@@ -2058,8 +2103,15 @@ impl Graph {
         &mut self,
         deleted_nodes: &RoaringTreemap,
         remove_docs: &mut FxHashMap<u64, RoaringTreemap>,
+        id_space: Option<&IdSpace>,
     ) -> Result<Vec<DeletedNodeLabel>, NodeOpError> {
-        self.refuse_undeletable(deleted_nodes)?;
+        // Both halves of "is this node live", and both belong to the id space:
+        // the bin's half needs only the bin, so it is asked whether or not there
+        // is a batch, and the boundary's half needs one.
+        IdSpace::refuse_recycled(deleted_nodes, &self.deleted_nodes)?;
+        if let Some(space) = id_space {
+            space.refuse_undeletable(deleted_nodes)?;
+        }
         self.deleted_nodes |= deleted_nodes;
         self.node_count -= deleted_nodes.len();
 
@@ -2426,18 +2478,49 @@ impl Graph {
         Ok(ids)
     }
 
-    /// Create relationships of a single type using flat arrays.
-    /// Avoids HashMap overhead while using individual GraphBLAS set calls.
-    pub fn create_relationships_bulk(
+    /// Create relationships this graph's own allocator issued.
+    ///
+    /// The counterpart of [`Self::create_allocated_nodes`], and for the same
+    /// reason: consuming the reservation belongs to the path that made one.
+    /// Ids arriving from an effects buffer were reserved on the *master*, so
+    /// [`Self::create_relationships_bulk`] leaves the counter alone and this
+    /// wrapper is what the write path calls.
+    pub fn create_allocated_relationships(
         &mut self,
         type_name: &Arc<String>,
         srcs: &[u64],
         dsts: &[u64],
         rel_ids: &[u64],
     ) {
+        self.reserved_relationship_count =
+            self.dec_reserved(self.reserved_relationship_count, srcs.len() as u64);
+        let _ = self.create_relationships_bulk(type_name, srcs, dsts, rel_ids, None);
+    }
+
+    /// Create relationships of a single type using flat arrays.
+    ///
+    /// Avoids HashMap overhead while using individual GraphBLAS set calls. Takes
+    /// ids from wherever the caller got them and consumes no reservation — the
+    /// write path wants [`Self::create_allocated_relationships`].
+    ///
+    /// # Errors
+    ///
+    /// [`IdSpaceError`], wrapped, when `id_space` is given and the ids do not fit
+    /// it — the relationship counterpart of what [`Self::create_nodes`] refuses.
+    pub fn create_relationships_bulk(
+        &mut self,
+        type_name: &Arc<String>,
+        srcs: &[u64],
+        dsts: &[u64],
+        rel_ids: &[u64],
+        id_space: Option<&mut IdSpace>,
+    ) -> Result<(), NodeOpError> {
+        if let Some(space) = id_space {
+            let ids: RoaringTreemap = rel_ids.iter().copied().collect();
+            space.record_created(&ids, &self.deleted_relationships)?;
+        }
         let count = srcs.len() as u64;
         self.relationship_count += count;
-        self.reserved_relationship_count -= count;
 
         for &id in rel_ids {
             if self.deleted_relationships.is_empty() {
@@ -2488,6 +2571,7 @@ impl Graph {
         let type_ids: Vec<u64> = vec![type_id; rel_ids.len()];
         self.relationship_type_matrix
             .set_all::<true>(rel_ids.iter().copied().zip(type_ids.iter().copied()));
+        Ok(())
     }
 
     /// Fold oversized delta-plus into the base for all shared matrices at
@@ -2614,26 +2698,6 @@ impl Graph {
         self.deleted_nodes.len()
     }
 
-    /// The first node id that has never been handed out.
-    ///
-    /// Ids below this are either live or sitting in the recycle bin; ids at or
-    /// above it are untouched. Derived, not stored — `reserve_node` computes the
-    /// next id the same way — which is exactly why a replica whose `node_count`
-    /// or bin has drifted from the primary's will start allocating ids the
-    /// primary would not, the moment it is promoted.
-    ///
-    /// **Not `max_node_id() + 1`**, though the arithmetic agrees whenever the
-    /// graph holds a live node. `max_node_id` returns a 0 *sentinel* for an
-    /// empty graph, which is indistinguishable from a graph whose highest id is
-    /// 0 — so a caller asking "has this id been handed out?" reads id 0 as used
-    /// on a graph that has never allocated anything. Substituting it made
-    /// `recreating_a_recycled_id_is_allowed` reject the very first
-    /// `CREATE_NODE` of id 0 with `NodeAlreadyLive`.
-    #[must_use]
-    pub fn first_unallocated_node_id(&self) -> u64 {
-        self.node_count + self.deleted_nodes.len()
-    }
-
     #[must_use]
     pub const fn deleted_nodes(&self) -> &RoaringTreemap {
         &self.deleted_nodes
@@ -2676,9 +2740,16 @@ impl Graph {
         &mut self,
         rels: &RoaringTreemap,
         index_remove_edge_docs: &mut FxHashMap<u64, FxHashMap<u64, (u64, u64)>>,
-    ) -> Result<Vec<DeletedEdge>, String> {
+        id_space: Option<&IdSpace>,
+    ) -> Result<Vec<DeletedEdge>, NodeOpError> {
         if rels.is_empty() {
             return Ok(Vec::new());
+        }
+        // Both halves of "is this relationship live", exactly as the node side
+        // asks them: the bin needs no batch, the boundary needs one.
+        IdSpace::refuse_recycled(rels, &self.deleted_relationships)?;
+        if let Some(space) = id_space {
+            space.refuse_undeletable(rels)?;
         }
         let num_types = self.relationship_matrices.len();
 

--- a/graph/src/graph/id_space.rs
+++ b/graph/src/graph/id_space.rs
@@ -1,0 +1,607 @@
+//! Validating an id space across a batch of creates and deletes.
+//!
+//! Written for nodes and used for relationships too: both are counted ids with a
+//! recycle bin, and neither the invariant below nor the checks that enforce it
+//! mention which. The caller says which entity it is asking about when it renders
+//! a refusal.
+//!
+//! ## The invariant, and why the graph cannot check it alone
+//!
+//! `Graph` tracks liveness with `node_count` and `deleted_nodes` and no
+//! live set, so the only boundary it can offer is
+//! `node_count + deleted_nodes.len()`. That is the boundary *if the id space is
+//! dense*, and `max_node_id` is the same arithmetic — so an assertion written in
+//! terms of them checks one derivation of the state against another derivation
+//! of the same state, and passes on a graph that is already wrong.
+//!
+//! Density holds between batches, not within one. The effects apply path ingests
+//! records grouped by shape rather than ordered by id, so a create of 500..600
+//! may precede one of 0..500; between them the graph holds 100 live nodes whose
+//! highest id is 599 and reports its boundary as 100.
+//!
+//! ## What this holds
+//!
+//! The boundary as it stood before the batch, and every id at or above it that
+//! the batch has created. That is enough to state the invariant directly:
+//!
+//! ```text
+//! created == [ entry_bound, entry_bound + created.len() )
+//! ```
+//!
+//! Two independent things can break it, so [`IdSpace::verify`] checks both.
+//!
+//! **The shape of what arrived.** Ids created at or above the boundary must
+//! fill the range from it upward with no hole. An allocator hands out the lowest
+//! free id, so it cannot reach an id without having handed out everything below
+//! — a batch that leaves a hole did not come from one. This is the check that
+//! catches a replica which has missed a buffer: told to create 500..600 when its
+//! own boundary is 0, it would otherwise accept an id space its master does not
+//! have and collide on its next allocation.
+//!
+//! **That the graph counted it.** `node_count` is an independent counter, and
+//! comparing the graph's own boundary against `entry_bound + created.len()` is
+//! the only place anything checks it against a value not derived from it.
+//!
+//! This is a backstop rather than the front line. The two ways an id can be
+//! wrong — already live, or claimed twice by this batch — are both refused at
+//! the record by [`IdSpace::create`], which names the id. What is left
+//! for the count is anything that moves `node_count` without going through the
+//! operations that maintain the batch, which is to say a path that does not
+//! exist today and would be a mistake tomorrow.
+//!
+//! Nothing here knows about replication, buffers or a peer engine. It is a
+//! statement about one graph and the ids handed to it.
+
+use roaring::RoaringTreemap;
+use thiserror::Error;
+
+/// Why a batch of ids does not describe a possible id space.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum IdSpaceError {
+    /// A delete named an id at or above the entry boundary that this batch never
+    /// created, so it was never allocated here at all.
+    #[error("{0} was never allocated here")]
+    NeverCreated(u64),
+
+    /// Ids are missing between the entry boundary and the highest one created.
+    #[error("{entry_bound}..={highest} were allocated but only {created} of them created")]
+    Hole {
+        entry_bound: u64,
+        highest: u64,
+        created: u64,
+    },
+
+    /// The graph's own boundary is not where the created ids put it — it
+    /// counted something twice, or not at all.
+    #[error("the graph's boundary is {graph_bound}, but the ids created put it at {expected}")]
+    Miscounted { graph_bound: u64, expected: u64 },
+
+    /// Already free: it is in the recycle bin, so there is nothing to delete.
+    #[error("{0} is already in the recycle bin")]
+    AlreadyRecycled(u64),
+
+    /// An id below the boundary and not free: it was handed out before the
+    /// batch and has not been given back, so it is live.
+    #[error("{id} is already live below the boundary {entry_bound}")]
+    AlreadyLive { id: u64, entry_bound: u64 },
+
+    /// A batch named `u64::MAX`, which has no boundary above it.
+    #[error("{0} is past the end of the id space")]
+    IdOutOfRange(u64),
+}
+
+/// An id space, observed across one batch of creates and deletes.
+///
+/// Built before the batch, told what it creates, and checked once at the end.
+/// It decides nothing while the batch runs — [`Graph::create_nodes`] already
+/// refuses an id that is live below the boundary — so this records and then
+/// judges, rather than gating each step.
+pub struct IdSpace {
+    /// The boundary as it stood before the batch: ids below it were handed out,
+    /// ids at or above it never were.
+    entry_bound: u64,
+    /// Every id at or above `entry_bound` this batch has created. Only grows —
+    /// a later delete does not un-allocate an id, it frees one that was.
+    created: RoaringTreemap,
+}
+
+impl IdSpace {
+    /// The id space as it stands before a batch.
+    ///
+    /// `node_count + deleted_nodes_count` is the boundary *because* this is
+    /// taken between batches, where the id space is dense. That assumption is
+    /// stated once, here, rather than implied by an accessor every caller has to
+    /// know not to trust.
+    ///
+    /// Not `max_node_id() + 1`, though the arithmetic agrees whenever the graph
+    /// holds a live node: `max_node_id` returns a 0 *sentinel* when it holds
+    /// none, which is indistinguishable from a graph whose highest id is 0 and
+    /// reads as "id 0 has been handed out".
+    #[must_use]
+    pub(crate) fn at(entry_bound: u64) -> Self {
+        Self {
+            entry_bound,
+            created: RoaringTreemap::new(),
+        }
+    }
+
+    /// Refuse ids that are already free.
+    ///
+    /// Associated rather than a method, because this half of "is this node live"
+    /// needs the recycle bin and nothing else — no boundary, so no batch. That
+    /// is what lets the write path, which never opens one, be answered by the
+    /// same code as the effects path instead of a second copy of it.
+    ///
+    /// # Errors
+    ///
+    /// [`IdSpaceError::AlreadyRecycled`] for the lowest id already in the bin.
+    pub(crate) fn refuse_recycled(
+        nodes: &RoaringTreemap,
+        recycled: &RoaringTreemap,
+    ) -> Result<(), IdSpaceError> {
+        match (nodes & recycled).min() {
+            Some(id) => Err(IdSpaceError::AlreadyRecycled(id)),
+            None => Ok(()),
+        }
+    }
+
+    /// Record `nodes` as created by this batch, or refuse them and record
+    /// nothing.
+    ///
+    /// `recycled` is the ids that are free right now — the graph's recycle bin.
+    /// An id in it is free whatever its value, so it is neither live nor a
+    /// duplicate, and removing it is what lets the two checks below tell a
+    /// genuine double claim from a legitimate recreate.
+    ///
+    /// One operation rather than a check and a record the caller sequences,
+    /// because the order between them is load-bearing: recording first would
+    /// leave the duplicate check finding the ids it had just inserted. Merged,
+    /// there is no order for a caller to get wrong and no way to record without
+    /// checking.
+    ///
+    /// # Errors
+    ///
+    /// [`IdSpaceError::AlreadyLive`] for the lowest id that is already live —
+    /// either handed out before the batch, or claimed earlier within it.
+    ///
+    /// [`IdSpaceError::IdOutOfRange`] for `u64::MAX`. Nothing can be allocated
+    /// above it, and letting it through would wrap the arithmetic in
+    /// [`Self::verify`].
+    pub(crate) fn record_created(
+        &mut self,
+        nodes: &RoaringTreemap,
+        recycled: &RoaringTreemap,
+    ) -> Result<(), IdSpaceError> {
+        if nodes.contains(u64::MAX) {
+            return Err(IdSpaceError::IdOutOfRange(u64::MAX));
+        }
+
+        // What is not free: the only ids either check can object to.
+        let claimed = nodes - recycled;
+
+        // Live before the batch: below the boundary and not free.
+        if let Some(id) = claimed.min().filter(|&id| id < self.entry_bound) {
+            return Err(IdSpaceError::AlreadyLive {
+                id,
+                entry_bound: self.entry_bound,
+            });
+        }
+        // Live because *this batch* created it. `created` alone cannot say that
+        // — it still holds ids the batch has since deleted, and recreating one of
+        // those is legitimate, which is how a multi-commit query reaches a
+        // replica. The recycle bin is what separates them, and it is gone from
+        // `claimed`: an id this batch created and then deleted is in the bin, so
+        // anything left that `created` also holds was claimed twice.
+        //
+        // `is_disjoint` first, so the ordinary record answers from container
+        // headers and only a genuine duplicate pays for the intersection.
+        if !self.created.is_disjoint(&claimed) {
+            let id = (&claimed & &self.created)
+                .min()
+                .expect("the sets are not disjoint");
+            return Err(IdSpaceError::AlreadyLive {
+                id,
+                entry_bound: self.entry_bound,
+            });
+        }
+
+        // Both arms are the same operation — union in the ids at or above the
+        // boundary — and differ only in whether anything has to be trimmed first.
+        // A recycled id sits below the boundary and was already counted in it, so
+        // it is not the id space growing.
+        //
+        // The allocator hands out recycled ids before fresh ones, so a single
+        // create can carry both and neither arm is unusual. Trimming a copy
+        // rather than filtering the iterator keeps the slow arm a container
+        // merge too, instead of an insert per id.
+        if nodes.min().is_some_and(|min| min >= self.entry_bound) {
+            self.created |= nodes;
+        } else {
+            let mut above = nodes.clone();
+            above.remove_range(..self.entry_bound);
+            self.created |= above;
+        }
+        Ok(())
+    }
+
+    /// Check that ids the batch is about to delete were allocated here.
+    ///
+    /// The half that needs a batch. The other half — whether the id is already
+    /// free — is [`Self::refuse_recycled`], which needs only the bin, so a caller
+    /// with no batch can still ask it. Together they are liveness.
+    ///
+    /// # Errors
+    ///
+    /// [`IdSpaceError::NeverCreated`] for the highest id at or above the entry
+    /// boundary that this batch did not create. Above the boundary it was never
+    /// allocated before the batch either, so nothing has ever held it.
+    pub(crate) fn refuse_undeletable(
+        &self,
+        nodes: &RoaringTreemap,
+    ) -> Result<(), IdSpaceError> {
+        // Nothing at or above the boundary means nothing this type can object
+        // to, and that is the ordinary delete — of nodes that predate the batch
+        // entirely. One `max` settles it without touching the sets.
+        if nodes.max().is_none_or(|max| max < self.entry_bound) {
+            return Ok(());
+        }
+        // Otherwise a set difference, which is a container merge. Walking the
+        // ids and probing `created` per id reads as the cheaper option and is
+        // not: measured over 100k ids, the walk costs 561us where the difference
+        // costs 1.1us when every id was created by this batch, and 224us against
+        // 966ns on a mixed delete. It only wins on the shape the guard above has
+        // already returned from.
+        match (nodes - &self.created)
+            .max()
+            .filter(|&id| id >= self.entry_bound)
+        {
+            Some(id) => Err(IdSpaceError::NeverCreated(id)),
+            None => Ok(()),
+        }
+    }
+
+    /// Check that the batch left a possible id space behind.
+    ///
+    /// # Errors
+    ///
+    /// [`IdSpaceError::Hole`] if the created ids do not fill the range from the
+    /// entry boundary upward, and [`IdSpaceError::Miscounted`] if the graph's own
+    /// boundary disagrees with where those ids put it. See the module docs for
+    /// why both are needed.
+    pub(crate) fn verify(
+        &self,
+        graph_bound: u64,
+    ) -> Result<(), IdSpaceError> {
+        let created = self.created.len();
+        // `created == [entry_bound, entry_bound + created.len())`, spelled as the
+        // two things that make it true: the set starts at the boundary, and it has
+        // no gap between there and its highest id.
+        //
+        // Both are checked rather than one derived from the other. That the lowest
+        // id is the boundary does follow from the second equality — every recorded
+        // id is at or above the boundary, so `len` of them spanning exactly `len`
+        // slots can start nowhere else — but that argument leans on an invariant
+        // `created` maintains, and a check here should not have to know what
+        // another function promises. Stated outright it holds regardless.
+        //
+        // Subtractions rather than `highest - entry_bound + 1 == len`: the set is
+        // non-empty in this branch, so neither side can wrap, where the `+ 1`
+        // form can.
+        //
+        // The order of the two tests is load-bearing for that. `||`
+        // short-circuits, so `highest - entry_bound` is only reached once the
+        // lowest id is known to *be* the boundary — and the lowest cannot exceed
+        // the highest. Swap them and a set sitting entirely below the boundary,
+        // which is the case the first test exists to catch, underflows instead.
+        if let Some((_, highest)) =
+            self.created
+                .min()
+                .zip(self.created.max())
+                .filter(|&(lowest, highest)| {
+                    lowest != self.entry_bound || created - 1 != highest - self.entry_bound
+                })
+        {
+            return Err(IdSpaceError::Hole {
+                entry_bound: self.entry_bound,
+                highest,
+                created,
+            });
+        }
+
+        let expected = self
+            .entry_bound
+            .checked_add(created)
+            .ok_or(IdSpaceError::IdOutOfRange(u64::MAX))?;
+        if graph_bound != expected {
+            return Err(IdSpaceError::Miscounted {
+                graph_bound,
+                expected,
+            });
+        }
+        Ok(())
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::{IdSpace, IdSpaceError};
+    use crate::graph::graph::{Graph, NodeOpError};
+    use crate::graph::graphblas::test_init::ensure_init;
+    use roaring::RoaringTreemap;
+    use rustc_hash::FxHashMap;
+
+    fn graph() -> Graph {
+        ensure_init();
+        Graph::new(64, 64, 0, 0, "t")
+    }
+
+    fn ids(v: &[u64]) -> RoaringTreemap {
+        v.iter().copied().collect()
+    }
+
+    fn range(r: std::ops::Range<u64>) -> RoaringTreemap {
+        r.collect()
+    }
+
+    /// Through the graph's own operations, because that is where the batch is
+    /// maintained — a test that fed the batch directly would not exercise the
+    /// thing that makes a caller unable to forget.
+    fn create(
+        g: &mut Graph,
+        space: &mut IdSpace,
+        nodes: &RoaringTreemap,
+    ) -> Result<(), NodeOpError> {
+        g.create_nodes(nodes, space)
+    }
+
+    fn delete(
+        g: &mut Graph,
+        space: &IdSpace,
+        nodes: &RoaringTreemap,
+    ) -> Result<(), NodeOpError> {
+        g.delete_nodes(nodes, &mut FxHashMap::default(), Some(space))
+            .map(|_| ())
+    }
+
+    #[test]
+    fn ids_arriving_out_of_order_still_fill_the_range() {
+        // The case a boundary derived from the counter cannot express: the high
+        // half arrives first, so mid-batch the graph reports its boundary as 100
+        // while id 599 is allocated.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &range(500..600)).expect("the high half is legitimate");
+        create(&mut g, &mut space, &range(0..500)).expect("and so is the low half");
+        space
+            .verify(g.node_id_bound())
+            .expect("the batch closed the hole");
+        assert_eq!(g.node_count(), 600);
+    }
+
+    #[test]
+    fn a_hole_left_at_the_end_is_reported() {
+        // 500..600 and nothing else. An allocator hands out the lowest free id,
+        // so it cannot reach 500 without having handed out 0..499 — whoever
+        // produced this was not working from the same id space.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &range(500..600)).expect("nothing is wrong yet");
+
+        let err = space
+            .verify(g.node_id_bound())
+            .expect_err("must report the hole");
+        assert_eq!(
+            err,
+            IdSpaceError::Hole {
+                entry_bound: 0,
+                highest: 599,
+                created: 100,
+            }
+        );
+    }
+
+    #[test]
+    fn a_node_the_batch_never_recorded_is_caught_by_the_counter() {
+        // The half of the invariant the shape check cannot see. `created` stays
+        // contiguous from the boundary, so `Hole` is satisfied and says nothing —
+        // but the graph counted a node the batch never recorded, and only
+        // comparing its own boundary against `entry_bound + created.len()`
+        // notices. That is why both checks are here rather than one.
+        //
+        // The extra node arrives by the write path, which records nothing into a
+        // batch. On a replica the same shape is an applied record the batch did
+        // not account for.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &range(0..3)).expect("three ids, all recorded");
+        space
+            .verify(g.node_id_bound())
+            .expect("the graph and the batch agree so far");
+
+        g.add_reserved_node_count(1);
+        g.create_allocated_nodes(&ids(&[3]));
+
+        let err = space
+            .verify(g.node_id_bound())
+            .expect_err("the counter moved and the recorded ids did not");
+        assert_eq!(
+            err,
+            IdSpaceError::Miscounted {
+                graph_bound: 4,
+                expected: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn a_range_that_starts_above_the_boundary_is_a_hole() {
+        // The tightest form of the same failure, and why the lowest id is checked
+        // rather than derived: {1,2,3} is internally consecutive, so a test of
+        // `highest - lowest` alone would pass it. Measured from the boundary it is
+        // one short, and id 0 is the id nobody accounted for.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[1, 2, 3])).expect("the graph takes them");
+
+        let err = space
+            .verify(g.node_id_bound())
+            .expect_err("id 0 is unaccounted for");
+        assert_eq!(
+            err,
+            IdSpaceError::Hole {
+                entry_bound: 0,
+                highest: 3,
+                created: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn an_id_claimed_twice_is_refused_at_the_record() {
+        // The set absorbs the duplicate, so the range still looks whole and the
+        // count check would only report a discrepancy at the end. Intersecting
+        // the incoming ids with what the batch has already created names the id
+        // where it happens — and does not fire on a legitimate recreate, because
+        // the caller has removed the recycle bin first and a recreated id is in
+        // it. See `creating_deleting_and_recreating_one_id_in_a_batch`.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &range(0..6)).expect("six fresh ids");
+
+        let err = create(&mut g, &mut space, &ids(&[5])).expect_err("5 is already this batch's");
+        assert_eq!(
+            err,
+            NodeOpError::IdSpace(IdSpaceError::AlreadyLive {
+                id: 5,
+                entry_bound: 0
+            })
+        );
+        assert_eq!(g.node_count(), 6, "and nothing was applied for it");
+    }
+
+    #[test]
+    fn a_recycled_id_does_not_grow_the_space() {
+        // Ids below the entry boundary were counted in the boundary the batch
+        // started from, so recreating one leaves the range and the count alone.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0, 1])).expect("two fresh ids");
+        delete(&mut g, &space, &ids(&[0])).expect("deleting what this batch created");
+        space.verify(g.node_id_bound()).expect("whole");
+
+        // A fresh batch: id 0 sits in the recycle bin, so it is free to come
+        // back and does not extend the range — which is only true if the bin is
+        // part of the boundary this batch started from.
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0])).expect("id 0 is free");
+        space.verify(g.node_id_bound()).expect("whole again");
+    }
+
+    #[test]
+    fn creating_deleting_and_recreating_one_id_in_a_batch() {
+        // Three commits of one query reach a replica as a single buffer, and the
+        // allocator hands the freed id straight back, so `C(0) · D(0) · C(0)` is
+        // legitimate. The set does not shrink on the delete, so the recreate adds
+        // nothing and the range stays whole.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0])).expect("create");
+        delete(&mut g, &space, &ids(&[0])).expect("delete");
+        create(&mut g, &mut space, &ids(&[0])).expect("the recreate is legitimate");
+        space.verify(g.node_id_bound()).expect("whole");
+        assert_eq!(g.node_count(), 1);
+    }
+
+    #[test]
+    fn a_cancelled_reservation_arrives_as_a_pair() {
+        // What a create-then-delete in one segment ships: both ids created, then
+        // one deleted. The id space grew by two and one of them is free.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0, 1])).expect("create");
+        delete(&mut g, &space, &ids(&[0])).expect("delete");
+        space.verify(g.node_id_bound()).expect("whole");
+        assert_eq!(g.node_count(), 1);
+        assert_eq!(g.deleted_nodes_count(), 1);
+    }
+
+    #[test]
+    fn deleting_the_same_id_twice_inside_one_batch_is_refused() {
+        // Where the two halves of "is it live" have to cooperate. The batch owns
+        // the boundary half — id 1 is at or above the boundary, and the batch did
+        // create it, so `deletable` is satisfied both times. The graph owns the
+        // other half, and the first delete put id 1 in the recycle bin, so the
+        // second is refused there.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0, 1])).expect("create");
+        delete(&mut g, &space, &ids(&[1])).expect("the first delete is legitimate");
+
+        let err = delete(&mut g, &space, &ids(&[1])).expect_err("the second is not");
+        assert_eq!(err, NodeOpError::IdSpace(IdSpaceError::AlreadyRecycled(1)));
+        assert_eq!(g.node_count(), 1, "and it was not deleted twice");
+    }
+
+    #[test]
+    fn deleting_a_live_id_from_before_the_batch_is_allowed() {
+        // The other side of the same split: id 0 is *below* the boundary, so the
+        // batch has nothing to say about it — `deletable` only speaks for ids at
+        // or above. Whether it is live is the recycle bin's answer, and it is not
+        // in the bin, so the delete stands.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0, 1])).expect("create");
+        space.verify(g.node_id_bound()).expect("whole");
+
+        let mut space = IdSpace::at(g.node_id_bound());
+        delete(&mut g, &space, &ids(&[0])).expect("a live id from before the batch");
+        assert_eq!(g.node_count(), 1);
+        space
+            .verify(g.node_id_bound())
+            .expect("a delete leaves no hole");
+    }
+
+    #[test]
+    fn deleting_an_id_never_created_is_refused() {
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0, 1])).expect("create");
+
+        let err = delete(&mut g, &space, &ids(&[7])).expect_err("7 was never allocated");
+        assert_eq!(err, NodeOpError::IdSpace(IdSpaceError::NeverCreated(7)));
+    }
+
+    #[test]
+    fn the_first_id_zero_is_not_read_as_already_handed_out() {
+        // `max_node_id()` returns 0 for an empty graph, so a boundary taken from
+        // it reads as "id 0 has been handed out" and refuses this.
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        create(&mut g, &mut space, &ids(&[0])).expect("id 0 is fresh");
+        space.verify(g.node_id_bound()).expect("whole");
+    }
+
+    #[test]
+    fn the_last_id_is_refused_rather_than_wrapping_the_arithmetic() {
+        let mut g = graph();
+        let mut space = IdSpace::at(g.node_id_bound());
+        let err = create(&mut g, &mut space, &ids(&[u64::MAX])).expect_err("not creatable");
+        assert_eq!(
+            err,
+            NodeOpError::IdSpace(IdSpaceError::IdOutOfRange(u64::MAX))
+        );
+    }
+
+    #[test]
+    fn the_allocators_own_ids_are_not_validated() {
+        // The write path's ids came from `reserve_nodes`, so there is nothing to
+        // check and no batch to record into. It goes through the other entry
+        // point entirely, which accepts a gap — that is what makes it a different
+        // question rather than this one with the batch left out.
+        let mut g = graph();
+        g.add_reserved_node_count(2);
+        g.create_allocated_nodes(&ids(&[0, 5]));
+        g.delete_nodes(&ids(&[0]), &mut FxHashMap::default(), None)
+            .expect("delete");
+        assert_eq!(g.node_count(), 1);
+    }
+}

--- a/graph/src/graph/mod.rs
+++ b/graph/src/graph/mod.rs
@@ -66,4 +66,5 @@ pub mod cow;
 pub mod endpoint_index;
 pub mod graph;
 pub mod graphblas;
+pub mod id_space;
 pub mod mvcc_graph;

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -1031,7 +1031,7 @@ impl Pending {
                     dsts.push(to.into());
                     ids.push(rel_id.into());
                 }
-                g.create_relationships_bulk(type_name, &srcs, &dsts, &ids);
+                g.create_allocated_relationships(type_name, &srcs, &dsts, &ids);
             }
         }
         if !self.set_labels.is_empty() {
@@ -1101,7 +1101,13 @@ impl Pending {
             stats.borrow_mut().nodes_deleted += self.deleted_nodes.len();
             self.deleted_node_labels = g
                 .borrow_mut()
-                .delete_nodes(&self.deleted_nodes, &mut self.index_docs.node_removes)
+                .delete_nodes(
+                    &self.deleted_nodes,
+                    &mut self.index_docs.node_removes,
+                    // The write path allocates its own ids, so the id space is
+                    // dense by construction and there is no batch to validate.
+                    None,
+                )
                 .map_err(|e| e.to_string())?;
         }
         // Take relationship deletions BEFORE implicit edge processing
@@ -1140,7 +1146,13 @@ impl Pending {
         if !explicit_rels.is_empty() {
             let endpoints = g
                 .borrow_mut()
-                .delete_relationships(&explicit_rels, &mut self.index_docs.edge_removes)?;
+                .delete_relationships(
+                    &explicit_rels,
+                    &mut self.index_docs.edge_removes,
+                    // No batch: the write path allocated these ids itself.
+                    None,
+                )
+                .map_err(|e| e.to_string())?;
             // Use the actually-removed relationships (delete_relationships skips
             // stale/missing ids) for stats and effects/constraint bookkeeping.
             stats.borrow_mut().relationships_deleted += endpoints.len();

--- a/src/commands/bulk_insert.rs
+++ b/src/commands/bulk_insert.rs
@@ -496,7 +496,7 @@ fn process_edge_token(
         return Ok(());
     }
 
-    g.create_relationships_bulk(&type_name, &srcs, &dsts, &edge_ids);
+    g.create_allocated_relationships(&type_name, &srcs, &dsts, &edge_ids);
     unsafe { maybe_yield(raw_ctx) };
 
     if !resolved_rel_attrs.is_empty() {


### PR DESCRIPTION
Closes #2739

Stacked on #2570 — **base is `feat/effects-v3`, not `main`.** One commit.

## The problem

Two ad-hoc checks in the apply path stood in for a question the graph cannot
answer: a boundary frozen at buffer entry, and a running set of the ids the
buffer had created so far. Neither is the question. Whether the ids a batch
hands the graph describe a *possible id space* is, and nothing could ask it.

`Graph` tracks node liveness with `node_count` and `deleted_nodes` and no live
set, so the only boundary it can offer is `node_count + deleted_nodes.len()`.
That is the boundary *if the id space is dense*, and `max_node_id` is the same
arithmetic — so an assertion written in terms of them checks one derivation of
the state against another derivation of the same state, and passes on a graph
that is already wrong.

Density holds between batches, not within one. Records are ingested grouped by
shape rather than ordered by id, so a create of 500..600 may precede one of
0..500; between them the graph holds 100 live nodes whose highest id is 599 and
reports its boundary as 100.

## What this adds

`graph::id_space::NodeIdSpace` holds the boundary as it stood before a batch and
every id at or above it the batch has ingested, which states the invariant
directly:

```
ingested == [ entry_bound, entry_bound + ingested.len() )
```

It lives beside the graph rather than in the effects module because that is what
it is about — nothing in it knows about replication, buffers or a peer engine.
It is passed to `create_nodes` and `delete_nodes`, which maintain and consult it
themselves:

```rust
pub fn create_nodes(&mut self, nodes: &RoaringTreemap, id_space: Option<&mut NodeIdSpace>)
pub fn delete_nodes(&mut self, nodes, remove_docs, id_space: Option<&NodeIdSpace>)
```

An argument rather than state on `Graph`, so a caller cannot silently forget to
start a batch, and `None` is visible at the call site. `create_nodes` reads the
entry boundary off the space it is handed, so its `first_unallocated` parameter
is gone: a boundary that disagrees with the batch it accompanies is no longer
expressible. The write path allocates its own ids and passes `None`.

## The two checks, and why both

**The shape of what arrived.** Ids at or above the boundary must fill the range
from it upward. An allocator hands out the lowest free id, so it cannot reach an
id without having handed out everything below — a batch that leaves a hole did
not come from one. This is what catches a replica that has missed a buffer: told
to create 500..600 when its own boundary is 0, it would otherwise accept an id
space its master does not have and collide on its next allocation.

**That the graph counted it.** The same id ingested twice moves `node_count`
twice while the set absorbs the duplicate, so the range still looks whole.
Comparing the graph's own boundary against `entry_bound + ingested.len()` is the
only place anything checks that counter against a value not derived from it.

Neither subsumes the other: the first misses a duplicate inside an otherwise
complete range, the second misses a hole, because the ids in a truncated batch
really were counted.

Both conditions of the first check are tested rather than one derived from the
other. That the lowest id is the boundary does follow from the cardinality
equality — every recorded id is at or above the boundary, so `len` of them
spanning exactly `len` slots can start nowhere else — but that argument leans on
an invariant maintained in another function, and a check should not have to know
what its neighbours promise.

## What goes away

- `IndexOps::created_here` and `IndexOps::entry_unallocated`
- `Graph::first_unallocated_node_id` — a derived quantity that read as ground
  truth. The one place the derivation is sound now states its own assumption
  instead of implying it everywhere.
- the `first_unallocated` parameter on `create_nodes`

## One behaviour change

An id claimed twice in one buffer is still refused, but by the count at the end
of the batch rather than at the record, and **without naming the id**. Naming it
would need the set to remember how many times each id arrived, or to shrink on
delete — and a delete followed by a recreate of the same id inside one buffer is
legitimate, so no record-level check can tell the two apart.

## Verification

Alongside #2570's emission fix, on a master/replica pair at default config,
running a cancelled reservation, a bulk create and a scattered delete:

```
id lists, master vs replica         identical
divergence and forced-resync lines  0
replica cmdstat_graph.EFFECT        applied
```

| | |
|---|---|
| `cargo test -p graph` | 332 pass, 1 pre-existing failure (`build_bool_is_iso_and_grb_build_is_not`, fails identically on the base) |
| e2e, functions, MVCC, concurrency | 138 pass |
| flow | 1477 pass, 0 fail |
| TCK | pass |
| `cargo fmt --check`, `clippy --all-targets` | clean, no new warnings |

Not benchmarked: the change is on the replica's apply path, and the effects
benches live in #2705. Per record it adds one set union and removes an
intersection and a union against `created_here`, which grew monotonically across
a buffer where the ingested set is a merge — so a net win is likely on large
buffers, but that is reasoning rather than a measurement.

## Follow-up, not in this PR

`Graph::reserved_node_count` is a count standing in for a set, which is why
`create_allocated_nodes` has to be unchecked: the checked form would reject a
transaction's own reservations. Making it an exact set would let that unchecked
variant go away and give the write path the same guarantee this PR gives the
apply path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for node and relationship ID ranges, duplicates, gaps, recycled IDs, and allocation-count mismatches during batch updates.
  * Improved error reporting for invalid graph changes, including whether the issue affects nodes or relationships.
  * Updated bulk insertion and pending changes to use consistent ID allocation checks.
* **Reliability**
  * Strengthened safeguards against inconsistent graph state during create and delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->