### PR TITLE
Fix Value Hash Join matching join keys that contain NULL

### DIFF
--- a/graph/src/runtime/ops/value_hash_join.rs
+++ b/graph/src/runtime/ops/value_hash_join.rs
@@ -24,8 +24,15 @@
 //! The table has two representations (see [`JoinHashTable`]): an `i64`-keyed
 //! fast path when every build key is integer-valued, and a general `Value`
 //! table (hash-to-bucket, then exact `Value` equality) for everything else.
-//! NULL keys are skipped on both sides (Cypher NULL != NULL semantics).
+//!
+//! Keys carrying a NULL cannot join, because Cypher `=` is three-valued and a
+//! NULL operand makes the predicate UNKNOWN rather than TRUE. A key like
+//! `[1, null]` is not itself NULL, yet `[1, null] = [1, null]` is still NULL,
+//! so [`keys_match`] rejects any comparison the `Value` layer flagged as
+//! inconclusive, and the build side additionally drops such keys outright via
+//! [`contains_null`] so they never reach the table.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use ahash::RandomState;
@@ -40,7 +47,7 @@ use crate::runtime::{
     eval::ExprEval,
     row::{Row, RowView},
     runtime::Runtime,
-    value::Value,
+    value::{CompareValue, DisjointOrNull, Value},
 };
 use orx_tree::{Dyn, NodeIdx, NodeRef};
 
@@ -113,13 +120,62 @@ fn hash_value(value: &Value) -> u64 {
     JOIN_HASH_SEED.hash_one(value)
 }
 
+/// True when `value` is NULL or hides a NULL anywhere inside a list, path or
+/// map.
+///
+/// Such a key can never join. Cypher `=` is three-valued, and
+/// `Value::compare_value` propagates that faithfully: comparing `[1, null]`
+/// with `[1, null]` yields `(Ordering::Equal, DisjointOrNull::ComparedNull)` —
+/// "equal as far as the non-NULL elements go, but the answer is UNKNOWN". A
+/// NULL nested at any depth bubbles the flag all the way out through
+/// `compare_list`/`compare_map`, so the result is never a genuine match.
+///
+/// This runs on the *build* side only, once per key as it is materialised:
+/// such a key would otherwise occupy a bucket that nothing can ever hit, and
+/// every probe landing on that bucket would pay to compare against it. The
+/// probe side deliberately does not repeat the deep scan — [`keys_match`]
+/// already rejects these keys for free, so scanning there would only tax the
+/// far more common null-free container key. The integer fast path skips the
+/// test entirely, since an `i64` cannot hide a NULL.
+fn contains_null(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::List(items) | Value::Path(items) => items.iter().any(contains_null),
+        Value::Map(entries) => entries.values().any(contains_null),
+        _ => false,
+    }
+}
+
+/// Cypher `=` between two join keys: a match only when they compare equal *and*
+/// the comparison was conclusive.
+///
+/// `Value`'s `PartialEq` is `compare_value(..).0 == Ordering::Equal`, which
+/// throws the [`DisjointOrNull`] flag away and so collapses UNKNOWN into TRUE:
+/// `[1, null] == [1, null]` reports `true` even though Cypher says the
+/// predicate is NULL. Keeping the flag is what makes the join agree with the
+/// `Filter` it replaces. `DisjointOrNull::Disjoint` is rejected for the same
+/// reason — `compare_map` reports `(Equal, Disjoint)` for maps whose values
+/// have incomparable types, which is FALSE, not TRUE.
+///
+/// This costs nothing over `PartialEq`: the flag is already computed and
+/// returned by the same `compare_value` call, so the inner bucket scan just
+/// stops discarding it.
+fn keys_match(
+    a: &Value,
+    b: &Value,
+) -> bool {
+    let (ordering, disjoint_or_null) = a.compare_value(b);
+    ordering == Ordering::Equal && matches!(disjoint_or_null, DisjointOrNull::None)
+}
+
 /// Map a key to the `i64` the [`JoinHashTable::Int`] fast path is keyed on,
 /// honouring `Value`'s numeric equality (`Int(n)` and the whole float `n.0`
 /// compare equal and hash identically, so they must share a key). Integers map
 /// directly; a float maps only if it round-trips through `i64` exactly (a whole
 /// number, in range — matching the `Value` `Hash`/`compare_value` rules);
 /// anything else (string, non-whole float, NaN, …) can't equal an integer key,
