### PR TITLE
fix(constraint): composite UNIQUE is vacuously satisfied when any property is NULL

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3768,7 +3768,9 @@ impl Graph {
                         self.get_node_attribute(NodeId(node_id), prop)
                     });
                     if key.is_empty() {
-                        continue; // NULL in key → vacuously satisfied, skip
+                        // a constrained property is NULL or absent, so this node
+                        // does not participate in the constraint
+                        continue;
                     }
                     if !seen.insert(key) {
                         return false;
@@ -3786,6 +3788,8 @@ impl Graph {
                         self.get_relationship_attribute(RelationshipId(edge_id), prop)
                     });
                     if key.is_empty() {
+                        // a constrained property is NULL or absent, so this edge
+                        // does not participate in the constraint
                         continue;
                     }
                     if !seen.insert(key) {

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3768,7 +3768,7 @@ impl Graph {
                         self.get_node_attribute(NodeId(node_id), prop)
                     });
                     if key.is_empty() {
-                        continue; // All NULL → skip
+                        continue; // NULL in key → vacuously satisfied, skip
                     }
                     if !seen.insert(key) {
                         return false;
@@ -3797,26 +3797,29 @@ impl Graph {
         }
     }
 
+    /// Build the composite unique-constraint key for `properties`.
+    ///
+    /// Returns an empty key as soon as *any* constrained property is NULL or
+    /// absent: such a key is unknown, and an unknown key cannot be proven to
+    /// collide with another, so the entity satisfies the constraint vacuously.
+    /// Callers treat an empty key as "this entity does not participate in the
+    /// constraint" and skip it.
     #[must_use]
     pub fn build_composite_key(
         properties: &[Arc<String>],
         mut get: impl FnMut(&Arc<String>) -> Option<Value>,
     ) -> Vec<u8> {
-        let mut all_null = true;
         let mut key = Vec::new();
         for prop in properties {
             match get(prop) {
                 Some(v) if !matches!(v, Value::Null) => {
-                    all_null = false;
                     key.extend_from_slice(format!("{v:?}").as_bytes());
                 }
-                _ => {
-                    key.push(0); // NULL marker
-                }
+                _ => return Vec::new(),
             }
             key.push(b'|');
         }
-        if all_null { Vec::new() } else { key }
+        key
     }
 
     /// Drop a constraint by type, entity type, label and properties.
@@ -4414,5 +4417,64 @@ mod reclaim_ids_tests {
         let pool = RoaringTreemap::new();
         assert!(reclaim(&pool, 0, 10).is_empty());
         assert!(reclaim(&pool, 7, 10).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod composite_key_tests {
+    use super::*;
+
+    fn key(
+        props: &[&str],
+        present: &[(&str, Value)],
+    ) -> Vec<u8> {
+        let props: Vec<Arc<String>> = props.iter().map(|p| Arc::new((*p).to_string())).collect();
+        Graph::build_composite_key(&props, |p| {
+            present
+                .iter()
+                .find(|(name, _)| name == &p.as_str())
+                .map(|(_, v)| v.clone())
+        })
+    }
+
+    /// Every constrained property present → a real key that discriminates.
+    #[test]
+    fn complete_key_is_built_and_discriminates() {
+        let a = key(&["a", "b"], &[("a", Value::Int(1)), ("b", Value::Int(2))]);
+        assert!(!a.is_empty());
+        assert_eq!(
+            a,
+            key(&["a", "b"], &[("a", Value::Int(1)), ("b", Value::Int(2))])
+        );
+        assert_ne!(
+            a,
+            key(&["a", "b"], &[("a", Value::Int(1)), ("b", Value::Int(3))])
+        );
+    }
+
+    /// A missing or NULL component makes the whole key unknown, so the entity
+    /// is vacuously unique — regardless of which component it is.
+    #[test]
+    fn any_null_component_yields_empty_key() {
+        assert!(key(&["a", "b"], &[("a", Value::Int(1))]).is_empty());
+        assert!(key(&["a", "b"], &[("b", Value::Int(2))]).is_empty());
+        assert!(key(&["a", "b"], &[]).is_empty());
+        assert!(key(&["a", "b"], &[("a", Value::Int(1)), ("b", Value::Null)]).is_empty());
+        assert!(key(&["a", "b"], &[("a", Value::Null), ("b", Value::Int(2))]).is_empty());
+        assert!(
+            key(
+                &["a", "b", "c"],
+                &[("a", Value::Int(1)), ("c", Value::Int(3))]
+            )
+            .is_empty()
+        );
+    }
+
+    /// For a single property ALL and ANY coincide, so behaviour is unchanged.
+    #[test]
+    fn single_property_is_unaffected() {
+        assert!(!key(&["a"], &[("a", Value::Int(1))]).is_empty());
+        assert!(key(&["a"], &[]).is_empty());
+        assert!(key(&["a"], &[("a", Value::Null)]).is_empty());
     }
 }

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -1195,7 +1195,9 @@ impl Pending {
                         g.get_node_attribute(node_id.into(), prop)
                     });
                     if key.is_empty() {
-                        continue; // NULL in key → vacuously satisfied, no violation
+                        // a constrained property is NULL or absent, so this node
+                        // does not participate in the constraint
+                        continue;
                     }
 
                     // Build a set of all existing keys for this label in one pass
@@ -1207,6 +1209,7 @@ impl Pending {
                                     g.get_node_attribute(other_id.into(), prop)
                                 });
                             if other_key.is_empty() {
+                                // likewise, this node does not participate
                                 continue;
                             }
                             if let Some(&existing_id) = seen.get(&other_key)
