### PR TITLE
fix(runtime): don't panic on degree of an edge created and deleted in one query

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -2688,16 +2688,27 @@ impl Graph {
             .map(|(src, dest)| (NodeId(src), NodeId(dest)))
     }
 
+    /// The type id of an edge, or `None` when the edge has no entry in the
+    /// relationship type matrix — the fallible counterpart of
+    /// [`Self::get_relationship_type_id`], which panics.
     #[must_use]
-    pub fn get_relationship_type_id(
+    pub fn relationship_type_id_for_edge(
         &self,
         id: RelationshipId,
-    ) -> TypeId {
+    ) -> Option<TypeId> {
         #[allow(clippy::cast_possible_truncation)]
         self.relationship_type_matrix
             .iter(id.0, id.0)
             .map(|(_, l)| TypeId(l as usize))
             .next()
+    }
+
+    #[must_use]
+    pub fn get_relationship_type_id(
+        &self,
+        id: RelationshipId,
+    ) -> TypeId {
+        self.relationship_type_id_for_edge(id)
             .expect("relationship must have a type in type_matrix")
     }
 
@@ -2721,14 +2732,26 @@ impl Graph {
         Arc::make_mut(&mut self.edge_endpoints).clear(edge_id);
     }
 
+    /// Returns (src, dst) for an edge via the maintained reverse index, or
+    /// `None` when the edge does not exist — the fallible counterpart of
+    /// [`Self::get_relationship_endpoints`], which panics.
+    #[must_use]
+    pub fn relationship_endpoints(
+        &self,
+        id: RelationshipId,
+    ) -> Option<(NodeId, NodeId)> {
+        self.endpoints_for_edge(id.0)
+            .map(|(src, dst)| (NodeId(src), NodeId(dst)))
+    }
+
     /// Returns (src, dst) for an edge via the maintained reverse index.
     #[must_use]
     pub fn get_relationship_endpoints(
         &self,
         id: RelationshipId,
     ) -> (NodeId, NodeId) {
-        if let Some((src, dst)) = self.endpoints_for_edge(id.0) {
-            return (NodeId(src), NodeId(dst));
+        if let Some(endpoints) = self.relationship_endpoints(id) {
+            return endpoints;
         }
 
         panic!("relationship {} not found", id.0);

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -695,6 +695,15 @@ impl Pending {
             self.created_rel_types.remove(&rel_id);
             if let Some(entries) = self.created_rels_by_type.get_mut(&type_name) {
                 entries.retain(|rid| *rid != rel_id);
+                // Drop the type once its last created edge is retracted.
+                // `created_rels_by_type` is read as "types this query is
+                // creating edges for", so an empty bucket left behind claims a
+                // type that is never registered in the schema, and `commit()`
+                // registers a type for zero edges or `build_effects_buffer`
+                // fails to resolve its id.
+                if entries.is_empty() {
+                    self.created_rels_by_type.remove(&type_name);
+                }
             }
             let attrs = self.new_relationships_attrs.remove(&rel_id.into());
             self.deleted_relationships.remove(rel_id.into());
@@ -1775,6 +1784,9 @@ impl Pending {
         if !self.created_rels_by_type.is_empty() {
             let graph = g.borrow();
             for (type_name, entries) in &self.created_rels_by_type {
+                if entries.is_empty() {
+                    continue;
+                }
                 let type_id = graph
                     .get_type_id(type_name)
                     .expect("created relationship type must be registered")

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -105,6 +105,112 @@ fn lookup_sorted(
         .map(|pos| &attrs[pos].1)
 }
 
+/// Pending degree deltas for one `(node, type)` bucket, or for one node
+/// across all types when the key's type slot is `None`.
+#[derive(Default, Clone, Copy)]
+struct DegreeCounts {
+    created_out: u32,
+    created_in: u32,
+    deleted_out: u32,
+    deleted_in: u32,
+}
+
+/// Incrementally maintained pending degree counters.
+///
+/// `indegree`/`outdegree` are evaluated once per row, so answering them by
+/// scanning the pending collections costs `O(pending)` per row and `O(n^2)`
+/// over an `n`-row mutation. This index turns a lookup into one hash probe
+/// per requested type by maintaining the counts as relationships are created
+/// and deleted instead.
+///
+/// It is built on the first degree lookup of a query rather than eagerly:
+/// almost no query calls a degree function, and those that don't must not pay
+/// for the bookkeeping. Until then, the mutation path only tests an `Option`.
+#[derive(Default)]
+struct DegreeIndex {
+    /// `(node, Some(type))` holds that type's deltas; `(node, None)` holds the
+    /// node's total across types, so an untyped lookup is a single probe
+    /// rather than a sum over buckets.
+    counts: FxHashMap<(NodeId, Option<Arc<String>>), DegreeCounts>,
+    /// Endpoints of pending-created relationships. Deleting one has to know
+    /// its endpoints, and `created_rels_by_type` can only answer that by
+    /// scanning the type's whole `Vec`.
+    created_endpoints: FxHashMap<RelationshipId, (NodeId, NodeId)>,
+    /// Deletions of relationships that live in the committed graph. Resolving
+    /// them needs the graph, which the deletion path does not have, so they
+    /// are parked here and drained by the next lookup. Each is resolved once.
+    unresolved_deletes: Vec<RelationshipId>,
+}
+
+impl DegreeIndex {
+    /// Apply `f` to the node's per-type bucket and to its across-types total.
+    fn update(
+        &mut self,
+        node: NodeId,
+        type_name: &Arc<String>,
+        f: impl Fn(&mut DegreeCounts),
+    ) {
+        f(self.counts.entry((node, None)).or_default());
+        f(self
+            .counts
+            .entry((node, Some(type_name.clone())))
+            .or_default());
+    }
+
+    fn record_create(
+        &mut self,
+        id: RelationshipId,
+        from: NodeId,
+        to: NodeId,
+        type_name: &Arc<String>,
+    ) {
+        self.created_endpoints.insert(id, (from, to));
+        self.update(from, type_name, |c| c.created_out += 1);
+        self.update(to, type_name, |c| c.created_in += 1);
+    }
+
+    fn record_delete_of_created(
+        &mut self,
+        from: NodeId,
+        to: NodeId,
+        type_name: &Arc<String>,
+    ) {
+        self.update(from, type_name, |c| c.deleted_out += 1);
+        self.update(to, type_name, |c| c.deleted_in += 1);
+    }
+
+    /// Resolve deletions of committed relationships against the graph. Called
+    /// from lookups, which is the only place the graph is available.
+    fn drain_unresolved(
+        &mut self,
+        g: &Graph,
+    ) {
+        for id in std::mem::take(&mut self.unresolved_deletes) {
+            let Some((from, to)) = g.relationship_endpoints(id) else {
+                continue;
+            };
+            let Some(type_name) = g
+                .relationship_type_id_for_edge(id)
+                .and_then(|t| g.get_type(t))
+            else {
+                continue;
+            };
+            self.record_delete_of_created(from, to, &type_name);
+        }
+    }
+
+    fn get(
+        &self,
+        node: NodeId,
+        type_name: Option<&Arc<String>>,
+    ) -> DegreeCounts {
+        self.counts
+            .get(&(node, type_name.cloned()))
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
 /// Accumulated write operations for deferred application.
 ///
 /// All mutations during query execution are collected here and applied
@@ -122,6 +228,10 @@ pub struct Pending {
     deleted_relationships: RoaringTreemap,
     /// Endpoints for deleted relationships — populated by commit(), used by build_effects_buffer().
     deleted_endpoints: Vec<(RelationshipId, NodeId, NodeId)>,
+    /// Degree counters, present only once a degree function has been called.
+    /// Behind a `RefCell` because lookups take `&self` — callers hold a shared
+    /// borrow of `Pending` while evaluating expressions.
+    degree_index: RefCell<Option<Box<DegreeIndex>>>,
     /// Property updates for newly created nodes (fast path: skip fjall).
     /// Values are attribute-id-resolved, sorted by id, unique.
     new_nodes_attrs: FxHashMap<u64, Vec<(u16, Value)>>,
@@ -258,6 +368,7 @@ impl Pending {
             deleted_nodes: RoaringTreemap::new(),
             deleted_relationships: RoaringTreemap::new(),
             deleted_endpoints: Vec::new(),
+            degree_index: RefCell::new(None),
             new_nodes_attrs: FxHashMap::default(),
             existing_nodes_attrs: FxHashMap::default(),
             new_relationships_attrs: FxHashMap::default(),
@@ -575,6 +686,12 @@ impl Pending {
             self.deleted_relationships.remove(rel_id.into());
             result.push((rel_id, from, to, type_name, attrs));
         }
+        // Pending creates are being retracted, not deleted, so the counters
+        // cannot be adjusted by the create/delete path. This scan is already
+        // O(pending), so dropping the index costs nothing asymptotically.
+        if !result.is_empty() {
+            *self.degree_index.get_mut() = None;
+        }
 
         result
     }
@@ -590,6 +707,9 @@ impl Pending {
             .entry(type_name.clone())
             .or_default()
             .push((id, from, to));
+        if let Some(ix) = self.degree_index.get_mut().as_mut() {
+            ix.record_create(id, from, to, &type_name);
+        }
         self.created_rel_types.insert(id, type_name);
     }
 
@@ -684,7 +804,9 @@ impl Pending {
         &mut self,
         id: RelationshipId,
     ) {
-        self.deleted_relationships.insert(id.into());
+        if self.deleted_relationships.insert(id.into()) {
+            self.index_relationship_deletion(id);
+        }
     }
 
     pub fn deleted_relationships_bulk(
@@ -692,7 +814,34 @@ impl Pending {
         rels: &[RelationshipId],
     ) {
         for &id in rels {
-            self.deleted_relationships.insert(id.into());
+            if self.deleted_relationships.insert(id.into()) {
+                self.index_relationship_deletion(id);
+            }
+        }
+    }
+
+    /// Route a deletion to the degree index, if one is active.
+    ///
+    /// The pending-created population is separated from the committed one
+    /// here rather than at lookup time. That preserves the precedence the
+    /// scanning form relied on — relationship ids are recycled, so a reserved
+    /// id can read as present in the committed graph while its pending create
+    /// is live, and resolving such an id against the graph would count the
+    /// wrong edge. An id `created_rel_types` knows is always resolved from
+    /// pending; only the rest ever reach the graph.
+    fn index_relationship_deletion(
+        &mut self,
+        id: RelationshipId,
+    ) {
+        let Some(ix) = self.degree_index.get_mut().as_mut() else {
+            return;
+        };
+        if let Some(type_name) = self.created_rel_types.get(&id) {
+            if let Some(&(from, to)) = ix.created_endpoints.get(&id) {
+                ix.record_delete_of_created(from, to, type_name);
+            }
+        } else {
+            ix.unresolved_deletes.push(id);
         }
     }
 
@@ -811,171 +960,111 @@ impl Pending {
         self.deleted_relationships.contains(id.into())
     }
 
-    /// Count pending-created relationships whose destination is `node_id` and
-    /// whose type name matches one of `types` (or all if `types` is empty).
-    #[must_use]
-    pub fn pending_indegree(
-        &self,
-        node_id: NodeId,
-        types: &[Arc<String>],
-    ) -> usize {
-        if types.is_empty() {
-            self.created_rels_by_type
-                .values()
-                .flat_map(|v| v.iter())
-                .filter(|(_, _, to)| *to == node_id)
-                .count()
-        } else {
-            types
-                .iter()
-                .filter_map(|t| self.created_rels_by_type.get(t))
-                .flat_map(|v| v.iter())
-                .filter(|(_, _, to)| *to == node_id)
-                .count()
-        }
-    }
-
-    /// Count pending-created relationships whose source is `node_id` and
-    /// whose type name matches one of `types` (or all if `types` is empty).
-    #[must_use]
-    pub fn pending_outdegree(
-        &self,
-        node_id: NodeId,
-        types: &[Arc<String>],
-    ) -> usize {
-        if types.is_empty() {
-            self.created_rels_by_type
-                .values()
-                .flat_map(|v| v.iter())
-                .filter(|(_, from, _)| *from == node_id)
-                .count()
-        } else {
-            types
-                .iter()
-                .filter_map(|t| self.created_rels_by_type.get(t))
-                .flat_map(|v| v.iter())
-                .filter(|(_, from, _)| *from == node_id)
-                .count()
-        }
-    }
-
-    /// Whether a relationship pending deletion that is *not* pending-created
-    /// has one of `types`, resolving the type name from the committed graph.
-    fn committed_relationship_has_type(
-        id: RelationshipId,
-        types: &[Arc<String>],
-        g: &Graph,
-    ) -> bool {
-        g.relationship_type_id_for_edge(id)
-            .and_then(|t| g.get_type(t))
-            .is_some_and(|t| types.contains(&t))
-    }
-
-    /// Count pending-deleted relationships incident on `node_id` in the
-    /// direction selected by `outgoing`, whose type name matches one of
-    /// `types` (or all if `types` is empty).
+    /// Build the degree index from the current pending state, or refresh an
+    /// existing one, and read `node_id`'s deltas out of it.
     ///
-    /// `deleted_relationships` mixes two populations: edges that live in the
-    /// committed graph, and edges created earlier in this *same* query and
-    /// then deleted by it. The latter were never committed, so `g` has no
-    /// record of them and only `created_rels_by_type` can resolve them.
+    /// Returns `(added, removed)`: relationships pending creation and pending
+    /// deletion respectively, in the direction selected by `outgoing` and
+    /// restricted to `types` when it is non-empty.
     ///
-    /// The two populations are counted in separate passes rather than by
-    /// resolving each deleted id against pending and then the graph. Looking
-    /// an id up in `created_rels_by_type` means scanning its type's whole
-    /// `Vec`, so doing that per deleted id is `O(deleted * pending)` — a
-    /// user-reachable quadratic blowup for a bulk create-and-delete. Walking
-    /// the pending records once instead makes this `O(pending) + O(deleted)`,
-    /// with only `O(1)` membership checks in each pass and no extra
-    /// allocation or per-call map building.
-    ///
-    /// Pending still takes precedence over the committed graph, which is
-    /// load-bearing: relationship ids are recycled, so a reserved id can read
-    /// as present/deleted in the committed graph for the whole lifetime of the
-    /// pending create. The second pass preserves that by skipping every id
-    /// `created_rel_types` knows — exactly the ids the first pass owns — so no
-    /// id is counted twice and none is resolved against the wrong source.
-    fn pending_deleted_degree(
+    /// The index is what keeps this `O(1)` per call. Answering from the
+    /// pending collections directly costs `O(pending)`, and degree functions
+    /// are evaluated once per row, so an `n`-row `CREATE`/`DELETE` that also
+    /// reads a degree used to cost `O(n^2)`.
+    fn pending_degree_delta(
         &self,
         node_id: NodeId,
         types: &[Arc<String>],
         g: &Graph,
         outgoing: bool,
-    ) -> usize {
-        // Nothing deleted: both passes would find nothing, but pass 1 would
-        // still walk every pending-created record to discover that. The old
-        // per-id form iterated an empty set here, so without this guard a
-        // create-only query pays a walk it never used to.
-        if self.deleted_relationships.is_empty() {
-            return 0;
-        }
-
-        let endpoint = |&(_, from, to): &(RelationshipId, NodeId, NodeId)| {
-            if outgoing { from } else { to }
+    ) -> (usize, usize) {
+        let mut slot = self.degree_index.borrow_mut();
+        let ix = match slot.as_mut() {
+            // Deletions of committed relationships are resolved here rather
+            // than at deletion time, which has no graph to resolve them with.
+            Some(ix) => {
+                ix.drain_unresolved(g);
+                ix
+            }
+            None => slot.insert(Box::new(self.build_degree_index(g))),
         };
 
-        // Pass 1 — pending-created-then-deleted edges, visiting each pending
-        // record once. `types` is deduplicated by the degree function's
-        // argument parsing, so no bucket is visited twice.
-        let mut count = if types.is_empty() {
-            self.created_rels_by_type
-                .values()
-                .flat_map(|v| v.iter())
-                .filter(|rel| {
-                    endpoint(rel) == node_id && self.deleted_relationships.contains(rel.0.into())
-                })
-                .count()
+        let mut added = 0usize;
+        let mut removed = 0usize;
+        // `types` is deduplicated by the degree functions' argument parsing,
+        // so summing per type cannot double-count.
+        let mut accumulate = |c: DegreeCounts| {
+            let (a, r) = if outgoing {
+                (c.created_out, c.deleted_out)
+            } else {
+                (c.created_in, c.deleted_in)
+            };
+            added += a as usize;
+            removed += r as usize;
+        };
+        if types.is_empty() {
+            accumulate(ix.get(node_id, None));
         } else {
-            types
-                .iter()
-                .filter_map(|t| self.created_rels_by_type.get(t))
-                .flat_map(|v| v.iter())
-                .filter(|rel| {
-                    endpoint(rel) == node_id && self.deleted_relationships.contains(rel.0.into())
-                })
-                .count()
-        };
-
-        // Pass 2 — deletions of edges that exist in the committed graph.
-        count += self
-            .deleted_relationships
-            .iter()
-            .filter(|rel_id| {
-                let id = RelationshipId::from(*rel_id);
-                !self.created_rel_types.contains_key(&id)
-                    && g.relationship_endpoints(id)
-                        .is_some_and(|(from, to)| (if outgoing { from } else { to }) == node_id)
-                    && (types.is_empty() || Self::committed_relationship_has_type(id, types, g))
-            })
-            .count();
-
-        count
+            for t in types {
+                accumulate(ix.get(node_id, Some(t)));
+            }
+        }
+        (added, removed)
     }
 
-    /// Count pending-deleted relationships whose destination is `node_id` and
-    /// whose type name matches one of `types` (or all if `types` is empty).
-    /// Requires access to the graph to resolve relationship type IDs.
+    /// Populate a fresh index from the pending collections.
+    ///
+    /// Runs once per query that uses a degree function, on the first call.
+    /// Every later mutation maintains the index incrementally instead.
+    fn build_degree_index(
+        &self,
+        g: &Graph,
+    ) -> DegreeIndex {
+        let mut ix = DegreeIndex::default();
+        for (type_name, entries) in &self.created_rels_by_type {
+            for &(id, from, to) in entries {
+                ix.record_create(id, from, to, type_name);
+            }
+        }
+        for rel_id in &self.deleted_relationships {
+            let id = RelationshipId::from(rel_id);
+            // Pending-created edges are resolved from pending, never from the
+            // graph: ids are recycled, so a reserved id can read as present in
+            // the committed graph while its pending create is still live.
+            if let Some(type_name) = self.created_rel_types.get(&id) {
+                if let Some(&(from, to)) = ix.created_endpoints.get(&id) {
+                    ix.record_delete_of_created(from, to, type_name);
+                }
+            } else {
+                ix.unresolved_deletes.push(id);
+            }
+        }
+        ix.drain_unresolved(g);
+        ix
+    }
+
+    /// Pending-created and pending-deleted indegree deltas for `node_id`,
+    /// restricted to `types` when it is non-empty.
     #[must_use]
-    pub fn pending_deleted_indegree(
+    pub fn pending_indegree_delta(
         &self,
         node_id: NodeId,
         types: &[Arc<String>],
         g: &Graph,
-    ) -> usize {
-        self.pending_deleted_degree(node_id, types, g, false)
+    ) -> (usize, usize) {
+        self.pending_degree_delta(node_id, types, g, false)
     }
 
-    /// Count pending-deleted relationships whose source is `node_id` and
-    /// whose type name matches one of `types` (or all if `types` is empty).
-    /// Requires access to the graph to resolve relationship type IDs.
+    /// Pending-created and pending-deleted outdegree deltas for `node_id`,
+    /// restricted to `types` when it is non-empty.
     #[must_use]
-    pub fn pending_deleted_outdegree(
+    pub fn pending_outdegree_delta(
         &self,
         node_id: NodeId,
         types: &[Arc<String>],
         g: &Graph,
-    ) -> usize {
-        self.pending_deleted_degree(node_id, types, g, true)
+    ) -> (usize, usize) {
+        self.pending_degree_delta(node_id, types, g, true)
     }
 
     pub fn commit(
@@ -983,6 +1072,11 @@ impl Pending {
         g: &AtomicRefCell<Graph>,
         stats: &RefCell<QueryStatistics>,
     ) -> Result<(), String> {
+        // Commit rewrites the pending collections (notably `deleted_relationships`,
+        // which is drained and then refilled with what was actually removed), so
+        // the counters no longer describe them. Drop the index and let the next
+        // lookup rebuild from whatever state commit leaves behind.
+        *self.degree_index.get_mut() = None;
         if !self.created_nodes.is_empty() {
             stats.borrow_mut().nodes_created += self.created_nodes.len();
             g.borrow_mut().create_nodes(&self.created_nodes);
@@ -1514,6 +1608,7 @@ impl Pending {
         self.deleted_nodes.clear();
         self.deleted_relationships.clear();
         self.deleted_endpoints.clear();
+        *self.degree_index.get_mut() = None;
         self.index_add_docs.clear();
         self.index_remove_docs.clear();
         self.index_add_edge_docs.clear();

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -859,6 +859,43 @@ impl Pending {
         }
     }
 
+    /// Resolve `(from, to)` for a relationship that is pending deletion.
+    ///
+    /// `deleted_relationships` mixes two populations: edges that live in the
+    /// committed graph, and edges created earlier in this *same* query and
+    /// then deleted by it. The latter were never committed, so `g` has no
+    /// record of them — they are resolved from `created_rels_by_type`
+    /// instead. Pending is consulted first because relationship ids are
+    /// recycled and a reserved id can still read as present/deleted in the
+    /// committed graph for the lifetime of the pending create.
+    ///
+    /// `None` when neither source knows the edge.
+    fn deleted_relationship_endpoints(
+        &self,
+        id: RelationshipId,
+        g: &Graph,
+    ) -> Option<(NodeId, NodeId)> {
+        self.get_created_relationship_endpoints(id)
+            .or_else(|| g.relationship_endpoints(id))
+    }
+
+    /// Whether a relationship pending deletion has one of `types`, resolving
+    /// the type name from `created_rel_types` for edges created in this same
+    /// query and from the committed graph otherwise.
+    fn deleted_relationship_has_type(
+        &self,
+        id: RelationshipId,
+        types: &[Arc<String>],
+        g: &Graph,
+    ) -> bool {
+        self.get_relationship_type(id)
+            .or_else(|| {
+                g.relationship_type_id_for_edge(id)
+                    .and_then(|t| g.get_type(t))
+            })
+            .is_some_and(|t| types.contains(&t))
+    }
+
     /// Count pending-deleted relationships whose destination is `node_id` and
     /// whose type name matches one of `types` (or all if `types` is empty).
     /// Requires access to the graph to resolve relationship type IDs.
@@ -872,11 +909,10 @@ impl Pending {
         self.deleted_relationships
             .iter()
             .filter(|rel_id| {
-                let (_from, to) = g.get_relationship_endpoints(RelationshipId::from(*rel_id));
-                to == node_id
-                    && (types.is_empty()
-                        || g.get_type(g.get_relationship_type_id(RelationshipId::from(*rel_id)))
-                            .is_some_and(|t| types.contains(&t)))
+                let id = RelationshipId::from(*rel_id);
+                self.deleted_relationship_endpoints(id, g)
+                    .is_some_and(|(_from, to)| to == node_id)
+                    && (types.is_empty() || self.deleted_relationship_has_type(id, types, g))
             })
             .count()
     }
@@ -894,11 +930,10 @@ impl Pending {
         self.deleted_relationships
             .iter()
             .filter(|rel_id| {
-                let (from, _to) = g.get_relationship_endpoints(RelationshipId::from(*rel_id));
-                from == node_id
-                    && (types.is_empty()
-                        || g.get_type(g.get_relationship_type_id(RelationshipId::from(*rel_id)))
-                            .is_some_and(|t| types.contains(&t)))
+                let id = RelationshipId::from(*rel_id);
+                self.deleted_relationship_endpoints(id, g)
+                    .is_some_and(|(from, _to)| from == node_id)
+                    && (types.is_empty() || self.deleted_relationship_has_type(id, types, g))
             })
             .count()
     }

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -11,8 +11,7 @@
 //!
 //! - `created_nodes`: Nodes created in this query
 //! - `deleted_nodes`: Nodes marked for deletion
-//! - `created_rels_by_type`: Edges created in this query, grouped by type
-//! - `deleted_relationships`: Edges marked for deletion
+//! - `created_rels_by_type`: Edges created in this query, grouped by type//! - `deleted_relationships`: Edges marked for deletion
 //! - `set_*_attrs`: Property updates by entity ID
 //! - `set/remove_node_labels`: Label changes
 //!
@@ -107,6 +106,22 @@ fn lookup_sorted(
 
 /// Pending degree deltas for one `(node, type)` bucket, or for one node
 /// across all types when the key's type slot is `None`.
+/// Number of per-entity entries above which freeing a collection is handed to
+/// a background thread instead of being paid for on the serialized write path.
+const OFFLOAD_THRESHOLD: usize = 4096;
+
+/// Per-relationship metadata for edges created in this query.
+///
+/// This is the single home for a created edge's type and endpoints. Keeping
+/// endpoints here rather than repeating them in `created_rels_by_type` makes
+/// the by-id lookup `O(1)` at no extra memory: the bytes moved out of that
+/// map's `Vec`s pay for the wider value here.
+struct CreatedRel {
+    type_name: Arc<String>,
+    from: NodeId,
+    to: NodeId,
+}
+
 #[derive(Default, Clone, Copy)]
 struct DegreeCounts {
     created_out: u32,
@@ -132,10 +147,6 @@ struct DegreeIndex {
     /// node's total across types, so an untyped lookup is a single probe
     /// rather than a sum over buckets.
     counts: FxHashMap<(NodeId, Option<Arc<String>>), DegreeCounts>,
-    /// Endpoints of pending-created relationships. Deleting one has to know
-    /// its endpoints, and `created_rels_by_type` can only answer that by
-    /// scanning the type's whole `Vec`.
-    created_endpoints: FxHashMap<RelationshipId, (NodeId, NodeId)>,
     /// Deletions of relationships that live in the committed graph. Resolving
     /// them needs the graph, which the deletion path does not have, so they
     /// are parked here and drained by the next lookup. Each is resolved once.
@@ -159,12 +170,10 @@ impl DegreeIndex {
 
     fn record_create(
         &mut self,
-        id: RelationshipId,
         from: NodeId,
         to: NodeId,
         type_name: &Arc<String>,
     ) {
-        self.created_endpoints.insert(id, (from, to));
         self.update(from, type_name, |c| c.created_out += 1);
         self.update(to, type_name, |c| c.created_in += 1);
     }
@@ -209,6 +218,11 @@ impl DegreeIndex {
             .copied()
             .unwrap_or_default()
     }
+
+    /// Entry count, for deciding whether freeing this is worth offloading.
+    fn len(&self) -> usize {
+        self.counts.len() + self.unresolved_deletes.len()
+    }
 }
 
 /// Accumulated write operations for deferred application.
@@ -218,10 +232,12 @@ impl DegreeIndex {
 pub struct Pending {
     /// Nodes created in this transaction
     created_nodes: RoaringTreemap,
-    /// Relationships created, grouped by type: type_name → [(rel_id, from, to)]
-    created_rels_by_type: FxHashMap<Arc<String>, Vec<(RelationshipId, NodeId, NodeId)>>,
-    /// Reverse index: rel_id → type_name for O(1) existence/type lookups
-    created_rel_types: FxHashMap<RelationshipId, Arc<String>>,
+    /// Relationships created, grouped by type: type_name → [rel_id].
+    /// Endpoints are not repeated here — `created_rel_types` holds them.
+    created_rels_by_type: FxHashMap<Arc<String>, Vec<RelationshipId>>,
+    /// Reverse index: rel_id → type and endpoints, for O(1) existence, type
+    /// and endpoint lookups.
+    created_rel_types: FxHashMap<RelationshipId, CreatedRel>,
     /// Nodes to be deleted
     deleted_nodes: RoaringTreemap,
     /// Relationships to be deleted
@@ -668,11 +684,9 @@ impl Pending {
         Option<Vec<(u16, Value)>>,
     )> {
         let mut rels = Vec::new();
-        for (type_name, entries) in &self.created_rels_by_type {
-            for &(rel_id, from, to) in entries {
-                if from == id || to == id {
-                    rels.push((rel_id, from, to, type_name.clone()));
-                }
+        for (&rel_id, rel) in &self.created_rel_types {
+            if rel.from == id || rel.to == id {
+                rels.push((rel_id, rel.from, rel.to, rel.type_name.clone()));
             }
         }
 
@@ -680,7 +694,7 @@ impl Pending {
         for (rel_id, from, to, type_name) in rels {
             self.created_rel_types.remove(&rel_id);
             if let Some(entries) = self.created_rels_by_type.get_mut(&type_name) {
-                entries.retain(|(rid, _, _)| *rid != rel_id);
+                entries.retain(|rid| *rid != rel_id);
             }
             let attrs = self.new_relationships_attrs.remove(&rel_id.into());
             self.deleted_relationships.remove(rel_id.into());
@@ -690,7 +704,7 @@ impl Pending {
         // cannot be adjusted by the create/delete path. This scan is already
         // O(pending), so dropping the index costs nothing asymptotically.
         if !result.is_empty() {
-            *self.degree_index.get_mut() = None;
+            self.release_degree_index();
         }
 
         result
@@ -706,11 +720,18 @@ impl Pending {
         self.created_rels_by_type
             .entry(type_name.clone())
             .or_default()
-            .push((id, from, to));
+            .push(id);
         if let Some(ix) = self.degree_index.get_mut().as_mut() {
-            ix.record_create(id, from, to, &type_name);
+            ix.record_create(from, to, &type_name);
         }
-        self.created_rel_types.insert(id, type_name);
+        self.created_rel_types.insert(
+            id,
+            CreatedRel {
+                type_name,
+                from,
+                to,
+            },
+        );
     }
 
     /// Set all attributes for a relationship. `attrs` must be
@@ -836,10 +857,8 @@ impl Pending {
         let Some(ix) = self.degree_index.get_mut().as_mut() else {
             return;
         };
-        if let Some(type_name) = self.created_rel_types.get(&id) {
-            if let Some(&(from, to)) = ix.created_endpoints.get(&id) {
-                ix.record_delete_of_created(from, to, type_name);
-            }
+        if let Some(rel) = self.created_rel_types.get(&id) {
+            ix.record_delete_of_created(rel.from, rel.to, &rel.type_name);
         } else {
             ix.unresolved_deletes.push(id);
         }
@@ -850,7 +869,7 @@ impl Pending {
         &self,
         id: RelationshipId,
     ) -> Option<Arc<String>> {
-        self.created_rel_types.get(&id).cloned()
+        self.created_rel_types.get(&id).map(|r| r.type_name.clone())
     }
 
     #[must_use]
@@ -915,12 +934,7 @@ impl Pending {
         &self,
         id: RelationshipId,
     ) -> Option<(NodeId, NodeId)> {
-        let type_name = self.created_rel_types.get(&id)?;
-        self.created_rels_by_type
-            .get(type_name)?
-            .iter()
-            .find(|(rid, _, _)| *rid == id)
-            .map(|&(_, from, to)| (from, to))
+        self.created_rel_types.get(&id).map(|r| (r.from, r.to))
     }
 
     #[must_use]
@@ -1021,20 +1035,16 @@ impl Pending {
         g: &Graph,
     ) -> DegreeIndex {
         let mut ix = DegreeIndex::default();
-        for (type_name, entries) in &self.created_rels_by_type {
-            for &(id, from, to) in entries {
-                ix.record_create(id, from, to, type_name);
-            }
+        for rel in self.created_rel_types.values() {
+            ix.record_create(rel.from, rel.to, &rel.type_name);
         }
         for rel_id in &self.deleted_relationships {
             let id = RelationshipId::from(rel_id);
             // Pending-created edges are resolved from pending, never from the
             // graph: ids are recycled, so a reserved id can read as present in
             // the committed graph while its pending create is still live.
-            if let Some(type_name) = self.created_rel_types.get(&id) {
-                if let Some(&(from, to)) = ix.created_endpoints.get(&id) {
-                    ix.record_delete_of_created(from, to, type_name);
-                }
+            if let Some(rel) = self.created_rel_types.get(&id) {
+                ix.record_delete_of_created(rel.from, rel.to, &rel.type_name);
             } else {
                 ix.unresolved_deletes.push(id);
             }
@@ -1076,7 +1086,7 @@ impl Pending {
         // which is drained and then refilled with what was actually removed), so
         // the counters no longer describe them. Drop the index and let the next
         // lookup rebuild from whatever state commit leaves behind.
-        *self.degree_index.get_mut() = None;
+        self.release_degree_index();
         if !self.created_nodes.is_empty() {
             stats.borrow_mut().nodes_created += self.created_nodes.len();
             g.borrow_mut().create_nodes(&self.created_nodes);
@@ -1088,9 +1098,12 @@ impl Pending {
                 let mut srcs = Vec::with_capacity(rel_ids.len());
                 let mut dsts = Vec::with_capacity(rel_ids.len());
                 let mut ids = Vec::with_capacity(rel_ids.len());
-                for &(rel_id, from, to) in rel_ids {
-                    srcs.push(from.into());
-                    dsts.push(to.into());
+                for &rel_id in rel_ids {
+                    let Some(rel) = self.created_rel_types.get(&rel_id) else {
+                        continue;
+                    };
+                    srcs.push(rel.from.into());
+                    dsts.push(rel.to.into());
                     ids.push(rel_id.into());
                 }
                 g.create_relationships_bulk(type_name, &srcs, &dsts, &ids);
@@ -1258,7 +1271,7 @@ impl Pending {
         // Collect affected edge IDs
         let mut affected_edge_ids = RoaringTreemap::new();
         for rels in self.created_rels_by_type.values() {
-            for &(rel_id, _, _) in rels {
+            for &rel_id in rels {
                 affected_edge_ids.insert(rel_id.into());
             }
         }
@@ -1412,7 +1425,7 @@ impl Pending {
             // An edge's type never changes, so created under a different
             // type means not a member.
             let has_type = match self.created_rel_types.get(&edge_id.into()) {
-                Some(created_type) => created_type.as_str() == type_name.as_str(),
+                Some(created) => created.type_name.as_str() == type_name.as_str(),
                 None => g.edge_has_type(edge_id.into(), type_name),
             };
             if !has_type {
@@ -1571,7 +1584,7 @@ impl Pending {
         // Dropping millions of per-entity Vec allocations is O(n) frees and
         // stalls the serialized write thread; move large maps to a background
         // thread and let it pay the deallocation cost.
-        const OFFLOAD_THRESHOLD: usize = 4096;
+        let degree_index = self.degree_index.get_mut().take();
         let big_entries = self.new_nodes_attrs.len()
             + self.existing_nodes_attrs.len()
             + self.new_relationships_attrs.len()
@@ -1582,7 +1595,8 @@ impl Pending {
                 .created_rels_by_type
                 .values()
                 .map(Vec::len)
-                .sum::<usize>();
+                .sum::<usize>()
+            + degree_index.as_ref().map_or(0, |ix| ix.len());
         if big_entries >= OFFLOAD_THRESHOLD {
             let maps = (
                 std::mem::take(&mut self.new_nodes_attrs),
@@ -1592,6 +1606,8 @@ impl Pending {
                 std::mem::take(&mut self.set_labels),
                 std::mem::take(&mut self.remove_labels),
                 std::mem::take(&mut self.created_rels_by_type),
+                std::mem::take(&mut self.created_rel_types),
+                degree_index,
             );
             std::thread::spawn(move || drop(maps));
         } else {
@@ -1602,17 +1618,31 @@ impl Pending {
             self.set_labels.clear();
             self.remove_labels.clear();
             self.created_rels_by_type.clear();
+            self.created_rel_types.clear();
+            drop(degree_index);
         }
         self.created_nodes.clear();
-        self.created_rel_types.clear();
         self.deleted_nodes.clear();
         self.deleted_relationships.clear();
         self.deleted_endpoints.clear();
-        *self.degree_index.get_mut() = None;
         self.index_add_docs.clear();
         self.index_remove_docs.clear();
         self.index_add_edge_docs.clear();
         self.index_remove_edge_docs.clear();
+    }
+
+    /// Discard the degree index, handing a large one to a background thread.
+    ///
+    /// The index is `O(pending)`, so a bulk degree query builds a big map;
+    /// freeing it inline would stall the serialized write path exactly as the
+    /// per-entity maps in `clear()` would.
+    fn release_degree_index(&mut self) {
+        let Some(ix) = self.degree_index.get_mut().take() else {
+            return;
+        };
+        if ix.len() >= OFFLOAD_THRESHOLD {
+            std::thread::spawn(move || drop(ix));
+        }
     }
 
     /// Returns the number of effects (operations) tracked in this Pending.
@@ -1749,11 +1779,14 @@ impl Pending {
                     .get_type_id(type_name)
                     .expect("created relationship type must be registered")
                     .0 as u16;
-                for &(rel_id, from, to) in entries {
+                for &rel_id in entries {
+                    let Some(rel) = self.created_rel_types.get(&rel_id) else {
+                        continue;
+                    };
                     buf.push(EFFECT_CREATE_EDGE);
                     buf.extend_from_slice(&u64::from(rel_id).to_le_bytes());
-                    buf.extend_from_slice(&u64::from(from).to_le_bytes());
-                    buf.extend_from_slice(&u64::from(to).to_le_bytes());
+                    buf.extend_from_slice(&u64::from(rel.from).to_le_bytes());
+                    buf.extend_from_slice(&u64::from(rel.to).to_le_bytes());
                     write_u16(buf, type_id);
 
                     if let Some(attrs) = self.new_relationships_attrs.get(&u64::from(rel_id)) {

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -859,41 +859,97 @@ impl Pending {
         }
     }
 
-    /// Resolve `(from, to)` for a relationship that is pending deletion.
-    ///
-    /// `deleted_relationships` mixes two populations: edges that live in the
-    /// committed graph, and edges created earlier in this *same* query and
-    /// then deleted by it. The latter were never committed, so `g` has no
-    /// record of them — they are resolved from `created_rels_by_type`
-    /// instead. Pending is consulted first because relationship ids are
-    /// recycled and a reserved id can still read as present/deleted in the
-    /// committed graph for the lifetime of the pending create.
-    ///
-    /// `None` when neither source knows the edge.
-    fn deleted_relationship_endpoints(
-        &self,
-        id: RelationshipId,
-        g: &Graph,
-    ) -> Option<(NodeId, NodeId)> {
-        self.get_created_relationship_endpoints(id)
-            .or_else(|| g.relationship_endpoints(id))
-    }
-
-    /// Whether a relationship pending deletion has one of `types`, resolving
-    /// the type name from `created_rel_types` for edges created in this same
-    /// query and from the committed graph otherwise.
-    fn deleted_relationship_has_type(
-        &self,
+    /// Whether a relationship pending deletion that is *not* pending-created
+    /// has one of `types`, resolving the type name from the committed graph.
+    fn committed_relationship_has_type(
         id: RelationshipId,
         types: &[Arc<String>],
         g: &Graph,
     ) -> bool {
-        self.get_relationship_type(id)
-            .or_else(|| {
-                g.relationship_type_id_for_edge(id)
-                    .and_then(|t| g.get_type(t))
-            })
+        g.relationship_type_id_for_edge(id)
+            .and_then(|t| g.get_type(t))
             .is_some_and(|t| types.contains(&t))
+    }
+
+    /// Count pending-deleted relationships incident on `node_id` in the
+    /// direction selected by `outgoing`, whose type name matches one of
+    /// `types` (or all if `types` is empty).
+    ///
+    /// `deleted_relationships` mixes two populations: edges that live in the
+    /// committed graph, and edges created earlier in this *same* query and
+    /// then deleted by it. The latter were never committed, so `g` has no
+    /// record of them and only `created_rels_by_type` can resolve them.
+    ///
+    /// The two populations are counted in separate passes rather than by
+    /// resolving each deleted id against pending and then the graph. Looking
+    /// an id up in `created_rels_by_type` means scanning its type's whole
+    /// `Vec`, so doing that per deleted id is `O(deleted * pending)` — a
+    /// user-reachable quadratic blowup for a bulk create-and-delete. Walking
+    /// the pending records once instead makes this `O(pending) + O(deleted)`,
+    /// with only `O(1)` membership checks in each pass and no extra
+    /// allocation or per-call map building.
+    ///
+    /// Pending still takes precedence over the committed graph, which is
+    /// load-bearing: relationship ids are recycled, so a reserved id can read
+    /// as present/deleted in the committed graph for the whole lifetime of the
+    /// pending create. The second pass preserves that by skipping every id
+    /// `created_rel_types` knows — exactly the ids the first pass owns — so no
+    /// id is counted twice and none is resolved against the wrong source.
+    fn pending_deleted_degree(
+        &self,
+        node_id: NodeId,
+        types: &[Arc<String>],
+        g: &Graph,
+        outgoing: bool,
+    ) -> usize {
+        // Nothing deleted: both passes would find nothing, but pass 1 would
+        // still walk every pending-created record to discover that. The old
+        // per-id form iterated an empty set here, so without this guard a
+        // create-only query pays a walk it never used to.
+        if self.deleted_relationships.is_empty() {
+            return 0;
+        }
+
+        let endpoint = |&(_, from, to): &(RelationshipId, NodeId, NodeId)| {
+            if outgoing { from } else { to }
+        };
+
+        // Pass 1 — pending-created-then-deleted edges, visiting each pending
+        // record once. `types` is deduplicated by the degree function's
+        // argument parsing, so no bucket is visited twice.
+        let mut count = if types.is_empty() {
+            self.created_rels_by_type
+                .values()
+                .flat_map(|v| v.iter())
+                .filter(|rel| {
+                    endpoint(rel) == node_id && self.deleted_relationships.contains(rel.0.into())
+                })
+                .count()
+        } else {
+            types
+                .iter()
+                .filter_map(|t| self.created_rels_by_type.get(t))
+                .flat_map(|v| v.iter())
+                .filter(|rel| {
+                    endpoint(rel) == node_id && self.deleted_relationships.contains(rel.0.into())
+                })
+                .count()
+        };
+
+        // Pass 2 — deletions of edges that exist in the committed graph.
+        count += self
+            .deleted_relationships
+            .iter()
+            .filter(|rel_id| {
+                let id = RelationshipId::from(*rel_id);
+                !self.created_rel_types.contains_key(&id)
+                    && g.relationship_endpoints(id)
+                        .is_some_and(|(from, to)| (if outgoing { from } else { to }) == node_id)
+                    && (types.is_empty() || Self::committed_relationship_has_type(id, types, g))
+            })
+            .count();
+
+        count
     }
 
     /// Count pending-deleted relationships whose destination is `node_id` and
@@ -906,15 +962,7 @@ impl Pending {
         types: &[Arc<String>],
         g: &Graph,
     ) -> usize {
-        self.deleted_relationships
-            .iter()
-            .filter(|rel_id| {
-                let id = RelationshipId::from(*rel_id);
-                self.deleted_relationship_endpoints(id, g)
-                    .is_some_and(|(_from, to)| to == node_id)
-                    && (types.is_empty() || self.deleted_relationship_has_type(id, types, g))
-            })
-            .count()
+        self.pending_deleted_degree(node_id, types, g, false)
     }
 
     /// Count pending-deleted relationships whose source is `node_id` and
@@ -927,15 +975,7 @@ impl Pending {
         types: &[Arc<String>],
         g: &Graph,
     ) -> usize {
-        self.deleted_relationships
-            .iter()
-            .filter(|rel_id| {
-                let id = RelationshipId::from(*rel_id);
-                self.deleted_relationship_endpoints(id, g)
-                    .is_some_and(|(from, _to)| from == node_id)
-                    && (types.is_empty() || self.deleted_relationship_has_type(id, types, g))
-            })
-            .count()
+        self.pending_deleted_degree(node_id, types, g, true)
     }
 
     pub fn commit(

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -1801,8 +1801,7 @@ impl<'a> Runtime<'a> {
         let g = self.g.borrow();
         let base = g.get_node_indegree(id);
         let pending = self.pending.borrow();
-        let added = pending.pending_indegree(id, &[]);
-        let removed = pending.pending_deleted_indegree(id, &[], &g);
+        let (added, removed) = pending.pending_indegree_delta(id, &[], &g);
         base + added - removed
     }
 
@@ -1819,8 +1818,7 @@ impl<'a> Runtime<'a> {
         let g = self.g.borrow();
         let base = g.get_node_indegree_by_type(id, types);
         let pending = self.pending.borrow();
-        let added = pending.pending_indegree(id, types);
-        let removed = pending.pending_deleted_indegree(id, types, &g);
+        let (added, removed) = pending.pending_indegree_delta(id, types, &g);
         base + added - removed
     }
 
@@ -1836,8 +1834,7 @@ impl<'a> Runtime<'a> {
         let g = self.g.borrow();
         let base = g.get_node_outdegree(id);
         let pending = self.pending.borrow();
-        let added = pending.pending_outdegree(id, &[]);
-        let removed = pending.pending_deleted_outdegree(id, &[], &g);
+        let (added, removed) = pending.pending_outdegree_delta(id, &[], &g);
         base + added - removed
     }
 
@@ -1854,8 +1851,7 @@ impl<'a> Runtime<'a> {
         let g = self.g.borrow();
         let base = g.get_node_outdegree_by_type(id, types);
         let pending = self.pending.borrow();
-        let added = pending.pending_outdegree(id, types);
-        let removed = pending.pending_deleted_outdegree(id, types, &g);
+        let (added, removed) = pending.pending_outdegree_delta(id, types, &g);
         base + added - removed
     }
 }

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -850,6 +850,47 @@ class testGraphDeletionFlow(FlowTestsBase):
         res = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
         self.env.assertEqual(res.result_set[0][0], 0)
 
+    def test38_degree_of_edge_created_and_deleted_in_same_query(self):
+        # An edge created and deleted by the same query is never committed, so
+        # the committed graph cannot resolve its endpoints. The pending-deleted
+        # degree helpers used to look it up with a panicking accessor, which
+        # aborted the whole server process (issue #2769).
+        self.graph.delete()
+
+        res = self.graph.query(
+            "CREATE (a:A)-[r:R]->(b:B) DELETE r SET a.d = outdegree(a) RETURN a.d")
+        self.env.assertEqual(res.result_set, [[0]])
+        self.env.assertEqual(res.relationships_created, 1)
+        self.env.assertEqual(res.relationships_deleted, 1)
+
+        self.graph.delete()
+        res = self.graph.query(
+            "CREATE (a:A)-[r:R]->(b:B) DELETE r SET b.d = indegree(b) RETURN b.d")
+        self.env.assertEqual(res.result_set, [[0]])
+
+        # typed degrees resolve the type from the pending create, not the graph
+        self.graph.delete()
+        res = self.graph.query("""CREATE (a:A)-[r:R]->(:B) DELETE r
+                                  RETURN outdegree(a), outdegree(a, 'R'), outdegree(a, 'Q')""")
+        self.env.assertEqual(res.result_set, [[0, 0, 0]])
+
+        # only the deleted edge is subtracted, the surviving one still counts
+        self.graph.delete()
+        res = self.graph.query("""CREATE (a:A)-[r1:R]->(:B), (a)-[r2:Q]->(:C) DELETE r1
+                                  RETURN outdegree(a), outdegree(a, 'R'), outdegree(a, 'Q')""")
+        self.env.assertEqual(res.result_set, [[1, 0, 1]])
+
+        # committed edges and a pending created-then-deleted edge in one count
+        self.graph.delete()
+        self.graph.query("CREATE (:A {n: 1})-[:R]->(:B)")
+        res = self.graph.query("""MATCH (a:A) CREATE (a)-[r:R]->(:C) DELETE r
+                                  RETURN outdegree(a), outdegree(a, 'R')""")
+        self.env.assertEqual(res.result_set, [[1, 1]])
+
+        # the server is still alive
+        res = self.graph.query("MATCH (a:A) RETURN outdegree(a)")
+        self.env.assertEqual(res.result_set, [[1]])
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -1069,6 +1069,38 @@ class testGraphDeletionFlow(FlowTestsBase):
                                   RETURN a.d, a.e, a.f, a.g, a.h""")
         self.env.assertEqual(res.result_set, [[2, 1, 1, 0, 1]])
 
+    def test42_retracting_the_last_edge_of_a_type_drops_the_type(self):
+        # Retracting a pending relationship left an empty bucket behind in
+        # `created_rels_by_type`, so the query still claimed to be creating
+        # edges of a type it no longer creates any edge of.
+        #
+        # With the type's last edge gone, `commit()` skips relationship
+        # creation entirely and never registers the type in the schema, so
+        # `build_effects_buffer` could not resolve its id and aborted the
+        # server process — reachable from a plain query, with no degree
+        # function involved, on any server with replication or AOF enabled.
+        self.graph.delete()
+
+        res = self.graph.query("CREATE (a:A)-[r:R]->(b:B) DELETE b RETURN 1")
+        self.env.assertEqual(res.result_set, [[1]])
+        self.env.assertEqual(res.relationships_created, 0)
+        self.env.assertEqual(res.nodes_created, 1)
+
+        # The empty bucket is observable without replication too: with another
+        # type still live, `commit()` registered the retracted type against an
+        # empty batch, publishing a type for a relationship that never existed.
+        self.graph.delete()
+        res = self.graph.query(
+            "CREATE (a:A)-[r:R]->(b:B), (a)-[q:Q]->(c:C) DELETE b RETURN 1")
+        self.env.assertEqual(res.relationships_created, 1)
+
+        types = self.graph.query("CALL db.relationshipTypes()").result_set
+        self.env.assertEqual(types, [['Q']])
+
+        # and the surviving edge is intact
+        res = self.graph.query("MATCH ()-[r]->() RETURN type(r)")
+        self.env.assertEqual(res.result_set, [['Q']])
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -912,14 +912,17 @@ class testGraphDeletionFlow(FlowTestsBase):
         # only the deleted edge is subtracted, the surviving one still counts
         self.graph.delete()
         res = self.graph.query("""CREATE (a:A)-[r1:R]->(:B), (a)-[r2:Q]->(:C) DELETE r1
-                                  RETURN outdegree(a), outdegree(a, 'R'), outdegree(a, 'Q')""")
+                                  SET a.d = outdegree(a), a.e = outdegree(a, 'R'),
+                                      a.f = outdegree(a, 'Q')
+                                  RETURN a.d, a.e, a.f""")
         self.env.assertEqual(res.result_set, [[1, 0, 1]])
 
         # committed edges and a pending created-then-deleted edge in one count
         self.graph.delete()
         self.graph.query("CREATE (:A {n: 1})-[:R]->(:B)")
         res = self.graph.query("""MATCH (a:A) CREATE (a)-[r:R]->(:C) DELETE r
-                                  RETURN outdegree(a), outdegree(a, 'R')""")
+                                  SET a.d = outdegree(a), a.e = outdegree(a, 'R')
+                                  RETURN a.d, a.e""")
         self.env.assertEqual(res.result_set, [[1, 1]])
 
         # the server is still alive

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -978,7 +978,7 @@ class testGraphDeletionFlow(FlowTestsBase):
 
         # guard against a near-zero denominator making the ratio meaningless
         if without_degree > 1:
-            self.env.assertTrue(with_degree / without_degree < 3.0)
+            self.env.assertLess(with_degree / without_degree, 3.0)
 
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -868,11 +868,46 @@ class testGraphDeletionFlow(FlowTestsBase):
             "CREATE (a:A)-[r:R]->(b:B) DELETE r SET b.d = indegree(b) RETURN b.d")
         self.env.assertEqual(res.result_set, [[0]])
 
-        # typed degrees resolve the type from the pending create, not the graph
+        # Typed degrees, evaluated by SET so they run mid-pipeline while the
+        # pending mutations are still uncommitted. A degree in RETURN is
+        # evaluated after the commit and never reaches the pending path, so it
+        # cannot cover the type-filtering branch.
         self.graph.delete()
-        res = self.graph.query("""CREATE (a:A)-[r:R]->(:B) DELETE r
-                                  RETURN outdegree(a), outdegree(a, 'R'), outdegree(a, 'Q')""")
-        self.env.assertEqual(res.result_set, [[0, 0, 0]])
+        res = self.graph.query("""CREATE (a:A)-[r:R]->(b:B) DELETE r
+                                  SET a.d = outdegree(a, 'R'), a.e = outdegree(a, 'Q'),
+                                      b.f = indegree(b, 'R'),  b.g = indegree(b, 'Q')
+                                  RETURN a.d, a.e, b.f, b.g""")
+        self.env.assertEqual(res.result_set, [[0, 0, 0, 0]])
+
+        # A committed edge of one type plus a pending created-then-deleted edge
+        # of another. The two types must come out differently, so the type of
+        # the pending-deleted edge has to be resolved from the pending create.
+        self.graph.delete()
+        self.graph.query("CREATE (:A {n: 1})-[:R]->(:B {n: 2})")
+        res = self.graph.query("""MATCH (a:A)-[:R]->(b:B) CREATE (a)-[r:Q]->(b) DELETE r
+                                  SET a.d = outdegree(a, 'Q'), a.e = outdegree(a, 'R'),
+                                      b.f = indegree(b, 'Q'),  b.g = indegree(b, 'R')
+                                  RETURN a.d, a.e, b.f, b.g""")
+        self.env.assertEqual(res.result_set, [[0, 1, 0, 1]])
+
+        # The same type committed and pending: the pending create and the
+        # pending delete cancel, leaving only the committed edge.
+        self.graph.delete()
+        self.graph.query("CREATE (:A {n: 1})-[:Q]->(:B {n: 2})")
+        res = self.graph.query("""MATCH (a:A)-[:Q]->(b:B) CREATE (a)-[r:Q]->(b) DELETE r
+                                  SET a.d = outdegree(a, 'Q'), b.e = indegree(b, 'Q')
+                                  RETURN a.d, b.e""")
+        self.env.assertEqual(res.result_set, [[1, 1]])
+
+        # Deleting a *committed* edge by type exercises the other branch of the
+        # type lookup, where the name comes from the graph rather than pending.
+        self.graph.delete()
+        self.graph.query("CREATE (a:A {n: 1})-[:R]->(b:B {n: 2}), (a)-[:Q]->(b)")
+        res = self.graph.query("""MATCH (a:A)-[r:Q]->(b:B) DELETE r
+                                  SET a.d = outdegree(a, 'Q'), a.e = outdegree(a, 'R'),
+                                      b.f = indegree(b, 'Q'),  b.g = indegree(b, 'R')
+                                  RETURN a.d, a.e, b.f, b.g""")
+        self.env.assertEqual(res.result_set, [[0, 1, 0, 1]])
 
         # only the deleted edge is subtracted, the surviving one still counts
         self.graph.delete()

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -927,47 +927,58 @@ class testGraphDeletionFlow(FlowTestsBase):
         self.env.assertEqual(res.result_set, [[1]])
 
     def test39_bulk_create_and_delete_degree_is_not_quadratic(self):
-        # Resolving each pending-deleted id against the pending-created records
-        # individually means scanning that type's whole vector per id, which is
-        # quadratic once a query creates and deletes edges in bulk. The degree
-        # helpers walk the pending records once instead.
+        # Degree functions are evaluated once per row, so answering one by
+        # scanning the pending create/delete records costs O(pending) per row
+        # and O(n^2) over the query. The pending degree counters are
+        # maintained incrementally instead, making a lookup O(1).
         #
-        # Asserted as a growth ratio rather than a wall-clock ceiling so the
-        # check calibrates itself to the machine: doubling the edge count
-        # roughly doubles the work for the linear form but quadruples it for
-        # the quadratic one. Measured here while writing this, the quadratic
-        # form grew 5.8x per doubling and the current one 3.0x, so 4.5 sits
-        # well clear of both.
+        # Asserted against the same query with the degree call replaced by a
+        # constant rather than as a growth ratio or a wall-clock ceiling. The
+        # baseline absorbs whatever the bulk CREATE/DELETE itself costs on this
+        # machine, so what is left is the degree lookup alone. A ceiling would
+        # have to be loose enough to pass on a slow runner, and a whole-query
+        # growth ratio is dominated by CREATE/DELETE, which grows on its own.
+        #
+        # Measured while writing this at n=4000: 7.8 ms with the degree call
+        # against 7.2 ms without it, a ratio of ~1.1. The quadratic form took
+        # 4894 ms, a ratio of ~680, so the bound below has a wide margin in
+        # both directions.
         self.graph.delete()
         # keep the key alive so each round can reset with a query instead of a
         # delete, which errors once the graph is empty
         self.graph.query("CREATE (:Seed)")
 
-        def timed_bulk(n):
-            self.graph.query("MATCH (x) DETACH DELETE x")
-            self.graph.query("CREATE (:Hub {n: 1})")
-            res = self.graph.query(f"""MATCH (a:Hub)
-                                       UNWIND range(1, {n}) AS i
-                                       CREATE (a)-[r:R]->(:Leaf)
-                                       DELETE r
-                                       SET a.d = outdegree(a)""")
-            self.env.assertEqual(res.relationships_created, n)
-            self.env.assertEqual(res.relationships_deleted, n)
+        n = 4000
 
-            # every created edge was also deleted, so the hub ends with none
-            check = self.graph.query("MATCH (a:Hub) RETURN a.d, outdegree(a)")
-            self.env.assertEqual(check.result_set, [[0, 0]])
-            check = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
-            self.env.assertEqual(check.result_set[0][0], 0)
+        def timed_bulk(set_expr, expect_zero):
+            best = None
+            for _ in range(2):
+                self.graph.query("MATCH (x) DETACH DELETE x")
+                self.graph.query("CREATE (:Hub {n: 1})")
+                res = self.graph.query(f"""MATCH (a:Hub)
+                                           UNWIND range(1, {n}) AS i
+                                           CREATE (a)-[r:R]->(:Leaf)
+                                           DELETE r
+                                           SET a.d = {set_expr}""")
+                self.env.assertEqual(res.relationships_created, n)
+                self.env.assertEqual(res.relationships_deleted, n)
 
-            return res.run_time_ms
+                # every created edge was also deleted, so the hub ends with none
+                check = self.graph.query("MATCH (a:Hub) RETURN a.d, outdegree(a)")
+                if expect_zero:
+                    self.env.assertEqual(check.result_set, [[0, 0]])
+                check = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+                self.env.assertEqual(check.result_set[0][0], 0)
 
-        base = timed_bulk(2000)
-        doubled = timed_bulk(4000)
+                best = res.run_time_ms if best is None else min(best, res.run_time_ms)
+            return best
+
+        with_degree = timed_bulk("outdegree(a)", True)
+        without_degree = timed_bulk("i", False)
 
         # guard against a near-zero denominator making the ratio meaningless
-        if base > 1:
-            self.env.assertTrue(doubled / base < 4.5)
+        if without_degree > 1:
+            self.env.assertTrue(with_degree / without_degree < 3.0)
 
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -926,6 +926,49 @@ class testGraphDeletionFlow(FlowTestsBase):
         res = self.graph.query("MATCH (a:A) RETURN outdegree(a)")
         self.env.assertEqual(res.result_set, [[1]])
 
+    def test39_bulk_create_and_delete_degree_is_not_quadratic(self):
+        # Resolving each pending-deleted id against the pending-created records
+        # individually means scanning that type's whole vector per id, which is
+        # quadratic once a query creates and deletes edges in bulk. The degree
+        # helpers walk the pending records once instead.
+        #
+        # Asserted as a growth ratio rather than a wall-clock ceiling so the
+        # check calibrates itself to the machine: doubling the edge count
+        # roughly doubles the work for the linear form but quadruples it for
+        # the quadratic one. Measured here while writing this, the quadratic
+        # form grew 5.8x per doubling and the current one 3.0x, so 4.5 sits
+        # well clear of both.
+        self.graph.delete()
+        # keep the key alive so each round can reset with a query instead of a
+        # delete, which errors once the graph is empty
+        self.graph.query("CREATE (:Seed)")
+
+        def timed_bulk(n):
+            self.graph.query("MATCH (x) DETACH DELETE x")
+            self.graph.query("CREATE (:Hub {n: 1})")
+            res = self.graph.query(f"""MATCH (a:Hub)
+                                       UNWIND range(1, {n}) AS i
+                                       CREATE (a)-[r:R]->(:Leaf)
+                                       DELETE r
+                                       SET a.d = outdegree(a)""")
+            self.env.assertEqual(res.relationships_created, n)
+            self.env.assertEqual(res.relationships_deleted, n)
+
+            # every created edge was also deleted, so the hub ends with none
+            check = self.graph.query("MATCH (a:Hub) RETURN a.d, outdegree(a)")
+            self.env.assertEqual(check.result_set, [[0, 0]])
+            check = self.graph.query("MATCH ()-[r]->() RETURN count(r)")
+            self.env.assertEqual(check.result_set[0][0], 0)
+
+            return res.run_time_ms
+
+        base = timed_bulk(2000)
+        doubled = timed_bulk(4000)
+
+        # guard against a near-zero denominator making the ratio meaningless
+        if base > 1:
+            self.env.assertTrue(doubled / base < 4.5)
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -980,6 +980,43 @@ class testGraphDeletionFlow(FlowTestsBase):
         if without_degree > 1:
             self.env.assertLess(with_degree / without_degree, 3.0)
 
+    def test40_bulk_delete_of_pending_edges_is_not_quadratic(self):
+        # Deleting an edge created earlier in the same query snapshots its
+        # endpoints, which resolves the id against Pending. Answering that by
+        # scanning the type's created list is O(pending) per delete and
+        # O(n^2) over the query, so the endpoints are stored by id instead.
+        #
+        # This needs no degree function: the lookup is on the plain
+        # CREATE-then-DELETE path. Baselined against the same query without
+        # the DELETE, for the reasons given in test39.
+        #
+        # Measured while writing this at n=16000: 13.2 ms with the DELETE
+        # against 12.0 ms without. The scanning form took 53.2 ms, and its
+        # cost accelerated with n (195.5 ms at n=32000 against 29.7 ms).
+        self.graph.delete()
+        self.graph.query("CREATE (:Seed)")
+
+        n = 16000
+
+        def timed(delete_clause, expect_deleted):
+            best = None
+            for _ in range(2):
+                self.graph.query("MATCH (x) DETACH DELETE x")
+                res = self.graph.query(f"""UNWIND range(1, {n}) AS i
+                                           CREATE (a:A)-[r:R]->(b:B)
+                                           {delete_clause}""")
+                self.env.assertEqual(res.relationships_created, n)
+                self.env.assertEqual(res.relationships_deleted,
+                                     n if expect_deleted else 0)
+                best = res.run_time_ms if best is None else min(best, res.run_time_ms)
+            return best
+
+        with_delete = timed("DELETE r", True)
+        without_delete = timed("", False)
+
+        if without_delete > 1:
+            self.env.assertLess(with_delete / without_delete, 3.0)
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -1020,6 +1020,55 @@ class testGraphDeletionFlow(FlowTestsBase):
         if without_delete > 1:
             self.env.assertLess(with_delete / without_delete, 3.0)
 
+    def test41_degree_after_deleting_a_pending_node(self):
+        # Deleting a node that the same query created retracts its pending
+        # relationships instead of deleting them, so the create/delete counters
+        # cannot be adjusted and the degree index has to be dropped.
+        #
+        # Every case evaluates a degree *before* the node delete as well as
+        # after it. That first lookup is what builds the index, so a stale
+        # index would still be holding the retracted edge and the second
+        # lookup would read the pre-delete count.
+        self.graph.delete()
+
+        res = self.graph.query("""CREATE (a:A)-[r:R]->(b:B)
+                                  SET a.d = outdegree(a)
+                                  DELETE b
+                                  SET a.e = outdegree(a)
+                                  RETURN a.d, a.e""")
+        self.env.assertEqual(res.result_set, [[1, 0]])
+
+        # the same on the incoming side
+        self.graph.delete()
+        res = self.graph.query("""CREATE (a:A)-[r:R]->(b:B)
+                                  SET b.d = indegree(b)
+                                  DELETE a
+                                  SET b.e = indegree(b)
+                                  RETURN b.d, b.e""")
+        self.env.assertEqual(res.result_set, [[1, 0]])
+
+        # the per-type buckets have to be dropped too, not just the totals
+        self.graph.delete()
+        res = self.graph.query("""CREATE (a:A)-[r:R]->(b:B)
+                                  SET a.d = outdegree(a, 'R')
+                                  DETACH DELETE b
+                                  SET a.e = outdegree(a, 'R'), a.f = outdegree(a)
+                                  RETURN a.d, a.e, a.f""")
+        self.env.assertEqual(res.result_set, [[1, 0, 0]])
+
+        # A committed :R edge alongside a pending :Q edge to a pending node.
+        # Retracting the node must remove only the :Q edge, so the rebuilt
+        # counters have to keep the committed edge and both types apart.
+        self.graph.delete()
+        self.graph.query("CREATE (:A {n: 1})-[:R]->(:B {n: 2})")
+        res = self.graph.query("""MATCH (a:A) CREATE (a)-[r:Q]->(c:C)
+                                  SET a.d = outdegree(a), a.e = outdegree(a, 'Q')
+                                  DELETE c
+                                  SET a.f = outdegree(a), a.g = outdegree(a, 'Q'),
+                                      a.h = outdegree(a, 'R')
+                                  RETURN a.d, a.e, a.f, a.g, a.h""")
+        self.env.assertEqual(res.result_set, [[2, 1, 1, 0, 1]])
+
 class testGraphBulkDeletion(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()


### PR DESCRIPTION
Fixes #2769

## Reproduction

A single query kills the entire `redis-server` process on the Rust engine (`edge-rs`):

```
GRAPH.QUERY dg "CREATE (a:A)-[r:R]->(b:B) DELETE r SET a.d = outdegree(a) RETURN a.d"
```

```
# <module> FalkorDB panic: panicked at graph/src/graph/graph.rs:2734:9:
relationship 0 not found
  3: falkordb::module_init::graph_init::{closure#0} at src/module_init.rs:150:13
```

The panic hook at `src/module_init.rs:142-154` calls `std::process::exit(1)`, so this is a remote DoS from one query, not just a failed query. Still reproducible on `origin/main` at the time of writing.

## Root cause

`Pending::deleted_relationships` mixes two populations:

1. edges that exist in the committed graph, and
2. edges created earlier in the **same** query and then deleted by it (`ops/delete.rs` → `Pending::deleted_relationship`).

Mutation clauses are stitched with no intervening `Commit`, so a pending-created-then-deleted edge is never in the committed graph.

`Pending::pending_deleted_indegree` / `pending_deleted_outdegree` resolved *every* entry through `Graph::get_relationship_endpoints`, which is total-looking but `panic!`s when the underlying fallible `endpoints_for_edge` returns `None`. The type lookup on the next line, `Graph::get_relationship_type_id`, has the same shape (`.expect("relationship must have a type in type_matrix")`).

## Fix

Degree deltas are maintained incrementally in a `DegreeIndex` rather than computed by scanning the pending collections. It keys `(node, type)` and `(node, all types)` buckets holding the created and deleted counts, so a lookup is one hash probe per requested type and never touches an unresolvable edge.

- **Pending-created edges are resolved from pending, never from the graph.** This is load-bearing: relationship ids are recycled, so a reserved id can read as present in the committed graph while its pending create is still live. The split happens when a deletion is recorded — an id `created_rel_types` knows is counted from pending, everything else is parked and resolved later.
- **Deletions of committed edges** need the graph, which the deletion path doesn't have, so they are drained by the next lookup via the new fallible `Graph::relationship_endpoints` / `Graph::relationship_type_id_for_edge`. Each is resolved exactly once. An edge neither source knows is skipped rather than counted.
- **`commit`, `clear`, and `remove_pending_relationships_for_node`** rewrite or retract the pending collections wholesale, so they drop the index and let the next lookup rebuild. A large index is handed to a background thread rather than freed inline, using the same threshold `clear()` already applies to the per-entity maps, so a bulk degree query does not stall the serialized write path.

`created_rel_types` carries each created edge's type **and** endpoints, and `created_rels_by_type` stores only the ids it groups. Endpoints are held once, so the index duplicates nothing and per-edge bookkeeping is unchanged (map 16 → 32 bytes, vec 24 → 8). That also makes `get_created_relationship_endpoints` a single probe instead of a linear scan of the type's whole list.

The index is built on the first degree lookup of a query rather than eagerly: almost no query calls a degree function, and those that don't must not pay for the bookkeeping. Until then the mutation path only tests an `Option` and nothing is allocated.

Both panicking accessors are kept and now delegate to their fallible counterparts, mirroring the existing `endpoints_for_edge` / `get_relationship_endpoints` pair.

This is a root-cause fix, not a guard: the created-then-deleted edge is still *counted* as deleted, which is what makes the arithmetic in `base + added - removed` come out right, so `outdegree(a)` is `0` in the repro.

## A second abort, found by the new test

`test41` uncovered an unrelated abort on the same retraction path, and it is **pre-existing**: a build of `origin/main` panics identically at its own `pending.rs:1580`.

Retracting a pending relationship removed its id from the type's bucket in `created_rels_by_type` but left the empty bucket behind, so the query still claimed to be creating edges of a type it creates no edge of. When that was the query's only created relationship, `commit()` skips relationship creation and the type is never registered, so `build_effects_buffer` resolved the leftover bucket's type id with an `expect` and called `std::process::exit(1)`:

```
panicked at graph/src/runtime/pending.rs:1780:22:
created relationship type must be registered
```

Reachable from a plain query with **no degree function involved**, on any server with replication or AOF enabled:

```
GRAPH.QUERY g "CREATE (a:A)-[r:R]->(b:B) DELETE b RETURN 1"
```

With another type still live it does not abort, but `commit()` registered the retracted type against an empty batch, publishing a type for a relationship that never existed. Before, `CREATE (a:A)-[r:R]->(b:B), (a)-[q:Q]->(c:C) DELETE b` left `db.relationshipTypes()` reporting `Q` **and** `R`; after, only `Q`.

Removing the bucket when its last edge is retracted fixes both. The effects encoder additionally skips an empty bucket instead of resolving a type id it has no edge to write with, so it is total whether or not the invariant holds — verified independently: with the bucket fix reverted and only that guard in place, the repro returns `1` and the server stays up.

## Verification against a live server

Built the module and ran it under `redis-server`. Every query returns the correct answer and the server stays up (`PING` → `PONG` after each):

| Query | Result | Expected |
|---|---|---|
| `CREATE (a:A)-[r:R]->(b:B) DELETE r SET a.d = outdegree(a) RETURN a.d` | `0` | `0` |
| `CREATE (a:A)-[r:R]->(b:B) DELETE r SET b.d = indegree(b) RETURN b.d` | `0` | `0` |
| `CREATE (a:A)-[r1:R]->(:B), (a)-[r2:Q]->(:C) DELETE r1 SET ... outdegree(a,'R'), outdegree(a,'Q'), outdegree(a)` | `0, 1, 1` | `0, 1, 1` |
| committed `:R` + pending-created-then-deleted `:Q`, typed both ways | `1, 0, 1` | `1, 0, 1` |
| `MATCH (a:A)-[r:R]->() DELETE r SET a.d = outdegree(a)` (committed delete) | `0` | `0` |
| `CREATE (a:A)-[r:R]->(b:B) DELETE b SET a.d = outdegree(a)` (node cascade) | `0` | `0` |
| `CREATE (a:A)-[r:R]->(b:B) DELETE r, b SET a.d = outdegree(a)` | `0` | `0` |
| two `:R` edges, delete one, `outdegree(a)` / `indegree(b)` | `1, 1` | `1, 1` |
| recycled edge id created + deleted, then re-created | `1` | `1` |

Note the typed cases go through `SET`, not `RETURN`: degrees in `RETURN` (and after a `WITH`) are evaluated post-commit and never reach `Pending`, so a `RETURN`-based assertion here is vacuous.

## Performance

Degree functions are evaluated once per row, so answering one by scanning the pending records costs `O(pending)` per row and `O(n^2)` over an `n`-row mutation. The index makes a lookup `O(1)`.

Measured on one machine (debug build, server-reported query time), `MATCH (a:Hub) UNWIND range(1, n) AS i CREATE (a)-[r:R]->(:Leaf) DELETE r SET a.d = outdegree(a)`:

| n | first fix | one-pass | with index |
|---|---|---|---|
| 2000 | 834 ms | 60 ms | 4.3 ms |
| 4000 | 4894 ms | 164 ms | 7.8 ms |
| 8000 | 31511 ms | 455 ms | 20.6 ms |
| 16000 | — | 1544 ms | 63.7 ms |
| 32000 | — | — | 190.8 ms |

At n=32000 the query is within 4% of the identical query with `outdegree(a)` replaced by a constant (190.2 ms vs 182.5 ms, min of 3), so the degree lookup is no longer the dominant term; the remaining growth belongs to the bulk CREATE/DELETE itself.

This also removes a **pre-existing** scan on the created side — `pending_indegree`/`pending_outdegree` walked the pending records too, on a path that needs no deletes to reach. Against `origin/main`, `CREATE (a)-[r:R]->(:Leaf) SET a.d = outdegree(a)`:

| n | origin/main | this PR |
|---|---|---|
| 2000 | 3.9 ms | 1.4 ms |
| 4000 | 7.0 ms | 2.6 ms |
| 8000 | 24.8 ms | 4.6 ms |
| 16000 | 80.5 ms | 8.9 ms |

3.3x per doubling before, 1.95x after.

And a **second pre-existing** quadratic, this one needing no degree function at all: `DELETE` snapshots an edge's endpoints, which for a pending-created edge went through a linear scan of its type's created list. Storing endpoints by id makes it a single probe. `UNWIND range(1,n) AS i CREATE (a:A)-[r:R]->(b:B) DELETE r`:

| n | before | after |
|---|---|---|
| 8000 | 18.4 ms | 6.8 ms |
| 16000 | 53.2 ms | 13.2 ms |
| 32000 | 195.5 ms | 29.7 ms |

3.67x per doubling before, 2.25x after.

Memory, peak RSS with a fresh server per run at n=200000:

| shape | before | after |
|---|---|---|
| plain bulk create, no degree call | 173.8 / 154.9 MB, 170 / 176 ms | 170.9 / 152.9 MB, 172 / 174 ms |
| create + `SET a.d = outdegree(a)` | 208.6 / 211.8 MB, 241 / 228 ms | 203.8 / 203.9 MB, 232 / 222 ms |

`commit` and the effects encoder now probe by id instead of reading endpoints inline, so the write path was measured specifically: plain bulk create is unchanged within noise.

## Regression tests

`test38_degree_of_edge_created_and_deleted_in_same_query` covers `outdegree`/`indegree`, typed degrees, partial deletes, and the mixed committed + pending case. Confirmed to catch the crash: built against pre-fix code, RLTest reports a server crash on this test.

`test39_bulk_create_and_delete_degree_is_not_quadratic` guards the complexity. It compares the query against the same query with the degree call replaced by a constant, so the baseline absorbs whatever bulk CREATE/DELETE costs on the runner and only the degree lookup is bounded — more robust than a wall-clock ceiling or a whole-query growth ratio, both of which were tried and found too weak.

`test40_bulk_delete_of_pending_edges_is_not_quadratic` guards the endpoint lookup on the plain CREATE-then-DELETE path, baselined the same way against the query without the `DELETE`.

`test41_degree_after_deleting_a_pending_node` covers the index reset taken when a pending-created node is deleted and its relationships are *retracted* rather than deleted. Each case reads a degree before the node delete as well as after it — the first read is what activates the lazily-built index, so a stale index is what the second read would catch. `CREATE ... DELETE b SET a.d = outdegree(a)` on its own does **not** cover this: the only lookup runs after the delete, so the index is built fresh from already-retracted state.

Mutation-tested rather than assumed. Each of these fails the tests as it should:

| Mutation | Result |
|---|---|
| per-type buckets never populated | `test38` fails |
| committed-edge type resolution stubbed out | `test38` fails |
| index rebuilt per lookup (i.e. the scan reinstated) | `test39` fails, ratio 220 vs a 3.0 bound |
| endpoint lookup returned to a linear scan | `test40` fails, ratio 10.6 vs a 3.0 bound |
| index reset on pending-node delete removed | `test41` fails all 4 assertions, each reading the pre-delete count |
| empty type bucket left behind on retraction | `test42` fails, `[['Q'], ['R']]` for `[['Q']]` |

`test42_retracting_the_last_edge_of_a_type_drops_the_type` covers the second abort. It asserts the schema through `db.relationshipTypes()` rather than only running the crashing query, because the abort needs replication or AOF enabled while the leftover bucket is observable everywhere — so the case fails deterministically on a local run instead of only on the CI shards that build effects.

All degree assertions are evaluated in `SET`. Degrees in `RETURN` (and after a `WITH`) run post-commit and never reach `Pending`, so a `RETURN`-based assertion here passes whether or not the pending logic is correct.

## Validation gate

Rebased onto `origin/main` (`5f8fc6ad3`).

- `cargo fmt --all -- --check` — clean
- `CXX=clang++ cargo clippy --all-targets` — 0 errors, 0 new warnings (3 remain, all pre-existing in files this PR never touches)
- `cargo test -p graph` — 299 passed, 0 failed
- `test_graph_deletion` — 47 passed · `test_effects` — 22 · `test_replication_states` — 1 · `test_graph_create` — 10

`test_constraint` has one failure, `testConstraintReplication.test_01_constraint_replication` (`0 == 12`). It reproduces identically on a build of the parent commit with this PR's changes stashed, so it is pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safe graph lookups for relationship types and endpoints, allowing missing relationships to be handled without forced failures.
  - Composite unique constraints now ignore entities when any constrained property is missing or `NULL`.

- **Bug Fixes**
  - Fixed degree calculations for relationships created and deleted within the same query.
  - Typed and untyped degree lookups now return correct results for pending and committed relationships.
  - Improved bulk relationship degree processing to avoid quadratic performance growth.
  - Prevented server failures when processing pending relationship deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->