### PR TITLE
fix: prevent stale constraint activation during AOF replay

### DIFF
--- a/src/commands/cmd_constraint.c
+++ b/src/commands/cmd_constraint.c
@@ -390,7 +390,8 @@ static bool _Constraint_Create
 
 	// failed to add constraint
 	if (c == NULL) {
-		res = false ;
+		// Older AOFs contain both creation and activation announcements.
+		res = force_retrieve && status == CONSTRAINT_ALREADY_EXISTS ;
 		goto cleanup ;
 	}
 
@@ -406,6 +407,9 @@ static bool _Constraint_Create
 	RedisModule_Replicate (ctx, "GRAPH.EFFECT", "cb!", graph_name, buf, l) ;
 
 	rm_free (buf) ;
+
+	// Register the task while the constraint is still protected from DROP.
+	Constraint_Enforce (c, (struct GraphContext*)gc, ctx) ;
 
 cleanup:
 
@@ -424,9 +428,6 @@ cleanup:
 	if (res == false) {
 		// TODO: give additional information to caller
 		RedisModule_ReplyWithError (ctx, error_msg) ;
-	} else {
-		// constraint creation succeeded, enforce constraint
-		Constraint_Enforce (c, (struct GraphContext*)gc) ;
 	}
 
 	QueryCtx_Free  () ;

--- a/src/commands/cmd_effect.c
+++ b/src/commands/cmd_effect.c
@@ -74,7 +74,7 @@ int Graph_Effect
 	const char *effects_buff = RedisModule_StringPtrLen (argv[2], &l) ;
 
 	// apply effects
-	bool ok = Effects_Apply (gc, effects_buff, l) ;
+	bool ok = Effects_Apply (gc, effects_buff, l, ctx) ;
 
 	// restore graph sync policy
 	Graph_SetMatrixPolicy (g, policy) ;

--- a/src/constraint/constraint.c
+++ b/src/constraint/constraint.c
@@ -369,7 +369,8 @@ void Constraint_Replicate
 void Constraint_Enforce
 (
 	Constraint c,            // constraint to enforce
-	struct GraphContext *gc  // graph context
+	struct GraphContext *gc, // graph context
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 ) {
 	ASSERT(c != NULL);
 	ASSERT(Constraint_GetStatus(c) == CT_PENDING);
@@ -378,7 +379,7 @@ void Constraint_Enforce
 	Constraint_IncPendingChanges(c);
 
 	// add constraint enforcement task
-	Indexer_EnforceConstraint(c, (GraphContext*)gc);
+	Indexer_EnforceConstraint(c, (GraphContext*)gc, redis_ctx);
 }
 
 // enforce constraint on all relevant nodes

--- a/src/constraint/constraint.h
+++ b/src/constraint/constraint.h
@@ -164,11 +164,13 @@ void Constraint_Replicate
 );
 
 // tries to enforce constraint on all relevant entities
-// sets constraint status to pending
+// Caller holds the graph lock until the task owns its references.
+// The task captures its own publication context in the same Redis database.
 void Constraint_Enforce
 (
-	Constraint c,     // constraint to enforce
-	GraphContext *gc  // graph context
+	Constraint c,          // constraint to enforce
+	GraphContext *gc,       // graph context
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 );
 
 // enforce constraint on all relevant nodes

