### PR TITLE
perf: let an unlabelled point lookup use an index

### DIFF
--- a/flow_tests_done.txt
+++ b/flow_tests_done.txt
@@ -115,3 +115,4 @@ tests/flow/test_varlength_traversal
 tests/flow/test_vecsim.py
 tests/flow/test_wcc.py
 tests/flow/test_with_clause
+tests/flow/test_unlabeled_index_scan.py

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -982,6 +982,62 @@ impl Graph {
         self.relationship_count
     }
 
+    /// A label carried by **every** live node, if one exists.
+    ///
+    /// `MATCH (n)` and `MATCH (n:L)` select the same set when `L` is universal,
+    /// so a pattern that names no label can borrow `L` and reach `L`'s indexes
+    /// instead of degrading to an all-node scan plus a filter. That is the only
+    /// route by which an unlabelled point lookup can use an index at all:
+    /// borrowing a *non*-universal label would silently drop nodes that carry
+    /// the property without carrying the label.
+    ///
+    /// Each label matrix is diagonal, so a node contributes at most one entry
+    /// and `nvals == node_count` is exact proof of coverage rather than a
+    /// heuristic — it cannot be reached by two labels splitting the graph, and
+    /// `delete_nodes` clears a deleted node's label entries, so a stale entry
+    /// cannot inflate the count either.
+    ///
+    /// O(number of labels): `nvals` is O(1) per label once its pending work is
+    /// applied. Returns `None` for an empty graph, where there is nothing to
+    /// optimize.
+    ///
+    /// **This is a property of the data, not of the schema**, so a plan built on
+    /// it must re-check it before trusting it — adding one unlabelled node
+    /// falsifies it without bumping `schema_version`, and query plans are cached
+    /// against `schema_version`. See `IR::NodeByIndexScan::assumed_universal_label`.
+    #[must_use]
+    pub fn universal_label(&self) -> Option<Arc<String>> {
+        if self.node_count == 0 {
+            return None;
+        }
+        self.node_labels
+            .iter()
+            .enumerate()
+            .find(|(idx, _)| {
+                self.labels_matices
+                    .get(*idx)
+                    .is_some_and(|m| m.nvals() == self.node_count)
+            })
+            .map(|(_, label)| label.clone())
+    }
+
+    /// Whether `label` is still carried by every live node.
+    ///
+    /// The runtime re-check for a plan produced under
+    /// [`universal_label`](Self::universal_label); see that method for why a
+    /// re-check is required rather than optional.
+    #[must_use]
+    pub fn is_universal_label(
+        &self,
+        label: &str,
+    ) -> bool {
+        self.node_count != 0
+            && self
+                .get_label_id(label)
+                .and_then(|id| self.labels_matices.get(id.0))
+                .is_some_and(|m| m.nvals() == self.node_count)
+    }
+
     /// Number of nodes with the given label (by label index).
     #[must_use]
     pub fn label_node_count_by_idx(
@@ -4229,6 +4285,121 @@ mod attr_id_space_tests {
 
     fn attr(s: &str) -> Arc<String> {
         Arc::new(s.to_string())
+    }
+
+    /// Build a graph of `n` nodes and give the first `labeled` of them `label`.
+    fn graph_with_labeled(
+        name: &str,
+        n: usize,
+        labeled: usize,
+        label: &str,
+    ) -> Graph {
+        let mut g = Graph::new(64, 64, 1, 0, name);
+        let ids = g.reserve_nodes(n).expect("reserve");
+        let set: RoaringTreemap = ids.iter().map(|id| id.0).collect();
+        g.create_nodes(&set);
+        if labeled > 0 {
+            let label_id = g.get_label_id_mut(label);
+            let rows: Vec<u64> = ids[..labeled].iter().map(|id| id.0).collect();
+            let cols: Vec<u64> = vec![label_id.0 as u64; labeled];
+            let mut docs = FxHashMap::default();
+            g.set_nodes_labels_bulk(&rows, &cols, &mut docs, true);
+        }
+        g
+    }
+
+    /// A label every node carries is universal; one that covers only part of the
+    /// graph is not.
+    ///
+    /// This is the invariant the unlabelled-pattern index rewrite rests on. If
+    /// a partially-covering label were reported universal, `MATCH (n) WHERE
+    /// n.p = v` would be answered from that label's index and would silently
+    /// drop nodes carrying `p` without the label.
+    #[test]
+    fn universal_label_requires_covering_every_live_node() {
+        ensure_init();
+
+        let g = graph_with_labeled("universal_all", 10, 10, "Person");
+        assert_eq!(
+            g.universal_label().as_deref().map(String::as_str),
+            Some("Person"),
+            "a label on every node is universal"
+        );
+        assert!(g.is_universal_label("Person"));
+
+        let g = graph_with_labeled("universal_partial", 10, 9, "Person");
+        assert_eq!(
+            g.universal_label(),
+            None,
+            "one unlabelled node out of ten must defeat the proof"
+        );
+        assert!(!g.is_universal_label("Person"));
+
+        let g = graph_with_labeled("universal_none", 10, 0, "Person");
+        assert_eq!(
+            g.universal_label(),
+            None,
+            "no labels at all is not universal"
+        );
+    }
+
+    /// An empty graph has no universal label, and an unknown label is never one.
+    ///
+    /// Reporting a universal label for an empty graph would be vacuously true
+    /// but useless, and it would let a plan be built on a proof that the very
+    /// first `CREATE` invalidates.
+    #[test]
+    fn universal_label_edge_cases() {
+        ensure_init();
+        let g = Graph::new(64, 64, 1, 0, "universal_empty");
+        assert_eq!(g.universal_label(), None);
+        assert!(!g.is_universal_label("Person"));
+
+        let g = graph_with_labeled("universal_unknown", 4, 4, "Person");
+        assert!(
+            !g.is_universal_label("Company"),
+            "a label the graph has never seen is not universal"
+        );
+    }
+
+    /// Deleting nodes must not leave a label looking universal, or wider.
+    ///
+    /// `nvals == node_count` is only exact proof while a deleted node's label
+    /// entries are cleared. `delete_nodes` does clear them; this pins that,
+    /// because if it stopped doing so the count could match by coincidence
+    /// while a live node lacked the label.
+    #[test]
+    fn universal_label_survives_deletes() {
+        ensure_init();
+        let mut g = graph_with_labeled("universal_delete", 10, 5, "Person");
+        assert_eq!(g.universal_label(), None, "half-labelled to begin with");
+
+        // Drop the five unlabelled nodes; the label now covers what remains.
+        let doomed: RoaringTreemap = (5..10).collect();
+        let mut remove_docs = FxHashMap::default();
+        g.delete_nodes(&doomed, &mut remove_docs).expect("delete");
+        assert_eq!(
+            g.universal_label().as_deref().map(String::as_str),
+            Some("Person"),
+            "after the unlabelled nodes go, the label covers every live node"
+        );
+
+        // And the converse: dropping labelled nodes must not leave stale
+        // entries that keep the count looking right.
+        let mut g = graph_with_labeled("universal_delete2", 10, 10, "Person");
+        let doomed: RoaringTreemap = (0..5).collect();
+        let mut remove_docs = FxHashMap::default();
+        g.delete_nodes(&doomed, &mut remove_docs).expect("delete");
+        assert!(
+            g.is_universal_label("Person"),
+            "five live nodes, five label entries"
+        );
+        assert_eq!(g.node_count(), 5);
+        assert_eq!(
+            g.label_node_count_by_idx(0),
+            5,
+            "a deleted node's label entry must be gone, not stale"
+        );
     }
 
     /// A name has one id, whichever kind of entity introduced it.

--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -123,6 +123,17 @@ pub enum IR {
         node: Arc<QueryNode<Arc<String>, Variable>>,
         index: Arc<String>,
         query: Arc<IndexQuery<QueryExpr<Variable>>>,
+        /// Set when the pattern named no label and the optimizer borrowed one
+        /// that `Graph::universal_label` proved every live node carries, so an
+        /// unlabelled point lookup could reach an index.
+        ///
+        /// That proof is a property of the *data*, and plans are cached against
+        /// `schema_version`, which adding an unlabelled node does not bump. So
+        /// the runtime re-checks it per execution and falls back to an all-node
+        /// scan when it no longer holds; the optimizer keeps the original
+        /// `Filter` in place for that case, which is why the fallback is
+        /// correct rather than merely wider.
+        assumed_universal_label: bool,
     },
     /// Scan edges using an index, replacing CondTraverse when a filter
     /// can be pushed into the edge index.
@@ -565,8 +576,20 @@ impl Display for IR {
             Self::IncludePending { node } => {
                 write!(f, "Include Pending | {node}")
             }
-            Self::NodeByIndexScan { node, .. } => {
-                write!(f, "Node By Index Scan | {node}")
+            Self::NodeByIndexScan {
+                node,
+                assumed_universal_label,
+                ..
+            } => {
+                if *assumed_universal_label {
+                    // Bracketed inside the existing argument segment rather than
+                    // added as another `|` field: clients split an explain line on
+                    // `|` and keep the first argument, so a new segment would be
+                    // silently dropped (and would change a stable output shape).
+                    write!(f, "Node By Index Scan | {node} [universal label]")
+                } else {
+                    write!(f, "Node By Index Scan | {node}")
+                }
             }
             Self::EdgeByIndexScan {
                 relationship: rel, ..

--- a/graph/src/planner/optimizer/utilize_index.rs
+++ b/graph/src/planner/optimizer/utilize_index.rs
@@ -132,7 +132,24 @@ trait IndexSubject: Clone {
     /// (`NodeByLabelScan` for nodes, `CondTraverse` for edges). Returns
     /// `None` if the variant doesn't match or if `labels` / `types` is
     /// empty (no scan target to push the filter into).
-    fn match_scan_source(ir: &IR) -> Option<(Self, Self::Metadata)>;
+    ///
+    /// Takes `graph` because for nodes an *unlabelled* pattern is still a
+    /// candidate when some label covers the whole graph — see the node impl.
+    fn match_scan_source(
+        ir: &IR,
+        graph: &Graph,
+    ) -> Option<(Self, Self::Metadata)>;
+
+    /// Whether the label being scanned was borrowed from
+    /// `Graph::universal_label` rather than named by the pattern.
+    ///
+    /// When it was, the parent `Filter` must be retained: the runtime re-checks
+    /// the coverage proof and falls back to an all-node scan if it no longer
+    /// holds, and that fallback is only correct because the predicate is still
+    /// there to apply. Only nodes can borrow a label.
+    fn borrowed_label(_metadata: Self::Metadata) -> bool {
+        false
+    }
 
     /// Build the replacement IR after a successful pushdown
     /// (`NodeByIndexScan` or `EdgeByIndexScan`).
@@ -153,7 +170,9 @@ trait IndexSubject: Clone {
 }
 
 impl IndexSubject for Arc<QueryNode<Arc<String>, Variable>> {
-    type Metadata = ();
+    /// Whether the scanned label was borrowed from `universal_label` because
+    /// the pattern named none.
+    type Metadata = bool;
 
     fn alias(&self) -> &Variable {
         &self.alias
@@ -182,25 +201,55 @@ impl IndexSubject for Arc<QueryNode<Arc<String>, Variable>> {
     ) -> Scan<Self> {
         try_distance_index_scan(subject, attr, filter, attr_side, constant_node, label)
     }
-    fn match_scan_source(ir: &IR) -> Option<(Self, Self::Metadata)> {
-        let IR::NodeByLabelScan { node } = ir else {
-            return None;
+    fn match_scan_source(
+        ir: &IR,
+        graph: &Graph,
+    ) -> Option<(Self, Self::Metadata)> {
+        let node = match ir {
+            IR::NodeByLabelScan { node } | IR::AllNodeScan(node) => node,
+            _ => return None,
         };
-        if node.labels.is_empty() {
-            return None;
+        if !node.labels.is_empty() {
+            return Some((node.clone(), false));
         }
-        Some((node.clone(), ()))
+        // An unlabelled pattern can still reach an index, but only by borrowing
+        // a label that *every* live node carries: `MATCH (n)` and `MATCH (n:L)`
+        // then select the same set. Without this, `MATCH (n) WHERE n.id = $x`
+        // degrades to an all-node scan plus a per-node property fetch even when
+        // a perfectly good index exists — measured at 1.9M instructions against
+        // 384k for the same predicate written with the label.
+        //
+        // Borrowing a non-universal label would be wrong, not just narrower: a
+        // node can carry `id` without carrying the label. `universal_label`
+        // proves coverage rather than guessing it, and the flag returned here
+        // makes the runtime re-prove it (the proof is about data, and plans
+        // outlive the data they were compiled against).
+        let label = graph.universal_label()?;
+        let mut labels = OrderSet::default();
+        labels.insert(label);
+        Some((
+            Arc::new(QueryNode::new(
+                node.alias.clone(),
+                labels,
+                node.attrs.clone(),
+            )),
+            true,
+        ))
+    }
+    fn borrowed_label(metadata: bool) -> bool {
+        metadata
     }
     fn build_scan_ir(
         self,
         index: Arc<String>,
         query: Arc<IndexQuery<QueryExpr<Variable>>>,
-        _metadata: (),
+        metadata: bool,
     ) -> IR {
         IR::NodeByIndexScan {
             node: self,
             index,
             query,
+            assumed_universal_label: metadata,
         }
     }
     fn with_primary_label(
@@ -252,7 +301,10 @@ impl IndexSubject for Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>
     ) -> Scan<Self> {
         None
     }
-    fn match_scan_source(ir: &IR) -> Option<(Self, Self::Metadata)> {
+    fn match_scan_source(
+        ir: &IR,
+        _graph: &Graph,
+    ) -> Option<(Self, Self::Metadata)> {
         let IR::CondTraverse {
             relationship,
             transposed,
@@ -962,8 +1014,9 @@ fn rewrite_until_stable<F>(
 fn match_scan_with_filter<T: IndexSubject>(
     plan: &DynTree<IR>,
     idx: NodeIdx<Dyn<IR>>,
+    graph: &Graph,
 ) -> Option<(T, QueryExpr<Variable>, T::Metadata)> {
-    let (subject, metadata) = T::match_scan_source(plan.node(idx).data())?;
+    let (subject, metadata) = T::match_scan_source(plan.node(idx).data(), graph)?;
     let IR::Filter(filter) = plan.node(idx).parent()?.data() else {
         return None;
     };
@@ -1002,7 +1055,11 @@ fn apply_filter_pushdown<T: IndexSubject>(
     original_filter: &QueryExpr<Variable>,
     metadata: T::Metadata,
 ) {
-    let keep_filter = needs_post_filter(original_filter, subject.alias().id);
+    // A borrowed label always keeps the filter: the runtime may fall back to an
+    // all-node scan when the coverage proof no longer holds, and only the
+    // retained predicate makes that fallback correct instead of merely wider.
+    let keep_filter =
+        T::borrowed_label(metadata) || needs_post_filter(original_filter, subject.alias().id);
     let subject = reorder_subject_labels(subject, &index);
     let scan_ir = subject.build_scan_ir(index, Arc::new(query), metadata);
     let mut op = plan.node_mut(idx);
@@ -1044,7 +1101,10 @@ fn apply_inline_rewrite<T: IndexSubject>(
     inline_filter: DynTree<ExprIR<Variable>>,
     metadata: T::Metadata,
 ) {
-    if needs_inline_post_filter(&inline_filter) {
+    // Same reasoning as in `apply_filter_pushdown`: a borrowed label needs the
+    // predicate kept above the scan so the runtime's all-node fallback stays
+    // correct.
+    if T::borrowed_label(metadata) || needs_inline_post_filter(&inline_filter) {
         plan.node_mut(idx)
             .push_parent(IR::Filter(Arc::new(inline_filter.clone())));
     }
@@ -1065,7 +1125,7 @@ fn try_index_rewrite<T: IndexSubject>(
     idx: NodeIdx<Dyn<IR>>,
     graph: &Graph,
 ) -> bool {
-    if let Some((subject, filter, metadata)) = match_scan_with_filter::<T>(plan, idx)
+    if let Some((subject, filter, metadata)) = match_scan_with_filter::<T>(plan, idx, graph)
         && let Some((label, query, remaining)) = try_filter_pushdown(&subject, &filter, graph)
     {
         apply_filter_pushdown(
@@ -1074,7 +1134,7 @@ fn try_index_rewrite<T: IndexSubject>(
         return true;
     }
 
-    if let Some((subject, metadata)) = T::match_scan_source(plan.node(idx).data())
+    if let Some((subject, metadata)) = T::match_scan_source(plan.node(idx).data(), graph)
         && let Some((_, label, attr, inline_filter)) = get_inline_attr_index(graph, &subject)
     {
         apply_inline_rewrite(plan, idx, subject, label, attr, inline_filter, metadata);

--- a/graph/src/runtime/ops/node_by_index_scan.rs
+++ b/graph/src/runtime/ops/node_by_index_scan.rs
@@ -35,6 +35,7 @@ use crate::runtime::{
 use orx_tree::{Dyn, NodeIdx, NodeRef};
 
 use super::batched_result_emitter::{BatchedResultEmitter, RowIter};
+use crate::runtime::orderset::OrderSet;
 
 pub struct NodeByIndexScanOp<'a> {
     pub(crate) runtime: &'a Runtime<'a>,
@@ -50,6 +51,10 @@ pub struct NodeByIndexScanOp<'a> {
     /// performs the shared pack-and-gather emit.
     emitter: BatchedResultEmitter<'a, NodeId>,
     pub(crate) idx: NodeIdx<Dyn<IR>>,
+    /// The pattern named no label and the optimizer borrowed one that covered
+    /// every live node, so this scan may only use the index while that still
+    /// holds. See [`coverage_holds`](Self::coverage_holds).
+    assumed_universal_label: bool,
 }
 
 impl<'a> NodeByIndexScanOp<'a> {
@@ -60,6 +65,7 @@ impl<'a> NodeByIndexScanOp<'a> {
         index: &'a Arc<String>,
         query: &'a IndexQuery<QueryExpr<Variable>>,
         idx: NodeIdx<Dyn<IR>>,
+        assumed_universal_label: bool,
     ) -> Self {
         let extra_labels = if node_pattern.labels.len() > 1 {
             Some(node_pattern.labels.iter().skip(1).cloned().collect())
@@ -75,7 +81,29 @@ impl<'a> NodeByIndexScanOp<'a> {
             extra_labels,
             emitter: BatchedResultEmitter::new(node_pattern.alias.id),
             idx,
+            assumed_universal_label,
         }
+    }
+
+    /// Whether the borrowed label still covers every live node.
+    ///
+    /// `utilize_index` may rewrite an unlabelled pattern into an index scan on
+    /// a label that `Graph::universal_label` proved every node carried. That is
+    /// a fact about the *data*, but plans are cached against `schema_version`,
+    /// and creating one unlabelled node falsifies it without bumping that. So
+    /// the assumption is re-proved here, once per execution, against the
+    /// snapshot this query actually runs on.
+    ///
+    /// `true` when no assumption was made, so the common path costs nothing.
+    fn coverage_holds(&self) -> bool {
+        if !self.assumed_universal_label {
+            return true;
+        }
+        self.node_pattern
+            .labels
+            .iter()
+            .next()
+            .is_some_and(|label| self.runtime.g.borrow().is_universal_label(label))
     }
 
     fn evaluate_index_query<R: crate::runtime::row::RowView + ?Sized>(
@@ -274,6 +302,7 @@ impl<'a> Iterator for NodeByIndexScanOp<'a> {
     type Item = Result<Batch<'a>, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let coverage = self.coverage_holds();
         loop {
             // For each active parent row, evaluate the index query and queue the
             // matching node ids (falling back to a label scan when the index
@@ -288,7 +317,14 @@ impl<'a> Iterator for NodeByIndexScanOp<'a> {
                 // Check if the index can satisfy this query. If not
                 // (e.g. non-indexable value types), fall back to a
                 // label scan.
-                let base: Box<dyn Iterator<Item = NodeId>> = if Self::can_utilize_index(&q) {
+                let base: Box<dyn Iterator<Item = NodeId>> = if !coverage {
+                    // The borrowed label no longer covers the whole graph, so
+                    // neither the index nor a scan of that label would see every
+                    // candidate. Widen to all live nodes; `utilize_index` kept the
+                    // original predicate above this scan precisely so that this
+                    // fallback filters rather than over-returns.
+                    Box::new(self.runtime.g.borrow().get_nodes(&OrderSet::default(), 0))
+                } else if Self::can_utilize_index(&q) {
                     Box::new(self.runtime.g.borrow().get_indexed_nodes(self.index, q))
                 } else {
                     Box::new(
@@ -298,7 +334,12 @@ impl<'a> Iterator for NodeByIndexScanOp<'a> {
                             .get_nodes(&self.node_pattern.labels, 0),
                     )
                 };
-                let iter: Box<dyn Iterator<Item = NodeId> + 'a> = match &self.extra_labels {
+                let extra = if coverage {
+                    self.extra_labels.as_ref()
+                } else {
+                    None
+                };
+                let iter: Box<dyn Iterator<Item = NodeId> + 'a> = match extra {
                     Some(extra) => {
                         let extra = extra.clone();
                         let runtime = self.runtime;

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -915,7 +915,12 @@ impl<'a> Runtime<'a> {
                     idx,
                 )))
             }
-            IR::NodeByIndexScan { node, index, query } => {
+            IR::NodeByIndexScan {
+                node,
+                index,
+                query,
+                assumed_universal_label,
+            } => {
                 let child = pop_or_once(&mut children);
                 Ok(BatchOp::NodeByIndexScan(NodeByIndexScanOp::new(
                     self,
@@ -924,6 +929,7 @@ impl<'a> Runtime<'a> {
                     index,
                     query,
                     idx,
+                    *assumed_universal_label,
                 )))
             }
             IR::EdgeByIndexScan {

--- a/tests/flow/test_unlabeled_index_scan.py
+++ b/tests/flow/test_unlabeled_index_scan.py
@@ -1,0 +1,144 @@
+from common import *
+from index_utils import *
+
+GRAPH_ID = "unlabeled_index_scan"
+
+
+class testUnlabeledIndexScan():
+    """An unlabelled pattern may borrow a label that covers the whole graph.
+
+    `MATCH (n) WHERE n.p = v` cannot normally use an index, because the index is
+    per label and an unlabelled pattern matches every node. When some label is
+    carried by *every* live node, though, `MATCH (n)` and `MATCH (n:L)` select
+    the same set, so the optimizer may borrow L and reach its index.
+
+    The proof is about the data, not the schema. Creating one unlabelled node
+    falsifies it and does not bump `schema_version`, which is what query plans
+    are cached against — so the runtime re-checks it and widens to an all-node
+    scan when it no longer holds. These tests pin both halves: that the rewrite
+    happens, and that it never changes an answer.
+    """
+
+    def __init__(self):
+        self.env, self.db = Env()
+        self.graph = self.db.select_graph(GRAPH_ID)
+
+    def tearDown(self):
+        self.graph.delete()
+
+    def _seed(self, n=100, label='Person'):
+        self.graph.query(
+            f"UNWIND range(0, {n - 1}) AS i CREATE (:{label} {{v: i}})")
+        self.graph.create_node_range_index(label, 'v')
+        wait_for_indices_to_sync(self.graph)
+
+    def test01_unlabeled_lookup_uses_the_index(self):
+        self._seed()
+        q = "MATCH (n) WHERE n.v = 42 RETURN n.v"
+        plan = str(self.graph.explain(q))
+        self.env.assertIn("Node By Index Scan", plan)
+        self.env.assertIn("[universal label]", plan)
+        self.env.assertEquals(self.graph.query(q).result_set, [[42]])
+
+    def test02_no_rewrite_when_a_node_is_unlabeled(self):
+        """One unlabelled node defeats the proof, so the plan must not use it."""
+        self._seed()
+        self.graph.query("CREATE ({v: 42})")
+        plan = str(self.graph.explain("MATCH (n) WHERE n.v = 42 RETURN n.v"))
+        self.env.assertIn("All Node Scan", plan)
+        self.env.assertNotIn("[universal label]", plan)
+
+    def test03_unlabeled_node_is_still_found(self):
+        """The whole point: borrowing a label must not lose a node.
+
+        A node carrying `v` without the label is invisible to the label's
+        index, so if the rewrite fired here the answer would be wrong.
+        """
+        self._seed()
+        self.graph.query("CREATE ({v: 42})")
+        res = self.graph.query("MATCH (n) WHERE n.v = 42 RETURN count(n)")
+        self.env.assertEquals(res.result_set, [[2]])
+
+    def test04_cached_plan_widens_when_the_proof_lapses(self):
+        """The decisive case for the runtime re-check.
+
+        The plan is compiled and cached while the label is universal, then an
+        unlabelled node with the same property is added. `schema_version` does
+        not change, so the *same cached plan* runs again and must still find
+        both nodes.
+        """
+        self._seed()
+        q = "MATCH (n) WHERE n.v = 7 RETURN count(n)"
+        self.env.assertEquals(self.graph.query(q).result_set, [[1]])
+        plan = str(self.graph.explain(q))
+        self.env.assertIn("[universal label]", plan)
+
+        self.graph.query("CREATE ({v: 7})")
+        res = self.graph.query(q)
+        self.env.assertTrue(res.cached_execution)
+        self.env.assertEquals(res.result_set, [[2]])
+
+    def test05_borrowed_label_survives_a_deleted_node(self):
+        """Deleting the unlabelled node restores the proof, and the answer."""
+        self._seed()
+        self.graph.query("CREATE ({v: 7})")
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v = 7 RETURN count(n)").result_set,
+            [[2]])
+        self.graph.query("MATCH (n) WHERE n.v = 7 AND labels(n) = [] DELETE n")
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v = 7 RETURN count(n)").result_set,
+            [[1]])
+
+    def test06_second_label_does_not_defeat_the_proof(self):
+        """A universal label may coexist with a partial one.
+
+        Every node is `:Person`; some are additionally `:Admin`. `:Person` still
+        covers the graph, so the rewrite is valid — and must pick a label that
+        covers, not merely the first one it finds.
+        """
+        self._seed()
+        self.graph.query("MATCH (n:Person) WHERE n.v < 10 SET n:Admin")
+        q = "MATCH (n) WHERE n.v = 42 RETURN n.v"
+        plan = str(self.graph.explain(q))
+        self.env.assertIn("Node By Index Scan", plan)
+        self.env.assertEquals(self.graph.query(q).result_set, [[42]])
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v = 3 RETURN count(n)").result_set,
+            [[1]])
+
+    def test07_range_and_inline_forms(self):
+        """The rewrite must be correct for a range predicate and inline attrs."""
+        self._seed()
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v >= 98 RETURN count(n)").result_set,
+            [[2]])
+        self.env.assertEquals(
+            self.graph.query("MATCH (n {v: 5}) RETURN n.v").result_set, [[5]])
+        self.graph.query("CREATE ({v: 99})")
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v >= 98 RETURN count(n)").result_set,
+            [[3]])
+        self.env.assertEquals(
+            self.graph.query("MATCH (n {v: 99}) RETURN count(n)").result_set, [[2]])
+
+    def test08_traversal_endpoint_lookup(self):
+        """The shape the gap was measured on: an unlabelled traversal endpoint."""
+        self._seed()
+        self.graph.query(
+            "MATCH (a:Person), (b:Person) WHERE a.v = 1 AND b.v = 2 "
+            "CREATE (a)-[:KNOWS]->(b)")
+        q = "MATCH (a)-[:KNOWS]->(b) WHERE b.v = 2 RETURN a.v"
+        plan = str(self.graph.explain(q))
+        self.env.assertIn("Node By Index Scan", plan)
+        self.env.assertEquals(self.graph.query(q).result_set, [[1]])
+
+    def test09_empty_graph_is_not_universal(self):
+        """An empty graph has no universal label, so nothing to borrow."""
+        self.graph.create_node_range_index('Person', 'v')
+        wait_for_indices_to_sync(self.graph)
+        plan = str(self.graph.explain("MATCH (n) WHERE n.v = 1 RETURN n"))
+        self.env.assertNotIn("[universal label]", plan)
+        self.env.assertEquals(
+            self.graph.query("MATCH (n) WHERE n.v = 1 RETURN count(n)").result_set,
+            [[0]])


### PR DESCRIPTION
## What

`MATCH (n) WHERE n.p = $v` could not use an index **at all**. `utilize_index`
only rewrites `NodeByLabelScan`, so an unlabelled pattern degraded to an
all-node scan plus a per-node property fetch:

| same predicate, same index | instructions |
|---|---:|
| `MATCH (n:Person) WHERE n.id = 5000` | 371,140 |
| `MATCH (n) WHERE n.id = 5000` | 1,857,542 |

A 5x penalty for omitting a label that, in these graphs, every node carries
anyway.

## Why the obvious fix is wrong

Borrowing *any* label's index for an unlabelled pattern is not merely narrow, it
is **incorrect**: a node can carry `p` without carrying the label, and answering
from that label's index silently drops it. That is why this was left as a design
note rather than patched.

The rewrite *is* valid under one condition: some label is carried by **every**
live node, in which case `MATCH (n)` and `MATCH (n:L)` select the same set, and
borrowing `L` is semantics-preserving by construction.

`Graph::universal_label` looks for such a label, and the check is proof rather
than a heuristic:

- each label matrix is **diagonal**, so a node contributes at most one entry;
  therefore `nvals == node_count` cannot be reached by two labels splitting the
  graph between them;
- `delete_nodes` clears a deleted node's label entries, so a stale entry cannot
  inflate the count into a false positive;
- it is **O(number of labels)** — `nvals` is O(1) per label once pending work is
  applied — so it costs nothing at plan time.

Once a universal label is found, the label is injected into the pattern and the
*existing* index machinery does the rest unchanged: label reordering, the
`extra_labels` post-verification, range-conjunct merging, inline `{attr: value}`
attributes. There is no new operator and no new index type.

## The part that needed real care: a cached plan can outlive its premise

Universality is a property of the **data**, but plans are cached against
`schema_version`, and `CREATE ({p: 1})` does not bump that. So a plan compiled
while the label was universal could keep running after it stopped being true —
and silently miss rows.

So the borrowed label is recorded on the IR
(`NodeByIndexScan::assumed_universal_label`), the runtime **re-proves it once per
execution** against the snapshot it actually runs on, and widens to an all-node
scan when it no longer holds. `utilize_index` keeps the original `Filter` above
the scan in that case (reusing the existing `keep_filter` "runtime safety net"
path), which is what makes the fallback *correct* rather than merely wider.

Verified end to end, which is the test I most wanted to see pass:

```
1) MATCH (n) WHERE n.v = 7 RETURN count(n)   -> 1     (plan now cached)
2) CREATE ({v: 7})                                    (premise falsified)
3) MATCH (n) WHERE n.v = 7 RETURN count(n)   -> 2     Cached execution: 1
```

The cached plan widened at runtime and found the unlabelled node.

## Results

10k `:Person {id}` + a 10k `:KNOWS` ring, index on `:Person(id)`:

| query | before | after | speedup |
|---|---:|---:|---:|
| `MATCH (n) WHERE n.id = 5000` | 1,857,542 | **412,185** | **4.51x** |
| `MATCH (a)-[:KNOWS]->(b) WHERE b.id = 5000` | 1,905,375 | **450,767** | **4.23x** |

Server-reported internal execution time:

| shape | before | after | speedup |
|---|---:|---:|---:|
| one-hop dst filter | 0.0930 ms | **0.0182 ms** | 5.1x |
| one-hop src filter | 0.0956 ms | **0.0219 ms** | 4.4x |

450,767 is the same cost as writing the label yourself (448,739) — which is
exactly the goal: an unlabelled query now gets the plan it would have got with
the label. Note that 174k of the remaining 412k is the per-query protocol floor,
so the query work itself is ~238k against 1.68M before.

Nothing else moves. A graph containing any unlabelled node plans precisely as it
did (`EXPLAIN` shows `All Node Scan` and the annotation is absent), and a graph
with no index is untouched.

## Explain output

A borrowed label is visible, so nobody has to wonder why the plan mentions a
label the query did not:

```
Project
    Filter
        Node By Index Scan | (n:Person) [universal label]
```

It is bracketed **inside** the existing argument segment rather than added as
another `|` field, because clients split an explain line on `|` and keep the
first argument — a new segment is silently dropped client-side (I hit this: the
first version of these tests failed for that reason, not because the rewrite was
absent).

## Testing

- `cargo test -p graph`: **190 passed, 0 failed** — 3 new, pinning that a
  partially-covering label is *not* universal (the soundness invariant), the
  empty-graph and unknown-label cases, and that deletes leave no stale entry
  that could fake coverage.
- **9 new flow tests**, `tests/flow/test_unlabeled_index_scan.py`, all passing:
  the rewrite fires; it does *not* fire when a node is unlabelled; an unlabelled
  node sharing the property is still found; the cached-plan case above; delete
  restores the proof; a partial second label does not defeat a universal one;
  range and inline-attribute forms; the traversal-endpoint shape; the empty
  graph.
- TCK: **2,456 scenarios passed, 0 failed**.
- `test_e2e` + `test_functions` + `test_mvcc` + `test_concurrency`: 138 passed.
- Flow: **1,480 passed, 0 failed, 3 consecutive full runs** (a 4th run hit
  `test_udf_cluster` timing out on cluster setup — that also fails on unmodified
  `main`, so it is pre-existing and unrelated).
- `cargo fmt --check` clean; `clippy --all-targets` adds no new warnings.

## Where this leaves the gap

This was measured against issundb, which **auto-indexes every scalar node
property** and answered the same shape in 85.2k instructions — 22x cheaper than
FalkorDB. After this change FalkorDB is at 412k, so the gap closes to 4.8x, and
subtracting the 174k protocol floor that an embedded engine does not pay it is
~2.7x on query work.

Two follow-ups this does not attempt, recorded rather than smuggled in:

1. **Multi-label graphs where no single label covers everything** still fall back
   to a scan. The general form is a union of index scans over all labels that
   have the index, plus a residual for anything they do not cover, deduplicated —
   which needs `Union` + `Distinct` in a scan position and a cheap way to prove
   the residual empty. That is a feature, not a patch.
2. **A label scan costs ~167 instructions/node more than an all-node scan** over
   the identical nodes (`get_nodes` documents the unlabelled path avoiding "the
   per-element GraphBLAS row-iterator overhead"; the single-label path at
   `graph.rs:1959` still pays it via `VersionedMatrix::iter`'s three-way MVCC
   delta merge). Worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved index-based lookup performance for unlabeled nodes when a label applies to all live nodes.
  - Automatically falls back to scanning all live nodes when label coverage changes, preserving query results.
  - Added graph checks for universal labels and clearer plan output when this optimization is used.

- **Tests**
  - Added coverage for empty, partially labeled, changing, and unlabeled graph scenarios, including cached plans and filtered queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->