### PR TITLE
perf: size an index scan's first batch to the downstream LIMIT (draft: surfaces a pre-existing deadlock)

### DIFF
--- a/graph/src/runtime/ops/batched_result_emitter.rs
+++ b/graph/src/runtime/ops/batched_result_emitter.rs
@@ -510,6 +510,19 @@ pub struct BatchedResultEmitter<'a, I: GatherItem> {
     /// produces a small first batch instead of eagerly packing a whole
     /// `BATCH_SIZE` worth of work.
     pack_ceiling: usize,
+    /// When set, [`pack_ceiling`](Self::pack_ceiling) doubles back up towards
+    /// [`BATCH_SIZE`] after every emitted batch.
+    ///
+    /// A lowered ceiling is a bet that the downstream `Limit` is satisfied by
+    /// the first small batch. The bet is free when it pays off and unbounded
+    /// when it does not: a row-reducing operator between this one and the
+    /// `Limit` (a selective `CondTraverse`, say) can discard every row, and a
+    /// ceiling pinned at `LIMIT 10` would then walk the whole input ten rows at
+    /// a time. Growing the ceiling geometrically bounds that regression — the
+    /// input is still consumed in `O(log BATCH_SIZE)` extra `emit_lazy` calls
+    /// and at most 2x the ideal number of packed rows — while keeping the small
+    /// first batch that makes the common case cheap.
+    grow_pack_ceiling: bool,
 }
 
 impl<'a, I: GatherItem> BatchedResultEmitter<'a, I> {
@@ -524,6 +537,7 @@ impl<'a, I: GatherItem> BatchedResultEmitter<'a, I> {
             pending: None,
             cursor: 0,
             pack_ceiling: BATCH_SIZE,
+            grow_pack_ceiling: false,
         }
     }
 
@@ -556,6 +570,27 @@ impl<'a, I: GatherItem> BatchedResultEmitter<'a, I> {
             && cap < BATCH_SIZE
         {
             self.set_pack_ceiling(cap.max(1));
+        }
+    }
+
+    /// Like [`apply_record_cap`](Self::apply_record_cap), but lets the ceiling
+    /// grow back to [`BATCH_SIZE`] over successive batches.
+    ///
+    /// Use this where the row budget is only a *hint* — a leaf scan whose rows
+    /// pass through a possibly row-reducing operator before the `Limit` — as
+    /// opposed to [`apply_record_cap`](Self::apply_record_cap), which suits an
+    /// operator whose own output the budget actually bounds. See
+    /// [`grow_pack_ceiling`](Self::grow_pack_ceiling) for why the growth
+    /// matters.
+    pub(crate) fn apply_hinted_record_cap(
+        &mut self,
+        record_cap: Option<usize>,
+    ) {
+        if let Some(cap) = record_cap
+            && cap < BATCH_SIZE
+        {
+            self.set_pack_ceiling(cap.max(1));
+            self.grow_pack_ceiling = true;
         }
     }
 
@@ -726,6 +761,9 @@ impl<'a, I: GatherItem> BatchedResultEmitter<'a, I> {
             }
             self.drain_pending_entry(&mut indices, &mut lanes, &mut count, should_expand);
         }
+        if self.grow_pack_ceiling {
+            self.pack_ceiling = self.pack_ceiling.saturating_mul(2).min(BATCH_SIZE);
+        }
         Ok(self.finish_batch(&indices, lanes, count, should_expand))
     }
 
