### PR TITLE
fix: validate grouped projections and isolate aggregate slots

### DIFF
--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -1144,6 +1144,30 @@ impl Binder {
             })
             .collect();
 
+        // Aggregate outputs run against the grouped row, whose slots belong
+        // to projection aliases rather than the input expressions. Resolve
+        // reads of recognized grouping keys to those slots, and reject input
+        // variables that would otherwise silently evaluate to null.
+        let has_aggregation = projected.iter().any(|(_, expr)| expr.is_aggregation());
+        if has_aggregation {
+            let grouped_slots: HashMap<AggregationKey, Variable> = projected
+                .iter()
+                .filter(|(_, expr)| !expr.is_aggregation())
+                .filter_map(|(alias, expr)| {
+                    AggregationKey::from_node(&expr.root()).map(|key| (key, alias.clone()))
+                })
+                .collect();
+            for (_, expr) in &mut projected {
+                if expr.is_aggregation() {
+                    *expr = Arc::new(resolve_aggregate_output(
+                        &expr.root(),
+                        &grouped_slots,
+                        &mut Vec::new(),
+                    )?);
+                }
+            }
+        }
+
         // When an ORDER BY expression (or a sub-expression within it) is an
         // aggregation that matches a projected aggregation, rewrite it to
         // reference the projected alias before binding.
@@ -1180,7 +1204,6 @@ impl Binder {
         // e.g. WITH count(X) AS cnt ORDER BY X  — X is not projected
         // But ORDER BY t.v is fine when RETURN t.v, count(t.v) — t is
         // used in the group-by key expression t.v.
-        let has_aggregation = projected.iter().any(|(_, e)| e.is_aggregation());
         if has_aggregation {
             let has_disallowed = self
                 .copy_from_parent
@@ -2518,6 +2541,87 @@ fn rewrite_compiled_regex(
         }),
         children,
     )