@@ -1265,6 +1268,8 @@ impl Pending {
                         g.get_relationship_attribute(edge_id.into(), prop)
                     });
                     if key.is_empty() {
+                        // a constrained property is NULL or absent, so this edge
+                        // does not participate in the constraint
                         continue;
                     }
 
@@ -1277,6 +1282,7 @@ impl Pending {
                                     g.get_relationship_attribute(other_eid.into(), prop)
                                 });
                             if other_key.is_empty() {
+                                // likewise, this edge does not participate
                                 continue;
                             }
                             if let Some(&existing_id) = seen.get(&other_key)

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -1195,7 +1195,7 @@ impl Pending {
                         g.get_node_attribute(node_id.into(), prop)
                     });
                     if key.is_empty() {
-                        continue; // All NULL → no violation
+                        continue; // NULL in key → vacuously satisfied, no violation
                     }
 
                     // Build a set of all existing keys for this label in one pass

--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -998,6 +998,137 @@ class testConstraintEdges():
         except ResponseError as e:
             self.env.assertContains("unique constraint violation, on edge of relationship-type Artist", str(e))
 
+# a composite UNIQUE constraint is vacuously satisfied when ANY of the
+# constrained properties is NULL / absent: the composite key is unknown, and an
+# unknown key can not be proven to collide with another. see issue #2778
+COMPOSITE_NULL_GRAPH_ID = "composite_unique_nulls"
+
+class testCompositeUniqueConstraintNulls():
+    def __init__(self):
+        self.env, self.db = Env()
+        self.con = self.env.getConnection()
+        self.con.delete(COMPOSITE_NULL_GRAPH_ID)
+        self.g = self.db.select_graph(COMPOSITE_NULL_GRAPH_ID)
+
+    def test01_partial_nodes_accepted(self):
+        g = self.g
+
+        create_unique_node_constraint(g, "P", "a", "b", sync=True)
+        c = get_constraint(g, "UNIQUE", "NODE", "P", "a", "b")
+        self.env.assertEqual(c.status, "OPERATIONAL")
+
+        # two nodes agreeing on 'a', both missing 'b'
+        g.query("CREATE (:P {a: 1})")
+        g.query("CREATE (:P {a: 1})")
+
+        # mirrored: two nodes agreeing on 'b', both missing 'a'
+        g.query("CREATE (:P {b: 7})")
+        g.query("CREATE (:P {b: 7})")
+
+        # an explicit NULL is equivalent to an absent property
+        g.query("CREATE (:P {a: 1, b: NULL})")
+
+        self.env.assertEqual(g.query("MATCH (n:P) RETURN count(n)").result_set[0][0], 5)
+
+    def test02_full_duplicate_still_rejected(self):
+        g = self.g
+
+        # every constrained property present -> the key is known and enforced
+        g.query("CREATE (:P {a: 5, b: 6})")
+
+        try:
+            g.query("CREATE (:P {a: 5, b: 6})")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation on node of type P", str(e))
+
+        # a key sharing only one component is still distinct
+        g.query("CREATE (:P {a: 5, b: 7})")
+
+        self.env.assertEqual(g.query("MATCH (n:P) RETURN count(n)").result_set[0][0], 7)
+
+    def test03_completing_a_partial_key_is_enforced(self):
+        g = self.g
+
+        # this node's key is unknown, so it is accepted
+        g.query("CREATE (:P {a: 100, tag: 'partial'})")
+
+        # filling in the missing property would produce a real duplicate
+        g.query("CREATE (:P {a: 100, b: 200})")
+        try:
+            g.query("MATCH (n:P {tag: 'partial'}) SET n.b = 200")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation on node of type P", str(e))
+
+        # completing it to a distinct key is fine, and dropping the property
+        # makes the key unknown again
+        g.query("MATCH (n:P {tag: 'partial'}) SET n.b = 201")
+        g.query("MATCH (n:P {tag: 'partial'}) REMOVE n.b")
+
+    def test04_single_property_constraint_unchanged(self):
+        # for a single property "any null" and "all null" coincide
+        g = self.g
+
+        create_unique_node_constraint(g, "S", "a", sync=True)
+        c = get_constraint(g, "UNIQUE", "NODE", "S", "a")
+        self.env.assertEqual(c.status, "OPERATIONAL")
+
+        g.query("CREATE (:S {a: 1})")
+
+        try:
+            g.query("CREATE (:S {a: 1})")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation on node of type S", str(e))
+
+        g.query("CREATE (:S {a: 2})")
+
+        # nodes missing the constrained property do not participate
+        g.query("CREATE (:S {z: 1})")
+        g.query("CREATE (:S {z: 2})")
+
+        self.env.assertEqual(g.query("MATCH (n:S) RETURN count(n)").result_set[0][0], 4)
+
+    def test05_constraint_creation_over_existing_partial_data(self):
+        g = self.g
+
+        # partial entities must not block the constraint from becoming
+        # operational...
+        g.query("CREATE (:E {a: 1}), (:E {a: 1}), (:E {b: 2}), (:E {b: 2}), (:E {a: 3, b: 3})")
+        create_unique_node_constraint(g, "E", "a", "b", sync=True)
+        c = get_constraint(g, "UNIQUE", "NODE", "E", "a", "b")
+        self.env.assertEqual(c.status, "OPERATIONAL")
+
+        # ...but genuine duplicates must
+        g.query("CREATE (:D {a: 1, b: 1}), (:D {a: 1, b: 1})")
+        create_unique_node_constraint(g, "D", "a", "b", sync=True)
+        c = get_constraint(g, "UNIQUE", "NODE", "D", "a", "b")
+        self.env.assertEqual(c.status, "FAILED")
+
+    def test06_partial_edges_accepted(self):
+        g = self.g
+
+        create_unique_edge_constraint(g, "R", "a", "b", sync=True)
+        c = get_constraint(g, "UNIQUE", "RELATIONSHIP", "R", "a", "b")
+        self.env.assertEqual(c.status, "OPERATIONAL")
+
+        g.query("CREATE (:N {i: 1}), (:N {i: 2})")
+
+        # two edges agreeing on 'a', both missing 'b'
+        g.query("MATCH (x:N {i:1}), (y:N {i:2}) CREATE (x)-[:R {a: 1}]->(y)")
+        g.query("MATCH (x:N {i:1}), (y:N {i:2}) CREATE (x)-[:R {a: 1}]->(y)")
+
+        # a fully specified key is still enforced
+        g.query("MATCH (x:N {i:1}), (y:N {i:2}) CREATE (x)-[:R {a: 2, b: 2}]->(y)")
+        try:
+            g.query("MATCH (x:N {i:1}), (y:N {i:2}) CREATE (x)-[:R {a: 2, b: 2}]->(y)")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation, on edge of relationship-type R", str(e))
+
+        self.env.assertEqual(g.query("MATCH ()-[r:R]->() RETURN count(r)").result_set[0][0], 3)
+
 MONITOR_ATTACHED = False
 
 class testConstraintReplication():


