### PR TITLE
fix: keep a label that is re-added in the same query that removes it

### DIFF
--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -1996,3 +1996,179 @@ pub fn read_value(
         _ => Err(format!("unknown value tag in effects buffer: {tag}")),
     }
 }
+
+#[cfg(test)]
+mod label_effect_tests {
+    use super::*;
+    use crate::graph::graphblas::test_init::ensure_init;
+
+    /// The one node every scenario below stages labels on.
+    const NODE: u64 = 0;
+
+    /// A graph whose only labels are `names`, and a `Pending` that has already
+    /// taken its schema baseline — so `build_effects_buffer` emits no
+    /// `EFFECT_ADD_SCHEMA`, and the label records are the entire buffer.
+    fn fixture(names: &[&str]) -> (AtomicRefCell<Graph>, Vec<LabelId>, Pending) {
+        ensure_init();
+        let g = AtomicRefCell::new(Graph::new(16, 16, 1, 0, "label_effects"));
+        let labels: Vec<LabelId> = {
+            let mut graph = g.borrow_mut();
+            names.iter().map(|n| graph.get_label_id_mut(n)).collect()
+        };
+        let mut pending = Pending::new();
+        pending.set_schema_baseline(&g);
+        (g, labels, pending)
+    }
+
+    /// One label record, exactly as `build_effects_buffer` writes it: the
+    /// opcode, the node id as u64 LE, the label count as u16 LE, then the ids.
+    fn record(
+        opcode: u8,
+        labels: &[LabelId],
+    ) -> Vec<u8> {
+        let mut rec = vec![opcode];
+        rec.extend_from_slice(&NODE.to_le_bytes());
+        rec.extend_from_slice(&(labels.len() as u16).to_le_bytes());
+        for label in labels {
+            rec.extend_from_slice(&(usize::from(*label) as u16).to_le_bytes());
+        }
+        rec
+    }
+
+    /// A whole expected buffer: the version header, then the records.
+    ///
+    /// Every assertion here compares the *entire* buffer against one of these
+    /// rather than scanning for an opcode byte. Scanning would not be sound —
+    /// a node id, a label count or a label id can itself be 7 or 8, so a scan
+    /// could invent a record that is not there and miss one that is. Whole
+    /// buffer equality has neither failure mode, and it pins the absence of a
+    /// record as tightly as it pins the presence of one.
+    fn buffer(records: &[Vec<u8>]) -> Vec<u8> {
+        let mut buf = vec![EFFECTS_VERSION];
+        for rec in records {
+            buf.extend_from_slice(rec);
+        }
+        buf
+    }
+
+    fn build(
+        pending: &Pending,
+        g: &AtomicRefCell<Graph>,
+    ) -> (Vec<u8>, u64) {
+        let mut buf = Vec::new();
+        let n_effects = pending.build_effects_buffer(g, &mut buf);
+        (buf, n_effects)
+    }
+
+    /// Positive control for [`cancelled_add_leaves_no_set_labels_record`]: an
+    /// uncancelled `SET n:L` does write an `EFFECT_SET_LABELS`. Without this,
+    /// a `build_effects_buffer` that had stopped emitting label records
+    /// altogether would satisfy the cancellation tests vacuously.
+    #[test]
+    fn plain_set_writes_a_set_labels_record() {
+        let (g, labels, mut pending) = fixture(&["L"]);
+        let l = labels[0];
+
+        pending.set_node_labels(NODE.into(), &[l].into_iter().collect());
+
+        let (buf, n_effects) = build(&pending, &g);
+        assert_eq!(buf, buffer(&[record(EFFECT_SET_LABELS, &[l])]));
+        assert_eq!(n_effects, 1);
+    }
+
+    /// Positive control for
+    /// [`cancelled_removal_leaves_no_remove_labels_record`]: an uncancelled
+    /// `REMOVE n:L` does write an `EFFECT_REMOVE_LABELS`.
+    #[test]
+    fn plain_remove_writes_a_remove_labels_record() {
+        let (g, labels, mut pending) = fixture(&["L"]);
+        let l = labels[0];
+
+        pending.remove_node_labels(NODE.into(), &[l]);
+
+        let (buf, n_effects) = build(&pending, &g);
+        assert_eq!(buf, buffer(&[record(EFFECT_REMOVE_LABELS, &[l])]));
+        assert_eq!(n_effects, 1);
+    }
+
+    /// `SET n:L REMOVE n:L`: the removal cancels the staged add, and the
+    /// emptied `set_labels` entry has to go with it. Leaving the entry behind
+    /// serializes an `EFFECT_SET_LABELS` carrying zero labels, which a replica
+    /// applies as a no-op — so master and replica agree either way and only the
+    /// buffer can tell that the wasted record was sent.
+    #[test]
+    fn cancelled_add_leaves_no_set_labels_record() {
+        let (g, labels, mut pending) = fixture(&["L"]);
+        let l = labels[0];
+
+        pending.set_node_labels(NODE.into(), &[l].into_iter().collect());
+        pending.remove_node_labels(NODE.into(), &[l]);
+
+        let (buf, n_effects) = build(&pending, &g);
+        assert_eq!(
+            buf,
+            buffer(&[record(EFFECT_REMOVE_LABELS, &[l])]),
+            "the cancelled add must leave no EFFECT_SET_LABELS behind"
+        );
+        assert_eq!(n_effects, 1);
+
+        assert!(
+            !pending.set_labels.contains_key(&NODE),
+            "the emptied set_labels entry must be dropped, not left empty"
+        );
+        assert_eq!(pending.node_has_label(NODE.into(), l), Some(false));
+    }
+
+    /// `REMOVE n:L SET n:L`, the mirror direction and the #2777 report: the add
+    /// cancels the staged removal, the label survives, and the emptied
+    /// `remove_labels` entry must not be serialized either.
+    #[test]
+    fn cancelled_removal_leaves_no_remove_labels_record() {
+        let (g, labels, mut pending) = fixture(&["L"]);
+        let l = labels[0];
+
+        pending.remove_node_labels(NODE.into(), &[l]);
+        pending.set_node_labels(NODE.into(), &[l].into_iter().collect());
+
+        let (buf, n_effects) = build(&pending, &g);
+        assert_eq!(
+            buf,
+            buffer(&[record(EFFECT_SET_LABELS, &[l])]),
+            "the cancelled removal must leave no EFFECT_REMOVE_LABELS behind"
+        );
+        assert_eq!(n_effects, 1);
+
+        assert!(
+            !pending.remove_labels.contains_key(&NODE),
+            "the emptied remove_labels entry must be dropped, not left empty"
+        );
+        assert_eq!(
+            pending.node_has_label(NODE.into(), l),
+            Some(true),
+            "the re-added label must survive the cancelled removal"
+        );
+    }
+
+    /// Cancellation is per label, not per node: `SET n:L:M REMOVE n:L` drops
+    /// only `L` from the add, and both records still go out.
+    #[test]
+    fn cancelling_one_label_of_several_keeps_the_rest() {
+        let (g, labels, mut pending) = fixture(&["L", "M"]);
+        let (l, m) = (labels[0], labels[1]);
+
+        pending.set_node_labels(NODE.into(), &[l, m].into_iter().collect());
+        pending.remove_node_labels(NODE.into(), &[l]);
+
+        assert_eq!(pending.node_has_label(NODE.into(), m), Some(true));
+
+        let (buf, n_effects) = build(&pending, &g);
+        assert_eq!(
+            buf,
+            buffer(&[
+                record(EFFECT_SET_LABELS, &[m]),
+                record(EFFECT_REMOVE_LABELS, &[l]),
+            ])
+        );
+        assert_eq!(n_effects, 2);
+    }
+}

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -410,15 +410,34 @@ impl Pending {
         }
     }
 