-/// so it returns `None`.
+/// so it returns `None`. Only scalar numerics are accepted, so a key that
+/// [`contains_null`] rejects can never reach the integer table.
 fn key_as_i64(key: &Value) -> Option<i64> {
     match key {
         Value::Int(n) => Some(*n),
@@ -133,14 +189,16 @@ fn key_as_i64(key: &Value) -> Option<i64> {
 
 /// Insert one build row into the general (`Value`) table, grouping rows that
 /// share a key under a single bucket entry (re-using it on a hash collision or
-/// a repeated key).
+/// a repeated key). Grouping uses the same [`keys_match`] test as probe, so two
+/// keys share an entry exactly when a probe key matching one must also match
+/// the other.
 fn insert_value(
     table: &mut ValueTable,
     key: Value,
     slot: RightRowRef,
 ) {
     let bucket = table.entry(hash_value(&key)).or_default();
-    match bucket.iter_mut().find(|(k, _)| *k == key) {
+    match bucket.iter_mut().find(|(k, _)| keys_match(k, &key)) {
         Some((_, refs)) => refs.push(slot),
         None => bucket.push((key, smallvec![slot])),
     }
@@ -246,9 +304,16 @@ impl<'a> ValueHashJoinOp<'a> {
                 };
                 match &mut value_table {
                     // General path already active: re-materialize the key value.
-                    Some(table) => insert_value(table, column.get(i), slot),
+                    Some(table) => {
+                        let key = column.get(i);
+                        if contains_null(&key) {
+                            continue;
+                        }
+                        insert_value(table, key, slot);
+                    }
                     // All-integer column: key directly on the `i64` — the
-                    // build side's hot path (no `Value` box / hash / drop).
+                    // build side's hot path (no `Value` box / hash / drop, and
+                    // no null scan, since an `i64` cannot hide a NULL).
                     None => {
                         if let Column::Ints(ints) = &column {
                             int_table.entry(ints[i]).or_default().push(slot);
@@ -257,6 +322,13 @@ impl<'a> ValueHashJoinOp<'a> {
                             // (`30.0 == 30`) via `key_as_i64`, otherwise promote the
                             // accumulated integer entries to the general table.
                             let key = column.get(i);
+                            // A NULL nested inside a container key (`[1, null]`)
+                            // is not caught by `nulls` above, and can never
+                            // compare equal under three-valued logic — drop it
+                            // here rather than seed a bucket nothing can hit.
+                            if contains_null(&key) {
+                                continue;
+                            }
                             if let Some(n) = key_as_i64(&key) {
                                 int_table.entry(n).or_default().push(slot);
                             } else {
@@ -294,12 +366,17 @@ impl<'a> ValueHashJoinOp<'a> {
                 };
                 table.get(&n)
             }
-            // General path: hash to the bucket, then re-check exact equality.
+            // General path: hash to the bucket, then re-check exact equality
+            // under three-valued logic (`PartialEq` would report a match for
+            // an UNKNOWN comparison; see [`keys_match`]).
             JoinHashTable::Value(table) => {
                 let Some(bucket) = table.get(&hash_value(key)) else {
                     return;
                 };
-                bucket.iter().find(|(k, _)| k == key).map(|(_, refs)| refs)
+                bucket
+                    .iter()
+                    .find(|(k, _)| keys_match(k, key))
+                    .map(|(_, refs)| refs)
             }
         };
         let Some(refs) = refs else {
@@ -374,6 +451,12 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
                         Err(e) => return Some(Err(e)),
                     }
                 };
+                // Cheap top-level early-out. A key with a NULL *nested* inside
+                // a container is not caught here on purpose: `keys_match`
+                // already rejects it, and paying for a deep scan on every
+                // probe row would tax the far more common null-free container
+                // key. The build side does scan deeply — once per build row —
+                // so no such key is ever in the table to be matched against.
                 if matches!(key, Value::Null) {
                     self.left_pos += 1;
                     continue;
@@ -421,5 +504,114 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use thin_vec::thin_vec;
+
+    use super::{contains_null, key_as_i64, keys_match};
+    use crate::runtime::{ordermap::OrderMap, value::Value};
+
+    fn list(items: Vec<Value>) -> Value {
+        Value::List(Arc::new(items.into_iter().collect()))
+    }
+
+    fn map(entries: Vec<(&str, Value)>) -> Value {
+        Value::Map(Arc::new(OrderMap::from_vec(
+            entries
+                .into_iter()
+                .map(|(k, v)| (Arc::new(k.to_string()), v))
+                .collect(),
+        )))
+    }
+
+    fn string(s: &str) -> Value {
+        Value::String(Arc::new(s.to_string()))
+    }
+
+    #[test]
+    fn contains_null_sees_through_containers() {
+        // Scalars: only NULL itself.
+        assert!(contains_null(&Value::Null));
+        assert!(!contains_null(&Value::Int(1)));
+        assert!(!contains_null(&Value::Float(1.5)));
+        assert!(!contains_null(&Value::Bool(true)));
+        assert!(!contains_null(&string("x")));
+
+        // Lists, at any depth.
+        assert!(contains_null(&list(vec![Value::Int(1), Value::Null])));
+        assert!(contains_null(&list(vec![list(vec![Value::Null])])));
+        assert!(!contains_null(&list(vec![Value::Int(1), Value::Int(2)])));
+        assert!(!contains_null(&list(vec![])));
+
+        // Maps, including nested inside a list.
+        assert!(contains_null(&map(vec![("a", Value::Null)])));
+        assert!(contains_null(&list(vec![map(vec![("a", Value::Null)])])));
+        assert!(!contains_null(&map(vec![("a", Value::Int(1))])));
+
+        // Paths share the list representation.
+        assert!(!contains_null(&Value::Path(Arc::new(thin_vec![]))));
+    }
+
+    #[test]
+    fn keys_match_requires_a_conclusive_equality() {
+        // This is the regression under test: `PartialEq` drops the
+        // `DisjointOrNull` flag, so it reports `[1, null] == [1, null]`,
+        // which turned an UNKNOWN predicate into a join match.
+        let null_list = list(vec![Value::Int(1), Value::Null]);
+        assert!(null_list == null_list, "PartialEq is deliberately laxer");
+        assert!(!keys_match(&null_list, &null_list));
+
+        // A NULL on only one side is no match either.
+        assert!(!keys_match(
+            &null_list,
+            &list(vec![Value::Int(1), Value::Int(2)])
+        ));
+        assert!(!keys_match(&Value::Null, &Value::Null));
+        assert!(!keys_match(&Value::Null, &Value::Int(1)));
+
+        // Maps whose values are of incomparable types compare FALSE, not TRUE.
+        assert!(!keys_match(
+            &map(vec![("a", Value::Int(1))]),
+            &map(vec![("a", string("1"))])
+        ));
+        assert!(!keys_match(
+            &map(vec![("a", Value::Null)]),
+            &map(vec![("a", Value::Null)])
+        ));
+    }
+
+    #[test]
+    fn keys_match_still_accepts_legitimate_joins() {
+        // Scalars, including Cypher's cross-type numeric equality.
+        assert!(keys_match(&Value::Int(30), &Value::Int(30)));
+        assert!(keys_match(&Value::Int(30), &Value::Float(30.0)));
+        assert!(!keys_match(&Value::Int(30), &Value::Int(31)));
+        assert!(keys_match(&string("a"), &string("a")));
+        assert!(!keys_match(&string("a"), &string("b")));
+
+        // NULL-free containers.
+        let pair = list(vec![Value::Int(1), Value::Int(2)]);
+        assert!(keys_match(&pair, &pair));
+        assert!(!keys_match(&pair, &list(vec![Value::Int(1)])));
+        assert!(keys_match(&list(vec![]), &list(vec![])));
+        let m = map(vec![("a", Value::Int(1)), ("b", string("x"))]);
+        assert!(keys_match(&m, &m));
+        assert!(!keys_match(&m, &map(vec![("a", Value::Int(1))])));
+    }
+
+    #[test]
+    fn integer_fast_path_never_sees_a_null_bearing_key() {
+        // The `Int` table can only ever be keyed by a scalar numeric, so a
+        // key that `contains_null` cannot reach it via `key_as_i64`.
+        assert_eq!(key_as_i64(&Value::Int(7)), Some(7));
+        assert_eq!(key_as_i64(&Value::Float(7.0)), Some(7));
+        assert_eq!(key_as_i64(&Value::Null), None);
+        assert_eq!(key_as_i64(&list(vec![Value::Int(1), Value::Null])), None);
+        assert_eq!(key_as_i64(&map(vec![("a", Value::Null)])), None);
     }
 }

--- a/graph/src/runtime/ops/value_hash_join.rs
+++ b/graph/src/runtime/ops/value_hash_join.rs
@@ -23,14 +23,11 @@
 //!
 //! The table has two representations (see [`JoinHashTable`]): an `i64`-keyed
 //! fast path when every build key is integer-valued, and a general `Value`
-//! table (hash-to-bucket, then exact `Value` equality) for everything else.
-//!
-//! Keys carrying a NULL cannot join, because Cypher `=` is three-valued and a
-//! NULL operand makes the predicate UNKNOWN rather than TRUE. A key like
-//! `[1, null]` is not itself NULL, yet `[1, null] = [1, null]` is still NULL,
-//! so [`keys_match`] rejects any comparison the `Value` layer flagged as
-//! inconclusive, and the build side additionally drops such keys outright via
-//! [`contains_null`] so they never reach the table.
+//! table (hash-to-bucket, then [`keys_match`] on the bucket) for everything
+//! else. Top-level NULL keys are skipped on both sides, and a key that merely
+//! *carries* a NULL (`[1, null]`) is rejected by [`keys_match`], because
+//! Cypher `=` is three-valued: a NULL operand makes the predicate UNKNOWN
+//! rather than TRUE.
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -120,46 +117,21 @@ fn hash_value(value: &Value) -> u64 {
     JOIN_HASH_SEED.hash_one(value)
 }
 
-/// True when `value` is NULL or hides a NULL anywhere inside a list, path or
-/// map.
-///
-/// Such a key can never join. Cypher `=` is three-valued, and
-/// `Value::compare_value` propagates that faithfully: comparing `[1, null]`
-/// with `[1, null]` yields `(Ordering::Equal, DisjointOrNull::ComparedNull)` —
-/// "equal as far as the non-NULL elements go, but the answer is UNKNOWN". A
-/// NULL nested at any depth bubbles the flag all the way out through
-/// `compare_list`/`compare_map`, so the result is never a genuine match.
-///
-/// This runs on the *build* side only, once per key as it is materialised:
-/// such a key would otherwise occupy a bucket that nothing can ever hit, and
-/// every probe landing on that bucket would pay to compare against it. The
-/// probe side deliberately does not repeat the deep scan — [`keys_match`]
-/// already rejects these keys for free, so scanning there would only tax the
-/// far more common null-free container key. The integer fast path skips the
-/// test entirely, since an `i64` cannot hide a NULL.
-fn contains_null(value: &Value) -> bool {
-    match value {
-        Value::Null => true,
-        Value::List(items) | Value::Path(items) => items.iter().any(contains_null),
-        Value::Map(entries) => entries.values().any(contains_null),
-        _ => false,
-    }
-}
-
 /// Cypher `=` between two join keys: a match only when they compare equal *and*
 /// the comparison was conclusive.
 ///
 /// `Value`'s `PartialEq` is `compare_value(..).0 == Ordering::Equal`, which
 /// throws the [`DisjointOrNull`] flag away and so collapses UNKNOWN into TRUE:
-/// `[1, null] == [1, null]` reports `true` even though Cypher says the
-/// predicate is NULL. Keeping the flag is what makes the join agree with the
-/// `Filter` it replaces. `DisjointOrNull::Disjoint` is rejected for the same
-/// reason — `compare_map` reports `(Equal, Disjoint)` for maps whose values
-/// have incomparable types, which is FALSE, not TRUE.
+/// `[1, null] == [1, null]` reports `true` even though `compare_list` flagged
+/// it `ComparedNull` — "equal as far as the non-NULL elements go, but the
+/// answer is UNKNOWN". Keeping the flag is what makes the join agree with the
+/// `Filter` it replaces. `Disjoint` is rejected for the same reason:
+/// `compare_map` reports `(Equal, Disjoint)` for maps whose values have
+/// incomparable types, which is FALSE, not TRUE.
 ///
-/// This costs nothing over `PartialEq`: the flag is already computed and
-/// returned by the same `compare_value` call, so the inner bucket scan just
-/// stops discarding it.
+/// This costs nothing over `PartialEq` — the flag is already computed and
+/// returned by the same `compare_value` call, so the bucket scan simply stops
+/// discarding it.
 fn keys_match(
     a: &Value,
     b: &Value,
@@ -174,8 +146,8 @@ fn keys_match(
 /// directly; a float maps only if it round-trips through `i64` exactly (a whole
 /// number, in range — matching the `Value` `Hash`/`compare_value` rules);
 /// anything else (string, non-whole float, NaN, …) can't equal an integer key,
-/// so it returns `None`. Only scalar numerics are accepted, so a key that
-/// [`contains_null`] rejects can never reach the integer table.
+/// so it returns `None`. Only scalar numerics are accepted, so a null-bearing
+/// key can never reach the integer table.
 fn key_as_i64(key: &Value) -> Option<i64> {
     match key {
         Value::Int(n) => Some(*n),
@@ -189,9 +161,9 @@ fn key_as_i64(key: &Value) -> Option<i64> {
 
 /// Insert one build row into the general (`Value`) table, grouping rows that
 /// share a key under a single bucket entry (re-using it on a hash collision or
-/// a repeated key). Grouping uses the same [`keys_match`] test as probe, so two
-/// keys share an entry exactly when a probe key matching one must also match
-/// the other.
+/// a repeated key). Grouping uses the same [`keys_match`] test as the probe
+/// side, so two keys share an entry exactly when a probe key matching one must
+/// also match the other.
 fn insert_value(
     table: &mut ValueTable,
     key: Value,
@@ -304,16 +276,9 @@ impl<'a> ValueHashJoinOp<'a> {
                 };
                 match &mut value_table {
                     // General path already active: re-materialize the key value.
-                    Some(table) => {
-                        let key = column.get(i);
-                        if contains_null(&key) {
-                            continue;
-                        }
-                        insert_value(table, key, slot);
-                    }
+                    Some(table) => insert_value(table, column.get(i), slot),
                     // All-integer column: key directly on the `i64` — the
-                    // build side's hot path (no `Value` box / hash / drop, and
-                    // no null scan, since an `i64` cannot hide a NULL).
+                    // build side's hot path (no `Value` box / hash / drop).
                     None => {
                         if let Column::Ints(ints) = &column {
                             int_table.entry(ints[i]).or_default().push(slot);
@@ -322,13 +287,6 @@ impl<'a> ValueHashJoinOp<'a> {
                             // (`30.0 == 30`) via `key_as_i64`, otherwise promote the
                             // accumulated integer entries to the general table.
                             let key = column.get(i);
-                            // A NULL nested inside a container key (`[1, null]`)
-                            // is not caught by `nulls` above, and can never
-                            // compare equal under three-valued logic — drop it
-                            // here rather than seed a bucket nothing can hit.
-                            if contains_null(&key) {
-                                continue;
-                            }
                             if let Some(n) = key_as_i64(&key) {
                                 int_table.entry(n).or_default().push(slot);
                             } else {
@@ -451,12 +409,8 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
                         Err(e) => return Some(Err(e)),
                     }
                 };
-                // Cheap top-level early-out. A key with a NULL *nested* inside
-                // a container is not caught here on purpose: `keys_match`
-                // already rejects it, and paying for a deep scan on every
-                // probe row would tax the far more common null-free container
-                // key. The build side does scan deeply — once per build row —
-                // so no such key is ever in the table to be matched against.
+                // Cheap top-level early-out; a NULL nested inside a container
+                // key is left to `keys_match`, which rejects it for free.
                 if matches!(key, Value::Null) {
                     self.left_pos += 1;
                     continue;
@@ -511,9 +465,7 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
 mod tests {
     use std::sync::Arc;
 
-    use thin_vec::thin_vec;
-
-    use super::{contains_null, key_as_i64, keys_match};
+    use super::{key_as_i64, keys_match};
     use crate::runtime::{ordermap::OrderMap, value::Value};
 
     fn list(items: Vec<Value>) -> Value {
@@ -531,30 +483,6 @@ mod tests {
 
     fn string(s: &str) -> Value {
         Value::String(Arc::new(s.to_string()))
-    }
-
-    #[test]
-    fn contains_null_sees_through_containers() {
-        // Scalars: only NULL itself.
-        assert!(contains_null(&Value::Null));
-        assert!(!contains_null(&Value::Int(1)));
-        assert!(!contains_null(&Value::Float(1.5)));
-        assert!(!contains_null(&Value::Bool(true)));
-        assert!(!contains_null(&string("x")));
-
-        // Lists, at any depth.
-        assert!(contains_null(&list(vec![Value::Int(1), Value::Null])));
-        assert!(contains_null(&list(vec![list(vec![Value::Null])])));
-        assert!(!contains_null(&list(vec![Value::Int(1), Value::Int(2)])));
-        assert!(!contains_null(&list(vec![])));
-
-        // Maps, including nested inside a list.
-        assert!(contains_null(&map(vec![("a", Value::Null)])));
-        assert!(contains_null(&list(vec![map(vec![("a", Value::Null)])])));
-        assert!(!contains_null(&map(vec![("a", Value::Int(1))])));
-
-        // Paths share the list representation.
-        assert!(!contains_null(&Value::Path(Arc::new(thin_vec![]))));
     }
 
     #[test]
@@ -606,8 +534,9 @@ mod tests {
 
     #[test]
     fn integer_fast_path_never_sees_a_null_bearing_key() {
-        // The `Int` table can only ever be keyed by a scalar numeric, so a
-        // key that `contains_null` cannot reach it via `key_as_i64`.
+        // The `Int` table is matched on the `i64` alone, with no `keys_match`
+        // check, so a null-bearing key must never map into it. `key_as_i64`
+        // accepts only scalar numerics, which is what guarantees that.
         assert_eq!(key_as_i64(&Value::Int(7)), Some(7));
         assert_eq!(key_as_i64(&Value::Float(7.0)), Some(7));
         assert_eq!(key_as_i64(&Value::Null), None);

--- a/graph/src/runtime/ops/value_hash_join.rs
+++ b/graph/src/runtime/ops/value_hash_join.rs
@@ -27,7 +27,8 @@
 //! else. Top-level NULL keys are skipped on both sides, and a key that merely
 //! *carries* a NULL (`[1, null]`) is rejected by [`keys_match`], because
 //! Cypher `=` is three-valued: a NULL operand makes the predicate UNKNOWN
-//! rather than TRUE.
+//! rather than TRUE. Build additionally drops any key that cannot match
+//! itself, since nothing can ever match it (see [`insert_value`]).
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -159,16 +160,66 @@ fn key_as_i64(key: &Value) -> Option<i64> {
     }
 }
 
+/// Cheap conservative pre-filter for the self-match test in [`insert_value`]:
+/// `false` only for keys that are *certain* to match themselves.
+///
+/// This is a performance hint, not the decision — correctness rests entirely on
+/// the exact `keys_match` check it gates. Being wrong in either direction is
+/// safe: a false positive just pays for that exact check, and a false negative
+/// only re-admits an unmatchable key to the table, where probe still rejects
+/// it. So unlisted variants answer `true` and get checked properly, which is
+/// also what keeps a newly added `Value` variant from silently slipping past.
+///
+/// It exists because the exact check is not free on the shapes that need it
+/// least: `compare_map` allocates and sorts both key lists on every call, so
+/// self-comparing every build key measured ~20% slower on map-valued keys,
+/// while this walk is a discriminant test per element.
+fn may_fail_self_match(value: &Value) -> bool {
+    match value {
+        // Self-comparison of these is `(Equal, None)` by construction.
+        Value::Bool(_)
+        | Value::Int(_)
+        | Value::String(_)
+        | Value::Node(_)
+        | Value::Relationship(_)
+        | Value::Datetime(_)
+        | Value::Date(_)
+        | Value::Time(_)
+        | Value::Duration(_) => false,
+        // NaN never compares equal, not even to itself.
+        Value::Float(f) => f.is_nan(),
+        // A container is unmatchable exactly when one of its members is.
+        Value::List(items) | Value::Path(items) => items.iter().any(may_fail_self_match),
+        Value::Map(entries) => entries.values().any(may_fail_self_match),
+        // Null (`ComparedNull`), Point (NaN coordinates), VecF32 (no typed arm
+        // in `compare_value`, so `Disjoint`) — and any future variant.
+        _ => true,
+    }
+}
+
 /// Insert one build row into the general (`Value`) table, grouping rows that
 /// share a key under a single bucket entry (re-using it on a hash collision or
 /// a repeated key). Grouping uses the same [`keys_match`] test as the probe
 /// side, so two keys share an entry exactly when a probe key matching one must
 /// also match the other.
+///
+/// A key that cannot match *itself* is dropped rather than stored. `keys_match`
+/// would reject it on every probe, so it can never join — and since grouping
+/// uses that same test, a repeated one (say N rows all keyed `[1, null]`, which
+/// all hash alike) would append a fresh entry per row and rescan the whole
+/// bucket to do it, making the build O(N²) and every colliding probe O(N).
+/// Self-comparison is the exact test, because an inconclusive comparison comes
+/// from the key's own contents: a NULL bubbles `ComparedNull` out through
+/// `compare_list`/`compare_map`, and nothing it is compared against can clear
+/// that.
 fn insert_value(
     table: &mut ValueTable,
     key: Value,
     slot: RightRowRef,
 ) {
+    if may_fail_self_match(&key) && !keys_match(&key, &key) {
+        return;
+    }
     let bucket = table.entry(hash_value(&key)).or_default();
     match bucket.iter_mut().find(|(k, _)| keys_match(k, &key)) {
         Some((_, refs)) => refs.push(slot),
@@ -465,7 +516,8 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
 mod tests {
     use std::sync::Arc;
 
-    use super::{key_as_i64, keys_match};
+    use super::{RightRowRef, may_fail_self_match};
+    use super::{ValueTable, insert_value, key_as_i64, keys_match};
     use crate::runtime::{ordermap::OrderMap, value::Value};
 
     fn list(items: Vec<Value>) -> Value {
@@ -542,5 +594,71 @@ mod tests {
         assert_eq!(key_as_i64(&Value::Null), None);
         assert_eq!(key_as_i64(&list(vec![Value::Int(1), Value::Null])), None);
         assert_eq!(key_as_i64(&map(vec![("a", Value::Null)])), None);
+    }
+
+    /// A key that cannot match itself never enters the table. Otherwise the
+    /// build degrades to O(N²): all N such keys hash alike, none groups with
+    /// any other under `keys_match`, so each row would append an entry and
+    /// rescan the bucket to discover it must.
+    #[test]
+    fn unmatchable_build_keys_never_enter_the_table() {
+        let mut table = ValueTable::default();
+        for row in 0..64 {
+            let slot = RightRowRef { batch: 0, row };
+            insert_value(&mut table, list(vec![Value::Int(1), Value::Null]), slot);
+            insert_value(&mut table, map(vec![("k", Value::Null)]), slot);
+            insert_value(&mut table, Value::Null, slot);
+        }
+        assert!(table.is_empty());
+
+        // A matchable key still groups its repeats under one entry.
+        for row in 0..64 {
+            insert_value(
+                &mut table,
+                list(vec![Value::Int(1), Value::Int(2)]),
+                RightRowRef { batch: 0, row },
+            );
+        }
+        let entries: usize = table.values().map(Vec::len).sum();
+        assert_eq!(entries, 1);
+        assert_eq!(table.values().next().unwrap()[0].1.len(), 64);
+    }
+
+    /// The pre-filter is only allowed to be wrong in the direction that costs
+    /// time: whenever it says `false`, the exact check it skips must have
+    /// agreed that the key matches itself. A `true` needs no justification.
+    #[test]
+    fn the_self_match_pre_filter_only_skips_keys_that_really_self_match() {
+        let corpus = vec![
+            Value::Null,
+            Value::Bool(true),
+            Value::Int(0),
+            Value::Float(1.5),
+            Value::Float(f64::NAN),
+            Value::Float(f64::INFINITY),
+            string("x"),
+            list(vec![]),
+            list(vec![Value::Int(1), Value::Int(2)]),
+            list(vec![Value::Int(1), Value::Null]),
+            list(vec![Value::Float(f64::NAN)]),
+            list(vec![list(vec![Value::Null])]),
+            list(vec![map(vec![("a", Value::Null)])]),
+            map(vec![]),
+            map(vec![("a", Value::Int(1))]),
+            map(vec![("a", Value::Null)]),
+            map(vec![("a", Value::Float(f64::NAN))]),
+            Value::Datetime(0),
+            Value::Date(0),
+            Value::Time(0),
+            Value::Duration(0),
+        ];
+        for v in corpus {
+            if !may_fail_self_match(&v) {
+                assert!(
+                    keys_match(&v, &v),
+                    "pre-filter waved through a key that cannot match itself: {v:?}"
+                );
+            }
+        }
     }
 }

--- a/graph/src/runtime/ops/value_hash_join.rs
+++ b/graph/src/runtime/ops/value_hash_join.rs
@@ -27,8 +27,9 @@
 //! else. Top-level NULL keys are skipped on both sides, and a key that merely
 //! *carries* a NULL (`[1, null]`) is rejected by [`keys_match`], because
 //! Cypher `=` is three-valued: a NULL operand makes the predicate UNKNOWN
-//! rather than TRUE. Build additionally drops any key that cannot match
-//! itself, since nothing can ever match it (see [`insert_value`]).
+//! rather than TRUE. Build additionally drops any key that
+//! [`Value::is_never_equal`] rejects, since nothing can ever match it (see
+//! [`insert_value`]).
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -160,64 +161,24 @@ fn key_as_i64(key: &Value) -> Option<i64> {
     }
 }
 
-/// Cheap conservative pre-filter for the self-match test in [`insert_value`]:
-/// `false` only for keys that are *certain* to match themselves.
-///
-/// This is a performance hint, not the decision — correctness rests entirely on
-/// the exact `keys_match` check it gates. Being wrong in either direction is
-/// safe: a false positive just pays for that exact check, and a false negative
-/// only re-admits an unmatchable key to the table, where probe still rejects
-/// it. So unlisted variants answer `true` and get checked properly, which is
-/// also what keeps a newly added `Value` variant from silently slipping past.
-///
-/// It exists because the exact check is not free on the shapes that need it
-/// least: `compare_map` allocates and sorts both key lists on every call, so
-/// self-comparing every build key measured ~20% slower on map-valued keys,
-/// while this walk is a discriminant test per element.
-fn may_fail_self_match(value: &Value) -> bool {
-    match value {
-        // Self-comparison of these is `(Equal, None)` by construction.
-        Value::Bool(_)
-        | Value::Int(_)
-        | Value::String(_)
-        | Value::Node(_)
-        | Value::Relationship(_)
-        | Value::Datetime(_)
-        | Value::Date(_)
-        | Value::Time(_)
-        | Value::Duration(_) => false,
-        // NaN never compares equal, not even to itself.
-        Value::Float(f) => f.is_nan(),
-        // A container is unmatchable exactly when one of its members is.
-        Value::List(items) | Value::Path(items) => items.iter().any(may_fail_self_match),
-        Value::Map(entries) => entries.values().any(may_fail_self_match),
-        // Null (`ComparedNull`), Point (NaN coordinates), VecF32 (no typed arm
-        // in `compare_value`, so `Disjoint`) — and any future variant.
-        _ => true,
-    }
-}
-
 /// Insert one build row into the general (`Value`) table, grouping rows that
 /// share a key under a single bucket entry (re-using it on a hash collision or
 /// a repeated key). Grouping uses the same [`keys_match`] test as the probe
 /// side, so two keys share an entry exactly when a probe key matching one must
 /// also match the other.
 ///
-/// A key that cannot match *itself* is dropped rather than stored. `keys_match`
-/// would reject it on every probe, so it can never join — and since grouping
-/// uses that same test, a repeated one (say N rows all keyed `[1, null]`, which
-/// all hash alike) would append a fresh entry per row and rescan the whole
-/// bucket to do it, making the build O(N²) and every colliding probe O(N).
-/// Self-comparison is the exact test, because an inconclusive comparison comes
-/// from the key's own contents: a NULL bubbles `ComparedNull` out through
-/// `compare_list`/`compare_map`, and nothing it is compared against can clear
-/// that.
+/// A key that [`Value::is_never_equal`] rejects is dropped rather than stored.
+/// `keys_match` would reject it on every probe, so it can never join — and
+/// since grouping uses that same test, a repeated one (say N rows all keyed
+/// `[1, null]`, which all hash alike) would append a fresh entry per row and
+/// rescan the whole bucket to do it, making the build O(N²) and every colliding
+/// probe O(N).
 fn insert_value(
     table: &mut ValueTable,
     key: Value,
     slot: RightRowRef,
 ) {
-    if may_fail_self_match(&key) && !keys_match(&key, &key) {
+    if key.is_never_equal() {
         return;
     }
     let bucket = table.entry(hash_value(&key)).or_default();
@@ -516,7 +477,7 @@ impl<'a> Iterator for ValueHashJoinOp<'a> {
 mod tests {
     use std::sync::Arc;
 
-    use super::{RightRowRef, may_fail_self_match};
+    use super::RightRowRef;
     use super::{ValueTable, insert_value, key_as_i64, keys_match};
     use crate::runtime::{ordermap::OrderMap, value::Value};
 
@@ -622,43 +583,5 @@ mod tests {
         let entries: usize = table.values().map(Vec::len).sum();
         assert_eq!(entries, 1);
         assert_eq!(table.values().next().unwrap()[0].1.len(), 64);
-    }
-
-    /// The pre-filter is only allowed to be wrong in the direction that costs
-    /// time: whenever it says `false`, the exact check it skips must have
-    /// agreed that the key matches itself. A `true` needs no justification.
-    #[test]
-    fn the_self_match_pre_filter_only_skips_keys_that_really_self_match() {
-        let corpus = vec![
-            Value::Null,
-            Value::Bool(true),
-            Value::Int(0),
-            Value::Float(1.5),
-            Value::Float(f64::NAN),
-            Value::Float(f64::INFINITY),
-            string("x"),
-            list(vec![]),
-            list(vec![Value::Int(1), Value::Int(2)]),
-            list(vec![Value::Int(1), Value::Null]),
-            list(vec![Value::Float(f64::NAN)]),
-            list(vec![list(vec![Value::Null])]),
-            list(vec![map(vec![("a", Value::Null)])]),
-            map(vec![]),
-            map(vec![("a", Value::Int(1))]),
-            map(vec![("a", Value::Null)]),
-            map(vec![("a", Value::Float(f64::NAN))]),
-            Value::Datetime(0),
-            Value::Date(0),
-            Value::Time(0),
-            Value::Duration(0),
-        ];
-        for v in corpus {
-            if !may_fail_self_match(&v) {
-                assert!(
-                    keys_match(&v, &v),
-                    "pre-filter waved through a key that cannot match itself: {v:?}"
-                );
-            }
-        }
     }
 }

--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -1404,12 +1404,17 @@ impl Value {
         let mut first_not_equal = Ordering::Equal;
         let mut null_counter: usize = 0;
         let mut not_equal_counter: usize = 0;
+        // members whose comparison was inconclusive for a reason other than
+        // NULL: incomparable types (`Disjoint`) or NaN
+        let mut inconclusive_counter: usize = 0;
 
         for (a_value, b_value) in a.iter().zip(b) {
             let (compare_result, disjoint_or_null) = a_value.compare_value(b_value);
             if disjoint_or_null != DisjointOrNull::None {
                 if disjoint_or_null == DisjointOrNull::ComparedNull {
                     null_counter += 1;
+                } else {
+                    inconclusive_counter += 1;
                 }
                 not_equal_counter += 1;
                 if first_not_equal == Ordering::Equal {
@@ -1423,14 +1428,31 @@ impl Value {
             }
         }
 
-        // if all the elements in the shared range yielded false comparisons
-        if not_equal_counter == min_len && null_counter < not_equal_counter {
+        // if all the elements in the shared range yielded false comparisons.
+        // `first_not_equal` still being `Equal` means no member actually
+        // decided the order — every comparison was inconclusive — so there is
+        // no conclusive verdict to report, and saying `None` here would claim
+        // the lists are equal.
+        if not_equal_counter == min_len
+            && null_counter < not_equal_counter
+            && first_not_equal != Ordering::Equal
+        {
             return (first_not_equal, DisjointOrNull::None);
         }
 
         // if there was a null comparison on non-disjoint arrays
         if null_counter > 0 && len_a == len_b {
             return (first_not_equal, DisjointOrNull::ComparedNull);
+        }
+
+        // a member compared inconclusively and no other member decided the
+        // order, so the list comparison is inconclusive too. Reachable only
+        // when a member pair shares a variant that `compare_value` has no arm
+        // for — `VecF32` today — since every other inconclusive comparison
+        // reports an ordering. Lists of unequal length keep their old answer:
+        // length alone still decides them.
+        if inconclusive_counter > 0 && first_not_equal == Ordering::Equal && len_a == len_b {
+            return (Ordering::Equal, DisjointOrNull::Disjoint);
         }
 
         // if there was a difference in some member, without any null compare
@@ -1994,6 +2016,12 @@ mod is_never_equal_tests {
         )))
     }
 
+    /// `compare_value` has no arm for a `VecF32` pair, so two of them compare
+    /// `Disjoint` however equal their contents look.
+    fn vector(items: Vec<f32>) -> Value {
+        Value::VecF32(Arc::new(items.into_iter().collect()))
+    }
+
     /// Every value whose `=` can never be TRUE, at any nesting depth.
     #[test]
     fn values_carrying_an_unknown_are_never_equal() {
@@ -2004,6 +2032,61 @@ mod is_never_equal_tests {
         assert!(map(vec![("a", Value::Null)]).is_never_equal());
         assert!(list(vec![map(vec![("a", Value::Null)])]).is_never_equal());
         assert!(map(vec![("a", Value::Float(f64::NAN))]).is_never_equal());
+
+        // A member `compare_value` cannot compare at all makes the container
+        // inconclusive too -- including the mixed case, where the list also
+        // carries a NULL, which used to slip through `compare_list`.
+        assert!(vector(vec![1.0, 2.0]).is_never_equal());
+        assert!(list(vec![vector(vec![1.0, 2.0])]).is_never_equal());
+        assert!(list(vec![vector(vec![1.0]), Value::Null]).is_never_equal());
+        assert!(list(vec![list(vec![vector(vec![1.0])])]).is_never_equal());
+        assert!(map(vec![("a", vector(vec![1.0]))]).is_never_equal());
+    }
+
+    /// `compare_list` must not report a conclusive verdict when no member
+    /// actually decided the order. Its "all members compared false" branch used
+    /// to return `(Equal, None)` in that case, which reads as *"these lists are
+    /// equal, definitively"* -- so `[vec, null]` matched itself, and two
+    /// different vectors in lists matched each other.
+    #[test]
+    fn compare_list_keeps_an_inconclusive_verdict() {
+        let vec_list = list(vec![vector(vec![1.0, 2.0])]);
+        assert_eq!(
+            vec_list.compare_value(&vec_list),
+            (Ordering::Equal, DisjointOrNull::Disjoint)
+        );
+        // Different vectors, same verdict: neither is comparable to the other.
+        assert_eq!(
+            vec_list.compare_value(&list(vec![vector(vec![9.0, 9.0])])),
+            (Ordering::Equal, DisjointOrNull::Disjoint)
+        );
+        // Mixed: one member incomparable, one member NULL.
+        let mixed = list(vec![vector(vec![1.0]), Value::Null]);
+        assert_eq!(
+            mixed.compare_value(&mixed),
+            (Ordering::Equal, DisjointOrNull::ComparedNull)
+        );
+
+        // Everything that already had a decisive ordering keeps it. A real
+        // inequality still outranks an unknown, NaN still reports an ordering,
+        // and length alone still decides lists of different length.
+        assert_eq!(
+            list(vec![Value::Int(1), Value::Null])
+                .compare_value(&list(vec![Value::Int(2), Value::Null])),
+            (Ordering::Less, DisjointOrNull::None)
+        );
+        assert_eq!(
+            list(vec![Value::Float(f64::NAN)]).compare_value(&list(vec![Value::Float(f64::NAN)])),
+            (Ordering::Less, DisjointOrNull::None)
+        );
+        assert_eq!(
+            vec_list.compare_value(&list(vec![vector(vec![1.0]), Value::Int(1)])),
+            (Ordering::Less, DisjointOrNull::None)
+        );
+        assert_eq!(
+            list(vec![Value::Int(1)]).compare_value(&list(vec![Value::Int(1)])),
+            (Ordering::Equal, DisjointOrNull::None)
+        );
     }
 
     /// Values that compare equal to themselves, so `=` can hold for them.
@@ -2048,6 +2131,11 @@ mod is_never_equal_tests {
             map(vec![("a", Value::Int(1))]),
             map(vec![("a", Value::Null)]),
             map(vec![("a", Value::Float(f64::NAN))]),
+            vector(vec![1.0, 2.0]),
+            list(vec![vector(vec![1.0, 2.0])]),
+            list(vec![vector(vec![1.0]), Value::Null]),
+            list(vec![list(vec![vector(vec![1.0])])]),
+            map(vec![("a", vector(vec![1.0]))]),
         ];
         for v in corpus {
             let self_matches =

--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -1479,6 +1479,72 @@ impl Value {
         }
         (Ordering::Equal, DisjointOrNull::None)
     }
+
+    /// True when Cypher `=` involving this value can never be TRUE — not even
+    /// against an identical copy of itself.
+    ///
+    /// `=` is three-valued, and [`Self::compare_value`] reports that faithfully
+    /// in its [`DisjointOrNull`] flag: `[1, null]` against `[1, null]` is
+    /// `(Ordering::Equal, ComparedNull)`, meaning *"equal as far as the
+    /// non-NULL elements go, but the answer is UNKNOWN"*. Such a value carries
+    /// its own verdict — an inconclusive comparison comes from its contents,
+    /// and nothing it is compared against can clear that — so comparing it with
+    /// itself decides the question for every possible partner. `ExprEval` maps
+    /// the same flags to `Value::Null` when it evaluates `=`, so a caller that
+    /// honours this predicate agrees with the `=` operator by construction.
+    ///
+    /// **Not for grouping.** `DISTINCT`, aggregation keys and `UNION` compare
+    /// under grouping semantics, where NULL *does* equal NULL: `UNWIND [null,
+    /// null] AS x RETURN DISTINCT x` is one row, while `null = null` is NULL.
+    /// This predicate answers the `=` question only. Its caller today is the
+    /// `Value Hash Join` operator, which uses it to keep a key that can never
+    /// join out of its hash table.
+    #[must_use]
+    pub fn is_never_equal(&self) -> bool {
+        // The exact test is a self-comparison, but it is not free on the shapes
+        // that need it least -- `compare_map` allocates and sorts both key
+        // lists on every call -- so a cheap walk gates it.
+        self.may_fail_self_match()
+            && !matches!(
+                self.compare_value(self),
+                (Ordering::Equal, DisjointOrNull::None)
+            )
+    }
+
+    /// Cheap conservative pre-filter for [`Self::is_never_equal`]: `false` only
+    /// for values that are *certain* to compare equal to themselves.
+    ///
+    /// A hint, not the decision — the exact comparison it gates is what
+    /// decides — so being wrong either way is safe: a false positive merely
+    /// pays for that comparison, and a false negative only reports `false` from
+    /// `is_never_equal` for a value that can never be equal, which is the
+    /// conservative answer every caller must already handle. Variants are
+    /// therefore listed only where `compare_value` is *known* to give a
+    /// conclusive self-comparison; everything else answers `true` and gets
+    /// compared properly, which is also what stops a newly added variant from
+    /// silently slipping past.
+    fn may_fail_self_match(&self) -> bool {
+        match self {
+            // Self-comparison of these is `(Equal, None)` by construction.
+            Self::Bool(_)
+            | Self::Int(_)
+            | Self::String(_)
+            | Self::Node(_)
+            | Self::Relationship(_)
+            | Self::Datetime(_)
+            | Self::Date(_)
+            | Self::Time(_)
+            | Self::Duration(_) => false,
+            // NaN never compares equal, not even to itself.
+            Self::Float(f) => f.is_nan(),
+            // A container is unmatchable exactly when one of its members is.
+            Self::List(items) | Self::Path(items) => items.iter().any(Self::may_fail_self_match),
+            Self::Map(entries) => entries.values().any(Self::may_fail_self_match),
+            // Null (`ComparedNull`), Point (NaN coordinates), VecF32 (no typed
+            // arm in `compare_value`, so `Disjoint`) -- and any future variant.
+            _ => true,
+        }
+    }
 }
 
 impl DisplayJson for Value {
@@ -1906,6 +1972,97 @@ impl Decode<19> for Value {
             si_type::T_TIME => Ok(Self::Time(r.read_signed()?)),
             si_type::T_DURATION => Ok(Self::Duration(r.read_signed()?)),
             _ => Err(format!("unknown SIType tag: {tag}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod is_never_equal_tests {
+    use super::{CompareValue, DisjointOrNull, OrderMap, Ordering, Value};
+    use std::sync::Arc;
+
+    fn list(items: Vec<Value>) -> Value {
+        Value::List(Arc::new(items.into_iter().collect()))
+    }
+
+    fn map(entries: Vec<(&str, Value)>) -> Value {
+        Value::Map(Arc::new(OrderMap::from_vec(
+            entries
+                .into_iter()
+                .map(|(k, v)| (Arc::new(k.to_string()), v))
+                .collect(),
+        )))
+    }
+
+    /// Every value whose `=` can never be TRUE, at any nesting depth.
+    #[test]
+    fn values_carrying_an_unknown_are_never_equal() {
+        assert!(Value::Null.is_never_equal());
+        assert!(Value::Float(f64::NAN).is_never_equal());
+        assert!(list(vec![Value::Int(1), Value::Null]).is_never_equal());
+        assert!(list(vec![list(vec![Value::Null])]).is_never_equal());
+        assert!(map(vec![("a", Value::Null)]).is_never_equal());
+        assert!(list(vec![map(vec![("a", Value::Null)])]).is_never_equal());
+        assert!(map(vec![("a", Value::Float(f64::NAN))]).is_never_equal());
+    }
+
+    /// Values that compare equal to themselves, so `=` can hold for them.
+    #[test]
+    fn ordinary_values_are_not_never_equal() {
+        assert!(!Value::Int(1).is_never_equal());
+        assert!(!Value::Float(1.5).is_never_equal());
+        assert!(!Value::Float(f64::INFINITY).is_never_equal());
+        assert!(!Value::Bool(true).is_never_equal());
+        assert!(!Value::String(Arc::new("x".to_string())).is_never_equal());
+        assert!(!Value::Datetime(0).is_never_equal());
+        assert!(!list(vec![]).is_never_equal());
+        assert!(!list(vec![Value::Int(1), Value::Int(2)]).is_never_equal());
+        assert!(!map(vec![]).is_never_equal());
+        assert!(!map(vec![("a", Value::Int(1))]).is_never_equal());
+    }
+
+    /// `is_never_equal` must agree with the self-comparison it stands for, and
+    /// the pre-filter must only ever skip values that really do self-match --
+    /// the invariant that lets the cheap walk gate the exact comparison.
+    #[test]
+    fn agrees_with_the_self_comparison_it_stands_for() {
+        let corpus = vec![
+            Value::Null,
+            Value::Bool(true),
+            Value::Int(0),
+            Value::Float(1.5),
+            Value::Float(f64::NAN),
+            Value::Float(f64::INFINITY),
+            Value::String(Arc::new("x".to_string())),
+            Value::Datetime(0),
+            Value::Date(0),
+            Value::Time(0),
+            Value::Duration(0),
+            list(vec![]),
+            list(vec![Value::Int(1), Value::Int(2)]),
+            list(vec![Value::Int(1), Value::Null]),
+            list(vec![Value::Float(f64::NAN)]),
+            list(vec![list(vec![Value::Null])]),
+            list(vec![map(vec![("a", Value::Null)])]),
+            map(vec![]),
+            map(vec![("a", Value::Int(1))]),
+            map(vec![("a", Value::Null)]),
+            map(vec![("a", Value::Float(f64::NAN))]),
+        ];
+        for v in corpus {
+            let self_matches =
+                matches!(v.compare_value(&v), (Ordering::Equal, DisjointOrNull::None));
+            assert_eq!(
+                v.is_never_equal(),
+                !self_matches,
+                "is_never_equal disagrees with the self-comparison for {v:?}"
+            );
+            if !v.may_fail_self_match() {
+                assert!(
+                    self_matches,
+                    "pre-filter waved through a value that cannot match itself: {v:?}"
+                );
+            }
         }
     }
 }

--- a/tests/flow/test_null_handling.py
+++ b/tests/flow/test_null_handling.py
@@ -127,6 +127,14 @@ class testNullHandlingFlow(FlowTestsBase):
         # rather than TRUE. The ValueHashJoin must agree with the equivalent
         # Filter plan instead of matching on plain structural equality (#2775).
         graph = self.db.select_graph(GRAPH_ID + "_nested_null_join")
+        # Clear first: an assertion failure below skips the delete at the end,
+        # and a rerun against the same server would otherwise append a second
+        # copy of the fixture and fail for the wrong reason. GRAPH.DELETE
+        # errors on an absent key, so the first run has to tolerate that.
+        try:
+            graph.delete()
+        except redis.ResponseError:
+            pass
         graph.query("""CREATE (:A {i: 1, s: 'x', w: 1}), (:A {i: 2, s: 'y'}),
                               (:B {i: 1, s: 'x', w: 1}), (:B {i: 2, s: 'y'}),
                               (:B {i: 3, s: 'z'})""")

--- a/tests/flow/test_null_handling.py
+++ b/tests/flow/test_null_handling.py
@@ -144,7 +144,10 @@ class testNullHandlingFlow(FlowTestsBase):
         null_keys = ["[a.i, a.missing] = [b.i, b.missing]",
                      "[[a.i, a.missing]] = [[b.i, b.missing]]",
                      "{k: a.missing} = {k: b.missing}",
-                     "[{k: a.missing}] = [{k: b.missing}]"]
+                     "[{k: a.missing}] = [{k: b.missing}]",
+                     # a vector has no comparison of its own, so it used to
+                     # mask the null beside it in the same list
+                     "[vecf32([1.0]), a.missing] = [vecf32([1.0]), b.missing]"]
 
         for predicate in null_keys:
             join = f"MATCH (a:A), (b:B) WHERE {predicate} RETURN a.i, b.i"
@@ -173,5 +176,19 @@ class testNullHandlingFlow(FlowTestsBase):
             query = f"MATCH (a:A), (b:B) WHERE {predicate} RETURN a.i, b.i ORDER BY a.i, b.i"
             self.env.assertContains("Value Hash Join", str(graph.explain(query)))
             self.env.assertEqual(graph.query(query).result_set, expected_result)
+
+        # A value Cypher cannot compare at all must not report equality just
+        # because it sits inside a list. Two vectors are never equal to each
+        # other, whatever their contents, and a null beside one still wins.
+        incomparable = [("vecf32([1.0,2.0]) = vecf32([1.0,2.0])", False),
+                        ("[vecf32([1.0,2.0])] = [vecf32([1.0,2.0])]", False),
+                        ("[vecf32([1.0,2.0])] = [vecf32([9.0,9.0])]", False),
+                        ("[vecf32([1.0]), null] = [vecf32([1.0]), null]", None),
+                        # length still decides lists of unequal length
+                        ("[vecf32([1.0])] = [vecf32([1.0]), 1]", False)]
+
+        for expression, expected in incomparable:
+            actual = graph.query(f"RETURN {expression}").result_set[0][0]
+            self.env.assertEqual(actual, expected)
 
         graph.delete()

--- a/tests/flow/test_null_handling.py
+++ b/tests/flow/test_null_handling.py
@@ -121,3 +121,49 @@ class testNullHandlingFlow(FlowTestsBase):
         actual_result = self.graph.query(query)
         expected_result = [['v1', 'v1']]
         self.env.assertEqual(actual_result.result_set, expected_result)
+
+        # A join key that merely *contains* a null is not itself null, but
+        # Cypher's three-valued logic still makes `[1, null] = [1, null]` NULL
+        # rather than TRUE. The ValueHashJoin must agree with the equivalent
+        # Filter plan instead of matching on plain structural equality (#2775).
+        graph = self.db.select_graph(GRAPH_ID + "_nested_null_join")
+        graph.query("""CREATE (:A {i: 1, s: 'x', w: 1}), (:A {i: 2, s: 'y'}),
+                              (:B {i: 1, s: 'x', w: 1}), (:B {i: 2, s: 'y'}),
+                              (:B {i: 3, s: 'z'})""")
+
+        # Predicates building a join key that holds a null at some depth --
+        # a.missing / b.missing are absent, hence NULL. None may produce a row.
+        null_keys = ["[a.i, a.missing] = [b.i, b.missing]",
+                     "[[a.i, a.missing]] = [[b.i, b.missing]]",
+                     "{k: a.missing} = {k: b.missing}",
+                     "[{k: a.missing}] = [{k: b.missing}]"]
+
+        for predicate in null_keys:
+            join = f"MATCH (a:A), (b:B) WHERE {predicate} RETURN a.i, b.i"
+            # The WITH is a barrier, so here the predicate stays a Filter over
+            # a Cartesian Product -- the same query, without the join rewrite.
+            filtered = f"MATCH (a:A), (b:B) WITH a, b WHERE {predicate} RETURN a.i, b.i"
+
+            # Verify the optimized plan really is the one under test.
+            self.env.assertContains("Value Hash Join", str(graph.explain(join)))
+            self.env.assertNotContains("Value Hash Join", str(graph.explain(filtered)))
+
+            expected_result = graph.query(filtered).result_set
+            self.env.assertEqual(expected_result, [])
+            self.env.assertEqual(graph.query(join).result_set, expected_result)
+
+        # Null-free keys must still join, across every table representation:
+        # integers (the i64 fast path), strings, lists and maps.
+        non_null_keys = [("a.i = b.i", [[1, 1], [2, 2]]),
+                         ("a.s = b.s", [[1, 1], [2, 2]]),
+                         ("[a.i, a.s] = [b.i, b.s]", [[1, 1], [2, 2]]),
+                         ("{p: a.i, q: a.s} = {p: b.i, q: b.s}", [[1, 1], [2, 2]]),
+                         # Only one side of this key is null, and coalesce removes it.
+                         ("coalesce(a.w, 0) = coalesce(b.w, 0)", [[1, 1], [2, 2], [2, 3]])]
+
+        for predicate, expected_result in non_null_keys:
+            query = f"MATCH (a:A), (b:B) WHERE {predicate} RETURN a.i, b.i ORDER BY a.i, b.i"
+            self.env.assertContains("Value Hash Join", str(graph.explain(query)))
+            self.env.assertEqual(graph.query(query).result_set, expected_result)
+
+        graph.delete()


### PR DESCRIPTION
Fixes #2775

## The defect

Cypher `=` is three-valued: `[1, null] = [1, null]` is NULL, not TRUE, so it must not produce a row. The `Value Hash Join` operator matched such keys anyway, so an optimised plan returned rows that the semantically identical unoptimised plan correctly rejected — two plans, same data, different answers.

```
GRAPH.QUERY nj "CREATE (:A {v:1}), (:B {v:1})"
GRAPH.QUERY nj "MATCH (a:A), (b:B) WHERE [a.v, a.w] = [b.v, b.w] RETURN a.v, b.v"
```

`a.w`/`b.w` are absent, hence NULL. `GRAPH.EXPLAIN` confirms the plan:

```
1) "Project"
2) "    Value Hash Join"
3) "        Node By Label Scan | (a:A)"
4) "        Node By Label Scan | (b:B)"
```

Before this change that returned **1 row**. Putting a `WITH a, b` barrier between the `MATCH` and the `WHERE` keeps the identical predicate as a `Filter` over a `Cartesian Product`, and that returned **0 rows** — the correct answer. After this change both return 0 rows.

## Root cause

`graph/src/runtime/ops/value_hash_join.rs` compared join keys with plain `PartialEq`:

```rust
bucket.iter().find(|(k, _)| k == key)
```

`Value`'s `PartialEq` is `compare_value(..).0 == Ordering::Equal` — it keeps the `Ordering` and throws the `DisjointOrNull` flag away. But `compare_list` reports `(Ordering::Equal, DisjointOrNull::ComparedNull)` for `[1, null]` vs `[1, null]`: *"equal as far as the non-NULL elements go, but the answer is UNKNOWN"*. Discarding that flag collapses UNKNOWN into TRUE, which is exactly the bug.

## The fix

Keep the flag. `keys_match` calls the same `compare_value` and requires `Ordering::Equal` **and** `DisjointOrNull::None`, so an inconclusive comparison is not a match:

```rust
fn keys_match(a: &Value, b: &Value) -> bool {
    let (ordering, disjoint_or_null) = a.compare_value(b);
    ordering == Ordering::Equal && matches!(disjoint_or_null, DisjointOrNull::None)
}
```

That replaces `==` at the two places join keys are compared — the probe-side bucket scan in `fill_matches`, and build-side bucket grouping in `insert_value`. Using it on both sides keeps the table invariant: two build keys share an entry exactly when a probe key matching one must also match the other. It also rejects `DisjointOrNull::Disjoint`, which `compare_map` reports for maps whose values have incomparable types (`{a: 1}` vs `{a: '1'}`) — that is FALSE, not TRUE, and `PartialEq` got it wrong too.

That replaces `==` at the two places join keys are compared — the probe-side bucket scan in `fill_matches`, and build-side bucket grouping in `insert_value`. Using it on both sides keeps the table invariant: two build keys share an entry exactly when a probe key matching one must also match the other.

It also rejects `DisjointOrNull::Disjoint`, which `compare_map` reports for maps whose values have incomparable types (`{a: 1}` vs `{a: '1'}`). That is FALSE, not TRUE, and `PartialEq` got it wrong too. This is not a separate judgement call: `all_equals`, the `=` operator the `Filter` plan runs, returns `Value::Null` for `ComparedNull` and `Value::Bool(false)` for `Disjoint` — both meaning "no row" — so rejecting both is what makes the two plans agree, which is the whole point of the fix. (One consequence beyond NULL: `VecF32` keys have no typed arm in `compare_value` and so compare `Disjoint`, and stop joining. `PartialEq` rated *any* two vectors equal, since it fell through to a variant-order comparison, so the previous behaviour was a cross product of wrong rows.)

### An inconclusive list comparison must stay inconclusive

[A second review catch](https://github.com/FalkorDB/FalkorDB/pull/2789#discussion_r3978594774) found the contract above leaking in a corner: `[vecf32([1.0]), null]` compared equal to *itself*, so a key carrying a NULL still joined.

`compare_list` returned from its "all members compared false" branch as `(first_not_equal, DisjointOrNull::None)` even when `first_not_equal` was still `Ordering::Equal` — that is, when no member had actually decided the order. Reporting `None` there claims *"equal, definitively"*. The branch is right whenever it holds a real ordering: `[1, null]` vs `[2, null]` is FALSE, because a definite inequality outranks an unknown. It is only wrong with nothing to stand on. It now requires a decisive ordering, and a member that compared inconclusively with no ordering to show reports `Disjoint` rather than `None`.

| expression | before | after |
|---|---|---|
| `[vecf32([1.0,2.0])] = [vecf32([9.0,9.0])]` | `true` | `false` |
| `[vecf32([1.0]), null] = [vecf32([1.0]), null]` | `true` | NULL |

Bare `vecf32(..) = vecf32(..)` was already `false`, so lists now agree with the scalars they hold. The path is reachable only through a member pair sharing a variant `compare_value` has no arm for — `VecF32` today — since every other inconclusive comparison reports an ordering. Lists of unequal length keep their old answer, length alone still deciding them, and **only the flag ever changes, never the ordering**, so ORDER BY and the comparison operators see what they saw before. Verified live: `[1,null] = [2,null]` FALSE, `[1,2] = [1,2]` TRUE, `[1,2] = [1,3]` FALSE, `[1] = [1,2]` FALSE, `[1,2] < [1,3]` TRUE.

### Build must not store a key that cannot match itself

Grouping with `keys_match` has one consequence that plain `==` did not, [caught in review](https://github.com/FalkorDB/FalkorDB/pull/2789#discussion_r3976771801): a *repeated* unmatchable key turns the build quadratic. N rows keyed `[1, null]` all hash alike, and none groups with any other — `keys_match` rejects the pair, as it must — so each row appended a fresh bucket entry after rescanning the whole bucket, and every colliding probe then scanned all N dead entries. Reproduced on N identical `[1, null]` build keys, ×4 per doubling:

| N | before |
|---|---|
| 2 500 | 33.1 ms |
| 5 000 | 150.9 ms (×4.56) |
| 10 000 | 673.1 ms (×4.46) |
| 20 000 | 2753.6 ms (×4.09) |
| 40 000 | exceeded the client socket timeout |

Such a key can never join, so it does not belong in the table. `insert_value` drops it, and the same workload is linear again — **2.6 ms at N=20 000, 5.0 ms at N=40 000**, ×1.9 per doubling.

Self-comparison is the exact test for "can never join", since an inconclusive comparison comes from the key's own contents and nothing it is compared against can clear that. It is not free, though, on the shapes that need it least: `compare_map` allocates and sorts both key lists on every call, so self-comparing every build key cost ~20% on map-valued keys (26.8 → 33.1 ms, best-of-7, 50k × 50k). So a cheap discriminant walk gates it, answering `false` only for keys certain to match themselves. That walk is a hint, not the decision: correctness rests on the exact comparison it gates, which makes it safe to be wrong in either direction (a false positive just pays for the comparison; a false negative only re-admits an unmatchable key that probe rejects anyway). Unlisted variants answer `true`, so a newly added `Value` variant cannot silently slip past.

Both halves live on `Value` as `Value::is_never_equal`, next to the `compare_value` flag propagation they mirror rather than in the operator that happens to need them — otherwise an operator would be carrying a list of variants that has to stay in step with a match statement in another file. Only the composed predicate is public; the bare pre-filter is conservative and meaningless alone, so a caller trusting it without the exact comparison would drop matchable keys.

Its doc comment carries the warning that makes centralising it worthwhile: **it answers the `=` question, not the grouping one.** `DISTINCT`, aggregation keys and `UNION` compare under grouping semantics, where NULL *does* equal NULL, and reaching for this predicate there would break them:

```
UNWIND [null, null] AS x RETURN DISTINCT x            -> 1 row (null)
UNWIND [[1,null],[1,null]] AS x RETURN DISTINCT x     -> 1 row ([1, NULL])
WITH 1 AS i WHERE [1,null] = [1,null] RETURN i        -> 0 rows
```

Same values, deliberately opposite answers. Those ops go through `ValuesDeduper`, which is hash-only with no equality check at all, and are right to.

`Value`'s `PartialEq` is deliberately **not** changed, and the optimisation still applies to list- and map-valued keys.

Strictening equality cannot break the hash-table invariant: `keys_match ⟹ PartialEq ⟹ equal hashes`, so a genuine match still lands in the bucket it hashed to.

## Performance

Null-free keys are at parity with `main` across every table representation. Best-of-7, 50k build × 50k probe rows, all matching:

| join key shape | main | this PR |
|---|---|---|
| int (`i64` fast path) | 7.4 ms | 6.9 ms |
| string | 12.0 ms | 11.2 ms |
| list `[int, str]` | 23.1 ms | 23.5 ms |
| map `{p: int, q: str}` | 26.8 ms | 26.7 ms |

Sub-millisecond differences are build-to-build variation; the load-bearing comparison is map keys at 26.7 ms against 33.1 ms with the exact comparison ungated, which shows the pre-filter still gates across the module boundary. `keys_match` itself costs nothing over `PartialEq` — it destructures the tuple that `compare_value` already returns, where `PartialEq` discarded half of it.

Every intermediate revision was measured rather than argued: probe-side deep null scanning (~2% list / ~5% map, dropped), no guard at all (O(N²), shown above), and an ungated exact guard (~20% on map keys, hence the pre-filter).

## Evidence that legitimate joins still work

A 19-case live-server suite compared the join plan against the `WITH`-barrier filter plan (asserting via `GRAPH.EXPLAIN` that the first really is a `Value Hash Join` and the second really is not), run against both the pre-fix and fixed modules.

**Cases that were broken (5 of 6 NULL cases failed pre-fix)** — including `{k: a.missing} = {k: b.missing}`, which returned the entire cross product:

| case | expected | pre-fix | after |
|---|---|---|---|
| list key with NULL on both sides | 0 | ✗ | ✓ |
| nested list key with NULL | 0 | ✗ | ✓ |
| map key with NULL value | 0 | ✗ | ✓ |
| list key holding a NULL-valued map | 1 | ✗ | ✓ |
| map key, one NULL member | 1 | ✗ | ✓ |
| list key, NULL on one side only | 1 | ✓ | ✓ |

**All 13 legitimate-join cases pass on both modules** — no regression: int key (fast path), string key, float key, cross-type numeric (`float = int`), int/float mixed column promotion, NULL-free list key, NULL-free nested list key, NULL-free map key, empty list key, expression key, duplicate keys on both sides, coalesced key (`NULL -> value`), heterogeneous key column.

## Tests

`tests/flow/test_null_handling.py::test08_null_value_hash_join` is extended to cover this. For four null-bearing key shapes it asserts the plan really contains `Value Hash Join`, that the `WITH`-barrier plan does not, and that both return the same (empty) result; then five null-free predicates (int, string, list, map, `coalesce`) assert the join is still chosen and still returns the right rows.

The test was re-confirmed sensitive against *this* revision: reverting only `value_hash_join.rs` to its `main` version and rebuilding makes all four null-bearing shapes fail —

```
❌ (FAIL): [[1, 1], [2, 2]] == []                                        test_null_handling.py:153
❌ (FAIL): [[1, 1], [2, 2]] == []                                        test_null_handling.py:153
❌ (FAIL): [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3]] == []        test_null_handling.py:153
❌ (FAIL): [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3]] == []        test_null_handling.py:153
Total Tests Run: 1, Total Tests Failed: 1, Total Tests Passed: 0
```

— the last two being the map-keyed shapes returning the full 6-row cross product. Restoring the fix returns it to green.

The fixture is also cleared before it is populated, per the same review: an assertion failure skips the `delete()` at the end, and a rerun against the same server would otherwise append a second copy and fail for the wrong reason.

Four Rust unit tests sit alongside the operator: `keys_match` rejecting inconclusive comparisons (explicitly pinning that `PartialEq` is laxer), `keys_match` still accepting real joins, the integer fast path never seeing a null-bearing key, and unmatchable build keys never entering the table while a matchable key's repeats still group under one entry. That last one was confirmed to fail without the guard (`assertion failed: table.is_empty()`).

Four more sit with `Value::is_never_equal` in value.rs: the values it must reject at any nesting depth (including `VecF32`, mixed `VecF32`/NULL and nested-container shapes), the ordinary ones it must not, that it agrees with the self-comparison it stands for over the whole corpus while the pre-filter only ever skips values that really do self-match, and `compare_list_keeps_an_inconclusive_verdict`, which pins both fixed cases plus the five regression guards above.

The flow test also asserts the mixed `VecF32`/NULL case as a join predicate, and five direct expression results for values Cypher cannot compare.

## Validation

- `cargo fmt --all -- --check` — clean
- `CXX=clang++ cargo clippy --all-targets` — no new warnings (3 pre-existing: `graph/src/effects/reader.rs`, `graph/src/runtime/ops/cond_var_len_traverse.rs`, `src/commands/bulk_insert.rs`)
- `cargo test -p graph` — 297 passed, 0 failed
- `tests/flow/test_null_handling.py` — 8/8 passed
- full flow suite — **1494 passed, 0 failed**
- TCK (`TCK_DONE=tck_done.txt`) — **173 features, 2456 scenarios passed, 0 failed** (run because this touches shared comparison semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