### PR DESCRIPTION
Fixes #2778

## Reproduction

A composite `UNIQUE` constraint wrongly rejected entities that were merely *missing* one of the constrained properties.

```
GRAPH.QUERY g1 "CREATE INDEX FOR (n:P) ON (n.a, n.b)"
GRAPH.CONSTRAINT CREATE g1 UNIQUE NODE P PROPERTIES 2 a b     # wait for OPERATIONAL

GRAPH.QUERY g1 "CREATE (:P {a: 1})"    # ok
GRAPH.QUERY g1 "CREATE (:P {a: 1})"    # (error) unique constraint violation on node of type P
```

Both nodes have an *unknown* composite key (`b` is absent), so neither can be proven to collide. The second `CREATE` must succeed. The same failure occurred mirrored (agree on `b`, both missing `a`), with an explicit `b: NULL`, on the relationship side, and — worse — when creating a constraint over existing data containing such partial entities, which went `FAILED` instead of `OPERATIONAL`.

## Root cause

`Graph::build_composite_key` (`graph/src/graph/graph.rs`) accumulated an `all_null` flag across *all* constrained properties and only returned the empty "does not participate in this constraint" key when **every** property was NULL:

```rust
let mut all_null = true;
for prop in properties {
    match get(prop) {
        Some(v) if !matches!(v, Value::Null) => { all_null = false; key.extend(...); }
        _ => { key.push(0); }   // NULL marker — still a comparable key!
    }
    key.push(b'|');
}
if all_null { Vec::new() } else { key }
```

That is the wrong reduction. A composite key is unknown as soon as **any** of its components is unknown, so this needs ANY, not ALL. With ALL, the `0` NULL marker stayed in the key and two distinct unknown keys compared *equal*, manufacturing a false collision.

