### PR TITLE
perf(aggregate): evaluate computed GROUP BY keys columnarly

### DIFF
--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -21,13 +21,14 @@
 //!
 //! Key and aggregation-input expressions are evaluated in bulk: a variable
 //! passthrough or `entity.property` is a single bulk attribute read, and any
-//! other input tree (`sum(n.age * 3)`) goes through
+//! other tree — a key (`WITH n.id % 100 AS bucket`) or an input
+//! (`sum(n.age * 3)`) alike — goes through
 //! [`VectorEval`](crate::runtime::vector_expr::VectorEval), which evaluates it
 //! column at a time. This includes single-argument `DISTINCT` aggregations
 //! (e.g. `count(DISTINCT n.id)`): the property column is still extracted in
-//! bulk and per-group deduplication is applied during accumulation. Inputs
-//! containing a nested aggregate, and multi-argument aggregations, still fall
-//! back to per-row evaluation.
+//! bulk and per-group deduplication is applied during accumulation. Keys and
+//! inputs containing a nested aggregate, and multi-argument aggregations, still
+//! fall back to per-row evaluation.
 
 use crate::parser::ast::{ExprIR, QueryExpr, Variable};
 use crate::planner::IR;
@@ -99,6 +100,18 @@ enum KeyExprKind {
     Variable(Variable),
     /// Property access: `GROUP BY n.age`
     Property { var: Variable, attr: Arc<String> },
+    /// Any other key expression: `GROUP BY n.id % 100`, `GROUP BY toUpper(n.name)`,
+    /// `GROUP BY CASE ... END`.
+    ///
+    /// Built by [`VectorEval`], the same evaluator [`AggInputKind::Computed`]
+    /// uses, so the key tree is evaluated column at a time. Before this variant
+    /// existed a key of any other shape made [`AggregateOp::analyze`] give up on
+    /// the *whole operator*: not just the key, but the bulk aggregate-input
+    /// extraction and the columnar accumulate loop with it, rebuilding a full
+    /// owned `Row` per row and re-walking every key and aggregate tree on it.
+    /// A computed grouping key is ordinary Cypher (`WITH n.id % 100 AS bucket,
+    /// count(*)`), so that was the common shape paying the slowest path.
+    Computed(QueryExpr<Variable>),
 }
 
 /// How an aggregation input expression can be evaluated in bulk.
@@ -225,20 +238,21 @@ impl<'a> AggregateOp<'a> {
                 ExprIR::Variable(var) => {
                     key_kinds.push(KeyExprKind::Variable(var.clone()));
                 }
-                ExprIR::Property(attr) => {
-                    if root.num_children() != 1 {
-                        return None;
-                    }
+                ExprIR::Property(attr) if root.num_children() == 1 => {
                     if let ExprIR::Variable(var) = root.child(0).data() {
                         key_kinds.push(KeyExprKind::Property {
                             var: var.clone(),
                             attr: attr.clone(),
                         });
                     } else {
-                        return None;
+                        key_kinds.push(KeyExprKind::Computed(tree.clone()));
                     }
                 }
-                _ => return None,
+                // A nested aggregate still falls back: it needs the per-row
+                // path's group-aware evaluation, the same reason
+                // `analyze_agg_tree` refuses one in an aggregate input.
+                _ if subtree_has_aggregate(&root) => return None,
+                _ => key_kinds.push(KeyExprKind::Computed(tree.clone())),
             }
         }
 
@@ -598,6 +612,14 @@ impl<'a> AggregateOp<'a> {
     }
 
     /// Extracts key values for all active rows in a batch.
