### PR TITLE
Stop deleting user graphs named like internal placeholders

### DIFF
--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -513,9 +513,9 @@ pub struct ThreadedGraph {
     /// would deadlock). An atomic load is well defined there; a plain `bool`
     /// read racing a store would not be.
     ///
-    /// Only ever transitions `true -> false`, when a load placeholder is
-    /// promoted in place to the real graph it was standing in for
-    /// ([`Self::clear_placeholder`]).
+    /// Set once at construction, and thereafter only ever transitions
+    /// `true -> false`, when a load placeholder is promoted in place to the
+    /// real graph it was standing in for ([`Self::clear_placeholder`]).
     placeholder: AtomicBool,
 }
 
@@ -523,9 +523,15 @@ unsafe impl Send for ThreadedGraph {}
 unsafe impl Sync for ThreadedGraph {}
 
 impl ThreadedGraph {
-    pub fn new(
+    /// Shared constructor. `placeholder` is baked in here rather than patched
+    /// afterwards so the `true -> false`-only invariant on
+    /// [`Self::placeholder`] holds from the moment the value exists — that
+    /// invariant is what makes the sweep's unsynchronized `data_ptr()` read
+    /// sound, so it must not be momentarily violated during construction.
+    fn build(
         cache_size: usize,
         name: &str,
+        placeholder: bool,
     ) -> Self {
         let (sender, receiver) = bounded_blocking(1024);
         Self {
@@ -534,8 +540,15 @@ impl ThreadedGraph {
             receiver,
             write_loop: AtomicBool::new(false),
             slow_log: SlowLog::new(),
-            placeholder: AtomicBool::new(false),
+            placeholder: AtomicBool::new(placeholder),
         }
+    }
+
+    pub fn new(
+        cache_size: usize,
+        name: &str,
+    ) -> Self {
+        Self::build(cache_size, name, false)
     }
 
     /// Create a `ThreadedGraph` flagged as module-internal bookkeeping.
@@ -544,9 +557,7 @@ impl ThreadedGraph {
     /// caller-supplied string can turn a user graph into one, and no
     /// placeholder construction site can forget to set the flag.
     pub fn new_placeholder(cache_size: usize) -> Self {
-        let mut tg = Self::new(cache_size, PLACEHOLDER_GRAPH_NAME);
-        tg.placeholder = AtomicBool::new(true);
-        tg
+        Self::build(cache_size, PLACEHOLDER_GRAPH_NAME, true)
     }
 
     /// Create a `ThreadedGraph` from an existing `MvccGraph`.

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -485,12 +485,38 @@ pub mod ffi {
 /// verbatim-query fallback is then a no-op propagation.
 pub static REPLICATION_CONSUMERS: AtomicBool = AtomicBool::new(false);
 
+/// Cosmetic name given to module-internal placeholder graphs. Only ever used
+/// for logging and for the `MvccGraph` constructor's `name` argument — never
+/// as evidence that a graph *is* a placeholder. See [`ThreadedGraph::placeholder`].
+const PLACEHOLDER_GRAPH_NAME: &str = "__placeholder__";
+
 pub struct ThreadedGraph {
     pub graph: MvccGraph,
     pub sender: MTx<Array<Box<WriteMessage>>>,
     pub receiver: Rx<Array<Box<WriteMessage>>>,
     pub write_loop: AtomicBool,
     pub slow_log: SlowLog,
+    /// True while this value is module bookkeeping rather than a user graph:
+    /// either the stand-in returned by `graph_rdb_load` for a not-yet-complete
+    /// multi-key load, or the dummy value attached to a virtual key so Redis
+    /// will include it in an RDB save.
+    ///
+    /// This must stay a structural property. It used to be inferred from the
+    /// graph *name* (`starts_with("__placeholder")`), which a client can pick
+    /// freely — so a user graph called `__placeholder_x` was mistaken for
+    /// bookkeeping and silently deleted by the pre-save sweep (issue #2773).
+    ///
+    /// Atomic, and never observed through a lock: the pre-save sweep in
+    /// `redis_type::scan_and_clean_graphdata_keys` reads it via `data_ptr()`
+    /// without taking the `RwLock` (mandatory in the BGSAVE fork child, where
+    /// acquiring a `parking_lot` lock held by a thread that no longer exists
+    /// would deadlock). An atomic load is well defined there; a plain `bool`
+    /// read racing a store would not be.
+    ///
+    /// Only ever transitions `true -> false`, when a load placeholder is
+    /// promoted in place to the real graph it was standing in for
+    /// ([`Self::clear_placeholder`]).
+    placeholder: AtomicBool,
 }
 
 unsafe impl Send for ThreadedGraph {}
@@ -508,7 +534,19 @@ impl ThreadedGraph {
             receiver,
             write_loop: AtomicBool::new(false),
             slow_log: SlowLog::new(),
+            placeholder: AtomicBool::new(false),
         }
+    }
+
+    /// Create a `ThreadedGraph` flagged as module-internal bookkeeping.
+    ///
+    /// The *only* way to produce a placeholder: the name is fixed here so no
+    /// caller-supplied string can turn a user graph into one, and no
+    /// placeholder construction site can forget to set the flag.
+    pub fn new_placeholder(cache_size: usize) -> Self {
+        let mut tg = Self::new(cache_size, PLACEHOLDER_GRAPH_NAME);
+        tg.placeholder = AtomicBool::new(true);
+        tg
     }
 
     /// Create a `ThreadedGraph` from an existing `MvccGraph`.
@@ -521,7 +559,25 @@ impl ThreadedGraph {
             receiver,
             write_loop: AtomicBool::new(false),
             slow_log: SlowLog::new(),
+            placeholder: AtomicBool::new(false),
         }
+    }
+
+    /// Whether this value is module bookkeeping (see [`Self::placeholder`]).
+    ///
+    /// Safe to call on a `&ThreadedGraph` obtained without holding the
+    /// `RwLock`, which is what the pre-save sweep needs.
+    pub fn is_placeholder(&self) -> bool {
+        self.placeholder.load(Ordering::Acquire)
+    }
+
+    /// Promote a load placeholder to a real graph.
+    ///
+    /// Call *after* the finalized `MvccGraph` has been installed: the release
+    /// store publishes that write to the sweep's lock-free `Acquire` load, so
+    /// a graph is never seen as real before its data is in place.
+    pub fn clear_placeholder(&self) {
+        self.placeholder.store(false, Ordering::Release);
     }
 }
 

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -112,7 +112,13 @@ unsafe extern "C" fn graph_rdb_load(
                     // that would displace the placeholder and leak any
                     // WriteMessages already routed through it.
                     let arc = if let Some(ph) = decode_state.placeholders.remove(&key_name) {
-                        ph.write().graph = mvcc;
+                        let mut guard = ph.write();
+                        guard.graph = mvcc;
+                        // No longer bookkeeping: this Arc now holds the real
+                        // graph, so the pre-save sweep must stop treating it
+                        // as a stale placeholder and deleting it.
+                        guard.clear_placeholder();
+                        drop(guard);
                         ph
                     } else {
                         let tg = ThreadedGraph::from_mvcc(mvcc);
@@ -127,7 +133,7 @@ unsafe extern "C" fn graph_rdb_load(
 
             // Graph not yet finalized - more keys still need to load.
             // Return a placeholder that will be replaced later.
-            let tg = ThreadedGraph::new(DEFAULT_CACHE_SIZE, "__placeholder__");
+            let tg = ThreadedGraph::new_placeholder(DEFAULT_CACHE_SIZE);
             let arc = Arc::new(RwLock::new(tg));
 
             // Store an Arc clone keyed by graph name for later finalization.
@@ -439,7 +445,7 @@ pub unsafe fn create_virtual_keys(ctx: *mut RedisModuleCtx) {
                     raw::RedisModule_OpenKey.unwrap()(ctx, rm_str, raw::KeyMode::WRITE.bits());
                 // Must pass a non-null value; Redis skips keys with null values during RDB save.
                 // Create a placeholder ThreadedGraph so graph_free can handle it.
-                let tg_placeholder = ThreadedGraph::new(DEFAULT_CACHE_SIZE, "__vkey_placeholder__");
+                let tg_placeholder = ThreadedGraph::new_placeholder(DEFAULT_CACHE_SIZE);
                 let boxed: Box<Arc<RwLock<ThreadedGraph>>> =
                     Box::new(Arc::new(RwLock::new(tg_placeholder)));
                 let value = Box::into_raw(boxed).cast();
@@ -585,17 +591,18 @@ unsafe fn scan_and_clean_graphdata_keys(
                     // SAFETY: In the BGSAVE fork child, threads that held the
                     // parking_lot RwLock at fork time are gone. Lock acquisition
                     // would deadlock. We bypass the lock via data_ptr() since the
-                    // fork child is single-threaded. The graph name is immutable
-                    // so reading it without locking is safe even on the main thread.
+                    // fork child is single-threaded. `is_placeholder()` is an
+                    // atomic load, so reading it without the lock is also safe on
+                    // the main thread during a synchronous SAVE.
                     let tg: &ThreadedGraph = &*graph_arc_ref.data_ptr();
-                    let g = tg.graph.read();
-                    let name = g.borrow().name().to_string();
-                    if name.starts_with("__placeholder") || name.starts_with("__vkey_placeholder") {
+                    // Test the structural flag, never the graph name: a client
+                    // is free to name a graph `__placeholder_x`, and matching on
+                    // that prefix silently destroyed such graphs on SAVE (#2773).
+                    if tg.is_placeholder() {
                         // Stale virtual key — mark for deletion.
                         stale_keys.push(key_name);
                     } else {
                         // Real graph — collect it.
-                        drop(g);
                         result.push((key_name, graph_arc_ref.clone()));
                     }
                 }
@@ -813,6 +820,9 @@ fn install_graph(
         // write loop — otherwise blocked clients in `waiting` state would
         // never be replied to.
         placeholder_tg.graph = mvcc;
+        // No longer bookkeeping: the real graph is installed, so the pre-save
+        // sweep must stop treating this Arc as a stale placeholder.
+        placeholder_tg.clear_placeholder();
     } else {
         eprintln!(
             "FalkorDB: WARNING - no placeholder pointer for graph '{graph_name}', graph data will be lost"

--- a/tests/flow/test_encode_decode.py
+++ b/tests/flow/test_encode_decode.py
@@ -432,3 +432,68 @@ class test_encode_decode(FlowTestsBase):
             "MATCH (n:Str) RETURN n.id, size(n.val) ORDER BY n.id"
         )
         self.env.assertEqual(expected.result_set, actual.result_set)
+
+    def test_18_user_graph_named_like_internal_placeholder(self):
+        # A user graph is free to be named `__placeholder...` /
+        # `__vkey_placeholder...`. The pre-save sweep used to classify a graph
+        # as module bookkeeping by matching those prefixes on its *name*, so a
+        # single synchronous SAVE silently deleted such a graph together with
+        # all of its data (issue #2773). Placeholder-ness is now a structural
+        # flag set only where the module itself builds a placeholder, so these
+        # names must be treated as ordinary graphs.
+        names = ["__placeholder_mydata", "__vkey_placeholder_mydata",
+                 "__placeholder", "__vkey_placeholder"]
+
+        # VKEY_MAX_ENTITY_COUNT is 10 for this suite, so 200 nodes spans many
+        # virtual keys — this exercises the multi-key save/load path too.
+        for name in names:
+            g = self.db.select_graph(name)
+            g.query("UNWIND range(1, 200) AS i CREATE (:Keep {v:i})")
+
+        expected = [[200, 20100]]
+        query = "MATCH (n:Keep) RETURN count(n), sum(n.v)"
+
+        for name in names:
+            self.env.assertEqual(
+                self.db.select_graph(name).query(query).result_set, expected)
+
+        # a save must leave the keyspace exactly as it found it: the graphs
+        # still there, and every virtual key it created cleaned up again.
+        # `telemetry{...}` keys are excluded — the module's telemetry flusher
+        # writes them on its own schedule, so they would race this snapshot.
+        def keyspace():
+            return sorted(k for k in self.redis_con.keys("*")
+                          if not k.startswith("telemetry"))
+
+        before = keyspace()
+
+        # a synchronous SAVE must not destroy them
+        self.redis_con.execute_command("SAVE")
+
+        for name in names:
+            self.env.assertTrue(self.redis_con.exists(name))
+            g = self.db.select_graph(name)
+            self.env.assertEqual(g.query(query).result_set, expected)
+        self.env.assertEqual(keyspace(), before)
+
+        # and they must survive a full RDB round-trip
+        self.redis_con.execute_command("DEBUG", "RELOAD")
+
+        for name in names:
+            self.env.assertTrue(self.redis_con.exists(name))
+            g = self.db.select_graph(name)
+            self.env.assertEqual(g.query(query).result_set, expected)
+        self.env.assertEqual(keyspace(), before)
+
+        # saving again exercises the graphs that were just rebuilt from the
+        # RDB through the placeholder path — they must be recognised as real
+        self.redis_con.execute_command("SAVE")
+
+        for name in names:
+            self.env.assertTrue(self.redis_con.exists(name))
+            g = self.db.select_graph(name)
+            self.env.assertEqual(g.query(query).result_set, expected)
+        self.env.assertEqual(keyspace(), before)
+
+        for name in names:
+            self.db.select_graph(name).delete()


### PR DESCRIPTION
Fixes #2773

## Reproduction

A single synchronous `SAVE` permanently destroyed any graph whose key name started with `__placeholder` or `__vkey_placeholder`, with no error to the client:

```
GRAPH.QUERY "__placeholder_mydata" "CREATE (:Keep {v:1})"    -- Nodes created: 1
EXISTS "__placeholder_mydata"                                --> 1
BGSAVE                                                       -- harmless
EXISTS "__placeholder_mydata"                                --> 1
SAVE                                                         --> OK
EXISTS "__placeholder_mydata"                                --> 0   <-- destroyed
GRAPH.QUERY "__placeholder_mydata" "MATCH (n) RETURN count(n)" --> 0
```

It is synchronous `SAVE`, not `BGSAVE`: `create_virtual_keys` runs only on `REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START`, and the BGSAVE fork-child path deliberately skips it. `SHUTDOWN` triggers a save too, so a server restart also lost the data.

## Root cause

`scan_and_clean_graphdata_keys` classified a `graphdata` key as stale module bookkeeping by string-matching the graph's **name**:

```rust
let name = g.borrow().name().to_string();
if name.starts_with("__placeholder") || name.starts_with("__vkey_placeholder") {
    stale_keys.push(key_name);   // deleted below
}
```

The only evidence used was a prefix the client is free to choose, so a real user graph was indistinguishable from a placeholder the module had created itself.

## Fix

Placeholder-ness is now a structural property rather than a name-derived guess.

- `ThreadedGraph` carries a `placeholder` flag, set only by the new `ThreadedGraph::new_placeholder` constructor.
- That constructor is the sole way to build a placeholder and it fixes the graph's name internally, so no caller-supplied string can turn a user graph into one, and no construction site can forget to set the flag. Both existing sites (`graph_rdb_load`'s multi-key stand-in and the dummy value attached to each virtual key in `create_virtual_keys`) go through it; those were the only two `__placeholder` / `__vkey_placeholder` literals in the crate.
- `scan_and_clean_graphdata_keys` tests the flag. The name is no longer load-bearing anywhere.

Two constraints the surrounding code documents are preserved:

- **No new lock acquisition in the sweep.** The sweep reads the flag through `data_ptr()` without taking the `parking_lot` `RwLock`, as before — mandatory in the BGSAVE fork child, where a lock held by a thread that no longer exists would deadlock. The change actually *removes* a lock acquisition there, since the old code had to take `tg.graph.read()` to reach the name.
- **Safe to read unlocked.** The flag is an `AtomicBool`, so the lock-free read is well defined. A plain `bool` would not be, because the flag is not purely write-once: a load placeholder is *promoted in place* to the real graph it stood in for (the Arc is reused deliberately, so `WriteMessage`s already routed through it are not lost). Both promotion sites — `graph_rdb_load`'s inline finalization and `install_graph` — now clear the flag, with a `Release` store paired against the sweep's `Acquire` load so a graph is never seen as real before its data is in place. This mirrors the old behaviour exactly: replacing the inner `MvccGraph` also replaced the name the old check read. Without it, any graph rebuilt from a multi-key RDB would be swept away by the next save.

A missed placeholder would leak a stale virtual key into the RDB, so the default is `false` (real graph) with the flag set explicitly at the only two construction sites, rather than the reverse.

## Verification

Live server, debug build:

```
### EXACT ISSUE #2773 REPRO ###
Nodes created: 1
EXISTS before      : 1
EXISTS after BGSAVE: 1
SAVE               : OK
EXISTS after SAVE  : 1     <-- survives
count(n)           : 1
n.v                : 1
```

Genuine virtual-key cleanup still works — `VKEY_MAX_ENTITY_COUNT 10`, two 300-node graphs (one of them named `__placeholder_big`):

```
SAVE: OK
keys after SAVE:  __placeholder_big  bigG  telemetry{...}      <-- no leftover vkeys
module log:       Created 29 virtual keys for graph __placeholder_big
                  Created 29 virtual keys for graph bigG
                  Deleted 29 virtual keys for graph bigG
                  Deleted 29 virtual keys for graph __placeholder_big
```

Restarting against the resulting RDB loads both graphs back intact (`count(n)=300`, `sum(n.i)=45150`), and saving *again* — which exercises graphs that came back through the placeholder-promotion path — creates and cleans up 29 virtual keys each and leaves the data intact.

## Regression test

`tests/flow/test_encode_decode.py::test_18_user_graph_named_like_internal_placeholder`. That suite already runs with `VKEY_MAX_ENTITY_COUNT 10`, so the 200-node graphs it creates span many virtual keys and exercise the multi-key path. It covers `__placeholder_mydata`, `__vkey_placeholder_mydata`, `__placeholder` and `__vkey_placeholder`, asserting each survives `SAVE`, a `DEBUG RELOAD` round-trip, and a second `SAVE` with its contents intact, and that each save leaves the keyspace exactly as it found it (proving every virtual key it created was cleaned up).

Confirmed to fail on the old code — all four graphs come back as `[[0, 0.0]]` with the key gone — and pass with the fix.

## Validation

- `cargo fmt --all -- --check` — clean
- `CXX=clang++ cargo clippy --all-targets` — 0 errors, only pre-existing warnings (none in changed code)
- `cargo test -p graph` — 286 passed, 0 failed
- `tests/flow/test_encode_decode` — 18/18, run repeatedly
- `test_rdb_load`, `test_graph_copy`, `test_rdb_c_layout`, `test_replication_states` — all pass, matching a stashed-changes baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user graphs with names resembling internal placeholder graphs could be incorrectly removed.
  * Ensured graph data remains intact across saves, reloads, and subsequent saves for these graph names.
  * Improved handling of graphs created during multi-key loading and virtual-key operations.
  * Preserved user-created graphs and their data when names overlap with reserved-looking naming patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->