### PR TITLE
Fix named path construction for CREATE on Rust main

### DIFF
--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -931,17 +931,21 @@ impl Planner {
         matches!(tree.node(idx).data(), IR::Apply) && tree.node(idx).num_children() > 1
     }
 
-    /// Walk past the Apply chain a `ForEach` or `Unwind` carries for pattern
+    /// Find the input of a clause, below named-path construction and the
+    /// Apply chain a `ForEach` or `Unwind` carries for pattern
     /// comprehensions in its list expression, so the preceding clause is
     /// stitched below the sub-plans rather than as an extra child.
     ///
     /// A freshly planned `ForEach` holds its body as the last child, so only a
     /// second child can be the chain; a freshly planned `Unwind` has no child
     /// at all, so any child it has is the chain.
-    fn descend_list_expr_applies(
+    fn descend_clause_input(
         tree: &DynTree<IR>,
         mut idx: NodeIdx<Dyn<IR>>,
     ) -> NodeIdx<Dyn<IR>> {
+        while matches!(tree.node(idx).data(), IR::PathBuilder(_)) {
+            idx = tree.node(idx).child(0).idx();
+        }
         let min_children = match tree.node(idx).data() {
             IR::ForEach { .. } => 2,
             IR::Unwind { .. } => 1,
@@ -1089,7 +1093,7 @@ impl Planner {
     /// variable holding its collected list — and an Apply chain to hang below
     /// the clause's operator.  The innermost Apply is deliberately left
     /// single-child: `plan_query` stitching inserts the preceding clause there
-    /// as child(0) (see `descend_list_expr_applies`).
+    /// as child(0) (see `descend_clause_input`).
     fn extract_list_expr_comprehensions(
         &mut self,
         expr: QueryExpr<Variable>,
@@ -2590,7 +2594,7 @@ impl Planner {
                 idx = res.node(idx).child(0).idx();
             }
         }
-        idx = Self::descend_list_expr_applies(&res, idx);
+        idx = Self::descend_clause_input(&res, idx);
         // Insert each remaining clause plan (in reverse order) at the
         // current insertion point, then walk down again to find the next
         // insertion point for the clause before it.
@@ -2669,7 +2673,7 @@ impl Planner {
                     idx = res.node(idx).child(0).idx();
                 }
             }
-            idx = Self::descend_list_expr_applies(&res, idx);
+            idx = Self::descend_clause_input(&res, idx);
         }
 
         // For write queries without an explicit WITH/RETURN commit, wrap
@@ -2979,7 +2983,15 @@ impl Planner {
                 for v in pattern.variables() {
                     self.visited.insert((v.id, v.scope_id));
                 }
-                tree!(IR::Create(Box::new(filtered)))
+                let create = tree!(IR::Create(Box::new(filtered)));
+                // Build from the full path: its components may include both
+                // newly created entities and entities bound by earlier clauses.
+                let paths = pattern.paths();
+                if paths.is_empty() {
+                    create
+                } else {
+                    tree!(IR::PathBuilder(paths.to_vec()), create)
+                }
             }
             QueryIR::Delete {
                 exprs,
@@ -3195,7 +3207,7 @@ impl Planner {
                 // Stitch body plans together (same as plan_query stitching)
                 let mut body_iter = body_plans.into_iter().rev();
                 let mut body_plan = body_iter.next().unwrap();
-                let mut idx = Self::descend_list_expr_applies(&body_plan, body_plan.root().idx());
+                let mut idx = Self::descend_clause_input(&body_plan, body_plan.root().idx());
                 for n in body_iter {
                     if body_plan.node(idx).num_children() > 0 {
                         idx = body_plan
@@ -3205,7 +3217,7 @@ impl Planner {
                     } else {
                         idx = body_plan.node_mut(idx).push_child_tree(n);
                     }
-                    idx = Self::descend_list_expr_applies(&body_plan, idx);
+                    idx = Self::descend_clause_input(&body_plan, idx);
                 }
                 // Do NOT wrap in Commit — mutations accumulate in pending
                 // across all iterations and are committed by the outer Commit

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -447,6 +447,108 @@ def test_graph_crud():
     assert res.nodes_deleted == 3
     assert res.relationships_deleted == 3
 
+
+def test_create_named_single_node_path():
+    res = query("CREATE p=(n) RETURN p, n, nodes(p), relationships(p), length(p)", write=True)
+    assert res.nodes_created == 1
+    assert len(res.result_set) == 1
+    p, n, nodes, edges, length = res.result_set[0]
+    assert isinstance(p, Path)
+    assert p == Path([n], [])
+    assert nodes == [n]
+    assert edges == []
+    assert length == 0
+
+
+@pytest.mark.parametrize(
+    "pattern, node_vars, edge_vars, node_count, edge_count",
+    [
+        ("(a)-[r:R]->(b)", "[a,b]", "[r]", 2, 1),
+        ("(a)<-[r:R]-(b)", "[a,b]", "[r]", 2, 1),
+        ("(a)-[r:R]->(b)-[s:S]->(c)", "[a,b,c]", "[r,s]", 3, 2),
+        ("(a)-[r:R]->(a)", "[a,a]", "[r]", 1, 1),
+    ],
+)
+def test_create_named_relationship_path(pattern, node_vars, edge_vars, node_count, edge_count):
+    res = query(
+        f"CREATE p={pattern} RETURN p, nodes(p), relationships(p), length(p), {node_vars}, {edge_vars}",
+        write=True,
+    )
+    assert res.nodes_created == node_count
+    assert res.relationships_created == edge_count
+    assert len(res.result_set) == 1
+    p, nodes, edges, length, expected_nodes, expected_edges = res.result_set[0]
+    assert isinstance(p, Path)
+    assert p == Path(expected_nodes, expected_edges)
+    assert nodes == expected_nodes
+    assert edges == expected_edges
+    assert length == edge_count
+
+
+def test_create_named_path_with_bound_endpoint():
+    query("CREATE (:Start {v: 7})", write=True)
+    res = query(
+        "MATCH (a:Start) CREATE p=(a)-[r:R]->(b:End) "
+        "RETURN p, a, r, b",
+        write=True,
+    )
+    assert res.nodes_created == 1
+    assert res.relationships_created == 1
+    assert len(res.result_set) == 1
+    p, a, r, b = res.result_set[0]
+    assert p == Path([a, b], [r])
+    assert a.properties == {"v": 7}
+
+
+def test_create_named_paths_across_with_and_rows():
+    res = query(
+        "UNWIND [1,2,3] AS v "
+        "CREATE p=(a:A {v: v}), q=(b:B {v: v})-[r:R]->(c:C) "
+        "WITH v, p AS single, q AS edge "
+        "RETURN v, nodes(single)[0].v, length(single), "
+        "nodes(edge)[0].v, length(edge) ORDER BY v",
+        write=True,
+    )
+    assert res.nodes_created == 9
+    assert res.relationships_created == 3
+    assert res.result_set == [[v, v, 0, v, 1] for v in [1, 2, 3]]
+
+
+def test_create_named_path_without_return():
+    res = query("UNWIND [1,2,3] AS v CREATE p=(n:N {v: v})", write=True)
+    assert res.result_set == []
+    assert res.nodes_created == 3
+    assert query("MATCH (n:N) RETURN n.v ORDER BY n.v").result_set == [[1], [2], [3]]
+
+
+@pytest.mark.parametrize("update_after_create", [False, True])
+def test_create_named_paths_in_foreach(update_after_create):
+    final_clause = " SET b.v=v" if update_after_create else ""
+    res = query(
+        "FOREACH (v IN [1,2,3] | "
+        "CREATE p=(a:A {v: v}) CREATE q=(a)-[:R]->(b:B)"
+        f"{final_clause})",
+        write=True,
+    )
+    assert res.nodes_created == 6
+    assert res.relationships_created == 3
+    res = query("MATCH (a:A)-[:R]->(b:B) RETURN a.v, b.v ORDER BY a.v")
+    assert res.result_set == [[v, v if update_after_create else None] for v in [1, 2, 3]]
+
+
+def test_match_and_merge_named_paths_after_create():
+    created = query("CREATE (a:A)-[r:R]->(b:B) RETURN a, r, b", write=True)
+    a, r, b = created.result_set[0]
+    expected = [[Path([a, b], [r])]]
+    assert query("MATCH p=(:A)-[:R]->(:B) RETURN p").result_set == expected
+    assert query("MERGE p=(:A)-[:R]->(:B) RETURN p", write=True).result_set == expected
+    created = query("MERGE p=(a:C)-[r:S]->(b:D) RETURN p, a, r, b", write=True)
+    assert created.nodes_created == 2
+    assert created.relationships_created == 1
+    p, a, r, b = created.result_set[0]
+    assert p == Path([a, b], [r])
+
+
 def test_match_node_by_id():
     query("UNWIND range(0, 1000) AS x CREATE (n:N {v: x})", write=True)
 


### PR DESCRIPTION
`CREATE p=(n) RETURN p` returns a null path on Rust main even though the node is created. This constructs named path values after CREATE, including components bound by earlier clauses. PathBuilder is also traversed when finding clause inputs, so named CREATE keeps executing correctly in UNWIND and multi-clause FOREACH bodies without RETURN.

Adds 11 regression cases covering single nodes, directed and multi-hop paths, self-loops, bound endpoints, WITH aliases and multiple rows, no-RETURN writes, FOREACH, and existing MATCH/MERGE path behavior. Related to #1279; this change targets the Rust implementation on `main`.

Validation used real Rust builds and Redis queries in [this dedicated public CI run](https://github.com/sen-ye/FalkorDB/actions/runs/34259873855). The tested production and test files were checked against this PR's two-file commit:

- Unmodified baseline with the new tests: 7 target failures, 5 passing controls.
- Candidate regression/control selection: 12 passed.
- `tests/test_e2e.py` and `tests/test_functions.py`: 134 passed, 1 skipped by the existing `EXISTING_ENV` guard for `test_load_csv`.
- Graph crate unit tests: 187 passed, 16 ignored; doctests: 2 passed, 2 ignored.
- Formatting passed. Clippy completed successfully with four warnings in untouched files.

AI assistance was used for implementation, review, and test design. The linked checks were actually executed; no human review is claimed. The CI helper files belong only to the fork's separate verification branch and are not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Named paths can now be created and returned for nodes, relationships, chained patterns, reversed relationships, and self-loops.
  * Named-path creation works with bound endpoints, multiple rows, `FOREACH`, and queries without a `RETURN` clause.
  * Previously created named paths can be used with subsequent `MATCH` and `MERGE` operations.

* **Bug Fixes**
  * Improved handling of named paths following path construction and clause chaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->