The fix replaces the accumulator with a short-circuit that returns `Vec::new()` on the first NULL/absent property.

All six call sites (`graph.rs` ×2, `runtime/pending.rs` ×4) already treat an empty key as "skip this entity", so this is exactly the contract they expect and **no call-site changes were needed** — the logic stays in one place.

## Corroboration

- The sibling **mandatory**-constraint path in the same file (`validate_mandatory_constraint`) already short-circuits on the *first* missing property — the correct shape existed a few dozen lines above.
- The **C reference implementation** does the same. From `src/constraint/unique_constraint.c` on `master`, in `EnforceUniqueEntity`:

  ```c
  for (uint8_t i = 0; i < _c->n_attr; i++) {
      AttributeID attr_id = _c->attrs[i] ;
      // make sure entity possesses attribute
      if (!AttributeSet_Get (attributes, attr_id, attrs + i)) {
          // entity satisfies constraint in a vacuous truth manner
          return true;
      }
      ...
  ```

  It returns vacuous truth on the **first** attribute the entity does not possess. This also matches SQL/openCypher `UNIQUE` semantics.

## Verification

Verified against a live `redis-server` with the built module, before and after the change. Pre-fix: **23 passed, 5 failed**. Post-fix: **28 passed, 0 failed**. The 5 that flipped are exactly the bug; nothing that previously rejected stopped rejecting.

| Case | Pre-fix | Post-fix |
|---|---|---|
| two nodes `{a:1}`, `b` absent | ❌ violation | ✅ accepted |
| mirrored: two nodes `{b:7}`, `a` absent | ❌ violation | ✅ accepted |
| explicit `{a:1, b:NULL}` | ❌ violation | ✅ accepted |
| constraint creation over existing partial data | ❌ `FAILED` | ✅ `OPERATIONAL` |
| two edges `[:R {a:1}]`, `b` absent | ❌ violation | ✅ accepted |
| **full duplicate `{a:5,b:6}`** | ✅ rejected | ✅ **still rejected** |
| **full duplicate regardless of property order** | ✅ rejected | ✅ **still rejected** |
| **`SET` completing a partial key into a real duplicate** | ✅ rejected | ✅ **still rejected** |
| **edge full duplicate `{a:2,b:2}`** | ✅ rejected | ✅ **still rejected** |
| **constraint creation over existing real duplicates** | ✅ `FAILED` | ✅ **still `FAILED`** |
| single-property `UNIQUE`, duplicate | ✅ rejected | ✅ still rejected |
| single-property `UNIQUE`, value absent | ✅ accepted | ✅ still accepted |
| `MANDATORY` constraint, partial node | ✅ rejected | ✅ still rejected |

Real duplicates are still rejected: whenever every constrained property is present the key is fully known and enforced exactly as before. Only entities with an unknown key are now skipped.

## Tests

- **Flow** — new `testCompositeUniqueConstraintNulls` class in `tests/flow/test_constraint.py` (6 tests): partial nodes accepted, full duplicate still rejected, `SET` completing a partial key into a duplicate still rejected, single-property constraint unchanged, constraint creation over existing partial data reaches `OPERATIONAL` while real duplicates still go `FAILED`, and the relationship-side equivalent.
- **Rust unit** — new `composite_key_tests` module pinning the helper contract directly: a complete key is built and discriminates, *any* NULL component yields an empty key, and the single-property case is unaffected (ALL and ANY coincide there).

## Validation gate

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | ✅ clean |
| `CXX=clang++ cargo clippy --all-targets` | ✅ exit 0 (3 warnings, all pre-existing in untouched files) |
| `cargo test -p graph` | ✅ 289 passed, 0 failed (incl. 3 new) |
| new flow tests | ✅ 6/6 |
| entire `tests/flow/test_constraint.py` | ✅ 22/23 |

The single flow failure is `testConstraintReplication.test_01_constraint_replication`, which is **pre-existing and unrelated**: it was reproduced identically on a pristine, unmodified `test_constraint.py` (`git stash` + re-run, failing at the original line). It asserts that a redis `MONITOR` thread captured 12 `GRAPH.CONSTRAINT` commands and captures 0 — a redis-py client artifact of the local venv, not a propagation problem. `test_02_async_validation_reaches_operational_on_replica`, which actually verifies the constraint reaches `OPERATIONAL` on the replica, passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Composite unique constraints now treat records with any NULL or missing constrained property as having an unknown key, preventing false uniqueness conflicts.
  * Explicit NULL values and absent properties now behave consistently for composite constraints.
  * Duplicate records with complete composite keys continue to be rejected.
  * Completing a previously partial composite key now correctly enforces uniqueness.
  * The corrected behavior applies to both node and edge constraints.
  * Existing single-property unique constraint behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->