+    /// Stage label adds for `id`, cancelling any removal of those same labels
+    /// staged earlier in this query. Mirrors [`Self::remove_node_labels`], which
+    /// cancels earlier adds; together they keep `set_labels` and `remove_labels`
+    /// disjoint per node, so the last clause to touch a label wins in either
+    /// direction (`REMOVE n:L SET n:L` keeps `L`, `SET n:L REMOVE n:L` drops it).
+    fn stage_node_labels(
+        &mut self,
+        raw_id: u64,
+        labels: &OrderSet<LabelId>,
+    ) {
+        let entry = self.set_labels.entry(raw_id).or_default();
+        for label in labels.iter() {
+            entry.push(usize::from(*label) as u64);
+        }
+        if let Some(removed) = self.remove_labels.get_mut(&raw_id) {
+            removed.retain(|&l| !labels.contains(&LabelId(l as usize)));
+            if removed.is_empty() {
+                self.remove_labels.remove(&raw_id);
+            }
+        }
+    }
+
     pub fn set_node_labels(
         &mut self,
         id: NodeId,
         labels: &OrderSet<LabelId>,
     ) {
-        let entry = self.set_labels.entry(id.into()).or_default();
-        for label in labels.iter() {
-            entry.push(usize::from(*label) as u64);
-        }
+        self.stage_node_labels(id.into(), labels);
     }
 
     pub fn set_nodes_labels(
@@ -427,13 +446,13 @@ impl Pending {
         labels: &OrderSet<LabelId>,
     ) {
         for id in ids {
-            let entry = self.set_labels.entry((*id).into()).or_default();
-            for label in labels.iter() {
-                entry.push(usize::from(*label) as u64);
-            }
+            self.stage_node_labels((*id).into(), labels);
         }
     }
 
+    /// Stage label removals for `id`, cancelling any add of those same labels
+    /// staged earlier in this query — the mirror image of
+    /// [`Self::stage_node_labels`], keeping the two sets disjoint per node.
     pub fn remove_node_labels(
         &mut self,
         id: NodeId,
@@ -445,6 +464,9 @@ impl Pending {
             // Remove from pending set labels
             if let Some(set) = self.set_labels.get_mut(&raw_id) {
                 set.retain(|&l| l != label_id);
+                if set.is_empty() {
+                    self.set_labels.remove(&raw_id);
+                }
             }
             self.remove_labels.entry(raw_id).or_default().push(label_id);
         }
@@ -454,9 +476,9 @@ impl Pending {
     /// added, `Some(false)` if it was removed, `None` if this query says nothing
     /// about it and the committed label matrix is the answer.
     ///
-    /// The precedence is [`Self::update_node_labels`]'s, which applies the adds
-    /// and then the removals, so a removal wins — the two must agree, since they
-    /// answer the same question for the same node.
+    /// `set_labels` and `remove_labels` are disjoint per node (see
+    /// [`Self::stage_node_labels`]), so at most one of the two branches below can
+    /// match and the order they are consulted in carries no meaning.
     pub fn node_has_label(
         &self,
         id: NodeId,
@@ -481,6 +503,11 @@ impl Pending {
         None
     }
 
+    /// Overlay this query's staged label changes onto `labels`.
+    ///
+    /// Adds are applied before removals, but the two sets are disjoint per node
+    /// (see [`Self::stage_node_labels`]), so no label is touched by both passes
+    /// and the order is immaterial.
     pub fn update_node_labels(
         &self,
         id: NodeId,
@@ -1132,8 +1159,9 @@ impl Pending {
     /// would force a pending-tuple materialization of its delta on every
     /// commit (`O(|delta|)` per write query, quadratic between folds) —
     /// measured as the dominant cost of small repeated creates. Mirrors
-    /// [`Self::update_node_labels`] semantics: a removed label wins over a
-    /// pending set.
+    /// [`Self::update_node_labels`] semantics; `set_labels` and `remove_labels`
+    /// are disjoint per node (see [`Self::stage_node_labels`]), so the two
+    /// branches below cannot both match.
     fn constraint_node_has_label(
         &self,
         g: &Graph,

--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -584,6 +584,68 @@ class testConstraintNodes():
         drop_node_range_index(self.g, "Author", "nickname")
         drop_node_range_index(self.g, "Author", "birthdate")
 
+    def test09_constraint_enforced_on_removed_and_readded_label(self):
+        # A label that is removed and re-added in the same query is still
+        # carried by the node at commit time, so constraints on it must be
+        # enforced. Before the fix for #2777 the pending add and the pending
+        # remove both sat in the transaction's bookkeeping and the remove won,
+        # so the node looked unlabelled to the constraint check and violations
+        # were silently let through.
+
+        #-----------------------------------------------------------------------
+        # unique constraint
+        #-----------------------------------------------------------------------
+        create_unique_node_constraint(self.g, "Rejoin", "v", sync=True)
+        self.g.query("CREATE (:Rejoin {v: 1})")
+
+        # duplicate created in the SAME query that removes and re-adds the
+        # constrained label must still be rejected
+        try:
+            self.g.query("MATCH (n:Rejoin {v: 1}) REMOVE n:Rejoin SET n:Rejoin CREATE (:Rejoin {v: 1})")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation on node of type Rejoin", str(e))
+
+        # the rejected query must not have left anything behind
+        self.env.assertEqual(self.g.query("MATCH (n:Rejoin) RETURN count(n)").result_set[0][0], 1)
+
+        # a node that re-acquires the label must also collide with an existing
+        # value it is updated into
+        self.g.query("CREATE (:Rejoin {v: 2})")
+        try:
+            self.g.query("MATCH (n:Rejoin {v: 2}) REMOVE n:Rejoin SET n:Rejoin SET n.v = 1")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("unique constraint violation on node of type Rejoin", str(e))
+        self.env.assertEqual(self.g.query("MATCH (n:Rejoin {v: 2}) RETURN count(n)").result_set[0][0], 1)
+
+        # genuinely dropping the label frees the value — the constraint must
+        # not be over-enforced
+        result = self.g.query("MATCH (n:Rejoin {v: 1}) REMOVE n:Rejoin CREATE (:Rejoin {v: 1})")
+        self.env.assertEqual(result.labels_removed, 1)
+        self.env.assertEqual(result.nodes_created, 1)
+        self.env.assertEqual(self.g.query("MATCH (n:Rejoin) RETURN count(n)").result_set[0][0], 2)
+
+        #-----------------------------------------------------------------------
+        # mandatory constraint
+        #-----------------------------------------------------------------------
+        create_mandatory_node_constraint(self.g, "Mandate", "p", sync=True)
+        self.g.query("CREATE (:Mandate {p: 1})")
+
+        # dropping the mandatory property while the label is removed and
+        # re-added must be rejected — the node still ends up labelled
+        try:
+            self.g.query("MATCH (n:Mandate) REMOVE n:Mandate SET n:Mandate SET n.p = NULL")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("mandatory constraint violation", str(e))
+        self.env.assertEqual(self.g.query("MATCH (n:Mandate) RETURN n.p").result_set[0][0], 1)
+
+        # dropping the label for real releases the node from the constraint
+        result = self.g.query("MATCH (n:Mandate) REMOVE n:Mandate SET n.p = NULL")
+        self.env.assertEqual(result.labels_removed, 1)
+        self.env.assertEqual(self.g.query("MATCH (n:Mandate) RETURN count(n)").result_set[0][0], 0)
+
 class testConstraintEdges():
     def __init__(self):
         self.env, self.db = Env()

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -495,6 +495,48 @@ class testEntityUpdate():
         self.env.assertEqual(result.labels_removed, 0)
         self.validate_node_labels(self.graph, labels, 1)
 
+    def test_31_mix_add_and_remove_same_label_on_labeled_node(self):
+        # https://github.com/FalkorDB/FalkorDB/issues/2777
+        # a label re-added in the same query that removes it must survive;
+        # the last clause to touch a label wins, in both directions
+        self.graph.delete()
+        self.graph.query("CREATE (:L {v: 1})")
+        self.validate_node_labels(self.graph, ["L"], 1)
+
+        # remove prior to set: the label is kept
+        result = self.graph.query("MATCH (n:L) REMOVE n:L SET n:L RETURN labels(n)")
+        self.env.assertEqual(result.result_set[0][0], ["L"])
+        self.env.assertEqual(result.labels_removed, 0)
+        # still reachable by a label scan, and still a single node
+        self.validate_node_labels(self.graph, ["L"], 1)
+        self.env.assertEqual(self.graph.query("MATCH (n) RETURN count(n)").result_set[0][0], 1)
+
+        # set prior to remove: the label is dropped
+        result = self.graph.query("MATCH (n:L) SET n:L REMOVE n:L RETURN labels(n)")
+        self.env.assertEqual(result.result_set[0][0], [])
+        self.env.assertEqual(result.labels_removed, 1)
+        self.validate_node_labels(self.graph, ["L"], 0)
+        # the node itself survives, it only lost the label
+        self.env.assertEqual(self.graph.query("MATCH (n) RETURN count(n)").result_set[0][0], 1)
+
+        # a different label added while the original one is removed
+        for query in ["MATCH (n:A) REMOVE n:A SET n:B RETURN labels(n)",
+                      "MATCH (n:A) SET n:B REMOVE n:A RETURN labels(n)"]:
+            self.graph.delete()
+            self.graph.query("CREATE (:A)")
+            result = self.graph.query(query)
+            self.env.assertEqual(result.result_set[0][0], ["B"])
+            self.validate_node_labels(self.graph, ["A"], 0)
+            self.validate_node_labels(self.graph, ["B"], 1)
+
+        # multiple nodes updated by a single query
+        self.graph.delete()
+        self.graph.query("UNWIND range(1, 5) AS i CREATE (:L {v: i})")
+        result = self.graph.query("MATCH (n:L) REMOVE n:L SET n:L RETURN count(n)")
+        self.env.assertEqual(result.result_set[0][0], 5)
+        self.env.assertEqual(result.labels_removed, 0)
+        self.validate_node_labels(self.graph, ["L"], 5)
+
     def test_32_mix_merge_and_remove_node_labels(self):
         self.graph.delete()
         labels_to_remove = ["Foo"]

--- a/tests/flow/test_label_update.py
+++ b/tests/flow/test_label_update.py
@@ -93,10 +93,14 @@ class testLabelUpdate():
 
     def test_remove_then_set_same_label(self):
         # Regression for #2777: a label removed and re-added in the same query
-        # must survive, and the cancelled removal must not be serialized as a
-        # stale EFFECT_REMOVE_LABELS. The mirror direction must not serialize a
-        # zero-label EFFECT_SET_LABELS either. Both are checked on the replica,
-        # which sees only the effects stream.
+        # must survive. What this pins is the replicated end state — master and
+        # replica agreeing that the node still carries L, which a stale
+        # EFFECT_REMOVE_LABELS would break on the replica alone.
+        #
+        # It does not pin the record set on the wire: a zero-label
+        # EFFECT_SET_LABELS applies as a no-op, so both sides agree whether or
+        # not one was sent. That is pinned on the buffer itself, by
+        # graph::runtime::pending::label_effect_tests.
         self.query_master_and_wait("CREATE (:A {v: 1})")
         self.query_master_and_wait("MATCH (n:A) SET n:L")
 

--- a/tests/flow/test_label_update.py
+++ b/tests/flow/test_label_update.py
@@ -91,6 +91,46 @@ class testLabelUpdate():
 
         self.env.assertTrue(graph_eq(self.master_graph, self.replica_graph))
 
+    def test_remove_then_set_same_label(self):
+        # Regression for #2777: a label removed and re-added in the same query
+        # must survive, and the cancelled removal must not be serialized as a
+        # stale EFFECT_REMOVE_LABELS. The mirror direction must not serialize a
+        # zero-label EFFECT_SET_LABELS either. Both are checked on the replica,
+        # which sees only the effects stream.
+        self.query_master_and_wait("CREATE (:A {v: 1})")
+        self.query_master_and_wait("MATCH (n:A) SET n:L")
+
+        # --- REMOVE then SET: the label is kept ---
+        # no WITH between the clauses: both land in the same segment, so the
+        # add has to cancel the staged removal rather than commit after it
+        res = self.query_master_and_wait("MATCH (n:A:L) REMOVE n:L SET n:L RETURN n")
+        self.env.assertEqual(res.labels_removed, 0)
+
+        res = self.query_master_and_wait("MATCH (n:A:L) RETURN count(n) AS c")
+        self.env.assertEqual(res.result_set[0][0], 1)
+
+        # the replica must still see the label, both in labels() and via a
+        # label scan — a stale EFFECT_REMOVE_LABELS would strip it there only
+        res = Graph(self.replica, GRAPH_ID).ro_query("MATCH (n:A:L) RETURN labels(n)")
+        self.env.assertEqual(len(res.result_set), 1)
+        self.env.assertContains("L", res.result_set[0][0])
+
+        self.env.assertTrue(graph_eq(self.master_graph, self.replica_graph))
+
+        # --- SET then REMOVE: the label is dropped ---
+        res = self.query_master_and_wait("MATCH (n:A:L) SET n:L REMOVE n:L RETURN n")
+        self.env.assertEqual(res.labels_removed, 1)
+
+        res = self.query_master_and_wait("MATCH (n:A:L) RETURN count(n) AS c")
+        self.env.assertEqual(res.result_set[0][0], 0)
+
+        # the node itself survives on the replica, it only lost the label
+        res = Graph(self.replica, GRAPH_ID).ro_query("MATCH (n:A) RETURN labels(n)")
+        self.env.assertEqual(len(res.result_set), 1)
+        self.env.assertNotContains("L", res.result_set[0][0])
+
+        self.env.assertTrue(graph_eq(self.master_graph, self.replica_graph))
+
     def test_redundant_label_set_remove(self):
         # A single query that touches the same label in multiple SET / REMOVE
         self.query_master_and_wait("CREATE (:A {v: 1})")


### PR DESCRIPTION
Fixes #2777

## Reproduction

```
GRAPH.QUERY lb "CREATE (:L {v:1})"
GRAPH.QUERY lb "MATCH (n:L) REMOVE n:L SET n:L RETURN labels(n)"
-- []   <-- wrong, the last clause asked for :L
GRAPH.QUERY lb "MATCH (n:L) RETURN count(n)"
-- 0    <-- node is now unreachable by label
GRAPH.QUERY lb "MATCH (n) RETURN count(n)"
-- 1    <-- node survives, but has lost its label permanently
```

This is silent data loss: the label is gone for good, and every label scan and index scan on `:L` stops seeing the node. It is also a **constraint bypass** — see below.

## Root cause

`Pending` stages label adds in `set_labels` and label removals in `remove_labels`, and both appliers — `update_node_labels` and `commit` — apply the adds first and the removals second.

The two mutators were asymmetric:

- `remove_node_labels` cancelled a previously staged add (it stripped the label from `set_labels` as well as recording the removal).
- `set_node_labels` / `set_nodes_labels` did **not** cancel a previously staged removal.

So after `REMOVE n:L SET n:L` the label sat in *both* sets, the removal ran last, and the add was silently discarded. The "removal wins" tie-break was even documented on `node_has_label`, `update_node_labels` and `constraint_node_has_label` as if it were intended.

`remove.rs` only stages a removal for labels the node actually has, which is why the existing `test_30_mix_add_and_remove_same_labels` did not catch this — it runs `REMOVE n:L SET n:L` against an *unlabelled* node, so nothing is ever staged in `remove_labels`.

## Fix

Make the two mutators symmetric: staging an add now strips that label from `remove_labels`, exactly mirroring what staging a removal already did for `set_labels`. The two sets are now **disjoint per node**, which is a real invariant rather than a tie-break, and makes last-writer-wins work in both directions.

Reordering `commit` to apply removals before adds was deliberately *not* chosen — that only flips which direction is broken (`SET n:L REMOVE n:L` would then wrongly keep the label).

Entries emptied by a cancellation are dropped from the map, so a `SET n:L REMOVE n:L` no longer replicates a zero-label `EFFECT_SET_LABELS` record, and `labels_removed` is no longer over-counted for a cancelled removal.

Every reader of the two sets was checked against the new invariant:

| Reader | Effect of disjointness |
| --- | --- |
| `node_has_label`, `update_node_labels`, `commit` | at most one of the two passes can touch a label, so the apply order is now immaterial |
| `constraint_node_has_label` | **behaviour corrected** — see below |
| `nodes_with_pending_label_removes` | a cancelled removal no longer hides the node from a label scan |
| `get_pending_nodes_with_labels`, `import_node_attrs`, `build_effects_buffer`, `check_constraints` | treat a missing key and an empty vec identically, so dropping emptied entries is equivalent |

Relationships have no analogue: `REMOVE r:X` is rejected with `Type mismatch: expected Node but was Relationship`, and a relationship carries a single immutable type.

## The constraint bypass

`constraint_node_has_label` consulted both sets with the same "removal wins" tie-break, so a node that removed and re-added a constrained label looked **unlabelled** to the constraint check while actually committing *with* the label. Uniqueness and mandatory constraints on it were silently skipped:

```
-- unique constraint on :Rejoin(v), with an existing (:Rejoin {v:1})
MATCH (n:Rejoin {v:1}) REMOVE n:Rejoin SET n:Rejoin CREATE (:Rejoin {v:1})
-- before: accepted, two :Rejoin nodes with v=1
-- after:  "unique constraint violation on node of type Rejoin"
```

```
-- mandatory constraint on :Mandate(p)
MATCH (n:Mandate) REMOVE n:Mandate SET n:Mandate SET n.p = NULL
-- before: accepted, leaving a :Mandate node with no p
-- after:  "mandatory constraint violation: node with label Mandate missing property p"
```

## Evidence — both directions, against a live server

Verified with a debug build of this branch loaded into `redis-server`:

| Query (node starts as `:L` / `:A`) | `labels(n)` | label scan | node count |
| --- | --- | --- | --- |
| `REMOVE n:L SET n:L` | `[L]` ✅ | 1 ✅ | 1 |
| `SET n:L REMOVE n:L` | `[]` ✅ | 0 ✅ | 1 |
| `REMOVE n:A SET n:B` | `[B]` ✅ | `:A` 0, `:B` 1 ✅ | 1 |
| `SET n:B REMOVE n:A` | `[B]` ✅ | `:A` 0, `:B` 1 ✅ | 1 |
| `REMOVE n:L` alone | `[]` ✅ | 0 ✅ | 1 |
| `SET n:L` alone (unlabelled) | `[L]` ✅ | 1 ✅ | 1 |
| `CREATE (n:L) REMOVE n:L SET n:L` | `[L]` ✅ | 1 ✅ | 1 |
| `CREATE (n:L) SET n:L REMOVE n:L` | `[]` ✅ | 0 ✅ | 1 |
| 5 nodes, `MATCH (n:L) REMOVE n:L SET n:L` | 5 × `[L]` ✅ | 5 ✅ | 5 |

With a range index on `:L(v)`, `Node By Index Scan` still returns the node after `REMOVE n:L SET n:L`, and a genuine `REMOVE n:L` still evicts it from the index.

## Regression tests

Three suites, covering the label result, the constraint enforcement, and the replicated effects stream. **Each was confirmed to fail on a build with the `pending.rs` change reverted.**

**1. `test_entity_update.py::testEntityUpdate::test_31_mix_add_and_remove_same_label_on_labeled_node`** — both directions on a node that actually carries the label (the gap in the existing `test_30`), plus the cross-label pair and a multi-node batch; asserts `labels(n)`, `labels_removed`, reachability via a label scan, and node survival. Reverted:

```
❌ (FAIL): [] == ['L']    test_entity_update.py:508
❌ (FAIL): 1.0 == 0       test_entity_update.py:509
❌ (FAIL): 0 == 1         test_entity_update.py:291   <- label scan finds nothing
```

**2. `test_constraint.py::testConstraintNodes::test09_constraint_enforced_on_removed_and_readded_label`** — the same-query duplicate scenario for both the unique and mandatory cases, plus the negative direction (a genuinely dropped label must free the value / release the node, so the constraints are not over-enforced). Reverted:

```
❌ (FAIL): False == True  test_constraint.py:605   <- duplicate CREATE not rejected
❌ (FAIL): False == True  test_constraint.py:617   <- collision on update not rejected
❌ (FAIL): False == True  test_constraint.py:639   <- mandatory violation not rejected
```

**3. `test_label_update.py::testLabelUpdate::test_remove_then_set_same_label`** — the `REMOVE`→`SET` direction under effects replication (`EFFECTS_THRESHOLD = 0`, master + replica), which existing coverage there exercised only as `SET`→`REMOVE`. It asserts replica state directly rather than only `graph_eq`, since the replica sees nothing but the effects stream: a stale `EFFECT_REMOVE_LABELS` would strip the label there alone. Reverted:

```
❌ (FAIL): 1.0 == 0   test_label_update.py:107   <- labels_removed
❌ (FAIL): 0 == 1     test_label_update.py:110   <- master lost :L
❌ (FAIL): 0 == 1     test_label_update.py:115   <- replica lost :L
```

Note for test 3: the clauses deliberately sit in one segment with no `WITH` between them. A `WITH` splits them into separately-committed segments where the two sets never overlap, so that form is correct even without this fix.

## Validation

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `CXX=clang++ cargo clippy --all-targets` | no new warnings (3 pre-existing, in files this PR does not touch: `reader.rs`, `cond_var_len_traverse.rs`, `bulk_insert.rs`) |
| `cargo test -p graph` | 286 passed, 0 failed |
| `tests/flow/test_entity_update` | 44 passed |
| `tests/flow/test_label_update` | 6 passed |
| `tests/flow/test_mix_labels` | 9 passed |
| `tests/flow/test_multi_label` | 12 passed |
| `tests/flow/test_effects` | 22 passed |
| `tests/flow/test_index_updates` | 11 passed |
| `tests/flow/test_constraint` | 17 passed, 1 failed — `testConstraintReplication.test_01_constraint_replication`, **pre-existing**: it fails identically (`0 == 12`) on a build with this change reverted |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed label updates so adding and removing the same label in one query follows the order of operations.
  - Ensured pending label changes are applied consistently for one or multiple nodes.
  - Preserved nodes while correctly reporting label additions and removals.
  - Corrected constraint enforcement when labels are removed and re-added within the same query.
  - Allowed composite unique constraints to accept incomplete values while still rejecting full duplicates.
  - Improved consistency across replicated data and change tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