+    ///
+    /// `Err(())` means "this batch cannot take the bulk path", not "the query
+    /// failed" — the caller replays the batch through
+    /// [`consume_batch_per_row`](Self::consume_batch_per_row). A
+    /// [`KeyExprKind::Computed`] evaluation error takes that same exit rather
+    /// than being reported here, so the error a failing key raises is still the
+    /// one the per-row evaluator produces, in its order, for the row that
+    /// produces it.
     fn extract_key_columns(
         runtime: &'a Runtime<'a>,
         batch: &Batch<'a>,
@@ -622,6 +644,17 @@ impl<'a> AggregateOp<'a> {
                     // int/float column, merging 9007199254740993 and
                     // 9007199254740992 into one group.
                     key_columns.push(runtime.materialize_node_property_values(&active_ids, attr));
+                }
+                KeyExprKind::Computed(tree) => {
+                    // `eval_values` hands back the exact `Value`s the scalar
+                    // evaluator would produce — its typed lanes are built by
+                    // `classify_exact_column`, which leaves a mixed int/float
+                    // column as `Values` rather than rounding it into `f64` —
+                    // so grouping compares the same keys either way.
+                    let col = VectorEval::new(runtime)
+                        .eval_values(&tree.root(), batch, active)
+                        .map_err(|_| ())?;
+                    key_columns.push(col);
                 }
             }
         }

--- a/tests/flow/test_aggregation.py
+++ b/tests/flow/test_aggregation.py
@@ -314,3 +314,83 @@ class testAggregations():
             self.graph.query("MATCH (n:M) RETURN sum(n.v)").result_set, [[4]])
         self.env.assertEqual(
             self.graph.query("MATCH ()-[r:R]->() RETURN sum(r.w)").result_set, [[2]])
