### PR TITLE
test(cow_btree): eliminate flaky snapshot test failure under thread contention (closes #2795)

### DIFF
--- a/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
+++ b/graph/src/index/falkordb/data_structures/cow_btree/tests.rs
@@ -201,13 +201,16 @@ fn snapshot_is_isolated_from_a_concurrent_writer() {
     let reader = thread::spawn(move || {
         // Re-read the whole snapshot for as long as the writer is mutating; it must never change.
         let mut reads = 0u64;
-        while !done_reader.load(Ordering::Relaxed) {
+        loop {
             assert_eq!(
                 snapshot.range(0, u64::MAX).collect::<Vec<_>>(),
                 expected,
                 "snapshot observed a concurrent writer's mutation"
             );
             reads += 1;
+            if done_reader.load(Ordering::Relaxed) {
+                break;
+            }
         }
         assert_eq!(snapshot.range(0, u64::MAX).collect::<Vec<_>>(), expected);
         reads


### PR DESCRIPTION
## Problem
In `snapshot_is_isolated_from_a_concurrent_writer`, the reader thread looped on `while !done_reader.load(Ordering::Relaxed)`. Under high thread contention (e.g. `--test-threads=16`), the main writer thread could complete all its mutations and set `done = true` before the OS scheduled the spawned reader thread for its first iteration. This resulted in `reads == 0` and triggered a false-positive assertion failure `assert!(reads > 0, "reader thread never completed a read")`.

## Solution
Changed the reader loop structure to execute at least one full read pass unconditionally (`loop { ... reads += 1; if done_reader.load(Ordering::Relaxed) { break; } }`) before exiting. This guarantees deterministic liveness and removes the thread-scheduling timing assumption while fully preserving the concurrent isolation test coverage.

Closes #2795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated snapshot isolation test behavior to ensure the reader performs at least one validation before stopping.
  * Improved coverage of concurrent read behavior when the completion signal is already set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->