+}
+
+#[derive(Eq, Hash, PartialEq)]
+enum AggregationKey {
+    Variable(u32, u32),
+    Property(u32, u32, Arc<String>),
+}
+
+impl AggregationKey {
+    /// CIP2021-07-07 recognizes variables and direct property/static map
+    /// access on variables. A computed key or a whole property chain is not
+    /// itself recognized, although it may be derived from a recognized key.
+    fn from_node(node: &DynNode<ExprIR<Variable>>) -> Option<Self> {
+        match node.data() {
+            ExprIR::Variable(var) => Some(Self::Variable(var.scope_id, var.id)),
+            ExprIR::Paren if node.num_children() == 1 => Self::from_node(&node.child(0)),
+            ExprIR::Property(property) if node.num_children() == 1 => {
+                match Self::from_node(&node.child(0)) {
+                    Some(Self::Variable(scope_id, id)) => {
+                        Some(Self::Property(scope_id, id, property.clone()))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+fn resolve_aggregate_output(
+    node: &DynNode<ExprIR<Variable>>,
+    grouped_slots: &HashMap<AggregationKey, Variable>,
+    locals: &mut Vec<(u32, u32)>,
+) -> Result<DynTree<ExprIR<Variable>>, String> {
+    match node.data() {
+        // Aggregate arguments and their result placeholders use input-row
+        // bindings. Rewriting those would change what gets aggregated.
+        ExprIR::FuncInvocation(function) if function.is_aggregate() => {
+            return Ok(node.clone_as_tree());
+        }
+        // The planner extracts these into Apply subplans before aggregation;
+        // they do not evaluate against the grouped output row.
+        ExprIR::PatternComprehension(_) => return Ok(node.clone_as_tree()),
+        _ => {}
+    }
+
+    if let Some(key) = AggregationKey::from_node(node)
+        && let Some(alias) = grouped_slots.get(&key)
+    {
+        return Ok(tree!(ExprIR::Variable(alias.clone())));
+    }
+
+    if let ExprIR::Variable(var) = node.data()
+        && !locals.contains(&(var.scope_id, var.id))
+    {
+        return Err(format!(
+            "Invalid aggregation: variable `{var}` must be a grouping key or used inside an aggregate function"
+        ));
+    }
+
+    // Recursive composition matters: grouping `n` permits `n.prop`, and
+    // grouping `m.inner` permits `m.inner.value`. A failed whole-expression
+    // key lookup must not reject these derivations before visiting children.
+    let mut resolved = DynTree::new(node.data().clone());
+    for (index, child) in node.children().enumerate() {
+        let outer_len = locals.len();
+        match node.data() {
+            ExprIR::ListComprehension(var) | ExprIR::Quantifier { var, .. } if index > 0 => {
+                locals.push((var.scope_id, var.id));
+            }
+            ExprIR::Reduce(vars) if index == 2 => {
+                locals.push((vars.accumulator.scope_id, vars.accumulator.id));
+                locals.push((vars.iterator.scope_id, vars.iterator.id));
+            }
+            _ => {}
+        }
+        let subtree = resolve_aggregate_output(&child, grouped_slots, locals)?;
+        locals.truncate(outer_len);
+        resolved.root_mut().push_child_tree(subtree);
+    }
+    Ok(resolved)
 }
 
 /// Recursively walk an ORDER BY expression tree and replace any aggregation

--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -41,7 +41,7 @@ use crate::runtime::{
     vector_expr::VectorEval,
 };
 use ahash::RandomState;
-use orx_tree::{Dyn, DynNode, DynTree, NodeIdx, NodeRef};
+use orx_tree::{Dfs, Dyn, DynNode, DynTree, NodeIdx, NodeRef};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -173,7 +173,7 @@ pub struct AggregateOp<'a> {
     pub(crate) runtime: &'a Runtime<'a>,
     pub(crate) child: Option<Box<BatchOp<'a>>>,
     keys: &'a [(Variable, QueryExpr<Variable>)],
-    agg: &'a [(Variable, QueryExpr<Variable>)],
+    agg: Vec<(Variable, QueryExpr<Variable>)>,
     copy_from_parent: &'a [(Variable, Variable)],
     default_acc: Option<Row>,
     errors: std::vec::IntoIter<String>,
@@ -192,8 +192,41 @@ impl<'a> AggregateOp<'a> {
         copy_from_parent: &'a [(Variable, Variable)],
         idx: NodeIdx<Dyn<IR>>,
     ) -> Self {
+        // Row indexes by id alone. Input-scope accumulators and expression
+        // locals can reuse output-key ids, so give these private temporaries
+        // slots above every binding this operator reads or writes.
+        let mut next_slot = 0;
+        for (name, tree) in keys.iter().chain(agg) {
+            next_slot = next_slot.max(name.id + 1);
+            for idx in tree.root().indices::<Dfs>() {
+                let id = match tree.node(idx).data() {
+                    ExprIR::Variable(var)
+                    | ExprIR::ListComprehension(var)
+                    | ExprIR::Quantifier { var, .. } => var.id,
+                    ExprIR::Reduce(vars) => vars.accumulator.id.max(vars.iterator.id),
+                    _ => 0,
+                };
+                next_slot = next_slot.max(id + 1);
+            }
+        }
+        for (a, b) in copy_from_parent {
+            next_slot = next_slot.max(a.id.max(b.id) + 1);
+        }
+        let agg: Vec<_> = agg
+            .iter()
+            .map(|(name, tree)| {
+                (
+                    name.clone(),
+                    Arc::new(isolate_aggregate_slots(
+                        &tree.root(),
+                        &mut next_slot,
+                        &mut Vec::new(),
+                    )),
+                )
+            })
+            .collect();
         let mut default_acc = Row::new();
-        for (_var, t) in agg {
+        for (_var, t) in &agg {
             Self::set_agg_expr_zero(&t.root(), &mut default_acc);
         }
 
@@ -243,7 +276,7 @@ impl<'a> AggregateOp<'a> {
         }
 
         let mut agg_kinds = Vec::with_capacity(self.agg.len());
-        for (_target, tree) in self.agg {
+        for (_target, tree) in &self.agg {
             {
                 let agg = Self::analyze_agg_tree(tree)?;
                 agg_kinds.push(agg);
@@ -405,7 +438,7 @@ impl<'a> AggregateOp<'a> {
                 Self::consume_batch_per_row(
                     self.runtime,
                     self.keys,
-                    self.agg,
+                    &self.agg,
                     self.copy_from_parent,
                     &batch,
                     &default_acc,
@@ -700,7 +733,7 @@ impl<'a> AggregateOp<'a> {
             Self::consume_batch_per_row(
                 self.runtime,
                 self.keys,
-                self.agg,
+                &self.agg,
                 self.copy_from_parent,
                 &batch,
                 &default_acc,
@@ -951,20 +984,14 @@ impl<'a> Iterator for AggregateOp<'a> {
                 break;
             };
             match (|| {
-                // Build a combined env with key values at both post-projection
-                // (name) and pre-projection (original_var) IDs, plus all
-                // accumulator values.  Acc values take precedence on collision.
+                // The binder resolves key reads to post-projection aliases.
+                // Original input ids must not be copied here: they can alias
+                // another projected key when the projection reorders inputs.
+                // Private accumulator slots are disjoint from all key slots.
                 let mut combined = key.clone();
-                for (name, tree) in self.keys {
-                    if let ExprIR::Variable(original_var) = tree.root().data()
-                        && let Some(value) = key.get(name)
-                    {
-                        combined.insert(original_var, value.clone());
-                    }
-                }
                 combined.merge(&acc);
                 let mut agg_outputs: Vec<(&Variable, Value)> = Vec::with_capacity(self.agg.len());
-                for (name, tree) in self.agg {
+                for (name, tree) in &self.agg {
                     let val = {
                         let this = &self.runtime;
                         let idx = tree.root().idx();
@@ -976,8 +1003,6 @@ impl<'a> Iterator for AggregateOp<'a> {
                             None,
                         )
                     }?;
-                    acc.insert(name, val.clone());
-                    combined.insert(name, val.clone());
                     agg_outputs.push((name, val));
                 }
                 // Insert pre-projection key variable values into acc so
@@ -999,15 +1024,13 @@ impl<'a> Iterator for AggregateOp<'a> {
                 // Unbind internal accumulator variables so they don't leak
                 // to downstream operators and collide with variables in
                 // subsequent scopes that reuse the same slot IDs.
-                for (_, tree) in self.agg {
+                for (_, tree) in &self.agg {
                     unbind_agg_accumulators(&tree.root(), &mut acc);
                 }
-                // Re-bind aggregate output names last: an accumulator slot id
-                // can coincide with another aggregate's output name (the binder
-                // may reuse slot IDs), and the unbind above would otherwise
-                // clear that output. Output bindings must win. This also matters
-                // for keyless empty-input groups where the output value is Null,
-                // since an unbound Null slot is dropped during columnar finish.
+                // Bind finalized outputs after assembling keys/copies and
+                // removing private accumulators. Keep explicit Null bindings
+                // for keyless empty-input groups: columnar finish drops an
+                // unbound Null slot.
                 for (name, val) in agg_outputs {
                     acc.insert(name, val);
                 }
@@ -1029,6 +1052,80 @@ impl<'a> Iterator for AggregateOp<'a> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Reassigns only temporaries used while evaluating an aggregate output.
+/// Aggregate arguments and grouping expressions still read the input row.
+fn isolate_aggregate_slots(
+    node: &DynNode<ExprIR<Variable>>,
+    next_slot: &mut u32,
+    locals: &mut Vec<(Variable, Variable)>,
+) -> DynTree<ExprIR<Variable>> {
+    if matches!(node.data(), ExprIR::PatternComprehension(_)) {
+        return node.clone_as_tree();
+    }
+    let allocate = |var: &Variable, next: &mut u32| {
+        let mut isolated = var.clone();
+        isolated.id = *next;
+        *next += 1;
+        isolated
+    };
+    if let ExprIR::FuncInvocation(function) = node.data()
+        && function.is_aggregate()
+    {
+        let mut result = DynTree::new(node.data().clone());
+        for (index, child) in node.children().enumerate() {
+            let subtree = if index + 1 == node.num_children()
+                && let ExprIR::Variable(accumulator) = child.data()
+            {
+                DynTree::new(ExprIR::Variable(allocate(accumulator, next_slot)))
+            } else {
+                child.clone_as_tree()
+            };
+            result.root_mut().push_child_tree(subtree);
+        }
+        return result;
+    }
+    if let ExprIR::Variable(var) = node.data()
+        && let Some((_, isolated)) = locals
+            .iter()
+            .rev()
+            .find(|(local, _)| local.id == var.id && local.scope_id == var.scope_id)
+    {
+        return DynTree::new(ExprIR::Variable(isolated.clone()));
+    }
+
+    let mut data = node.data().clone();
+    let mut introduced = Vec::new();
+    let body_start = match &mut data {
+        ExprIR::ListComprehension(var) | ExprIR::Quantifier { var, .. } => {
+            let isolated = allocate(var, next_slot);
+            introduced.push((var.clone(), isolated.clone()));
+            *var = isolated;
+            1
+        }
+        ExprIR::Reduce(vars) => {
+            let accumulator = allocate(&vars.accumulator, next_slot);
+            introduced.push((vars.accumulator.clone(), accumulator.clone()));
+            vars.accumulator = accumulator;
+            let iterator = allocate(&vars.iterator, next_slot);
+            introduced.push((vars.iterator.clone(), iterator.clone()));
+            vars.iterator = iterator;
+            2
+        }
+        _ => usize::MAX,
+    };
+    let mut result = DynTree::new(data);
+    for (index, child) in node.children().enumerate() {
+        let outer_len = locals.len();
+        if index >= body_start {
+            locals.extend(introduced.iter().cloned());
+        }
+        let subtree = isolate_aggregate_slots(&child, next_slot, locals);
+        locals.truncate(outer_len);
+        result.root_mut().push_child_tree(subtree);
+    }
+    result
+}
 
 /// Recursively walks an expression tree and unbinds each aggregate function's
 /// accumulator variable from the environment. This mirrors the recursion in

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -121,6 +121,108 @@ def assert_float_equal(f1, f2):
     assert abs(f1 - f2) < 1e-10, f"Expected {f1} to be close to {f2}"
 
 
+@pytest.mark.parametrize(
+    "statement",
+    [
+        pytest.param("MATCH (p) RETURN p.value + count(p)", id="property"),
+        pytest.param("MATCH (p) WITH p.value + count(p) AS total RETURN total", id="with"),
+        pytest.param("MATCH (p) RETURN p.value, p.other + count(p)", id="different-property"),
+        pytest.param("WITH 0 AS position RETURN collect(1)[position]", id="input-index"),
+        pytest.param("MATCH (_p) RETURN _p.value + count(_p)", id="underscore-property"),
+        pytest.param("UNWIND [2, 3] AS _v RETURN _v + count(*)", id="underscore-variable"),
+        pytest.param("WITH {inner: {value: 7}} AS m RETURN m.inner.value, m.inner.value + count(*)", id="nested-key"),
+        pytest.param("MATCH (p) RETURN p.value + 1, p.value + 1 + count(*)", id="computed-key"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) + size([v IN [1] | v + n])", id="list-capture"),
+        pytest.param("WITH [2, 3] AS v RETURN count(*) + size([v IN v | v])", id="list-shadow-input"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) + reduce(s = n, v IN [1] | s + v)", id="reduce-initial"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) + reduce(s = 0, v IN [1] | s + n)", id="reduce-capture"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) > 0 AND any(v IN [1] WHERE v < n)", id="quantifier-capture"),
+        pytest.param("MATCH (p) RETURN {value: p.value, total: count(*)}", id="map-value-capture"),
+        pytest.param("MATCH (p) RETURN CASE WHEN count(*) > 0 THEN p.value ELSE 0 END", id="case-capture"),
+        pytest.param("WITH {value: 7} AS m RETURN m.value, m['value'] + count(*)", id="dynamic-access-not-static-key"),
+    ],
+)
+def test_aggregate_projection_rejects_implicit_keys(statement):
+    common.g.query("CREATE (:Group {value: 4, other: 1}), (:Group {value: 4, other: 3})")
+    for execute in (common.g.query, common.g.ro_query):
+        with pytest.raises(ResponseError, match="Invalid aggregation"):
+            execute(statement)
+
+
+@pytest.mark.parametrize(
+    "statement, expected",
+    [
+        pytest.param("MATCH (p) RETURN count(p) + 3", [[5]], id="constant"),
+        pytest.param("MATCH (p) RETURN count(p) + $offset", [[5]], id="parameter"),
+        pytest.param("MATCH (p) RETURN max(p.value) - min(p.other)", [[3]], id="aggregate-operands"),
+        pytest.param("MATCH (p) RETURN p.value AS value, p.value + count(p)", [[4, 6]], id="property-alias"),
+        pytest.param("MATCH (p) RETURN p.value + count(p), p.value AS value", [[6, 4]], id="key-after-aggregate"),
+        pytest.param("MATCH (p) RETURN (p.value) AS value, (p).value + count(p)", [[4, 6]], id="parenthesized-key"),
+        pytest.param("MATCH (p) RETURN p.value, {value: p.value, total: count(*)}", [[4, {"value": 4, "total": 2}]], id="map-value-key"),
+        pytest.param("MATCH (p) RETURN p.value, CASE WHEN count(*) > 0 THEN p.value + count(*) ELSE 0 END", [[4, 6]], id="case-key"),
+        pytest.param("MATCH (p) WITH p.value AS value, count(p) AS total RETURN value + total", [[6]], id="separate-scope"),
+        pytest.param("MATCH (_p) RETURN _p.value AS value, _p.value + count(*)", [[4, 6]], id="underscore-key"),
+        pytest.param("WITH {inner: {value: 7}} AS m RETURN m, m.inner.value + count(*)", [[{"inner": {"value": 7}}, 8]], id="map-base"),
+        pytest.param("WITH {inner: {value: 7}} AS m RETURN m.inner, m.inner.value + count(*)", [[{"value": 7}, 8]], id="map-prefix"),
+        pytest.param("WITH {value: 7} AS m RETURN m, m['value'] + count(*)", [[{"value": 7}, 8]], id="dynamic-access-grouped-map"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) + size([v IN collect(n) | v * 2])", [[4]], id="list-aggregate-input"),
+        pytest.param("WITH [2, 3] AS v RETURN v, count(*) + size([v IN v | v])", [[[2, 3], 3]], id="list-shadow-key"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) + reduce(s = 0, v IN [2, 3] | s + v)", [[7]], id="reduce-locals"),
+        pytest.param("MATCH (p) RETURN p.value AS k, count(*) + reduce(s = 0, v IN [1] | s + p.value)", [[4, 6]], id="reduce-captured-key"),
+        pytest.param("MATCH (p) RETURN p.value AS k, count(*) + [v IN [1] | v + p.value][0]", [[4, 7]], id="list-captured-key"),
+        pytest.param("UNWIND [2, 3] AS n RETURN count(*) > 0 AND any(v IN [2, 3] WHERE v > 2)", [[True]], id="quantifier-local"),
+        pytest.param("WITH 0 AS position RETURN position, collect(9)[position]", [[0, 9]], id="grouped-index"),
+        pytest.param("MATCH (p) RETURN count(p) + p.value, sum(p.other) + p.value, p.value AS key", [[6, 8, 4]], id="multiple-aggregates-key-last"),
+        pytest.param("MATCH (p) WITH p.value AS k, 9 AS pad, count(p) AS c, sum(p.other) AS s RETURN k, pad, c, s", [[4, 9, 2, 4]], id="multiple-aggregates-with"),
+        pytest.param("UNWIND [[2, 7], [2, 7]] AS pair WITH pair[0] AS left, pair[1] AS right RETURN right, left, count(*) + left - right", [[7, 2, -3]], id="reordered-variable-keys"),
+        pytest.param("MATCH (p) RETURN 0 AS pad1, 1 AS pad2, p.value AS key, count(*) + [v IN [1] | v + p.value][0]", [[0, 1, 4, 7]], id="local-slot-isolation"),
+        pytest.param("MATCH (p) RETURN 0 AS pad1, 1 AS pad2, p.value AS key, count(*) + reduce(s = 0, v IN [1] | s + v + p.value)", [[0, 1, 4, 7]], id="reduce-slot-isolation"),
+        pytest.param("MATCH (p) WITH count(p) AS amount, p.value AS k WHERE p.value = 4 RETURN k, amount", [[4, 2]], id="with-parent-copy"),
+        pytest.param("MATCH (p) RETURN count(p) AS amount, p.value AS k ORDER BY p.value", [[2, 4]], id="orderby-parent-copy"),
+        pytest.param("MATCH (p:Absent) RETURN count(p) + 3, max(p.value)", [[3, None]], id="empty-multiple-aggregates"),
+        pytest.param("MATCH (p) RETURN count(distinct p.value) + p.value, collect(distinct p.value), p.value", [[5, [4], 4]], id="distinct-slots"),
+        pytest.param("UNWIND [1, 2] AS n CALL { WITH n MATCH (p:Group) RETURN p.value AS k, n AS copied, count(p) + p.value + n AS total } RETURN n, k, total ORDER BY n", [[1, 4, 7], [2, 4, 8]], id="correlated-aggregate"),
+    ],
+)
+def test_aggregate_projection_valid_composition(statement, expected):
+    common.g.query("CREATE (:Group {value: 4, other: 1}), (:Group {value: 4, other: 3})")
+    assert query(statement, params={"offset": 3}).result_set == expected
+
+
+@pytest.mark.parametrize("projection", ["p", "*"], ids=["explicit", "wildcard"])
+def test_aggregate_projection_grouped_entity(projection):
+    common.g.query("CREATE (:Group {value: 4}), (:Group {value: 7})")
+    statement = f"MATCH (p) RETURN {projection}, p.value + count(p)"
+    snapshots = []
+    for execute in (common.g.query, common.g.ro_query):
+        result = execute(statement).result_set
+        assert len(result) == 2
+        nodes = {}
+        for row in result:
+            assert len(row) == 2
+            node, value = row
+            assert isinstance(node, Node)
+            nodes[node.id] = (sorted(node.labels), node.properties, value)
+        assert len(nodes) == 2
+        assert sorted(nodes.values(), key=lambda row: row[1]["value"]) == [
+            (["Group"], {"value": 4}, 5),
+            (["Group"], {"value": 7}, 8),
+        ]
+        snapshots.append(nodes)
+    # No ORDER BY is requested, so compare both APIs by node identity rather
+    # than assuming their hash-aggregation output has the same row order.
+    assert snapshots[0] == snapshots[1]
+
+
+def test_aggregate_projection_rejects_before_execution():
+    common.g.query("RETURN 1")
+    statement = "MATCH (p) RETURN p.value + count(p)"
+    with pytest.raises(ResponseError, match="Invalid aggregation"):
+        common.g.query(statement)
+    with pytest.raises(ResponseError, match="Invalid aggregation"):
+        common.g.execute_command("GRAPH.EXPLAIN", common.g.name, statement)
+
+
 def test_return_values():
     res = query("RETURN null")
     assert res.result_set == [[None]]
@@ -1873,4 +1975,3 @@ def test_optional_match_null_merge():
         [10, [1]],
         [None, [2]],
     ]
-


### PR DESCRIPTION
`MATCH (p) RETURN p.value + count(p)` can silently return null because an ungrouped input property is read after aggregation. This change rejects those reads in RETURN/WITH, resolves recognized grouping keys to their output bindings, and keeps aggregate operands in the input scope. Private accumulator and post-aggregation local slots prevent collisions with projected keys, including when a grouping key appears after the aggregate expression.

Fixes #1451. Related to #2286 and the overlapping open PR #2393. This alternative uses direct variable/property keys with recursive validation: expressions derived from a grouped whole entity or map prefix remain valid, ordinary underscore-prefixed variables receive normal checks, and nested property chains are not automatically recognized as grouping keys. Those distinctions follow CIP2021-07-07. Comparison with #2393 is based on source review; its full branch was not runtime-tested here.

The 49 new cases cover invalid implicit keys, valid aliases and grouped entities, projection order, multiple accumulators, CASE/maps, lexical locals and captured keys, DISTINCT, correlated subqueries, parent copies, and rejection through GRAPH.EXPLAIN on an empty graph. Entity results are checked independently through GRAPH.QUERY and GRAPH.RO_QUERY without assuming row order.

Actual validation of product commit `165d1ae12d3afd2984e8be258fe0c2a0c90d168f`: [successful CI run](https://github.com/sen-ye/FalkorDB/actions/runs/34308275280).

- Same regression tests plus CRUD: original binder/runtime **32 failed, 18 passed**; candidate **50 passed**. The original reported case fails specifically because the expected ResponseError was not raised.
- Ordinary Python e2e/functions: **172 passed, 1 skipped**. The skip is the existing `test_load_csv` EXISTING_ENV guard.
- Existing aggregation, WITH, CALL subquery and comprehension flow suites: **101 passed on the original and 101 on the candidate**.
- Rust graph unit tests: **187 passed, 16 ignored**; doctests **2 passed, 2 ignored**.
- Formatting and Clippy completed successfully. Clippy reports four warnings in untouched files; baseline Clippy was not measured.

The CI workflow verifies the product files against the separate business commit and restores both production files for the baseline. Its workflow/scripts are on a separate verification branch and are not part of this PR.

Pattern comprehensions retain their existing pre-aggregation subplan treatment. This is not a complete TCK, performance, or cross-platform conformance claim. Implementation, test design and source review used OpenAI Codex assistance; no human review is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped aggregation projections so aggregate results correctly reference projected grouping keys.
  * Added validation for invalid aggregation expressions that mix aggregate outputs with non-grouped variable references.
  * Corrected handling of nested aggregate expressions, including list comprehensions, quantifiers, and reductions.
  * Aggregate projection validation now occurs before query execution, providing earlier feedback for unsupported queries.
  * Improved support for grouped entity projections and valid combinations of aggregate and non-aggregate expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->