+
+    def test_computed_grouping_key(self):
+        # A grouping key that is not a bare variable or `n.prop` -- `n.id % 100`,
+        # `toUpper(n.name)`, a CASE -- used to make the aggregate operator give
+        # up its columnar path entirely, taking the bulk aggregate-input reads
+        # down with it and rebuilding an owned row per input row. Such a key now
+        # goes through the same bulk evaluator the aggregate inputs use, so what
+        # matters here is that the two paths agree on every value exactly.
+        self.get_res_and_assertEquals(
+            "UNWIND range(0, 9) AS i RETURN i % 3 AS k, count(*) AS c ORDER BY k",
+            [[0, 4], [1, 3], [2, 3]])
+        self.get_res_and_assertEquals(
+            "UNWIND range(1, 6) AS i "
+            "RETURN i % 2 AS k, sum(i) AS s, min(i) AS mn, max(i) AS mx ORDER BY k",
+            [[0, 12, 2, 6], [1, 9, 1, 5]])
+
+        # Several computed keys at once.
+        self.get_res_and_assertEquals(
+            "UNWIND range(0, 5) AS i RETURN i % 2 AS a, i % 3 AS b, count(*) AS c ORDER BY a, b",
+            [[0, 0, 1], [0, 1, 1], [0, 2, 1], [1, 0, 1], [1, 1, 1], [1, 2, 1]])
+
+        # Keys that are not numbers: strings, booleans, lists, a CASE.
+        self.get_res_and_assertEquals(
+            "UNWIND ['a', 'A', 'b'] AS s RETURN toLower(s) AS k, count(*) AS c ORDER BY k",
+            [['a', 2], ['b', 1]])
+        self.get_res_and_assertEquals(
+            "UNWIND range(0, 3) AS i RETURN i % 2 = 0 AS k, count(*) AS c ORDER BY k",
+            [[False, 2], [True, 2]])
+        self.get_res_and_assertEquals(
+            "UNWIND range(0, 3) AS i RETURN [i % 2] AS k, count(*) AS c ORDER BY k",
+            [[[0], 2], [[1], 2]])
+        self.get_res_and_assertEquals(
+            "UNWIND range(0, 3) AS i "
+            "RETURN CASE WHEN i < 2 THEN 'lo' ELSE 'hi' END AS k, count(*) AS c ORDER BY k",
+            [['hi', 2], ['lo', 2]])
+
+        # null is a group of its own.
+        self.get_res_and_assertEquals(
+            "UNWIND [1, 2, null, null] AS i RETURN i % 2 AS k, count(*) AS c ORDER BY k",
+            [[0, 1], [1, 1], [None, 2]])
+
+        # Exactness: a key column holding both ints and floats must stay exact.
+        # Rounding it into f64 would pull 2^53+1 onto 2^53 and merge two
+        # integers that are not equal, and 1 and 1.0 have to keep grouping
+        # together the way the scalar evaluator compares them.
+        self.get_res_and_assertEquals(
+            "UNWIND [9007199254740993, 9007199254740992] AS i "
+            "RETURN i + 0 AS k, count(*) AS c ORDER BY k",
+            [[9007199254740992, 1], [9007199254740993, 1]])
+        self.get_res_and_assertEquals(
+            "UNWIND [1, 1.0, 2] AS i RETURN i + 0 AS k, count(*) AS c ORDER BY k",
+            [[1, 2], [2, 1]])
+
+        # An error raised while evaluating a key is still reported.
+        try:
+            self.graph.query("UNWIND [1, 0] AS i RETURN 1 / i AS k, count(*)")
+            self.env.assertTrue(False)
+        except redis.ResponseError as e:
+            self.env.assertContains("Division by zero", str(e))
+
+        # Node and relationship properties inside a computed key, and the
+        # aggregate inputs that now ride the bulk path alongside it.
+        self.graph.query("CREATE (:CK {v: 1})-[:CKR {w: 5}]->(:CK {v: 2}), (:CK {v: 3})")
+        self.get_res_and_assertEquals(
+            "MATCH (n:CK) RETURN n.v % 2 AS k, count(*) AS c ORDER BY k",
+            [[0, 1], [1, 2]])
+        self.get_res_and_assertEquals(
+            "MATCH ()-[r:CKR]->() RETURN r.w * 2 AS k, count(*) AS c ORDER BY k",
+            [[10, 1]])
+        self.get_res_and_assertEquals(
+            "MATCH (n:CK) RETURN n.v % 2 AS k, collect(n.v) AS vs ORDER BY k",
+            [[0, [2]], [1, [1, 3]]])
+        self.get_res_and_assertEquals(
+            "MATCH (n:CK) RETURN n.v % 2 AS k, count(DISTINCT n.v) AS c ORDER BY k",
+            [[0, 1], [1, 2]])
+
+        # A nested aggregate in a key still falls back to per-row evaluation.
+        self.get_res_and_assertEquals(
+            "UNWIND [1, 2, 3] AS i WITH count(i) + 0 AS k RETURN k, count(*) AS c",
+            [[3, 1]])


### PR DESCRIPTION
## Summary

`AggregateOp` has a columnar path and a per-row fallback, and `analyze()` chooses between them. A grouping key was only accepted as a bare variable or `n.prop`; anything else returned `None` — and `None` doesn't just deoptimize *that key*, it abandons the **whole operator**. The bulk aggregate-input reads and the columnar accumulate loop go down with it, and the operator rebuilds an owned `Row` per input row, re-walking every key and every aggregate tree scalar-wise.

Aggregate **inputs** already had `AggInputKind::Computed`, which evaluates an arbitrary tree a column at a time through `VectorEval`. The doc comment on that variant already spells out this exact argument. Keys just never got the same treatment — so `WITH n.id % 100 AS bucket, count(*)`, ordinary Cypher, was the common shape paying the slowest path.

This routes computed keys through that same evaluator.

## Changes

- `KeyExprKind::Computed(QueryExpr<Variable>)` — new variant mirroring `AggInputKind::Computed`.
- `analyze()` — key arms fall through to `Computed` instead of returning `None`. A key whose subtree contains an aggregate still falls back, for the same reason `analyze_agg_tree` refuses one in an aggregate input. `n.prop` where the child isn't a variable now routes to `Computed` rather than bailing.
- `extract_key_columns()` — a `Computed` arm calling `VectorEval::eval_values`.
- Flow test `test_computed_grouping_key` covering numeric/string/bool/list/CASE keys, multiple computed keys, nulls, float/int exactness, key evaluation errors, node & relationship properties, `collect`/`count(DISTINCT)` inputs riding along, and the nested-aggregate fallback.

