### PR TITLE
fix(runtime): handle LIMIT 0 by returning empty batch instead of None

### DIFF
--- a/graph/src/runtime/ops/limit.rs
+++ b/graph/src/runtime/ops/limit.rs
@@ -33,6 +33,11 @@ pub struct LimitOp<'a> {
     pub(crate) runtime: &'a Runtime<'a>,
     pub(crate) child: Box<BatchOp<'a>>,
     remaining: usize,
+    /// True when the operator was constructed with `LIMIT 0`. Tracked
+    /// separately from `remaining` so a positive limit that has been fully
+    /// consumed still terminates immediately instead of re-entering the
+    /// zero-limit path and pulling an extra child batch.
+    limit_zero: bool,
     /// For LIMIT 0, we still need to pull one batch from the child to
     /// execute any side effects and preserve output schema, then return
     /// an empty batch. This flag tracks whether we've done that.
@@ -41,6 +46,7 @@ pub struct LimitOp<'a> {
 }
 
 impl<'a> LimitOp<'a> {
+    /// Creates a limit operator yielding at most `limit` active rows.
     pub const fn new(
         runtime: &'a Runtime<'a>,
         child: Box<BatchOp<'a>>,
@@ -51,6 +57,7 @@ impl<'a> LimitOp<'a> {
             runtime,
             child,
             remaining: limit,
+            limit_zero: limit == 0,
             limit_zero_emitted: false,
             idx,
         }
@@ -62,27 +69,32 @@ impl<'a> LimitOp<'a> {
 impl<'a> Iterator for LimitOp<'a> {
     type Item = Result<Batch<'a>, String>;
 
+    /// Yields the next batch, trimmed to the remaining limit window.
     fn next(&mut self) -> Option<Self::Item> {
         // Special handling for LIMIT 0: we must still pull one batch from
         // the child to execute any side effects (e.g., pending mutations in
         // write queries) and to preserve the output schema. We return an
-        // empty batch once, then exhaust.
-        if self.remaining == 0 {
+        // empty batch once, then exhaust. Gated on the construction-time
+        // `limit_zero` flag so an exhausted positive limit keeps returning
+        // `None` immediately without consuming another child batch.
+        if self.limit_zero {
             if !self.limit_zero_emitted {
                 self.limit_zero_emitted = true;
                 // Pull one batch from child to execute side effects, then
                 // return an empty batch with the same schema.
-                if let Some(child_result) = self.child.next() {
-                    let mut batch = child_result?;
-                    // Trim to 0 active rows while preserving schema.
-                    batch.set_selection(Vec::new());
-                    return Some(Ok(batch));
-                }
-                // Child yielded nothing — return empty batch from default.
-                let mut batch = self.runtime.default_batch();
+                let mut batch = match self.child.next() {
+                    Some(Ok(batch)) => batch,
+                    Some(Err(error)) => return Some(Err(error)),
+                    None => return None,
+                };
+                // Trim to 0 active rows while preserving schema.
                 batch.set_selection(Vec::new());
                 return Some(Ok(batch));
             }
+            return None;
+        }
+
+        if self.remaining == 0 {
             return None;
         }
 

--- a/graph/src/runtime/ops/limit.rs
+++ b/graph/src/runtime/ops/limit.rs
@@ -6,12 +6,20 @@
 //! vector to include only the first `remaining` active entries. Once the
 //! limit count is exhausted, subsequent calls return `None`.
 //!
+//! Special case: LIMIT 0 returns one empty batch (to preserve schema and
+//! execute child side effects) then exhausts.
+//!
 //! ```text
 //!  LIMIT 5:
 //!
 //!  batch 1 (3 rows) ──► pass through (remaining: 5 -> 2)
 //!  batch 2 (4 rows) ──► trim to 2 rows (remaining: 2 -> 0)
 //!  batch 3           ──► None (exhausted)
+//!
+//!  LIMIT 0:
+//!
+//!  batch 1 (N rows) ──► trim to 0 rows, return empty batch
+//!  batch 2           ──► None (exhausted)
 //! ```
 
 use crate::planner::IR;
@@ -25,6 +33,10 @@ pub struct LimitOp<'a> {
     pub(crate) runtime: &'a Runtime<'a>,
     pub(crate) child: Box<BatchOp<'a>>,
     remaining: usize,
+    /// For LIMIT 0, we still need to pull one batch from the child to
+    /// execute any side effects and preserve output schema, then return
+    /// an empty batch. This flag tracks whether we've done that.
+    limit_zero_emitted: bool,
     pub(crate) idx: NodeIdx<Dyn<IR>>,
 }
 
@@ -39,6 +51,7 @@ impl<'a> LimitOp<'a> {
             runtime,
             child,
             remaining: limit,
+            limit_zero_emitted: false,
             idx,
         }
     }
@@ -50,11 +63,30 @@ impl<'a> Iterator for LimitOp<'a> {
     type Item = Result<Batch<'a>, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if self.remaining == 0 {
-                return None;
+        // Special handling for LIMIT 0: we must still pull one batch from
+        // the child to execute any side effects (e.g., pending mutations in
+        // write queries) and to preserve the output schema. We return an
+        // empty batch once, then exhaust.
+        if self.remaining == 0 {
+            if !self.limit_zero_emitted {
+                self.limit_zero_emitted = true;
+                // Pull one batch from child to execute side effects, then
+                // return an empty batch with the same schema.
+                if let Some(child_result) = self.child.next() {
+                    let mut batch = child_result?;
+                    // Trim to 0 active rows while preserving schema.
+                    batch.set_selection(Vec::new());
+                    return Some(Ok(batch));
+                }
+                // Child yielded nothing — return empty batch from default.
+                let mut batch = self.runtime.default_batch();
+                batch.set_selection(Vec::new());
+                return Some(Ok(batch));
             }
+            return None;
+        }
 
+        loop {
             let mut batch = match self.child.next()? {
                 Ok(batch) => batch,
                 Err(e) => return Some(Err(e)),

--- a/tests/flow/test_results.py
+++ b/tests/flow/test_results.py
@@ -438,3 +438,25 @@ class testResultSetFlow(FlowTestsBase):
         query = """CREATE (a:Person {name: 'Alice', age: 30})-[r:KNOWS {since: 2020}]->(a) WITH r, a DELETE a RETURN typeof(r)"""
         result = self.graph.query(query)
         self.env.assertEqual(result.result_set[0][0], "Edge")
+
+    # LIMIT 0 must return zero rows (with the header intact), not one NULL row.
+    # Regression test for https://github.com/FalkorDB/falkordb/issues/2733
+    def test19_limit_zero_returns_empty_result(self):
+        # Exact repro from the issue: bare RETURN with no input rows.
+        result = self.graph.query("RETURN 1 LIMIT 0")
+        self.env.assertEqual(result.result_set, [])
+        self.env.assertEqual(len(result.header), 1)
+
+        # LIMIT 0 over a MATCH stream.
+        result = self.graph.query("MATCH (a) RETURN a.name LIMIT 0")
+        self.env.assertEqual(result.result_set, [])
+        self.env.assertEqual(len(result.header), 1)
+
+        # LIMIT 0 combined with ORDER BY (sort + limit path).
+        result = self.graph.query("MATCH (a) RETURN a.name ORDER BY a.name LIMIT 0")
+        self.env.assertEqual(result.result_set, [])
+        self.env.assertEqual(len(result.header), 1)
+
+        # Sanity: a positive limit still returns rows.
+        result = self.graph.query("RETURN 1 LIMIT 1")
+        self.env.assertEqual(result.result_set, [[1]])


### PR DESCRIPTION
## Summary

Fixes issue #2733 where RETURN 1 LIMIT 0 returns a single NULL row instead of zero rows.

## Changes

- Added limit_zero construction flag in LimitOp::new() to detect zero‑limit cases.
- Modified 
ext() to gate on self.limit_zero before decrementing emaining, ensuring zero‑limit returns an empty batch instead of a NULL row.
- Replaced ? with explicit match on child.next() returning Option<Result<Batch, String>> to properly propagate child errors.
- Removed the default_batch() fallback (private to untime.rs).

## Verification

- Local cargo fmt --all -- --check passes.
- Python logic simulation of fixed vs. buggy LimitOp behaviour passed all 9 checks (LIMIT 0 empty/non‑empty child, LIMIT 5 truncation, error propagation, phantom batch avoidance).