--- a/src/effects/create_constraint_effect.c
+++ b/src/effects/create_constraint_effect.c
@@ -62,7 +62,8 @@ void EffectsBuffer_AddCreateConstraintEffect
 bool ApplyCreateConstraint
 (
 	FILE *stream,     // effects stream
-	GraphContext *gc  // graph to operate on
+	GraphContext *gc, // graph to operate on
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 ) {
 	//--------------------------------------------------------------------------
 	// effect format:
@@ -121,7 +122,7 @@ bool ApplyCreateConstraint
 
 			case CONSTRAINT_CREATED:
 				ASSERT (c != NULL) ;
-				Constraint_Enforce (c, (struct GraphContext *)gc) ;
+				Constraint_Enforce (c, (struct GraphContext *)gc, redis_ctx) ;
 				result = true ;
 				break ;
 

--- a/src/effects/effects.h
+++ b/src/effects/effects.h
@@ -46,7 +46,8 @@ bool Effects_Apply
 (
 	GraphContext *gc,          // graph to operate on
 	const char *effects_buff,  // encoded effects
-	size_t l                   // size of buffer
+	size_t l,                  // size of buffer
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 );
 
 // create a new effects-buffer

--- a/src/effects/effects_apply.c
+++ b/src/effects/effects_apply.c
@@ -705,7 +705,8 @@ bool Effects_Apply
 (
 	GraphContext *gc,          // graph to operate on
 	const char *effects_buff,  // encoded effects
-	size_t l                   // size of buffer
+	size_t l,                  // size of buffer
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 ) {
 	// validations
 	ASSERT (l > 0) ;  // buffer can't be empty
@@ -786,7 +787,7 @@ bool Effects_Apply
 				break ;
 
 			case EFFECT_CREATE_CONSTRAINT:
-				ok = ApplyCreateConstraint (stream, gc) ;
+				ok = ApplyCreateConstraint (stream, gc, redis_ctx) ;
 				break ;
 
 			case EFFECT_DROP_CONSTRAINT:

--- a/src/effects/effects_internal.h
+++ b/src/effects/effects_internal.h
@@ -111,7 +111,8 @@ bool ApplyDropIndex
 bool ApplyCreateConstraint
 (
 	FILE *stream,     // effects stream
-	GraphContext *gc  // graph to operate on
+	GraphContext *gc, // graph to operate on
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 );
 
 // process DropConstraint effect (drop_constraint_effect.c)

--- a/src/graph/graph_hub.c
+++ b/src/graph/graph_hub.c
@@ -713,8 +713,8 @@ Constraint GraphHub_AddConstraint
 			// remove constraint from schema
 			Schema_RemoveConstraint (s, c) ;
 
-			// free failed constraint
-			Constraint_Free (&c) ;
+			// Its enforcement task may still be finishing on the indexer.
+			Indexer_DropConstraint (c, gc) ;
 		}
 	}
 

--- a/src/index/indexer.c
+++ b/src/index/indexer.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <stdatomic.h>
+#include <string.h>
 
 // lock indexer task queue
 #define INDEXER_LOCK_QUEUE()                            \