@@ -763,5 +801,82 @@ where
     /// unchanged.
     pub(crate) const fn new_without_alias() -> Self {
         Self::with_binding(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hinted cap sizes the first batch and then doubles back to
+    /// [`BATCH_SIZE`], so a lowered ceiling can never pin the emitter to a tiny
+    /// batch for the whole scan.
+    ///
+    /// This is the property that makes the hint safe to apply at a leaf scan,
+    /// where a row-reducing operator downstream may discard everything the
+    /// small batch produced. Measured without it, `LIMIT 1` over a selective
+    /// one-hop cost 8.43G instructions against 91.5M with it — 92x.
+    #[test]
+    fn hinted_pack_ceiling_grows_back_to_batch_size() {
+        let mut e = BatchedResultEmitter::<NodeId>::new(0);
+        e.apply_hinted_record_cap(Some(10));
+        assert_eq!(e.pack_ceiling, 10, "first batch is sized to the hint");
+
+        // Each emit_lazy doubles the ceiling. Drive it directly: with no batch
+        // seeded, emit_lazy returns None but still advances the ceiling.
+        let mut seen = vec![e.pack_ceiling];
+        for _ in 0..12 {
+            let _ = e.emit_lazy(|_b, _row| Ok(None)).expect("no batch seeded");
+            seen.push(e.pack_ceiling);
+        }
+        assert_eq!(&seen[..5], &[10, 20, 40, 80, 160]);
+        assert_eq!(
+            e.pack_ceiling, BATCH_SIZE,
+            "ceiling saturates at BATCH_SIZE and never exceeds it"
+        );
+    }
+
+    /// A cap at or above a full batch is not a cap at all, and must not switch
+    /// on the growth bookkeeping.
+    #[test]
+    fn hinted_cap_at_or_above_batch_size_is_ignored() {
+        for cap in [BATCH_SIZE, BATCH_SIZE + 1, usize::MAX] {
+            let mut e = BatchedResultEmitter::<NodeId>::new(0);
+            e.apply_hinted_record_cap(Some(cap));
+            assert_eq!(e.pack_ceiling, BATCH_SIZE);
+            assert!(!e.grow_pack_ceiling, "cap {cap} should not enable growth");
+        }
+    }
+
+    /// `None` (no usable `Limit` ancestor) leaves the default ceiling.
+    #[test]
+    fn absent_hint_leaves_default_ceiling() {
+        let mut e = BatchedResultEmitter::<NodeId>::new(0);
+        e.apply_hinted_record_cap(None);
+        assert_eq!(e.pack_ceiling, BATCH_SIZE);
+        assert!(!e.grow_pack_ceiling);
+    }
+
+    /// `LIMIT 0` still has to run the operator — the downstream slicing op does
+    /// the final truncation — so the ceiling clamps to 1 rather than 0, which
+    /// would make `emit_lazy` spin without ever packing a row.
+    #[test]
+    fn zero_hint_clamps_to_one() {
+        let mut e = BatchedResultEmitter::<NodeId>::new(0);
+        e.apply_hinted_record_cap(Some(0));
+        assert_eq!(e.pack_ceiling, 1);
+        assert!(e.grow_pack_ceiling);
+    }
+
+    /// The non-growing [`apply_record_cap`] keeps its existing behaviour: it is
+    /// used where the budget really does bound the operator's own output.
+    #[test]
+    fn fixed_record_cap_does_not_grow() {
+        let mut e = BatchedResultEmitter::<NodeId>::new(0);
+        e.apply_record_cap(Some(10));
+        assert_eq!(e.pack_ceiling, 10);
+        assert!(!e.grow_pack_ceiling);
+        let _ = e.emit_lazy(|_b, _row| Ok(None)).expect("no batch seeded");
+        assert_eq!(e.pack_ceiling, 10, "fixed cap stays put");
     }
 }

--- a/graph/src/runtime/ops/edge_by_index_scan.rs
+++ b/graph/src/runtime/ops/edge_by_index_scan.rs
@@ -75,6 +75,11 @@ pub struct EdgeByIndexScanOp<'a> {
 }
 
 impl<'a> EdgeByIndexScanOp<'a> {
+    /// `record_cap` is the downstream `Skip`+`Limit` row budget, when one
+    /// reaches this scan. It sizes the first batch only: as a leaf, the budget
+    /// is a hint rather than a bound on this operator's own output, so the
+    /// ceiling grows back to `BATCH_SIZE` if that first small batch does not
+    /// satisfy the query. See `BatchedResultEmitter::apply_hinted_record_cap`.
     pub fn new(
         runtime: &'a Runtime<'a>,
         child: Box<BatchOp<'a>>,
@@ -82,21 +87,24 @@ impl<'a> EdgeByIndexScanOp<'a> {
         query: &'a IndexQuery<QueryExpr<Variable>>,
         transposed: bool,
         idx: NodeIdx<Dyn<IR>>,
+        record_cap: Option<usize>,
     ) -> Self {
         // Self-loop patterns like `MATCH (n)-[r:T]->(n)` share one alias on both
         // endpoints; bind it once (via `from`) and skip the `to` column so the
         // second insert can't overwrite the first.
         let to = (relationship_pattern.to.alias != relationship_pattern.from.alias)
             .then_some(relationship_pattern.to.alias.id);
+        let mut emitter = BatchedResultEmitter::with_binding(EdgeEndpoints {
+            from: relationship_pattern.from.alias.id,
+            to,
+            edge: relationship_pattern.alias.id,
+            transposed,
+        });
+        emitter.apply_hinted_record_cap(record_cap);
         Self {
             runtime,
             child,
-            emitter: BatchedResultEmitter::with_binding(EdgeEndpoints {
-                from: relationship_pattern.from.alias.id,
-                to,
-                edge: relationship_pattern.alias.id,
-                transposed,
-            }),
+            emitter,
             relationship_pattern,
             query,
             transposed,

--- a/graph/src/runtime/ops/node_by_index_scan.rs
+++ b/graph/src/runtime/ops/node_by_index_scan.rs
@@ -53,6 +53,11 @@ pub struct NodeByIndexScanOp<'a> {
 }
 
 impl<'a> NodeByIndexScanOp<'a> {
+    /// `record_cap` is the downstream `Skip`+`Limit` row budget, when one
+    /// reaches this scan. It sizes the first batch only: as a leaf, the budget
+    /// is a hint rather than a bound on this operator's own output, so the
+    /// ceiling grows back to `BATCH_SIZE` if that first small batch does not
+    /// satisfy the query. See `BatchedResultEmitter::apply_hinted_record_cap`.
     pub fn new(
         runtime: &'a Runtime<'a>,
         child: Box<BatchOp<'a>>,
@@ -60,7 +65,10 @@ impl<'a> NodeByIndexScanOp<'a> {
         index: &'a Arc<String>,
         query: &'a IndexQuery<QueryExpr<Variable>>,
         idx: NodeIdx<Dyn<IR>>,
+        record_cap: Option<usize>,
     ) -> Self {
+        let mut emitter = BatchedResultEmitter::new(node_pattern.alias.id);
+        emitter.apply_hinted_record_cap(record_cap);
         let extra_labels = if node_pattern.labels.len() > 1 {
             Some(node_pattern.labels.iter().skip(1).cloned().collect())
         } else {
@@ -73,7 +81,7 @@ impl<'a> NodeByIndexScanOp<'a> {
             index,
             query,
             extra_labels,
-            emitter: BatchedResultEmitter::new(node_pattern.alias.id),
+            emitter,
             idx,
         }
     }

--- a/graph/src/runtime/ops/node_by_label_and_id_scan.rs
+++ b/graph/src/runtime/ops/node_by_label_and_id_scan.rs
@@ -31,17 +31,25 @@ pub struct NodeByLabelAndIdScanOp<'a> {
 }
 
 impl<'a> NodeByLabelAndIdScanOp<'a> {
-    pub const fn new(
+    /// `record_cap` is the downstream `Skip`+`Limit` row budget, when one
+    /// reaches this scan. It sizes the first batch only: as a leaf, the budget
+    /// is a hint rather than a bound on this operator's own output, so the
+    /// ceiling grows back to `BATCH_SIZE` if that first small batch does not
+    /// satisfy the query. See `BatchedResultEmitter::apply_hinted_record_cap`.
+    pub fn new(
         runtime: &'a Runtime<'a>,
         child: Box<BatchOp<'a>>,
         node_pattern: &'a QueryNode<Arc<String>, Variable>,
         filter: &'a Vec<(QueryExpr<Variable>, ExprIR<Variable>)>,
         idx: NodeIdx<Dyn<IR>>,
+        record_cap: Option<usize>,
     ) -> Self {
+        let mut emitter = BatchedResultEmitter::new(node_pattern.alias.id);
+        emitter.apply_hinted_record_cap(record_cap);
         Self {
             runtime,
             child,
-            emitter: BatchedResultEmitter::new(node_pattern.alias.id),
+            emitter,
             node_pattern,
             filter,
             idx,

--- a/graph/src/runtime/ops/node_by_label_scan.rs
+++ b/graph/src/runtime/ops/node_by_label_scan.rs
@@ -46,16 +46,26 @@ pub struct NodeByLabelScanOp<'a> {
 }
 
 impl<'a> NodeByLabelScanOp<'a> {
-    pub const fn new(
+    /// `record_cap` is the downstream `Skip`+`Limit` row budget, when one
+    /// reaches this scan. It only sizes the *first* batch: the scan is a leaf,
+    /// so the budget is a hint rather than a bound on its own output — an
+    /// operator between it and the `Limit` may discard rows — and the ceiling
+    /// therefore grows back to `BATCH_SIZE` if the first small batch does not
+    /// satisfy the query. Without it, `... LIMIT 10` packs a full 1024-row
+    /// batch and throws away 99% of the work.
+    pub fn new(
         runtime: &'a Runtime<'a>,
         child: Box<BatchOp<'a>>,
         node_pattern: &'a QueryNode<Arc<String>, Variable>,
         idx: NodeIdx<Dyn<IR>>,
+        record_cap: Option<usize>,
     ) -> Self {
+        let mut emitter = BatchedResultEmitter::new(node_pattern.alias.id);
+        emitter.apply_hinted_record_cap(record_cap);
         Self {
             runtime,
             child,
-            emitter: BatchedResultEmitter::new(node_pattern.alias.id),
+            emitter,
             node_pattern,
             idx,
         }

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -919,6 +919,7 @@ impl<'a> Runtime<'a> {
             }
             IR::NodeByIndexScan { node, index, query } => {
                 let child = pop_or_once(&mut children);
+                let record_cap = self.record_cap(idx);
                 Ok(BatchOp::NodeByIndexScan(NodeByIndexScanOp::new(
                     self,
                     Box::new(child),
@@ -926,6 +927,7 @@ impl<'a> Runtime<'a> {
                     index,
                     query,
                     idx,
+                    record_cap,
                 )))
             }
             IR::EdgeByIndexScan {
@@ -934,6 +936,7 @@ impl<'a> Runtime<'a> {
                 transposed,
             } => {
                 let child = pop_or_once(&mut children);
+                let record_cap = self.record_cap(idx);
                 Ok(BatchOp::EdgeByIndexScan(EdgeByIndexScanOp::new(
                     self,
                     Box::new(child),
@@ -941,6 +944,7 @@ impl<'a> Runtime<'a> {
                     query,
                     *transposed,
                     idx,
+                    record_cap,
                 )))
             }
             IR::CartesianProduct => {
@@ -1182,12 +1186,14 @@ impl<'a> Runtime<'a> {
             }
             IR::NodeByLabelAndIdScan { node, filter } => {
                 let child = pop_or_once(&mut children);
+                let record_cap = self.record_cap(idx);
                 Ok(BatchOp::NodeByLabelAndIdScan(NodeByLabelAndIdScanOp::new(
                     self,
                     Box::new(child),
                     node,
                     filter,
                     idx,
+                    record_cap,
                 )))
             }
             IR::CondVarLenTraverse {

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -717,11 +717,13 @@ impl<'a> Runtime<'a> {
                     IR::AllNodeScan(n) => n,
                     _ => unreachable!(),
                 };
+                let record_cap = self.record_cap(idx);
                 Ok(BatchOp::NodeByLabelScan(NodeByLabelScanOp::new(
                     self,
                     Box::new(child),
                     node_pattern,
                     idx,
+                    record_cap,
                 )))
             }
             IR::IncludePending { node } => {


### PR DESCRIPTION
## What

Follow-up to #2757, which wired the downstream row budget into the
label/all-node scan only. The index scans use the same `BatchedResultEmitter`
and had the same defect, so this applies the same hinted (growing) ceiling to
`NodeByIndexScan`, `EdgeByIndexScan` and `NodeByLabelAndIdScan`.

**Stacked on #2757 — review and merge that one first.**

Same step-function signature, on an index-backed plan
(`MATCH (a:Person) WHERE a.id >= 0 RETURN id(a) LIMIT n`, index on
`:Person(id)`):

| query | instructions |
|---|---:|
| `index scan LIMIT 1` | 1,286,488 |
| `index scan LIMIT 1000` | 1,738,712 |
| `index scan LIMIT 1024` | 1,732,327 |
| `index scan LIMIT 2048` | 3,360,963 |

I had assumed the ~1.1M floor on `LIMIT 1` was fixed index-query setup cost.
It was not — `get_indexed_nodes` is already a lazy iterator, and that 1.1M was
batch packing. Hence the win is larger here than for the plain scan.

## Results

| query | before | after | speedup |
|---|---:|---:|---:|
| `index scan LIMIT 1` | 1,286,488 | 237,947 | **5.41x** |
| `index scan LIMIT 10` | 1,258,987 | 254,249 | **4.95x** |
| `index scan LIMIT 1000` | 1,738,712 | 1,746,761 | 1.00x |
| `index scan LIMIT 1024` | 1,732,327 | 1,741,837 | 1.00x |
| `index scan LIMIT 2048` | 3,360,963 | 3,366,096 | 1.00x |
| floor (`RETURN 1`) | 160,411 | 174,220 | 1.00x |

The geometric ceiling growth from #2757 bounds the selective-downstream case
here exactly as it does for the label scan, so an index scan whose rows are
discarded downstream degrades to at most 2x the ideal packed rows.

## Testing

- `cargo test -p graph`: 192 passed, 0 failed.
- TCK: 173 features / **2,456 scenarios passed, 0 failed**.
- `test_e2e` + `test_functions` + `test_mvcc` + `test_concurrency`: 138 passed.
- `cargo fmt --check` clean; `clippy --all-targets` adds no new warnings.
- Flow: 1,460+ passing, **0 failures**, but see below.

## A pre-existing deadlock this surfaced

Full-suite flow runs on this branch stalled three times (at different points:
1,463 / 1,386 / 1,440 tests in). No test failed; the run simply stopped making
progress. `sample` on the stuck servers shows the same pair of stacks every
time, in the same process:

```
A: populate_index_batch -> Indexer::commit -> RediSearch_IndexAddDocument
                        -> RediSearch_LockWrite              [blocked]

B: process_write_queued_query -> execute_query_write -> Runtime::query
                        -> CommitOp::next
                        -> Pending::commit_deferred_indexes
                        -> Graph::commit_edge_index
                        -> parking_lot RawMutex::lock_slow    [blocked]

main thread: aeProcessEvents -> afterSleep -> pthread_mutex_lock  [blocked on the GIL]
```

That is a lock-order inversion between the RediSearch write lock and the indexer
mutex — an index being populated in the background while a write query commits a
deferred edge index. Because the module GIL is held, `PING` also stops answering
(I confirmed a 120s `redis-cli ping` timeout), so this is a full server hang, not
just a stuck query. It is the class of bug `graph/src/locks.rs:7-16` warns about
("global -> per-graph -> indexer", noting an inversion once deadlocked the server
for six hours, #726).

**Nothing in this PR touches indexer locking, RediSearch, or
`commit_deferred_indexes`** — it only changes how many rows a scan packs into its
first batch. The plausible mechanism is that more, smaller batches change the
interleaving and widen an existing window. What I have established so far:

- `test_index_updates` (including `test11_failed_write_during_index_population`,
  the test whose workload matches the stacks) passes 3/3 in isolation on **both**
  this branch and `main`.
- A targeted concurrent repro — 4 writer threads creating edges while node and
  edge indexes are repeatedly created and dropped over 20k nodes — survives 12
  rounds on this branch without deadlocking.
- The stall points differ between runs, which is the signature of a race rather
  than a deterministic consequence of this change.
- #2757's own full-suite run completed 1,481/1,481.

## Attribution is settled: this PR triggers it

I did not want to guess, so I ran the full flow suite repeatedly on each variant
(the flaky `test_replication_states` excluded from all of them so it could not
confound the result; it passes standalone in 36s):

| build | full-suite runs completed |
|---|---|
| `main`, unmodified | **4 / 4** |
| #2757 alone (label + all-node scan hint) | **4 / 4** — 1,480/1,480, 0 failures |
| this PR (node + edge index scan hint) | **0 / 3** — stalled at 1,463 / 1,386 / 1,440 |
| this PR narrowed to the *node* index scans only | **0 / 2** — stalled at 1,393 / 1,389 |

So it is the index-scan path specifically, not the edge scan alone, and not the
plain-scan hint in #2757. Narrowing to `NodeByIndexScan` +
`NodeByLabelAndIdScan` and leaving `EdgeByIndexScan` untouched still stalls
(branch `perf/limit-aware-node-index-scan-batching`, kept for the record).

What that does *not* mean is that this PR contains the bug. The lock inversion
is in code this PR does not touch; what the change does is produce more, smaller
batches from an index scan, which evidently widens an existing window enough to
hit it reliably. The supporting evidence:

- `test_index_updates` — including `test11_failed_write_during_index_population`,
  whose workload matches the stacks exactly — passes 3/3 in isolation on **both**
  this branch and `main`.
- A targeted concurrent repro (4 writer threads creating edges while node and
  edge indexes are repeatedly created and dropped over 20k nodes) survives 12
  rounds here without deadlocking, so the trigger needs the suite's broader
  parallel load.
- The stall point differs every run, which is a race signature rather than a
  deterministic fault.

## Why this is a draft

An engine that can hang the whole server should not merge on a "probably
pre-existing" argument, so this stays a draft until the inversion is understood
and fixed. #2757 carries the bulk of the benefit, is independently validated at
4/4, and does not need this.

The deadlock is worth its own issue regardless of what happens to this PR — it
is reachable on `main` by any workload that populates an index while a write
commits a deferred edge index, and this branch is a reliable way to reproduce it.

Repro: check out this branch, `cargo build --release`, then
`RELEASE=1 VERBOSE=0 ./flow.sh`; it stalls within ~1,400 tests. `sample` any
server left at 0% CPU to see the two stacks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