**Why this is semantically safe:** `VectorEval` is already the sole evaluator for *every* `RETURN` projection (`project.rs`) and *every* `WHERE` predicate (`filter.rs`) — any divergence from the scalar evaluator would already be a visible bug elsewhere. Its typed lanes are built by `classify_exact_column`, which leaves a mixed int/float column as `Column::Values` rather than promoting to `f64`, so grouping still compares exact values and won't merge `9007199254740993` with `9007199254740992` (the hazard the existing comment in `extract_key_columns` warns about). A key that fails to evaluate returns `Err(())`, which means "replay this batch per-row" rather than "query failed" — so the error surfaced is still the per-row evaluator's, with its message and its ordering.

## Testing

| Suite | Result |
|---|---|
| `cargo test -p graph` | 186 passed (1 pre-existing local GraphBLAS-version failure, confirmed on base) |
| `pytest tests/test_e2e.py tests/test_functions.py` | 124 passed |
| TCK | 2456 scenarios passed, 0 failed |
| `pytest tests/test_mvcc.py tests/test_concurrency.py` | 14 passed |
| Flow suite | 1444 passed; same 5 pre-existing failures as base |
| `cargo fmt --check` / `cargo clippy --all-targets` | clean, 0 new warnings |
| `bench compare`, all 317 queries | no failures, no regressions |

Beyond the suites, a differential harness ran **50 aggregation queries** (mixed int/float, nulls, 2^53-boundary ints, strings, maps, lists, `DISTINCT`, percentiles, edges, division-by-zero) against modules built from base and from this branch: **results byte-identical**, only timing lines differ. The values asserted in the new flow test were each verified identical on the pre-change module first, so it's a true regression guard rather than a snapshot of new behaviour.

## Memory / Performance Impact

No per-entity overhead and no new persistent allocation; the change *removes* transient allocation by not building an owned `Row` per input row.

Callgrind on the `WITH pipeline` benchmark query (deterministic — this host has `perf_event_paranoid=4`, so hardware counters were unavailable):

**3,167,610 → 1,961,221 instructions/exec, −38.1%** (±0.2%)

Wall clock, 10k-node graph, median of 60 reps:

| query | before | after | |
|---|---|---|---|
| `GROUP BY p.id % 100` | 4.277 ms | 2.476 ms | **1.73x** |
| `GROUP BY p.age / 10` | 5.780 ms | 2.429 ms | **2.38x** |
| `GROUP BY toUpper(p.name)` | 15.308 ms | 11.097 ms | **1.38x** |
| `GROUP BY CASE ... END` | 5.258 ms | 2.352 ms | **2.24x** |
| two computed keys | 5.289 ms | 2.686 ms | **1.97x** |
| `WITH pipeline` (bench row) | 4.035 ms | 2.116 ms | **1.91x** |
| *control:* `GROUP BY p.age` | 2.285 ms | 2.387 ms | ~1.00x |
| *control:* `count(*)` | 0.631 ms | 0.509 ms | ~1.00x |

The controls are already-vectorized shapes and are unchanged, confirming the win comes from moving computed keys onto the existing path rather than from perturbing it.

## Related Issues

Closes #2763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Computed `GROUP BY` expressions, including arithmetic, conditional, property, and function-based keys, are now evaluated efficiently in batches.
  - Grouping results support null values and preserve exact numeric behavior for large integer values.

- **Bug Fixes**
  - Computed grouping-key errors, such as division by zero, are now propagated correctly.
  - Queries with nested aggregates in grouping keys continue to use per-row evaluation where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