@@ -57,6 +58,7 @@ typedef struct {
 typedef struct {
 	GraphContext *gc;  // graph object
 	Constraint c;      // constraint to enforce
+	RedisModuleCtx *publication; // owned context in the graph's database
 } ConstraintEnforceCtx;
 
 // constraint drop context
@@ -76,6 +78,7 @@ typedef struct {
 
 // forward declarations
 static void _indexer_PopTask(IndexerTask *task);
+void _indexer_AddTask(IndexerOp op, void *pdata);
 
 static Indexer *indexer = NULL;
 
@@ -119,6 +122,7 @@ static void _Indexer_ClearTasks(void) {
 			case INDEXER_CONSTRAINT_ENFORCE :
 				{
 					ConstraintEnforceCtx *ctx = (ConstraintEnforceCtx*)pdata ;
+					RedisModule_FreeThreadSafeContext(ctx->publication);
 					GraphContext_DecreaseRefCount (ctx->gc) ;
 					rm_free (ctx) ;
 					break ;
@@ -208,8 +212,9 @@ static void _indexer_enforce_constraint
 		// if index is not enabled and the constraint is not marked for deletion
 		// postpone the enforcement
 		if(!Index_Enabled(idx) && Constraint_PendingChanges(c) == 1) {
-			Indexer_EnforceConstraint(c, gc);
-			goto cleanup;
+			if (indexer->stop) goto cleanup;
+			_indexer_AddTask(INDEXER_CONSTRAINT_ENFORCE, ctx);
+			return;
 		}
 	}
 
@@ -227,22 +232,36 @@ static void _indexer_enforce_constraint
 	// as only active constraints are encoded within RDBs
 	// to make sure the constraint is introduced to the replica we re-issue it
 	// once the constraint becomes active
-	if(Constraint_GetStatus(c) == CT_ACTIVE) {
-		// lock before calling replicate
-		RedisModuleCtx *rm_ctx = RedisModule_GetThreadSafeContext(NULL);
+	{
+		// Serialize activation with key replacement and constraint deletion.
+		RedisModuleCtx *rm_ctx = ctx->publication;
 		RedisModule_ThreadSafeContextLock(rm_ctx);
 
-		Constraint_Replicate(rm_ctx, c, (const struct GraphContext*)gc);
+		// A retained GraphContext keeps memory alive, not the Redis key or
+		// its ownership. Check the exact generation under the publication lock.
+		const char *name = GraphContext_GetName(gc);
+		RedisModuleString *key_name = RedisModule_CreateString(rm_ctx, name, strlen(name));
+		RedisModuleKey *key = RedisModule_OpenKey(rm_ctx, key_name, REDISMODULE_READ);
+		GraphContext_AcquireReadLock(gc);
+		if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_MODULE &&
+			RedisModule_ModuleTypeGetValue(key) == gc &&
+			Constraint_PendingChanges(c) == 1 &&
+			Constraint_GetStatus(c) == CT_ACTIVE) {
+			Constraint_Replicate(rm_ctx, c, (const struct GraphContext*)gc);
+		}
+		GraphContext_ReleaseReadLock(gc);
+		RedisModule_CloseKey(key);
+		RedisModule_FreeString(rm_ctx, key_name);
 
-		// unlock and free
+		// Release publication locks before disposing of the task.
 		RedisModule_ThreadSafeContextUnlock(rm_ctx);
-		RedisModule_FreeThreadSafeContext(rm_ctx);
 	}
 
 	// decrease number of pending changes
 	Constraint_DecPendingChanges(c);
 
 cleanup:
+	RedisModule_FreeThreadSafeContext(ctx->publication);
 	// decrease graph reference count
 	GraphContext_DecreaseRefCount(gc);
 
@@ -520,8 +539,9 @@ void Indexer_DropIndex
 // adds the task for enforcing the given constraint to the indexer
 void Indexer_EnforceConstraint
 (
-	Constraint c,     // constraint to enforce
-	GraphContext *gc  // graph context
+	Constraint c,          // constraint to enforce
+	GraphContext *gc,       // graph context
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 ) {
 	ASSERT(c       != NULL);
 	ASSERT(gc      != NULL);
@@ -536,6 +556,8 @@ void Indexer_EnforceConstraint
 	ConstraintEnforceCtx *ctx = rm_malloc(sizeof(ConstraintEnforceCtx));
 	ctx->c  = c;
 	ctx->gc = gc;
+	ctx->publication = RedisModule_GetDetachedThreadSafeContext(redis_ctx);
+	RedisModule_SelectDb(ctx->publication, RedisModule_GetSelectedDb(redis_ctx));
 
 	// increase graph reference count
 	// count will be reduced once this task is perfomed

--- a/src/index/indexer.c
+++ b/src/index/indexer.c
@@ -6,6 +6,7 @@
 
 #include "indexer.h"
 #include "../redismodule.h"
+#include "../serializers/graphcontext_type.h"
 #include "../util/rmalloc.h"
 #include <assert.h>
 #include <pthread.h>
@@ -78,7 +79,7 @@ typedef struct {
 
 // forward declarations
 static void _indexer_PopTask(IndexerTask *task);
-void _indexer_AddTask(IndexerOp op, void *pdata);
+static void Indexer_AddTask(IndexerOp op, void *pdata);
 
 static Indexer *indexer = NULL;
 
@@ -213,7 +214,7 @@ static void _indexer_enforce_constraint
 		// postpone the enforcement
 		if(!Index_Enabled(idx) && Constraint_PendingChanges(c) == 1) {
 			if (indexer->stop) goto cleanup;
-			_indexer_AddTask(INDEXER_CONSTRAINT_ENFORCE, ctx);
+			Indexer_AddTask(INDEXER_CONSTRAINT_ENFORCE, ctx);
 			return;
 		}
 	}
@@ -244,6 +245,7 @@ static void _indexer_enforce_constraint
 		RedisModuleKey *key = RedisModule_OpenKey(rm_ctx, key_name, REDISMODULE_READ);
 		GraphContext_AcquireReadLock(gc);
 		if (RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_MODULE &&
+			RedisModule_ModuleTypeGetType(key) == GraphContextRedisModuleType_Get() &&
 			RedisModule_ModuleTypeGetValue(key) == gc &&
 			Constraint_PendingChanges(c) == 1 &&
 			Constraint_GetStatus(c) == CT_ACTIVE) {
@@ -337,7 +339,7 @@ static void *_indexer_run
 }
 
 // add a new task to indexer queue
-void _indexer_AddTask
+static void Indexer_AddTask
 (
 	IndexerOp op,
 	void *pdata
@@ -499,7 +501,7 @@ void Indexer_PopulateIndex
 	GraphContext_IncreaseRefCount (gc) ;
 
 	// place task into queue
-	_indexer_AddTask (INDEXER_IDX_POPULATE, ctx) ;
+	Indexer_AddTask (INDEXER_IDX_POPULATE, ctx) ;
 }
 
 // drops index asynchronously
@@ -532,7 +534,7 @@ void Indexer_DropIndex
 	GraphContext_IncreaseRefCount(gc);
 
 	// place task into queue
-	_indexer_AddTask(INDEXER_IDX_DROP, ctx);
+	Indexer_AddTask(INDEXER_IDX_DROP, ctx);
 }
 
 // enforces constraint
@@ -565,7 +567,7 @@ void Indexer_EnforceConstraint
 	// enforcement tasks and it is being asked to be deleted
 	GraphContext_IncreaseRefCount(gc);
 
-	_indexer_AddTask(INDEXER_CONSTRAINT_ENFORCE, ctx);
+	Indexer_AddTask(INDEXER_CONSTRAINT_ENFORCE, ctx);
 }
 
 // drops constraint asynchronously
@@ -597,7 +599,7 @@ void Indexer_DropConstraint
 	GraphContext_IncreaseRefCount(gc);
 
 	// place task into queue
-	_indexer_AddTask(INDEXER_CONSTRAINT_DROP, ctx);
+	Indexer_AddTask(INDEXER_CONSTRAINT_DROP, ctx);
 }
 
 // stop and free indexer
@@ -609,7 +611,7 @@ void Indexer_Stop(void) {
 	_Indexer_ClearTasks () ;
 
 	// add fake task to cause indexer thread to exit
-	_indexer_AddTask (INDEXER_EXIT, NULL) ;
+	Indexer_AddTask (INDEXER_EXIT, NULL) ;
 	
 	// wait for indexer thread to exit
 	pthread_join (indexer->t, NULL) ;

--- a/src/index/indexer.h
+++ b/src/index/indexer.h
@@ -47,7 +47,8 @@ void Indexer_DropIndex
 void Indexer_EnforceConstraint
 (
 	Constraint c,  // constraint to enforce
-	GraphContext *gc  // graph context
+	GraphContext *gc, // graph context
+	RedisModuleCtx *redis_ctx  // context whose database owns the graph
 );
 
 // drops constraint asynchronously

--- a/tests/flow/test_constraint.py
+++ b/tests/flow/test_constraint.py
@@ -1439,3 +1439,66 @@ class testConstraintAOF():
             self.env.assertTrue(False)
         except ResponseError as e:
             self.env.assertContains("mandatory constraint violation: edge with relationship-type Painted missing property year", str(e))
+
+    def test03_replay_does_not_publish_deleted_constraints(self):
+        # Activation is asynchronous: replay must not append it after a later
+        # DELETE, or the next restart resurrects the graph (or crashes).
+        removed = GRAPH_ID + '_removed'
+        reused = GRAPH_ID + '_reused'
+        for name in (removed, reused):
+            graph = self.db.select_graph(name)
+            graph.query('CREATE (:Old {id: 1})')
+            create_unique_node_constraint(graph, 'Old', 'id', sync=True)
+            create_mandatory_node_constraint(graph, 'Old', 'id', sync=True)
+            graph.delete()
+        graph = self.db.select_graph(reused)
+        graph.query('CREATE (:New {id: 2})')
+        create_unique_node_constraint(graph, 'New', 'id', sync=True)
+        create_mandatory_node_constraint(graph, 'New', 'id', sync=True)
+
+        for _ in range(2):
+            self.env.stop()
+            self.env.start()
+            self.con = self.env.getConnection()
+            self.env.assertEqual(self.con.exists(removed), 0)
+            graph = self.db.select_graph(reused)
+            wait_on_constraint(graph, 'UNIQUE', 'NODE', 'New', 'id')
+            wait_on_constraint(graph, 'MANDATORY', 'NODE', 'New', 'id')
+            self.env.assertEqual(graph.query('MATCH (n) RETURN n.id').result_set, [[2]])
+            constraints = list_constraints(graph)
+            self.env.assertEqual(len(constraints), 2)
+            for constraint in constraints:
+                self.env.assertEqual(constraint.label, 'New')
+                self.env.assertEqual(constraint.status, 'OPERATIONAL')
+            for query, error in [('CREATE (:New)', 'mandatory'),
+                                 ('CREATE (:New {id: 2})', 'unique')]:
+                try:
+                    graph.query(query)
+                    self.env.assertTrue(False)
+                except ResponseError as e:
+                    self.env.assertContains(error + ' constraint violation', str(e))
+
+    def test04_legacy_constraint_announcements_are_idempotent(self):
+        graph = self.db.select_graph(GRAPH_ID + '_legacy')
+        graph.query('CREATE (:Person {height: 1})')
+        create_mandatory_node_constraint(graph, 'Person', 'height', sync=True)
+        config = self.con.config_get('dir', 'appenddirname', 'appendfilename')
+        directory = os.path.join(config['dir'], config['appenddirname'])
+        with open(os.path.join(directory, config['appendfilename'] + '.manifest')) as manifest:
+            for line in manifest:
+                fields = dict(zip(line.split()[::2], line.split()[1::2]))
+                if fields.get('type') == 'i':
+                    incremental = os.path.join(directory, fields['file'])
+        self.env.stop()
+        # 4.18 AOFs announce successful constraints twice, as commands rather
+        # than effects. Keep the fixture synthetic and exercise the real loader.
+        args = ['GRAPH.CONSTRAINT', 'CREATE', graph.name, 'MANDATORY',
+                'NODE', 'Person', 'PROPERTIES', '1', 'height']
+        command = '*9\r\n' + ''.join(f'${len(arg)}\r\n{arg}\r\n' for arg in args)
+        with open(incremental, 'ab') as aof:
+            aof.write(command.encode() * 2)
+        self.env.start()
+        self.con = self.env.getConnection()
+        self.env.assertEqual(self.con.info('stats')['total_error_replies'], 0)
+        self.env.assertEqual(get_constraint(graph, 'MANDATORY', 'NODE',
+                                           'Person', 'height').status, 'OPERATIONAL')


### PR DESCRIPTION
## Summary

Fix constraint activation being appended to the AOF after its graph or constraint has been deleted. A second restart can recreate the deleted graph or crash while replaying the stale record.

## Changes

- Check that the graph still owns its Redis key and the constraint is still active before replicating activation, under the Redis and graph locks.
- Keep the task in its original Redis database and defer freeing replaced constraints until the indexer finishes with them.
- Accept duplicate legacy constraint creations during AOF loading and replication. Client commands still report duplicates.

Activation is still replicated because RDB snapshots omit pending constraints. This change targets the C `4.20` branch.

## Verification

- All 22 constraint flow tests pass on Redis 8.6.3, including replication.
- Two regression tests cover deletion/name reuse across two AOF restarts and duplicate legacy announcements. Both fail against 4.20.4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constraint recovery during AOF loading and replication.
  * Duplicate constraint announcements are now handled safely without errors.
  * Deleted constraints are no longer replayed or republished after graph deletion.
  * Recreated graphs retain only their current constraints across restarts.
  * Improved reliability when constraints are enforced asynchronously or while indexes are temporarily unavailable.

* **Tests**
  * Added regression coverage for constraint replay, graph recreation, deletion, and duplicate announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->